### PR TITLE
Add support for TCP Fast Open extension

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -506,6 +506,14 @@ vca_acct(void *arg)
 	VTAILQ_FOREACH(ls, &heritage.socks, list) {
 		CHECK_OBJ_NOTNULL(ls->transport, TRANSPORT_MAGIC);
 		assert (ls->sock > 0);		// We know where stdin is
+		if (cache_param->tcp_fastopen) {
+			int i;
+			i = VTCP_fastopen(ls->sock, cache_param->listen_depth);
+			if (i)
+				VSL(SLT_Error, ls->sock,
+				    "Kernel TCP Fast Open: sock=%d, ret=%d %s",
+				    ls->sock, i, strerror(errno));
+		}
 		AZ(listen(ls->sock, cache_param->listen_depth));
 		vca_tcp_opt_set(ls->sock, 1);
 		if (cache_param->accept_filter) {

--- a/configure.ac
+++ b/configure.ac
@@ -530,6 +530,34 @@ if test "$ac_cv_have_tcp_keep" = yes; then
 fi
 LIBS="${save_LIBS}"
 
+# Check if the OS supports TCP_FASTOPEN socket option
+save_LIBS="${LIBS}"
+LIBS="${LIBS} ${NET_LIBS}"
+AC_CACHE_CHECK([for TCP_FASTOPEN socket option],
+  [ac_cv_have_tcp_fastopen],
+  [AC_RUN_IFELSE(
+    [AC_LANG_PROGRAM([[
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+    ]],[[
+int s = socket(AF_INET, SOCK_STREAM, 0);
+int i;
+i = 5;
+if (setsockopt(s, SOL_TCP, TCP_FASTOPEN, &i, sizeof i))
+  return (1);
+return (0);
+    ]])],
+    [ac_cv_have_tcp_fastopen=yes],
+    [ac_cv_have_tcp_fastopen=no])
+  ])
+if test "$ac_cv_have_tcp_fastopen" = yes; then
+   AC_DEFINE([HAVE_TCP_FASTOPEN], [1], [Define if OS supports TCP_FASTOPEN socket option])
+fi
+LIBS="${save_LIBS}"
+
 # Run-time directory
 VARNISH_STATE_DIR='${localstatedir}/varnish'
 AC_SUBST(VARNISH_STATE_DIR)

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -986,6 +986,20 @@ PARAM(
 	/* func */	NULL
 )
 
+PARAM(
+	/* name */	tcp_fastopen,
+	/* typ */	bool,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* default */	"off",
+	/* units */	"bool",
+	/* flags */	MUST_RESTART,
+	/* s-text */
+	"Enable TCP Fast Open extension (if available in the kernel).",
+	/* l-text */	NULL,
+	/* func */	NULL
+)
+
 #if 0
 PARAM(
 	/* name */	tcp_keepalive_intvl,

--- a/include/vtcp.h
+++ b/include/vtcp.h
@@ -44,6 +44,7 @@ void VTCP_myname(int sock, char *abuf, unsigned alen,
 void VTCP_hisname(int sock, char *abuf, unsigned alen,
     char *pbuf, unsigned plen);
 int VTCP_filter_http(int sock);
+int VTCP_fastopen(int sock, int depth);
 int VTCP_blocking(int sock);
 int VTCP_nonblocking(int sock);
 int VTCP_linger(int sock, int linger);

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -186,6 +186,30 @@ VTCP_filter_http(int sock)
 
 #endif
 
+/*--------------------------------------------------------------------*/
+
+#ifdef HAVE_TCP_FASTOPEN
+
+int
+VTCP_fastopen(int sock, int depth)
+{
+	return (setsockopt(sock, SOL_TCP, TCP_FASTOPEN,
+	    &depth, sizeof depth));
+}
+
+#else
+
+int
+VTCP_fastopen(int sock, int depth)
+{
+	errno = EOPNOTSUPP;
+	(void)sock;
+	(void)depth;
+	return (-1);
+}
+
+#endif
+
 /*--------------------------------------------------------------------
  * Functions for controlling NONBLOCK mode.
  *


### PR DESCRIPTION
Disabled by default.

AFAIK this is only available in Linux and on a limited number of browsers (e.g. Chrome for Android).
FreeBSD has the code but it's not compiled in.

Open it in case someone is interested.