### PR TITLE
 Add an object head condition variable to wait on and use it for ESI

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -548,8 +548,6 @@ struct req {
 	const struct transport	*transport;
 	void			*transport_priv;
 
-	VTAILQ_ENTRY(req)	w_list;
-
 	struct objcore		*body_oc;
 
 	/* The busy objhead we sleep on */

--- a/bin/varnishd/cache/cache_ban_lurker.c
+++ b/bin/varnishd/cache/cache_ban_lurker.c
@@ -203,7 +203,7 @@ ban_lurker_test_ban(struct worker *wrk, struct vsl_log *vsl, struct ban *bt,
 			if (i)
 				ObjSendEvent(wrk, oc, OEV_BANCHG);
 		}
-		(void)HSH_DerefObjCore(wrk, &oc);
+		(void)HSH_DerefObjCore(wrk, &oc, 0);
 	}
 }
 

--- a/bin/varnishd/cache/cache_busyobj.c
+++ b/bin/varnishd/cache/cache_busyobj.c
@@ -171,7 +171,7 @@ VBO_ReleaseBusyObj(struct worker *wrk, struct busyobj **pbo)
 
 	if (bo->fetch_objcore != NULL) {
 		AN(wrk);
-		(void)HSH_DerefObjCore(wrk, &bo->fetch_objcore);
+		(void)HSH_DerefObjCore(wrk, &bo->fetch_objcore, -1);
 	}
 
 	VCL_Rel(&bo->vcl);

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -79,7 +79,6 @@ ved_include(struct req *preq, const char *src, const char *host,
 {
 	struct worker *wrk;
 	struct req *req;
-	enum req_fsm_nxt s;
 
 	CHECK_OBJ_NOTNULL(preq, REQ_MAGIC);
 	CHECK_OBJ_NOTNULL(ecx, ECX_MAGIC);
@@ -161,17 +160,8 @@ ved_include(struct req *preq, const char *src, const char *host,
 
 	req->ws_req = WS_Snapshot(req->ws);
 
-	while (1) {
-		req->wrk = wrk;
-		s = CNT_Request(wrk, req);
-		if (s == REQ_FSM_DONE)
-			break;
-		DSL(DBG_WAITINGLIST, req->vsl->wid,
-		    "loop waiting for ESI (%d)", (int)s);
-		assert(s == REQ_FSM_DISEMBARK);
-		AZ(req->wrk);
-		(void)usleep(10000);
-	}
+	req->wrk = wrk;
+	assert (CNT_Request(wrk, req) == REQ_FSM_DONE);
 
 	VRTPRIV_dynamic_kill(req->sp->privs, (uintptr_t)req);
 	CNT_AcctLogCharge(wrk->stats, req);

--- a/bin/varnishd/cache/cache_expire.c
+++ b/bin/varnishd/cache/cache_expire.c
@@ -193,7 +193,7 @@ exp_inbox(struct exp_priv *ep, struct objcore *oc, unsigned flags)
 		assert(oc->refcnt > 0);
 		AZ(oc->exp_flags);
 		ObjSendEvent(ep->wrk, oc, OEV_EXPIRE);
-		(void)HSH_DerefObjCore(ep->wrk, &oc);
+		(void)HSH_DerefObjCore(ep->wrk, &oc, 0);
 		return;
 	}
 
@@ -270,7 +270,7 @@ exp_expire(struct exp_priv *ep, double now)
 		VSLb(&ep->vsl, SLT_ExpKill, "EXP_Expired x=%u t=%.0f",
 		    ObjGetXID(ep->wrk, oc), EXP_Ttl(NULL, oc) - now);
 		ObjSendEvent(ep->wrk, oc, OEV_EXPIRE);
-		(void)HSH_DerefObjCore(ep->wrk, &oc);
+		(void)HSH_DerefObjCore(ep->wrk, &oc, 0);
 	}
 	return (0);
 }

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -950,7 +950,7 @@ vbf_fetch_thread(struct worker *wrk, void *priv)
 		CHECK_OBJ_NOTNULL(bo->stale_oc, OBJCORE_MAGIC);
 		/* We don't want the oc/stevedore ops in fetching thread */
 		if (!ObjCheckFlag(wrk, bo->stale_oc, OF_IMSCAND))
