### PR TITLE
Panic address dump

### DIFF
--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -280,6 +280,7 @@ child_sigsegv_handler(int s, siginfo_t *si, void *c)
 		 __FILE__,
 		 __LINE__,
 		 buf,
+		 NULL,
 		 VAS_ASSERT);
 }
 

--- a/bin/varnishtest/vtc_log.c
+++ b/bin/varnishtest/vtc_log.c
@@ -274,11 +274,12 @@ vtc_hexdump(struct vtclog *vl, int lvl, const char *pfx,
 
 static void __attribute__((__noreturn__))
 vtc_log_VAS_Fail(const char *func, const char *file, int line,
-    const char *cond, enum vas_e why)
+    const char *cond, const void *addr, enum vas_e why)
 {
 	struct vtclog *vl;
 
 	(void)why;
+	(void)addr;
 	vl = pthread_getspecific(log_key);
 	if (vl == NULL || vl->act) {
 		fprintf(stderr,

--- a/include/miniobj.h
+++ b/include/miniobj.h
@@ -30,19 +30,19 @@
 
 #define CHECK_OBJ(ptr, type_magic)					\
 	do {								\
-		assert((ptr)->magic == type_magic);			\
+		assertdump((ptr)->magic == type_magic, (ptr));		\
 	} while (0)
 
 #define CHECK_OBJ_NOTNULL(ptr, type_magic)				\
 	do {								\
 		assert((ptr) != NULL);					\
-		assert((ptr)->magic == type_magic);			\
+		assertdump((ptr)->magic == type_magic, (ptr));		\
 	} while (0)
 
 #define CHECK_OBJ_ORNULL(ptr, type_magic)				\
 	do {								\
 		if ((ptr) != NULL)					\
-			assert((ptr)->magic == type_magic);		\
+			assertdump((ptr)->magic == type_magic, (ptr));	\
 	} while (0)
 
 #define CAST_OBJ(to, from, type_magic)					\

--- a/include/vas.h
+++ b/include/vas.h
@@ -46,18 +46,27 @@ enum vas_e {
 	VAS_VCL,
 };
 
-typedef void vas_f(const char *, const char *, int, const char *, enum vas_e);
+typedef void vas_f(const char *, const char *, int, const char *,
+    const void *, enum vas_e);
 
 extern vas_f *VAS_Fail __attribute__((__noreturn__));
 
 #ifdef WITHOUT_ASSERTS
-#define assert(e)	((void)(e))
+#define assert(e)		((void)(e))
+#define assertdump(e, addr)	((void)(e))
 #else /* WITH_ASSERTS */
 #define assert(e)							\
 do {									\
 	if (!(e)) {							\
 		VAS_Fail(__func__, __FILE__, __LINE__,			\
-		    #e, VAS_ASSERT);					\
+		    #e, NULL, VAS_ASSERT);				\
+	}								\
+} while (0)
+#define assertdump(e, addr)						\
+do {									\
+	if (!(e)) {							\
+		VAS_Fail(__func__, __FILE__, __LINE__,			\
+		    #e, addr, VAS_ASSERT);				\
 	}								\
 } while (0)
 #endif
@@ -66,7 +75,14 @@ do {									\
 do {									\
 	if (!(e)) {							\
 		VAS_Fail(__func__, __FILE__, __LINE__,			\
-		    #e, VAS_MISSING);					\
+		    #e, NULL, VAS_MISSING);				\
+	}								\
+} while (0)
+#define xxxassertdump(e, addr)						\
+do {									\
+	if (!(e)) {							\
+		VAS_Fail(__func__, __FILE__, __LINE__,			\
+		    #e, addr, VAS_MISSING);				\
 	}								\
 } while (0)
 
@@ -78,13 +94,13 @@ do {									\
 #define diagnostic(foo)	assert(foo)
 #define WRONG(expl)							\
 do {									\
-	VAS_Fail(__func__, __FILE__, __LINE__, expl, VAS_WRONG);	\
+	VAS_Fail(__func__, __FILE__, __LINE__, expl, NULL, VAS_WRONG);	\
 } while (0)
 
 #define INCOMPL()							\
 do {									\
 	VAS_Fail(__func__, __FILE__, __LINE__,				\
-	    "", VAS_INCOMPLETE);					\
+	    "", NULL, VAS_INCOMPLETE);					\
 } while (0)
 
 #endif

--- a/lib/libvarnish/vas.c
+++ b/lib/libvarnish/vas.c
@@ -40,7 +40,7 @@
 
 static void __attribute__((__noreturn__))
 VAS_Fail_default(const char *func, const char *file, int line,
-    const char *cond, enum vas_e kind)
+    const char *cond, const void *addr, enum vas_e kind)
 {
 	int err = errno;
 
@@ -66,6 +66,9 @@ VAS_Fail_default(const char *func, const char *file, int line,
 	if (err)
 		fprintf(stderr,
 		    "  errno = %d (%s)\n", err, strerror(err));
+	if (addr)
+		fprintf(stderr,
+		    "  addr = %p\n", addr);
 	abort();
 }
 

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -64,7 +64,7 @@ vmod_panic(VRT_CTX, const char *str, ...)
 	va_start(ap, str);
 	b = VRT_String(ctx->ws, "PANIC: ", str, ap);
 	va_end(ap);
-	VAS_Fail("VCL", "", 0, b, VAS_VCL);
+	VAS_Fail("VCL", "", 0, b, NULL, VAS_VCL);
 }
 
 VCL_STRING __match_proto__(td_debug_author)


### PR DESCRIPTION
If an address is given to the VAS_Fail function, a memory dump of that
memory area is included in the panic output.
