### PR TITLE
Support reading Last-Modified from response header for IMS requests

### DIFF
--- a/bin/varnishd/cache/cache_rfc2616.c
+++ b/bin/varnishd/cache/cache_rfc2616.c
@@ -256,7 +256,7 @@ rfc2616_weak_compare(const char *p, const char *e)
 int
 RFC2616_Do_Cond(const struct req *req)
 {
-	const char *p, *e;
+	const char *p, *e, *l;
 	double ims, lm;
 
 	/*
@@ -276,6 +276,12 @@ RFC2616_Do_Cond(const struct req *req)
 		ims = VTIM_parse(p);
 		if (!ims || ims > req->t_req)	/* [RFC7232 3.3 p16] */
 			return (0);
+		if (http_GetHdr(req->resp, H_Last_Modified, &l)) {
+			lm = VTIM_parse(l);
+			if (!lm || lm > ims)
+				return (0);
+			return (1);
+		}
 		AZ(ObjGetDouble(req->wrk, req->objcore, OA_LASTMODIFIED, &lm));
 		if (lm > ims)
 			return (0);

--- a/bin/varnishtest/tests/b00049.vtc
+++ b/bin/varnishtest/tests/b00049.vtc
@@ -29,4 +29,12 @@ client c1 {
 	txreq -hdr "If-Modified-Since: Wed, 27 Apr 2016 14:00:00 GMT" -hdr "deliver: modify"
 	rxresp
 	expect resp.status == 200
+
+	txreq -hdr "If-Modified-Since: Wed, 27 Apr 2016 16:00:00 GMT" -hdr "deliver: modify"
+	rxresp
+	expect resp.status == 304
+
+	txreq -hdr "If-Modified-Since: Wed, 27 Apr 2016 18:00:00 GMT" -hdr "deliver: modify"
+	rxresp
+	expect resp.status == 304
 } -run

--- a/bin/varnishtest/tests/b00049.vtc
+++ b/bin/varnishtest/tests/b00049.vtc
@@ -1,0 +1,32 @@
+varnishtest "Changing Last Modified in vcl_deliver"
+ 
+server s1 {
+	rxreq
+	txresp -hdr "Last-Modified: Wed, 27 Apr 2016 14:00:00 GMT"
+} -start
+ 
+varnish v1 -vcl+backend {
+	sub vcl_deliver {
+		if (req.http.deliver == "modify") {
+			set resp.http.Last-Modified = "Wed, 27 Apr 2016 16:00:00 GMT";
+		}
+	}
+} -start
+ 
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "If-Modified-Since: Wed, 27 Apr 2016 14:00:00 GMT"
+	rxresp
+	expect resp.status == 304
+
+	txreq -hdr "If-Modified-Since: Wed, 27 Apr 2016 12:00:00 GMT"
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "If-Modified-Since: Wed, 27 Apr 2016 14:00:00 GMT" -hdr "deliver: modify"
+	rxresp
+	expect resp.status == 200
+} -run


### PR DESCRIPTION
This came up because a client is modifying Last-Modified in vcl_deliver to compensate for ESI handling. In particular, they are purging an ESI fragment and would like all pages to now reference this time in their Last-Modified.

The PR adds a block checking the resp header before falling back to the object timestamp. Several VTCs fail if we do not fallback to the object timestamp, so the fallback is needed.