### PR TITLE
Fix crashes in ESI parsing and report errors

### DIFF
--- a/bin/varnishd/cache/cache_esi_parse.c
+++ b/bin/varnishd/cache/cache_esi_parse.c
@@ -1044,8 +1044,11 @@ VEP_Finish(struct vep_state *vep)
 
 	CHECK_OBJ_NOTNULL(vep, VEP_MAGIC);
 
-	AZ(vep->include_src);
-	AZ(vep->attr_vsb);
+	if (vep->include_src)
+		VSB_destroy(&vep->include_src);
+	if (vep->attr_vsb)
+		VSB_destroy(&vep->attr_vsb);
+
 	if (vep->o_pending)
 		vep_mark_common(vep, vep->ver_p, vep->last_mark);
 	if (vep->o_wait > 0) {

--- a/bin/varnishd/cache/cache_esi_parse.c
+++ b/bin/varnishd/cache/cache_esi_parse.c
@@ -1049,6 +1049,14 @@ VEP_Finish(struct vep_state *vep)
 	if (vep->attr_vsb)
 		VSB_destroy(&vep->attr_vsb);
 
+	if (vep->state != VEP_START &&
+	    vep->state != VEP_BOM &&
+	    vep->state != VEP_TESTXML &&
+	    vep->state != VEP_NOTXML &&
+	    vep->state != VEP_NEXTTAG) {
+		vep_error(vep, "VEP ended inside a tag");
+	}
+
 	if (vep->o_pending)
 		vep_mark_common(vep, vep->ver_p, vep->last_mark);
 	if (vep->o_wait > 0) {


### PR DESCRIPTION
Two commits in one pull request. Release memory instead of crashing on malformed ESI (fixes #1904) and then add some error logging.