### PR TITLE
Bind before connect

### DIFF
--- a/bin/varnishd/cache/cache_backend_tcp.c
+++ b/bin/varnishd/cache/cache_backend_tcp.c
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 
 #include "cache.h"
+#include "common/heritage.h"
 
 #include "vrt.h"
 #include "vsa.h"
@@ -224,8 +225,8 @@ VBT_Open(const struct tcp_pool *tp, double tmo, const struct suckaddr **sa)
 	const struct suckaddr *soa6 = NULL;
 
 	if (FEATURE(FEATURE_BIND_BEFORE_CONNECT)) {
-		soa4 = vsa_ipv4_any;
-		soa6 = vsa_ipv6_any;
+		soa4 = (heritage.ipv4_src ? heritage.ipv4_src : vsa_ipv4_any);
+		soa6 = (heritage.ipv6_src ? heritage.ipv6_src : vsa_ipv6_any);
 	}
 
 	CHECK_OBJ_NOTNULL(tp, TCP_POOL_MAGIC);

--- a/bin/varnishd/common/heritage.h
+++ b/bin/varnishd/common/heritage.h
@@ -56,6 +56,10 @@ struct heritage {
 	/* Sockets from which to accept connections */
 	struct listen_sock_head		socks;
 
+	/* Source Addr for bind-before-connect */
+	struct suckaddr			*ipv4_src;
+	struct suckaddr			*ipv6_src;
+
 	/* Hash method */
 	const struct hash_slinger	*hash;
 

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -155,6 +155,7 @@ extern struct params mgt_param;
 
 /* mgt_param_tcp.c */
 void MCF_TcpParams(void);
+void SRC_Arg(const char*);
 
 /* mgt_shmem.c */
 void mgt_SHM_Init(void);

--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -644,7 +644,7 @@ Marg_poker(const struct vev *e, int what)
 	AN(ma);
 
 	/* Try to connect asynchronously */
-	s = VTCP_connect(ma->sa, -1);
+	s = VTCP_connect(ma->sa, NULL, -1, 0);
 	if (s < 0)
 		return (0);
 

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -201,6 +201,8 @@ usage(void)
 	fprintf(stderr, FMT, "-b address[:port]", "backend address and port");
 	fprintf(stderr, FMT, "", "  address: hostname or IP");
 	fprintf(stderr, FMT, "", "  port: port or service (default: 80)");
+	fprintf(stderr, FMT, "-B address", "source address used to connect to backends");
+	fprintf(stderr, FMT, "", "  address: hostname or IP");
 	fprintf(stderr, FMT, "-C", "print VCL code compiled to C language");
 	fprintf(stderr, FMT, "-d", "debug");
 	fprintf(stderr, FMT, "-F", "Run in foreground");
@@ -556,6 +558,8 @@ main(int argc, char * const *argv)
 
 	/* Various initializations */
 	VTAILQ_INIT(&heritage.socks);
+	heritage.ipv4_src = NULL;
+	heritage.ipv6_src = NULL;
 	mgt_evb = vev_new_base();
 	AN(mgt_evb);
 
@@ -565,7 +569,7 @@ main(int argc, char * const *argv)
 	cli_check(cli);
 
 	while ((o = getopt(argc, argv,
-	    "a:b:Cdf:Fh:i:j:l:M:n:P:p:r:S:s:T:t:VW:x:")) != -1) {
+	    "a:b:B:Cdf:Fh:i:j:l:M:n:P:p:r:S:s:T:t:VW:x:")) != -1) {
 		/*
 		 * -j must be the first argument if specified, because
 		 * it (may) affect subsequent argument processing.
@@ -588,6 +592,9 @@ main(int argc, char * const *argv)
 			break;
 		case 'b':
 			b_arg = optarg;
+			break;
+		case 'B':
+			SRC_Arg(optarg);
 			break;
 		case 'C':
 			C_flag = 1 - C_flag;

--- a/bin/varnishtest/tests/v00050.vtc
+++ b/bin/varnishtest/tests/v00050.vtc
@@ -1,0 +1,16 @@
+varnishtest "Test bind_before_connect"
+
+server s1 {
+       rxreq
+       expect remote.ip == "127.0.0.2"
+       txresp
+} -start
+
+varnish v1 -arg "-B 127.0.0.2" -vcl+backend { } -start
+
+varnish v1 -cliok "param.set feature +bind_before_connect"
+
+client c1 {
+        txreq
+	rxresp
+} -run

--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -15,7 +15,7 @@ HTTP accelerator daemon
 SYNOPSIS
 ========
 
-varnishd [-a address[:port][,PROTO]] [-b host[:port]] [-C] [-d] [-F] [-f config] [-h type[,options]] [-i identity] [-j jail[,jailoptions]] [-l vsl[,vsm]] [-M address:port] [-n name] [-P file] [-p param=value] [-r param[,param...]] [-S secret-file] [-s [name=]kind[,options]] [-T address[:port]] [-t TTL] [-V] [-W waiter]
+varnishd [-a address[:port][,PROTO]] [-b host[:port]] [-b address] [-C] [-d] [-F] [-f config] [-h type[,options]] [-i identity] [-j jail[,jailoptions]] [-l vsl[,vsm]] [-M address:port] [-n name] [-P file] [-p param=value] [-r param[,param...]] [-S secret-file] [-s [name=]kind[,options]] [-T address[:port]] [-t TTL] [-V] [-W waiter]
 
 DESCRIPTION
 ===========
@@ -45,6 +45,13 @@ OPTIONS
 
   Use the specified host as backend server. If port is not specified,
   the default is 8080.
+
+-B <address>
+
+  Source address used to connect to backends. The address can be a hostname,
+  an IPv4 or an IPv6 address. Only one IPv4 and one IPv6 can be set.
+  By default source address is set to ANY.
+  Only useful with bind_before_connect feature.
 
 -C
 

--- a/include/tbl/feature_bits.h
+++ b/include/tbl/feature_bits.h
@@ -67,4 +67,8 @@ FEATURE_BIT(HTTP2,		http2,
     "Support HTTP/2 protocol",
     "Enable HTTP/2 protocol support."
 )
+FEATURE_BIT(BIND_BEFORE_CONNECT,	bind_before_connect,
+    "Activate bind before connect",
+    "Move the 64k local ports limit to 64k connections per destination."
+)
 /*lint -restore */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -324,6 +324,21 @@ PARAM(
 )
 
 PARAM(
+	/* name */	connect_retry,
+	/* typ */	uint,
+	/* min */	"0",
+	/* max */	NULL,
+	/* default */	"3",
+	/* units */	NULL,
+	/* flags */	0,
+	/* s-text */
+	"Retry tcp connect to backend."
+	"Only useful with bind_before_connect",
+	/* l-text */	"",
+	/* func */	NULL
+)
+
+PARAM(
 	/* name */	critbit_cooloff,
 	/* typ */	timeout,
 	/* min */	"60.000",

--- a/include/vsa.h
+++ b/include/vsa.h
@@ -33,6 +33,9 @@
 struct suckaddr;
 extern const int vsa_suckaddr_len;
 
+extern const struct suckaddr *vsa_ipv4_any;
+extern const struct suckaddr *vsa_ipv6_any;
+
 int VSA_Sane(const struct suckaddr *);
 unsigned VSA_Port(const struct suckaddr *);
 int VSA_Compare(const struct suckaddr *, const struct suckaddr *);

--- a/include/vtcp.h
+++ b/include/vtcp.h
@@ -54,7 +54,8 @@ int VTCP_check_hup(int sock);
 void VTCP_name(const struct suckaddr *addr, char *abuf, unsigned alen,
     char *pbuf, unsigned plen);
 int VTCP_connected(int s);
-int VTCP_connect(const struct suckaddr *name, int msec);
+int VTCP_connect(const struct suckaddr *name, const struct suckaddr *source,
+    int msec, unsigned retry);
 int VTCP_open(const char *addr, const char *def_port, double timeout,
     const char **err);
 void VTCP_close(int *s);

--- a/lib/libvarnish/vsa.c
+++ b/lib/libvarnish/vsa.c
@@ -173,6 +173,20 @@ struct suckaddr {
 
 const int vsa_suckaddr_len = sizeof(struct suckaddr);
 
+static const struct suckaddr ipv4_any = { .magic = 0x4b1e9335,
+					 .sa4 = { .sin_family = AF_INET,
+						  .sin_addr.s_addr = INADDR_ANY,
+						  .sin_port = 0 }
+};
+static const struct suckaddr ipv6_any = { .magic = 0x4b1e9335,
+					 .sa6 = { .sin6_family = AF_INET6,
+						  .sin6_addr = IN6ADDR_ANY_INIT,
+						  .sin6_port = 0 }
+};
+
+const struct suckaddr *vsa_ipv4_any = &ipv4_any;
+const struct suckaddr *vsa_ipv6_any = &ipv6_any;
+
 /*
  * This VRT interface is for the VCC generated ACL code, which needs
  * to know the address family and a pointer to the actual address.


### PR DESCRIPTION
the MR is to propose to integrate the bind-before-connect logic in VTCP_connect.
This can be explain in https://idea.popcount.org/2014-04-03-bind-before-connect/

First patch, introduce retry mechanism to VTCP_connect.
It also fix an old misbehavior seen in production:
. VTCP_connect can fail with ETIMEDOUT errno.
. No retry is done and Varnish return 503 instantly

Second integrate the bind-before-connect logic.
VTCP_connect have now a  source suckaddr parameter.