-			(void)HSH_DerefObjCore(wrk, &bo->stale_oc);
+			(void)HSH_DerefObjCore(wrk, &bo->stale_oc, 0);
 	}
 #endif
 
@@ -982,7 +982,7 @@ vbf_fetch_thread(struct worker *wrk, void *priv)
 	// AZ(bo->fetch_objcore->boc);	// XXX
 
 	if (bo->stale_oc != NULL)
-		(void)HSH_DerefObjCore(wrk, &bo->stale_oc);
+		(void)HSH_DerefObjCore(wrk, &bo->stale_oc, 0);
 
 	wrk->vsl = NULL;
 	HSH_DerefBoc(wrk, bo->fetch_objcore);
@@ -1059,7 +1059,7 @@ VBF_Fetch(struct worker *wrk, struct req *req, struct objcore *oc,
 		wrk->stats->fetch_no_thread++;
 		(void)vbf_stp_fail(req->wrk, bo);
 		if (bo->stale_oc != NULL)
-			(void)HSH_DerefObjCore(wrk, &bo->stale_oc);
+			(void)HSH_DerefObjCore(wrk, &bo->stale_oc, 0);
 		HSH_DerefBoc(wrk, oc);
 		SES_Rel(bo->sp);
 		VBO_ReleaseBusyObj(wrk, &bo);
@@ -1081,6 +1081,6 @@ VBF_Fetch(struct worker *wrk, struct req *req, struct objcore *oc,
 	assert(oc->boc == boc);
 	HSH_DerefBoc(wrk, oc);
 	if (mode == VBF_BACKGROUND)
-		(void)HSH_DerefObjCore(wrk, &oc);
+		(void)HSH_DerefObjCore(wrk, &oc, -1);
 	THR_SetBusyobj(NULL);
 }

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -828,7 +828,7 @@ vbf_stp_error(struct worker *wrk, struct busyobj *bo)
 	http_SetHeader(bo->beresp, "Server: Varnish");
 
 	bo->fetch_objcore->t_origin = now;
-	if (!VTAILQ_EMPTY(&bo->fetch_objcore->objhead->waitinglist)) {
+	if (bo->fetch_objcore->objhead->waitinglist) {
 		/*
 		 * If there is a waitinglist, it means that there is no
 		 * grace-able object, so cache the error return for a

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -78,7 +78,6 @@ hsh_newobjhead(void)
 	XXXAN(oh);
 	oh->refcnt = 1;
 	VTAILQ_INIT(&oh->objcs);
-	VTAILQ_INIT(&oh->waitinglist);
 	Lck_New(&oh->mtx, lck_objhdr);
 	return (oh);
 }
@@ -153,7 +152,7 @@ HSH_DeleteObjHead(struct worker *wrk, struct objhead *oh)
 
 	AZ(oh->refcnt);
 	assert(VTAILQ_EMPTY(&oh->objcs));
-	assert(VTAILQ_EMPTY(&oh->waitinglist));
+	AZ(oh->waitinglist);
 	Lck_Delete(&oh->mtx);
 	wrk->stats->n_objecthead--;
 	FREE_OBJ(oh);
@@ -292,7 +291,7 @@ HSH_Insert(struct worker *wrk, const void *digest, struct objcore *oc,
 	VTAILQ_REMOVE(&oh->objcs, oc, hsh_list);
 	VTAILQ_INSERT_HEAD(&oh->objcs, oc, hsh_list);
 	oc->flags &= ~OC_F_BUSY;
-	if (!VTAILQ_EMPTY(&oh->waitinglist))
+	if (oh->waitinglist)
 		hsh_rush(wrk, oh);
 	Lck_Unlock(&oh->mtx);
 }
@@ -320,66 +319,96 @@ hsh_insert_busyobj(struct worker *wrk, struct objhead *oh)
 }
 
 /*---------------------------------------------------------------------
+ * waitinglist interface
  */
 
-enum lookup_e
-HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
-    int wait_for_busy, int always_insert)
+static inline struct wlist *
+hsh_wlist_new(void)
 {
-	struct worker *wrk;
-	struct objhead *oh;
-	struct objcore *oc;
-	struct objcore *exp_oc;
-	double exp_t_origin;
-	int busy_found;
-	enum lookup_e retval;
-	const uint8_t *vary;
+	struct wlist *wl;
 
-	AN(ocp);
-	*ocp = NULL;
-	AN(bocp);
-	*bocp = NULL;
+	ALLOC_OBJ(wl, WLIST_MAGIC);
+	XXXAN(wl);
+	VTAILQ_INIT(&wl->reqs);
+	AZ(pthread_cond_init(&wl->cv, NULL));
+	return (wl);
+}
 
-	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-	wrk = req->wrk;
-	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
-	CHECK_OBJ_NOTNULL(req->http, HTTP_MAGIC);
-	AN(hash);
-
-	hsh_prealloc(wrk);
-	if (DO_DEBUG(DBG_HASHEDGE))
-		hsh_testmagic(req->digest);
-
-	if (req->hash_objhead != NULL) {
-		/*
-		 * This req came off the waiting list, and brings an
-		 * oh refcnt with it.
-		 */
-		CHECK_OBJ_NOTNULL(req->hash_objhead, OBJHEAD_MAGIC);
-		oh = req->hash_objhead;
-		Lck_Lock(&oh->mtx);
-		req->hash_objhead = NULL;
-	} else {
-		AN(wrk->nobjhead);
-		oh = hash->lookup(wrk, req->digest, &wrk->nobjhead);
-	}
+static inline void
+hsh_wlist_finish(struct objhead *oh)
+{
+	struct wlist *wl;
 
 	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
+
+	wl = oh->waitinglist;
+	CHECK_OBJ_NOTNULL(wl, WLIST_MAGIC);
+
+	if (! VTAILQ_EMPTY(&wl->reqs))
+		return;
+
 	Lck_AssertHeld(&oh->mtx);
 
-	if (always_insert) {
-		/* XXX: should we do predictive Vary in this case ? */
-		/* Insert new objcore in objecthead and release mutex */
-		*bocp = hsh_insert_busyobj(wrk, oh);
-		/* NB: no deref of objhead, new object inherits reference */
-		Lck_Unlock(&oh->mtx);
-		return (HSH_MISS);
-	}
+	AZ(pthread_cond_broadcast(&wl->cv));
+	AZ(pthread_cond_destroy(&wl->cv));
+
+	FREE_OBJ(wl);
+	oh->waitinglist = NULL;
+}
+
+static inline void
+hsh_wlist_enq(struct wlist *wl, struct req *req)
+{
+	struct wlist_entry *we;
+
+	CHECK_OBJ_NOTNULL(wl, WLIST_MAGIC);
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+
+	ALLOC_OBJ(we, WLIST_ENTRY_MAGIC);
+	XXXAN(we);
+	we->req = req;
+
+	VTAILQ_INSERT_TAIL(&wl->reqs, we, list);
+}
+
+static inline struct req *
+hsh_wlist_deq(struct wlist *wl)
+{
+	struct wlist_entry *we;
+	struct req *req;
+
+	CHECK_OBJ_NOTNULL(wl, WLIST_MAGIC);
+
+	we = VTAILQ_FIRST(&wl->reqs);
+	if (we == NULL)
+		return NULL;
+
+	CHECK_OBJ_NOTNULL(we, WLIST_ENTRY_MAGIC);
+	req = we->req;
+	VTAILQ_REMOVE(&wl->reqs, we, list);
+	FREE_OBJ(we);
+
+	return (req);
+}
+
+/*---------------------------------------------------------------------
+ */
+
+static enum lookup_e
+hsh_lookup(struct objhead *oh, struct worker *wrk, struct req *req,
+    struct objcore **ocp, struct objcore **bocp)
+{
+	struct objcore *oc;
+	const uint8_t *vary;
+	enum lookup_e retval;
+
+	int busy_found = 0;
+	struct objcore *exp_oc = NULL;
+	double exp_t_origin = 0.0;
 
 	assert(oh->refcnt > 0);
-	busy_found = 0;
-	exp_oc = NULL;
-	exp_t_origin = 0.0;
+	Lck_AssertHeld(&oh->mtx);
+
 	VTAILQ_FOREACH(oc, &oh->objcs, hsh_list) {
 		/* Must be at least our own ref + the objcore we examine */
 		assert(oh->refcnt > 1);
@@ -469,32 +498,114 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 		return (HSH_MISS);
 	}
 
-	/* There are one or more busy objects, wait for them */
-
-	AZ(req->hash_ignore_busy);
-
-	if (wait_for_busy) {
-		VTAILQ_INSERT_TAIL(&oh->waitinglist, req, w_list);
-		if (DO_DEBUG(DBG_WAITINGLIST))
-			VSLb(req->vsl, SLT_Debug, "on waiting list <%p>", oh);
-	} else {
-		if (DO_DEBUG(DBG_WAITINGLIST))
-			VSLb(req->vsl, SLT_Debug, "hit busy obj <%p>", oh);
-	}
-
-	wrk->stats->busy_sleep++;
-	/*
-	 * The objhead reference transfers to the sess, we get it
-	 * back when the sess comes off the waiting list and
-	 * calls us again
-	 */
-	req->hash_objhead = oh;
-	req->wrk = NULL;
-	Lck_Unlock(&oh->mtx);
+	// oh->mtx still kept!
 	return (HSH_BUSY);
 }
 
+enum lookup_e
+HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
+    int always_insert)
+{
+	struct worker *wrk;
+	struct objhead *oh;
+	enum lookup_e r;
+
+	AN(ocp);
+	*ocp = NULL;
+	AN(bocp);
+	*bocp = NULL;
+
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	wrk = req->wrk;
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	CHECK_OBJ_NOTNULL(req->http, HTTP_MAGIC);
+	AN(hash);
+
+	hsh_prealloc(wrk);
+	if (DO_DEBUG(DBG_HASHEDGE))
+		hsh_testmagic(req->digest);
+
+	if (req->hash_objhead != NULL) {
+		/*
+		 * This req came off the waiting list, and brings an
+		 * oh refcnt with it.
+		 */
+		CHECK_OBJ_NOTNULL(req->hash_objhead, OBJHEAD_MAGIC);
+		oh = req->hash_objhead;
+		Lck_Lock(&oh->mtx);
+		req->hash_objhead = NULL;
+	} else {
+		AN(wrk->nobjhead);
+		oh = hash->lookup(wrk, req->digest, &wrk->nobjhead);
+	}
+
+	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
+	Lck_AssertHeld(&oh->mtx);
+
+	if (always_insert) {
+		/* XXX: should we do predictive Vary in this case ? */
+		/* Insert new objcore in objecthead and release mutex */
+		*bocp = hsh_insert_busyobj(wrk, oh);
+		/* NB: no deref of objhead, new object inherits reference */
+		Lck_Unlock(&oh->mtx);
+		return (HSH_MISS);
+	}
+
+	r = hsh_lookup(oh, wrk, req, ocp, bocp);
+
+	if (r != HSH_BUSY)
+		return (r);
+
+	/* There are one or more busy objects, wait for them */
+
+	AZ(req->hash_ignore_busy);
+	Lck_AssertHeld(&oh->mtx);
+
+	if (oh->waitinglist == NULL)
+		oh->waitinglist = hsh_wlist_new();
+
+	if (req->esi_level == 0) {
+		hsh_wlist_enq(oh->waitinglist, req);
+		if (DO_DEBUG(DBG_WAITINGLIST))
+			VSLb(req->vsl, SLT_Debug, "on waiting list <%p>", oh);
+
+		wrk->stats->busy_sleep++;
+		/*
+		 * The objhead reference transfers to the sess, we get it
+		 * back when the sess comes off the waiting list and
+		 * calls us again
+		 */
+		req->hash_objhead = oh;
+		req->wrk = NULL;
+		Lck_Unlock(&oh->mtx);
+		return (HSH_BUSY);
+	}
+
+	do {
+		Lck_AssertHeld(&oh->mtx);
+
+		if (oh->waitinglist == NULL)
+			oh->waitinglist = hsh_wlist_new();
+
+		if (DO_DEBUG(DBG_WAITINGLIST)) {
+			VSLb(req->vsl, SLT_Debug, "waiting for busy obj <%p>",
+			    oh);
+		}
+
+		CHECK_OBJ_NOTNULL(oh->waitinglist, WLIST_MAGIC);
+		(void)Lck_CondWait(&oh->waitinglist->cv, &oh->mtx, 0);
+
+		if (DO_DEBUG(DBG_WAITINGLIST)) {
+			VSLb(req->vsl, SLT_Debug, "woke up on obj <%p>" , oh);
+		}
+
+		r = hsh_lookup(oh, wrk, req, ocp, bocp);
+	} while (r == HSH_BUSY);
+
+	return (r);
+}
 /*---------------------------------------------------------------------
+ * must be called for non-empty waitinglist only
  */
 
 static void
@@ -503,18 +614,21 @@ hsh_rush(struct worker *wrk, struct objhead *oh)
 	unsigned u;
 	struct req *req;
 	struct sess *sp;
+	struct wlist *wl;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
+	wl = oh->waitinglist;
+	CHECK_OBJ_NOTNULL(wl, WLIST_MAGIC);
 	Lck_AssertHeld(&oh->mtx);
+	AZ(pthread_cond_broadcast(&wl->cv));
 	for (u = 0; u < cache_param->rush_exponent; u++) {
-		req = VTAILQ_FIRST(&oh->waitinglist);
+		req = hsh_wlist_deq(wl);
 		if (req == NULL)
 			break;
 		CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 		wrk->stats->busy_wakeup++;
 		AZ(req->wrk);
-		VTAILQ_REMOVE(&oh->waitinglist, req, w_list);
 		DSL(DBG_WAITINGLIST, req->vsl->wid, "off waiting list");
 		if (SES_Reschedule_Req(req)) {
 			/*
@@ -531,17 +645,17 @@ hsh_rush(struct worker *wrk, struct objhead *oh)
 				CNT_AcctLogCharge(wrk->stats, req);
 				Req_Release(req);
 				SES_Delete(sp, SC_OVERLOAD, NAN);
-				req = VTAILQ_FIRST(&oh->waitinglist);
+				req = hsh_wlist_deq(wl);
 				if (req == NULL)
 					break;
 				CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-				VTAILQ_REMOVE(&oh->waitinglist, req, w_list);
 				DSL(DBG_WAITINGLIST, req->vsl->wid,
 				    "kill from waiting list");
 			}
 			break;
 		}
 	}
+	hsh_wlist_finish(oh);
 }
 
 /*---------------------------------------------------------------------
@@ -683,7 +797,7 @@ HSH_Unbusy(struct worker *wrk, struct objcore *oc)
 	VTAILQ_REMOVE(&oh->objcs, oc, hsh_list);
 	VTAILQ_INSERT_HEAD(&oh->objcs, oc, hsh_list);
 	oc->flags &= ~OC_F_BUSY;
-	if (!VTAILQ_EMPTY(&oh->waitinglist))
+	if (oh->waitinglist)
 		hsh_rush(wrk, oh);
 	Lck_Unlock(&oh->mtx);
 	if (!(oc->flags & OC_F_PRIVATE))
@@ -836,7 +950,7 @@ HSH_DerefObjCore(struct worker *wrk, struct objcore **ocp)
 	r = --oc->refcnt;
 	if (!r)
 		VTAILQ_REMOVE(&oh->objcs, oc, hsh_list);
-	if (!VTAILQ_EMPTY(&oh->waitinglist))
+	if (oh->waitinglist)
 		hsh_rush(wrk, oh);
 	Lck_Unlock(&oh->mtx);
 	if (r != 0)
@@ -867,7 +981,7 @@ HSH_DerefObjHead(struct worker *wrk, struct objhead **poh)
 	TAKE_OBJ_NOTNULL(oh, poh, OBJHEAD_MAGIC);
 
 	if (oh == private_oh) {
-		assert(VTAILQ_EMPTY(&oh->waitinglist));
+		AZ(oh->waitinglist);
 		Lck_Lock(&oh->mtx);
 		assert(oh->refcnt > 1);
 		oh->refcnt--;
@@ -883,11 +997,12 @@ HSH_DerefObjHead(struct worker *wrk, struct objhead **poh)
 	 * just make the hold the same ref's as objcore, that would
 	 * confuse hashers.
 	 */
-	while (!VTAILQ_EMPTY(&oh->waitinglist)) {
+	while (oh->waitinglist) {
 		Lck_Lock(&oh->mtx);
 		assert(oh->refcnt > 0);
 		r = oh->refcnt;
-		hsh_rush(wrk, oh);
+		if (oh->waitinglist)
+			hsh_rush(wrk, oh);
 		Lck_Unlock(&oh->mtx);
 		if (r > 1)
 			break;

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -67,7 +67,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	if (VFP_Open(vfc) < 0) {
 		req->req_body_status = REQ_BODY_FAIL;
 		HSH_DerefBoc(req->wrk, req->body_oc);
-		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc));
+		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc, 0));
 		return (-1);
 	}
 
@@ -108,7 +108,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	VSLb_ts_req(req, "ReqBody", VTIM_real());
 	if (func != NULL) {
 		HSH_DerefBoc(req->wrk, req->body_oc);
-		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc));
+		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc, 0));
 		if (vfps != VFP_END) {
 			req->req_body_status = REQ_BODY_FAIL;
 			if (r == 0)
@@ -123,7 +123,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 
 	if (vfps != VFP_END) {
 		req->req_body_status = REQ_BODY_FAIL;
-		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc));
+		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc, 0));
 		return (-1);
 	}
 
