### PR TITLE
Postpone calling VBT_wait until after V1P_Process

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -297,8 +297,6 @@ vbe_dir_http1pipe(const struct director *d, struct req *req, struct busyobj *bo)
 	} else {
 		i = V1F_SendReq(req->wrk, bo, &v1a.bereq, 1);
 		VSLb_ts_req(req, "Pipe", W_TIM_real(req->wrk));
-		if (vbc->state == VBC_STATE_STOLEN)
-			VBT_Wait(req->wrk, vbc);
 		if (i == 0)
 			V1P_Process(req, vbc->fd, &v1a);
 		VSLb_ts_req(req, "PipeSess", W_TIM_real(req->wrk));

--- a/bin/varnishtest/tests/r01806.vtc
+++ b/bin/varnishtest/tests/r01806.vtc
@@ -1,0 +1,33 @@
+varnishtest "#1806: return pipe w/ STOLEN connection"
+
+server s1 {
+	rxreq
+	expect req.url == "/pass-me"
+	txresp -body "I was PASSed\n"
+
+	rxreq
+	expect req.url == "/pipe-me"
+	txresp -body "I was PIPEd\n"
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.url == "/pipe-me") {
+			return (pipe);
+		}
+
+		return (pass);
+	}
+} -start
+
+varnish v1 -cliok "param.set debug +syncvsl"
+
+client c1 {
+	txreq -url /pass-me
+	rxresp
+	expect resp.status == 200
+
+	txreq -req POST -url /pipe-me -body "asdf"
+	rxresp
+	expect resp.status == 200
+} -run


### PR DESCRIPTION
Fixes a bug where we went on the waiter prior to passing the request
body.

The VBT_Wait call is now handled in vbe_dir_finish.

Test case by thomaslc

Fixes: #1806