### PR TITLE
Eliminate duplicate Age and Accept-Ranges headers.

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -91,6 +91,7 @@ cnt_deliver(struct worker *wrk, struct req *req)
 	 * taken before the object entered into cache leading to negative
 	 * age. Truncate to zero in that case).
 	 */
+	http_Unset(req->resp, H_Age);
 	http_PrintfHeader(req->resp, "Age: %.0f",
 	    fmax(0., req->t_prev - req->objcore->t_origin));
 
@@ -278,6 +279,7 @@ cnt_transmit(struct worker *wrk, struct req *req)
 
 		if (cache_param->http_range_support &&
 		    http_IsStatus(req->resp, 200)) {
+			http_Unset(req->resp, H_Accept_Ranges);
 			http_SetHeader(req->resp, "Accept-Ranges: bytes");
 			if (sendbody && http_GetHdr(req->http, H_Range, &r))
 				VRG_dorange(req, r);

--- a/bin/varnishtest/tests/r01955.vtc
+++ b/bin/varnishtest/tests/r01955.vtc
@@ -1,0 +1,36 @@
+varnishtest "Correct handling of Age and headers for chained varnish servers"
+
+# The issue https://github.com/varnishcache/varnish-cache/issues/1955
+# concerns multiple Accept-Ranges headers as well as multiple Age
+# headers, but the problem with multiple Accept-Ranges cannot be
+# demonstrated by varnishtest (2016-05-26).
+
+# test by fgsch:
+
+server s1 {
+    rxreq
+    txresp -hdr "Cache-Control: max-age=1"
+} -start
+
+varnish v1 -vcl+backend {
+} -start
+
+varnish v2 -arg "-pdefault_grace=1" -vcl {
+    import std;
+    backend b1 {
+        .host = "${v1_addr}";
+        .port = "${v1_port}";
+    }
+    sub vcl_deliver {
+        std.collect(resp.http.age);
+    }
+} -start
+
+client c1 -connect ${v2_addr}:${v2_port} {
+    txreq
+    rxresp
+    delay 2
+    txreq
+    rxresp
+    expect resp.http.age == "2"
+} -run


### PR DESCRIPTION
When we have several layers of Varnish, in some cases we would send
multiple Age and Accept-Ranges headers to the client. This is fixed in
this commit. The test case demonstrates the problem for the Age
header.

Fixes: #1955