### PR TITLE
Maintain `-d` behaviour when log is overrun and reacquired

### DIFF
--- a/lib/libvarnishtools/vut.c
+++ b/lib/libvarnishtools/vut.c
@@ -320,7 +320,8 @@ VUT_Main(void)
 				continue;
 			}
 			c = VSL_CursorVSM(VUT.vsl, VUT.vsm,
-			    VSL_COPT_TAIL | VSL_COPT_BATCH);
+			    (VUT.d_opt ? VSL_COPT_TAILSTOP : VSL_COPT_TAIL)
+			    | VSL_COPT_BATCH);
 			if (c == NULL) {
 				VSL_ResetError(VUT.vsl);
 				VSM_Close(VUT.vsm);


### PR DESCRIPTION
I encountered three instances of Varnish 4.0.1 running on separate Ubuntu 14.04 virtual machines where `varnishlog -d` had output `Log overrun` followed by `Log reacquired` and had switched to ignoring the `-d` switch and began tailing the log indefinitely.

There was a [Trac ticket 1345](https://www.varnish-cache.org/trac/ticket/1345) for the original issue of `-d` not being honoured at all which was fixed in commit 047c517f210348d631eec949df9231c27ce7b759.

The commit modified the `VSL_CursorVSM` call in `VUT_Setup` to add the `VSL_COPT_TAILSTOP` flag if the `-d` switch had been specified. However, there is a second call to `VSL_CursorVSM` call in `VUT_Main` which is used in the `Log reqacquired` scenario. My change duplicates the logic to conditionally add the `VSL_COPT_TAILSTOP` flag there too.

I've applied my change to the 4.0 branch because that is the version of Varnish with which I experienced this issue but the latest code in newer branches appears to require the same change too.