### PR TITLE
Clarify the help text for d_opt/-d

### DIFF
--- a/include/vut_options.h
+++ b/include/vut_options.h
@@ -30,9 +30,8 @@
 /* VUT options */
 
 #define VUT_OPT_d \
-	VOPT("d", "[-d]", "Process old log entries on startup",		\
-	    "Start processing log records at the head of the log"	\
-	    " instead of the tail."					\
+	VOPT("d", "[-d]", "Process old log entries and exit",		\
+	    "Process log records at the head of the log and exit."	\
 	)
 
 #define VUT_OPT_D							\


### PR DESCRIPTION
I was trying to work out why my `varnishlog -d -D …` was dumping a PID to disk but never seemed to be alive when I tried to check after; [then I found this old Trac](https://www.varnish-cache.org/trac/ticket/1345)! This just clarifies for the newcomer.