### PR TITLE
material for least connections director

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -139,6 +139,20 @@ vbe_dir_healthy(const struct director *d, const struct busyobj *bo,
 	return (VBE_Healthy(be, changed));
 }
 
+static unsigned __match_proto__(vdi_status_f)
+vbe_dir_status(const struct director *d, const struct busyobj *bo,
+    double *changed, double *load)
+{
+	struct backend *be;
+
+	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+	CHECK_OBJ_ORNULL(bo, BUSYOBJ_MAGIC);
+	CAST_OBJ_NOTNULL(be, d->priv, BACKEND_MAGIC);
+	if (load != NULL)
+		*load = be->n_conn;
+	return (VBE_Healthy(be, changed));
+}
+
 static void __match_proto__(vdi_finish_f)
 vbe_dir_finish(const struct director *d, struct worker *wrk,
     struct busyobj *bo)
@@ -353,6 +367,7 @@ VBE_fill_director(struct backend *be)
 	d->vcl_name = be->vcl_name;
 	d->http1pipe = vbe_dir_http1pipe;
 	d->healthy = vbe_dir_healthy;
+	d->status = vbe_dir_status;
 	d->gethdrs = vbe_dir_gethdrs;
 	d->getbody = vbe_dir_getbody;
 	d->getip = vbe_dir_getip;

--- a/bin/varnishd/cache/cache_director.h
+++ b/bin/varnishd/cache/cache_director.h
@@ -45,6 +45,8 @@
 
 typedef unsigned vdi_healthy_f(const struct director *, const struct busyobj *,
     double *changed);
+typedef unsigned vdi_status_f(const struct director *, const struct busyobj *,
+    double *changed, double *load);
 
 typedef const struct director *vdi_resolve_f(const struct director *,
     struct worker *, struct busyobj *);
@@ -70,6 +72,7 @@ struct director {
 	char			*vcl_name;
 	vdi_http1pipe_f		*http1pipe;
 	vdi_healthy_f		*healthy;
+	vdi_status_f		*status;
 	vdi_resolve_f		*resolve;
 	vdi_gethdrs_f		*gethdrs;
 	vdi_getbody_f		*getbody;

--- a/doc/sphinx/reference/directors.rst
+++ b/doc/sphinx/reference/directors.rst
@@ -37,6 +37,7 @@ code instead::
             char                    *vcl_name;
             vdi_http1pipe_f         *http1pipe;
             vdi_healthy_f           *healthy;
+            vdi_status_f            *status;
             vdi_resolve_f           *resolve;
             vdi_gethdrs_f           *gethdrs;
             vdi_getbody_f           *getbody;
@@ -117,6 +118,16 @@ is cooling. You are also encouraged to comply with the
 
 
 .. _ref-writing-a-director-cluster:
+
+
+vdi_status_f (NEW)
+==================
+
+It extand ``healthy`` function to also report the load of backends.
+With default TCP backends, the load is the number of active connections.
+
+It will used for least-connections director (least-busy director in general case).
+
 
 Health Probes
 =============


### PR DESCRIPTION
I implemented a least-connections director. It needs to access the n_conn value from backend.
The patch introduce vdi_conn_f do to that.