@@ -239,7 +239,7 @@ VRB_Free(struct req *req)
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 
 	if (req->body_oc != NULL)
-		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc));
+		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc, 0));
 }
 
 /*----------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -367,10 +367,7 @@ cnt_lookup(struct worker *wrk, struct req *req)
 	AZ(req->objcore);
 	if (req->hash_objhead)
 		had_objhead = 1;
-	lr = HSH_Lookup(req, &oc, &busy,
-	    req->esi_level == 0 ? 1 : 0,
-	    req->hash_always_miss ? 1 : 0
-	);
+	lr = HSH_Lookup(req, &oc, &busy, req->hash_always_miss ? 1 : 0);
 	if (lr == HSH_BUSY) {
 		/*
 		 * We lost the session to a busy object, disembark the
@@ -777,7 +774,7 @@ cnt_purge(struct worker *wrk, struct req *req)
 	VRY_Prep(req);
 
 	AZ(req->objcore);
-	lr = HSH_Lookup(req, &oc, &boc, 1, 1);
+	lr = HSH_Lookup(req, &oc, &boc, 1);
 	assert (lr == HSH_MISS);
 	AZ(oc);
 	CHECK_OBJ_NOTNULL(boc, OBJCORE_MAGIC);

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -109,7 +109,7 @@ cnt_deliver(struct worker *wrk, struct req *req)
 		wrk->handling = VCL_RET_DELIVER;
 
 	if (wrk->handling != VCL_RET_DELIVER) {
-		(void)HSH_DerefObjCore(wrk, &req->objcore);
+		(void)HSH_DerefObjCore(wrk, &req->objcore, 0);
 		http_Teardown(req->resp);
 
 		switch (wrk->handling) {
@@ -216,7 +216,7 @@ cnt_synth(struct worker *wrk, struct req *req)
 		VSLb(req->vsl, SLT_Error, "Could not get storage");
 		req->doclose = SC_OVERLOAD;
 		VSLb_ts_req(req, "Resp", W_TIM_real(wrk));
-		(void)HSH_DerefObjCore(wrk, &req->objcore);
+		(void)HSH_DerefObjCore(wrk, &req->objcore, 0);
 		http_Teardown(req->resp);
 		return (REQ_FSM_DONE);
 	}
@@ -311,7 +311,7 @@ cnt_transmit(struct worker *wrk, struct req *req)
 	if (boc != NULL)
 		HSH_DerefBoc(wrk, req->objcore);
 
-	(void)HSH_DerefObjCore(wrk, &req->objcore);
+	(void)HSH_DerefObjCore(wrk, &req->objcore, 0);
 	http_Teardown(req->resp);
 
 	return (REQ_FSM_DONE);
@@ -335,7 +335,7 @@ cnt_fetch(struct worker *wrk, struct req *req)
 	if (req->objcore->flags & OC_F_FAILED) {
 		req->err_code = 503;
 		req->req_step = R_STP_SYNTH;
-		(void)HSH_DerefObjCore(wrk, &req->objcore);
+		(void)HSH_DerefObjCore(wrk, &req->objcore, 0);
 		AZ(req->objcore);
 		return (REQ_FSM_MORE);
 	}
@@ -413,7 +413,7 @@ cnt_lookup(struct worker *wrk, struct req *req)
 		VSLb(req->vsl, SLT_Debug, "XXXX HIT-FOR-PASS");
 		VSLb(req->vsl, SLT_HitPass, "%u",
 		    ObjGetXID(wrk, req->objcore));
-		(void)HSH_DerefObjCore(wrk, &req->objcore);
+		(void)HSH_DerefObjCore(wrk, &req->objcore, 0);
 		wrk->stats->cache_hitpass++;
 		req->req_step = R_STP_PASS;
 		return (REQ_FSM_MORE);
@@ -442,7 +442,7 @@ cnt_lookup(struct worker *wrk, struct req *req)
 			req->stale_oc = oc;
 			req->req_step = R_STP_MISS;
 		} else {
-			(void)HSH_DerefObjCore(wrk, &req->objcore);
+			(void)HSH_DerefObjCore(wrk, &req->objcore, 0);
 			/*
 			 * We don't have a busy object, so treat this
 			 * like a pass
@@ -469,10 +469,10 @@ cnt_lookup(struct worker *wrk, struct req *req)
 	}
 
 	/* Drop our object, we won't need it */
