### PR TITLE
Handle return(synth()) in vcl_pipe

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -588,8 +588,13 @@ cnt_pipe(struct worker *wrk, struct req *req)
 
 	VCL_pipe_method(req->vcl, wrk, req, bo, NULL);
 
-	if (wrk->handling == VCL_RET_SYNTH)
-		INCOMPL();
+	if (wrk->handling == VCL_RET_SYNTH) {
+		req->req_step = R_STP_SYNTH;
+		http_Teardown(bo->bereq);
+		VBO_ReleaseBusyObj(wrk, &bo);
+		THR_SetBusyobj(NULL);
+		return (REQ_FSM_MORE);
+	}
 	assert(wrk->handling == VCL_RET_PIPE);
 
 	SES_Close(req->sp, VDI_Http1Pipe(req, bo));

--- a/bin/varnishtest/tests/r01890.vtc
+++ b/bin/varnishtest/tests/r01890.vtc
@@ -1,0 +1,16 @@
+server s1 {
+        rxreq
+        txresp
+} -start
+
+varnish v1 -vcl+backend {
+        sub vcl_pipe {
+                return (synth(401));
+        }
+} -start
+
+client c1 {
+        txreq -req PROPFIND
+        rxresp
+        expect resp.status == 401
+} -run


### PR DESCRIPTION
Instead of panicking on a return(synth()) in vcl_pipe, we just proceed
to a normal synth.

Test by Dridi

Fixes #1890