### PR TITLE
Make sure that VFP_Close is always called if and only if VFP_Open was

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -235,8 +235,6 @@ vbf_stp_retry(struct worker *wrk, struct busyobj *bo)
 	bo->do_stream = 1;
 
 	/* reset fetch processors */
-	vfc->failed = 0;
-	VFP_Close(vfc);
 	VFP_Setup(vfc);
 
 	// XXX: BereqEnd + BereqAcct ?
@@ -638,6 +636,7 @@ vbf_stp_fetch(struct worker *wrk, struct busyobj *bo)
 	if (vbf_beresp2obj(bo)) {
 		(void)VFP_Error(bo->vfc, "Could not get storage");
 		bo->htc->doclose = SC_RX_BODY;
+		VFP_Close(bo->vfc);
 		VDI_Finish(bo->wrk, bo);
 		return (F_STP_ERROR);
 	}
@@ -661,6 +660,7 @@ vbf_stp_fetch(struct worker *wrk, struct busyobj *bo)
 	    VDI_GetBody(bo->wrk, bo) != 0) {
 		(void)VFP_Error(bo->vfc,
 		    "GetBody failed - workspace_backend overflow?");
+		VFP_Close(bo->vfc);
 		bo->htc->doclose = SC_OVERLOAD;
 		VDI_Finish(bo->wrk, bo);
 		return (F_STP_ERROR);


### PR DESCRIPTION
called

For some (out of workspace or stevedore allocationi failure) errors
VFP_Close would fail to be called when ending up not retrying the
fetch. This would then potentially leak VFP entry context data like
gzip buffers. Fix this by always calling VFP_Close() when changing
fetch state when VFP_Open() has been called.

Also VFP_Close() would for some retries be called twice, causing
double accounting log records print out. This happens when a late
error is caught and streaming is disabled, allowing a retry to be
attempted. Fix this by not unconditionally calling VFP_Close() in the
error state.