### PR TITLE
Use posix_fallocate if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,6 +245,7 @@ AC_CHECK_FUNCS([getdtablesize])
 AC_CHECK_FUNCS([nanosleep])
 AC_CHECK_FUNCS([setppriv])
 AC_CHECK_FUNCS([fallocate])
+AC_CHECK_FUNCS([posix_fallocate])
 AC_CHECK_FUNCS([closefrom])
 
 save_LIBS="${LIBS}"

--- a/lib/libvarnish/vfil.c
+++ b/lib/libvarnish/vfil.c
@@ -209,6 +209,16 @@ VFIL_allocate(int fd, off_t size, int insist)
 		}
 	}
 #endif
+#if defined(HAVE_POSIX_FALLOCATE)
+	{
+		int error;
+		error = posix_fallocate(fd, 0, size);
+		if (!error)
+			return (0);
+		if (error == ENOSPC)
+			return (-1);
+	}
+#endif
 	if (!insist)
 		return (0);
 


### PR DESCRIPTION
If both fallocate and posix_fallocate are available, try the former and fallback to the posix one if the filesystem is not ext4.