### PR TITLE
A configuration file for Varnish

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -2,6 +2,7 @@
 
 SUBDIRS = \
 	varnishadm \
+	varnishctl \
 	varnishd \
 	varnishhist \
 	varnishlog \

--- a/bin/varnishctl/Makefile.am
+++ b/bin/varnishctl/Makefile.am
@@ -1,0 +1,3 @@
+dist_sbin_SCRIPTS = varnishctl
+
+# TODO: man page generation and whatnots

--- a/bin/varnishctl/varnishctl
+++ b/bin/varnishctl/varnishctl
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+set -e
+set -u
+
+PROG="$0"
+FILE=
+NAME=
+
+#
+# Temporary
+#
+
+shopt -s expand_aliases
+alias INCOMPL='fail "Incomplete code line %d" "$LINENO"'
+
+#
+# Utility functions
+#
+
+warn() {
+	fmt="$1"
+	shift
+	printf "%s: $fmt\n" "$PROG" "$@" >&2
+}
+
+fail() {
+	warn "$@"
+	exit 1
+}
+
+version() {
+	echo varnishctl 0.1 >&2
+	exit
+}
+
+usage() {
+	cat >&2 <<-EOF
+	usage: $PROG [-f config] [-n name] <command> [params...]
+	       $PROG -V
+
+	Available commands: TODO
+	EOF
+	exit 1
+}
+
+#
+# Configuration reader
+#
+# The parameter is a function that will handle all key/value pairs.
+#
+
+read_config() {
+	CALLBACK="$1"
+	[ -z "$CALLBACK" ] && fail "read_config: missing callback argument"
+
+	sed '/^#/d ; /^$/d' |
+	while IFS== read K V
+	do
+		K="$(printf %s "$K" | sed 's/[ \t]*$//')"
+		V="$(printf %s "$V" | sed 's/[ \t]*$// ; s/^[ \t]*//')"
+
+		LEN=$(expr "$K" : '^[a-z0-9_]*$' || :)
+		[ "$LEN" = 0 -o "$LEN" != "${#K}" ] &&
+		fail "invalid key: %s" "$K"
+
+		OPT=
+		case "$K" in
+		address)	OPT=a ;;
+		backend)	OPT=b ;;
+		vcl_file)	OPT=f ;;
+		hash)		OPT=h ;;
+		identity)	OPT=i ;;
+		shmlog)		OPT=l ;;
+		remote_cli)	OPT=M ;;
+		pid_file)	OPT=P ;;
+		read_only)	OPT=r ;;
+		secret_file)	OPT=S ;;
+		storage)	OPT=s ;;
+		cli)		OPT=T ;;
+		waiter)		OPT=W ;;
+		jail)		"$CALLBACK" jail "$V" ;;
+		*)		"$CALLBACK" param "$K" "$V" ;;
+		esac
+
+		[ -z "$OPT" ] || "$CALLBACK" option $OPT "$V"
+	done
+}
+
+#
+# Configuration handlers
+#
+
+jail_opt() {
+	[ "$1" = jail ] || return 0
+	printf " -j %q" "$2"
+}
+
+varnishd_opts() {
+	case "$1" in
+	jail)	return 0 ;;
+	option)	printf " -%s %q" "$2" "$3" ;;
+	param)	printf " -p %s=%q" "$2" "$3" ;;
+	*)	fail "unknown configuration: %s" "$1" ;;
+	esac
+}
+
+varnishadm_opts() {
+	[ "$1" = option ] || return 0
+	case "$2" in
+	S|T)
+		printf " -%s %q" "$2" "$3"
+		;;
+	esac
+}
+
+echo_pidfile() {
+	[ "$1" = option -a "$2" = P ] || return 0
+	printf "%s\n" "$3"
+}
+
+param_set() {
+	[ "$1" = param ] || return 0
+
+	OPTS="$(read_config varnishadm_opts <$FILE)"
+	[ -n "$NAME" ] && OPTS="$(printf "%s %s %q" "$OPTS" -n "$NAME")"
+
+	EXEC="$(printf "varnishadm%s param.set %s %q" "$OPTS" "$2" "$3")"
+	printf >&2 "exec: %s\n" "$EXEC"
+	#eval "exec $EXEC"
+}
+
+#
+# Sub-commands
+#
+
+cmd_varnishd() {
+	[ -z "$FILE" ] && warn "varnishd: missing a config file" && usage
+
+	JAIL="$(read_config jail_opt <$FILE)"
+	OPTS="$(read_config varnishd_opts <$FILE)"
+	[ -n "$NAME" ] && OPTS="$(printf "%s -n %q" "$OPTS" "$NAME")"
+
+	for OPT
+	do
+		OPTS="$(printf "%s %q" "$OPTS" "$OPT")"
+	done
+
+	EXEC="$(printf "varnishd%s%s" "$JAIL" "$OPTS")"
+	printf >&2 "exec: %s\n" "$EXEC"
+	#eval "exec $EXEC"
+}
+
+cmd_pidfile() {
+	[ $# -gt 0 ] && fail "pidfile: too many parameters"
+	[ -z "$FILE" ] && warn "pidfile: missing a config file" && usage
+
+	read_config echo_pidfile <$FILE |
+	tail -1
+}
+
+cmd_param_reload() {
+	[ $# -gt 0 ] && fail "param.reload: too many parameters"
+	[ -z "$FILE" ] && warn "param.reload: missing a config file" && usage
+	read_config param_set <$FILE
+}
+
+cmd_vcl_reload() {
+	INCOMPL
+}
+
+cmd_reload() {
+	cmd_param_reload "$@"
+	cmd_vcl_reload "$@"
+}
+
+#
+# Script execution
+#
+
+while getopts f:n:V OPT
+do
+	case $OPT in
+	f) FILE="$OPTARG" ;;
+	n) NAME="$OPTARG" ;;
+	V) version ;;
+	?) usage ;;
+	esac
+done
+
+shift $((OPTIND - 1))
+
+if [ $# = 0 ]
+then
+	warn "missing a command"
+	usage
+fi
+
+CMD="$1"
+shift
+
+FUNC="$(echo "cmd_$CMD" | tr . _)"
+TYPE="$(command -v "$FUNC" || :)"
+
+if [ "$FUNC" != "$TYPE" ]
+then
+	printf "%s: unknown command: %s\n" "$PROG" "$CMD" >&2
+	usage
+fi
+
+$FUNC "$@"

--- a/configure.ac
+++ b/configure.ac
@@ -677,6 +677,7 @@ AC_CONFIG_FILES([
     Makefile
     bin/Makefile
     bin/varnishadm/Makefile
+    bin/varnishctl/Makefile
     bin/varnishd/Makefile
     bin/varnishlog/Makefile
     bin/varnishstat/Makefile

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -30,6 +30,23 @@
 
 /*lint -save -e525 -e539 */
 
+#ifdef PARAM_RESERVED
+PARAM(
+	/* name */	address,
+	/* typ */	string,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* default */	NULL,
+	/* units */	NULL,
+	/* flags */	RESERVED,
+	/* s-text */
+	"Listen for client requests on the specified address and port.",
+	/* l-text */	NULL,
+	/* func */	NULL
+)
+#endif /* ifdef PARAM_RESERVED */
+
+#ifndef PARAM_RESERVED
 PARAM(
 	/* name */	accept_filter,
 	/* typ */	bool,
@@ -1501,5 +1518,6 @@ PARAM(
 	/* l-text */	"",
 	/* func */	NULL
 )
+#endif /* ifndef PARAM_RESERVED */
 
 /*lint -restore */


### PR DESCRIPTION
:warning: Far from being usable, work in progress ahead :warning:

 Hello,

This is an idea I've had for at least a couple years now, and I started the implementation around the 10 years anniversary. I suggest we start the new decade by fixing something that bugs people on a regular basis: command-line configuration.

This pull request was motivated by recent activity:
#1929
varnishcache/pkg-varnish-cache#16
varnishcache/pkg-varnish-cache#18
varnishcache/pkg-varnish-cache#24

# Goals

My goal is to introduce a configuration file in Varnish, it has nothing to do with VCL that I'll designate as policy to emphasize the difference.

It would be an alternative to the current situation: `varnishd [configure on the command line]`

Instead, I want to introduce a very simple file format that would match most people's expectations on configuration:

```
# The equivalent of the default config on my machine
address     = :6081
cli         = 127.0.0.1:6082
pid_file    = /var/run/varnish.pid
secret_file = /etc/varnish/secret
vcl_file    = /etc/varnish/default.vcl
storage     = malloc,256M
jail        = unix,user=varnish
```

Starting Varnish with this configuration should result in the following execution:

```
varnishd -j unix,user=varnish -a :6081 -T 127.0.0.1:6082 -P /var/run/varnish.pid -S /etc/varnish/secret -f /etc/varnish/default.vcl -s malloc,256M
```

Of course, it passes the `cc_command` test :)

# Current situation

On Linux systems I have seen at least three blessed approaches to service configuration.

### sysvinit services

A shell script is sourced by the init service and looks like a configuration file that eventually reveals its true nature once you build the final variable: `DAEMON_OPTS`.

Example:

```bash
# Things picked up by the init script
NFILES=131072
MEMLOCK=82000
NPROCS="unlimited"
RELOAD_VCL=1

# Things needed for a service reload
VARNISH_VCL_CONF=/etc/varnish/default.vcl
VARNISH_ADMIN_LISTEN_ADDRESS=127.0.0.1
VARNISH_ADMIN_LISTEN_PORT=6082
VARNISH_SECRET_FILE=/etc/varnish/secret

# Things ignored by the init script
VARNISH_LISTEN_PORT=6081
VARNISH_MIN_THREADS=50
VARNISH_MAX_THREADS=1000
VARNISH_STORAGE_SIZE=256M
VARNISH_STORAGE="malloc,${VARNISH_STORAGE_SIZE}"
VARNISH_TTL=120

# The beast
DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
             -f ${VARNISH_VCL_CONF} \
             -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
             -p thread_pool_min=${VARNISH_MIN_THREADS} \
             -p thread_pool_max=${VARNISH_MAX_THREADS} \
             -S ${VARNISH_SECRET_FILE} \
             -s ${VARNISH_STORAGE}"
```

This is an excellent solution if, like me, you enjoy shell double- or triple-expansion and solve shell puzzles while watching Inception in reverse. Otherwise it's a working solution with pitfalls showing up usually when people start persisting `-p` parameters but tend to forget the backslashes.

### systemd's EnvironmentFile (pkg-varnish-cache/redhat)

Variables defined in systemd environment files can't reference other environment variables. So you can kiss your `DAEMON_OPTS` goodbye, at least in the sysvinit form described above.

And of course, I don't like the idea of using environment variables to build a command line, they should be used to build (surprise) an environment.

### systemd (pkg-varnish-cache/debian)

It looks like it's not doing anything special, you just write your `varnishd` command-line in the service file. I'm not familiar with Debian and its downstream distributions.

# Proposed solution

The introduction of a new `varnishctl` command that would understand the configuration file format and abstract some of the operations. This avoids changing anything with `varnishd` or other binaries, which are perfectly fine for me the way they currently are.

```
usage: varnishctl [-f config] [-n name] <command> [params...]
       varnishctl -V

Available commands: TODO & TBD
```

Examples:

```bash
# commands suitable for sysvinit/systemd services
varnishctl -f /etc/varnish/varnish.conf varnishd
varnishctl -f /etc/varnish/varnish.conf reload

# command useful for sysvinit services
pid="$(varnishctl -f /etc/varnish/varnish.conf pidfile)"

# it can also come handy when debugging varnish locally
varnishctl -n /somewhere -f test.conf varnishd -d
```

The available commands can be tested safely, they currently work in a dry-run mode:

- `varnishd`: execute varnishd and summon Captain Obvious
- `param.reload`: reload all parameters using `varnishadm`
- `vcl.reload`: reload the current `vcl_file` (not done yet)
- `reload`: `param.reload && reload` (would improve service reload)
- `pidfile`: print the PID file

I also plan to support `varnishncsa` explicitly, and virtually any VUT. I can expand on that later.

# File format

The file format is quite simple:

- empty lines are ignored
- lines starting with a `#` are ignored
- remaining lines must follow a key=value format
- spaces and tabs are allowed around the `=` symbol
- a key may appear more than once
- available keys should eventually be documented in `varnish.conf(5)`

All `varnishd` options that take arguments are mapped to keys, unknown keys are assumed to be `varnish-cli` parameters. You may declare your jail anywhere, the damn script will take care of making it the very first option.

Another sample:

```
# multiple listen addresses
address = :80
address = localhost:8443,PROXY

# multiple storage backends
storage = web=malloc,10G
storage = videos=malloc,100G
storage = junk=malloc,100M
```

Command-line options that don't take arguments can however be passed on the `varnishctl` command line as demonstrated with the debugging example.

```
# the debugging example from above
varnishctl -n /somewhere -f test.conf varnishd -d
```

I have purposely written `varnishctl` in shell to keep things simple. If I can't get away with `sed` or `awk` one-liners or other established programs and shell built-ins, then I don't implement a command. So far, I haven't abandoned anything :)

# Dirty details

### It requires bash

Because I don't want to implement shell quoting, I rely on bash's `printf %q` that works out of the box. There are no other bashisms, otherwise I'd consider it a bug and a personal disgrace :)

### It leaks in the PARAM table

In the commit 667880e I show how I'd like to treat `varnishctl` parameters as first-class citizens. This would remove the risk of introducing new parameters with conflicting names. This is the reason why I would not maintain it out of tree. I expect this initiative to stabilize soon, once in place.

Having them in the PARAM table would help avoid conflicts but also generate a manual.

### Paranoid shell

I use [ShellCheck](http://www.shellcheck.net/) so sometimes variables may appear to be unnecessary enclosed in double quotes, or other oddities. I follow ShellCheck's recommendations when I agree, which is often.

### Naming things

Every keys/params, commands, functions etc were named using my legendary inadequation to naming things. If you think anything should be renamed I will of course disagree but you should let me know regardless.

# That's it for now

I would like to introduce that in the varnish source tree with proper non-regression testing, and not relegate this as a packaging issue that could be perceived as an afterthought. If this is not adopted, and someone wants to pick it up, help yourself because I would not maintain it further. If approved, I will complete the work in the master branch and turn the insallation on once ready.

I don't expect changes after it's done, unless `varnishd` grows new options, in which case it should be low maintenance (update the shell script, the PARAM table, ???, profit). It would also replace the `varnish_reload_vcl` script and extend the reload scope to parameters.

I'm also considering an ini-like file format so you don't need one config file per `-n instance` but rather keep a single one:

```
# shared/common params

[xxx]
# params for the `-n xxx` instance

[/opt/custom]
# it should support absolute-path instances too
```

That would be an experiment if `varnishctl` gets in, and retained only if complexity gets under control.

I have seen people expecting this kind of facility from Varnish numerous times, and it get embarrassing during training when my only answer is:

>  It's trivial to configure your sysvinit service, just be a shell nerd like me :)