### PR TITLE
Proper handling of duplicate headers on IMS headers merge

### DIFF
--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -992,6 +992,8 @@ HTTP_Merge(struct worker *wrk, struct objcore *oc, struct http *to)
 	const char *ptr;
 	unsigned u;
 	const char *p;
+	unsigned nhd_before_merge;
+	unsigned v;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
@@ -1009,10 +1011,12 @@ HTTP_Merge(struct worker *wrk, struct objcore *oc, struct http *to)
 		http_SetH(to, u, ptr);
 		ptr = strchr(ptr, '\0') + 1;
 	}
+	nhd_before_merge = to->nhd;
 	while (*ptr != '\0') {
 		p = strchr(ptr, ':');
 		AN(p);
-		if (!http_findhdr(to, p - ptr, ptr))
+		v = http_findhdr(to, p - ptr, ptr);
+		if (v == 0 || v >= nhd_before_merge)
 			http_SetHeader(to, ptr);
 		ptr = strchr(ptr, '\0') + 1;
 	}

--- a/bin/varnishtest/tests/r01879.vtc
+++ b/bin/varnishtest/tests/r01879.vtc
@@ -1,0 +1,48 @@
+varnishtest "r01879: Check duplicate headers handling on IMS header merge"
+
+server s1 {
+	rxreq
+	txresp -hdr {etag: "foo"} -hdr "foo: a" -hdr "foo: b" -body "bdy"
+	rxreq
+	expect req.http.if-none-match == {"foo"}
+	txresp -status 304 -hdr {etag: "foo"}  -hdr "foo: c" -hdr "foo: d"
+	rxreq
+	txresp -hdr {etag: "bar"} -hdr "foo: a" -hdr "foo: b" -body "bdy"
+	rxreq
+	expect req.http.if-none-match == {"bar"}
+	txresp -status 304 -hdr {etag: "bar"}
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_backend_response {
+		set beresp.ttl = 0.00001s;
+		set beresp.grace = 0.1s;
+		set beresp.keep = 9999s;
+	}
+	sub vcl_deliver {
+		std.collect(resp.http.foo);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.foo == "a, b"
+	delay .5
+	txreq
+	rxresp
+	expect resp.http.foo == "c, d"
+	delay .5
+} -run
+
+client c2 {
+	txreq
+	rxresp
+	expect resp.http.foo == "a, b"
+	delay .5
+	txreq
+	rxresp
+	expect resp.http.foo == "a, b"
+} -run


### PR DESCRIPTION
This fixes a problem when a backend replies with 304 Not Modified
(after a http conditional request from varnish) and does not supply a
header that was duplicate in the cached object.

Before this patch, varnish would only supply (by copying from the
expired object) the first instance of a duplicate header.