### PR TITLE
Deal with fetch failures in ved_stripgzip

### DIFF
--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -709,8 +709,14 @@ ved_stripgzip(struct req *req, const struct boc *boc)
 	memset(foo.tailbuf, 0xdd, sizeof foo.tailbuf);
 
 	/* OA_GZIPBITS is not valid until BOS_FINISHED */
-	if (boc != NULL)
+	if (boc != NULL) {
 		ObjWaitState(req->objcore, BOS_FINISHED);
+		if (req->objcore->flags & OC_F_FAILED) {
+			/* No way of signalling errors in the middle of
+			   the ESI body. Omit this ESI fragment. */
+			return;
+		}
+	}
 
 	AN(ObjCheckFlag(req->wrk, req->objcore, OF_GZIPED));
 

--- a/bin/varnishtest/tests/r01953.vtc
+++ b/bin/varnishtest/tests/r01953.vtc
@@ -1,0 +1,29 @@
+varnishtest "#1953: ved_stripgzip and failed object"
+
+server s1 {
+	rxreq
+	txresp -gzipbody {<1><esi:include src="/2"/></1>}
+
+	rxreq
+	txresp -nolen -hdr "Content-Encoding: gzip" -hdr "Content-Length: 42"
+	# No body sent, will cause fetch error
+	# The delay allows time for the ESI deliver thread to get to the point
+	# where it is waiting for this body
+	delay 1
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+		if (bereq.url == "/") {
+			set beresp.do_esi = true;
+		}
+	}
+} -start
+
+client c1 {
+	txreq -hdr "Accept-Encoding: gzip"
+	rxresp
+	expect resp.http.Content-Encoding == "gzip"
+	gunzip
+	expect resp.body == "<1></1>"
+} -run


### PR DESCRIPTION
An object failing fetch that is waited upon by the ESI delivery code
would cause asserts finding an empty object. If waiting for an object,
check the status of the object and deliver zero bytes if failed.

Fixes: #1953