### PR TITLE
Handle return(synth()) in vcl_pipe

### DIFF
--- a/bin/varnishtest/tests/r01890.vtc
+++ b/bin/varnishtest/tests/r01890.vtc
@@ -1,0 +1,16 @@
+server s1 {
+        rxreq
+        txresp
+} -start
+
+varnish v1 -vcl+backend {
+        sub vcl_pipe {
+                return (synth(401));
+        }
+} -start
+
+client c1 {
+        txreq -req PROPFIND
+        rxresp
+        expect resp.status == 401
+} -run


### PR DESCRIPTION
Instead of panicking on a return(synth()) in vcl_pipe, we just proceed
to a normal synth.

Test by Dridi

Fixes #1890