-	(void)HSH_DerefObjCore(wrk, &req->objcore);
+	(void)HSH_DerefObjCore(wrk, &req->objcore, 0);
 
 	if (busy != NULL) {
-		(void)HSH_DerefObjCore(wrk, &busy);
+		(void)HSH_DerefObjCore(wrk, &busy, 1);
 		VRY_Clear(req);
 	}
 
@@ -498,7 +498,7 @@ cnt_miss(struct worker *wrk, struct req *req)
 		wrk->stats->cache_miss++;
 		VBF_Fetch(wrk, req, req->objcore, req->stale_oc, VBF_NORMAL);
 		if (req->stale_oc != NULL)
-			(void)HSH_DerefObjCore(wrk, &req->stale_oc);
+			(void)HSH_DerefObjCore(wrk, &req->stale_oc, 0);
 		req->req_step = R_STP_FETCH;
 		return (REQ_FSM_MORE);
 	case VCL_RET_SYNTH:
@@ -515,8 +515,8 @@ cnt_miss(struct worker *wrk, struct req *req)
 	}
 	VRY_Clear(req);
 	if (req->stale_oc != NULL)
-		(void)HSH_DerefObjCore(wrk, &req->stale_oc);
-	AZ(HSH_DerefObjCore(wrk, &req->objcore));
+		(void)HSH_DerefObjCore(wrk, &req->stale_oc, 0);
+	AZ(HSH_DerefObjCore(wrk, &req->objcore, 0));
 	return (REQ_FSM_MORE);
 }
 
@@ -782,7 +782,7 @@ cnt_purge(struct worker *wrk, struct req *req)
 
 	HSH_Purge(wrk, boc->objhead, 0, 0, 0);
 
-	AZ(HSH_DerefObjCore(wrk, &boc));
+	AZ(HSH_DerefObjCore(wrk, &boc, 0));
 
 	VCL_purge_method(req->vcl, wrk, req, NULL, NULL);
 	switch (wrk->handling) {

--- a/bin/varnishd/hash/hash_slinger.h
+++ b/bin/varnishd/hash/hash_slinger.h
@@ -95,6 +95,7 @@ struct wlist {
 
 	VTAILQ_HEAD(, wlist_entry)	reqs;
 	pthread_cond_t			cv;
+	unsigned			cv_waiting;
 };
 
 struct objhead {
@@ -127,7 +128,7 @@ void HSH_Fail(struct objcore *);
 void HSH_Unbusy(struct worker *, struct objcore *);
 void HSH_DeleteObjHead(struct worker *, struct objhead *oh);
 int HSH_DerefObjHead(struct worker *, struct objhead **poh);
-int HSH_DerefObjCore(struct worker *, struct objcore **ocp);
+int HSH_DerefObjCore(struct worker *, struct objcore **ocp, int rushmax);
 #endif /* VARNISH_CACHE_CHILD */
 
 extern const struct hash_slinger hsl_slinger;

--- a/bin/varnishd/storage/storage_lru.c
+++ b/bin/varnishd/storage/storage_lru.c
@@ -198,6 +198,6 @@ LRU_NukeOne(struct worker *wrk, struct lru *lru)
 	ObjSlim(wrk, oc);
 
 	VSLb(wrk->vsl, SLT_ExpKill, "LRU x=%u", ObjGetXID(wrk, oc));
-	(void)HSH_DerefObjCore(wrk, &oc);	// Ref from ObjSnipe
+	(void)HSH_DerefObjCore(wrk, &oc, 0);	// Ref from ObjSnipe
 	return (1);
 }

--- a/bin/varnishd/storage/storage_persistent_silo.c
+++ b/bin/varnishd/storage/storage_persistent_silo.c
@@ -173,7 +173,7 @@ smp_load_seg(struct worker *wrk, const struct smp_sc *sc,
 		HSH_Insert(wrk, so->hash, oc, ban);
 		AN(oc->ban);
 		HSH_DerefBoc(wrk, oc);	// XXX Keep it an stream resurrection?
-		(void)HSH_DerefObjCore(wrk, &oc);
+		(void)HSH_DerefObjCore(wrk, &oc, -1);
 		wrk->stats->n_vampireobject++;
 	}
 	Pool_Sumstat(wrk);

--- a/bin/varnishtest/tests/r00345.vtc
+++ b/bin/varnishtest/tests/r00345.vtc
@@ -11,12 +11,17 @@ server s1 {
 	txresp -body {DATA}
 } -start
 
-varnish v1 -arg "-p debug=+workspace" -vcl+backend {
+varnish v1 -arg "-p debug=+waitinglist" -vcl+backend {
 	sub vcl_backend_response {
 		if (bereq.url == "/") {
 			set beresp.do_esi = true;
 		}
 	}
+} -start
+
+logexpect l1 -v v1 {
+	expect * *	Debug		"waiting for busy obj"
+	expect * *	Debug		"woke up on obj"
 } -start
 
 client c1 {
@@ -37,3 +42,5 @@ client c1 {
 	rxresp
 	expect resp.bodylen == 4
 } -run
+
+logexpect l1 -wait

--- a/bin/varnishtest/tests/r00345.vtc
+++ b/bin/varnishtest/tests/r00345.vtc
@@ -43,4 +43,6 @@ client c1 {
 	expect resp.bodylen == 4
 } -run
 
+varnish v1 -expect busy_sleep_esi >= 1
+varnish v1 -expect busy_wakeup_esi >= 1
 logexpect l1 -wait

--- a/include/tbl/vsc_f_main.h
+++ b/include/tbl/vsc_f_main.h
@@ -254,6 +254,18 @@ VSC_F(busy_wakeup,		uint64_t, 1, 'c', 'i', info,
 	" and rescheduled."
 )
 
+VSC_F(busy_sleep_esi,		uint64_t, 1, 'c', 'i', info,
+    "ESI worker threads blocked on busy objhdr",
+	"Number of times ESI processing threads blocked because"
+	" they found a busy object."
+)
+
+VSC_F(busy_wakeup_esi,		uint64_t, 1, 'c', 'i', info,
+    "ESI worker threads resumed on busy objhdr",
+	"Number of times ESI processing threads got worken up after"
+	" waiting for a busy object."
+)
+
 VSC_F(busy_killed,		uint64_t, 1, 'c', 'i', info,
     "Number of requests killed after sleep on busy objhdr",
 	"Number of requests killed from the busy object sleep list"


### PR DESCRIPTION
    Add an object head condition variable to wait on and use it for ESI
    
    Previously, ved_include() for ESI include processing retried the
    CNT_Request() FSM step if it hit a busy object, sleeping 10ms
    inbetween attempts. This could lead to starvation symptoms, for
    example in the following scenario when ved_include() "probes", with
    high probability, would always hit the busy case:
    
    - ESI include requires variant A of an object
    - other requests contantly insert variant B with ttl = grace = 0
    - backend requests need long processing time
    
    We now add, next to the waitinglist head, a condition variable which
    gets signalled whenever requests on the waitinglist get woken up in
    hsh_rush(). As all other struct objhead members, it is protected by
    the struct objhead mtx.
    
    ESI threads now block on this condition variable whenver they hit a
    busy object. Parking an ESI processing request on the waitinglist like
    esi_level == 0 requests could be more efficient, but would require
    handling much of the state currently in the ESI processing thread
    differntly, so blocking the ESI thread should be the best viable
    option.
    
    Most of HSH_Lookup() is now in hsh_lookup() to allow retries without
    re-aquiring oh->mtx.
