### PR TITLE
Include grace time before creating hit-for-pass object

### DIFF
--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -152,7 +152,7 @@ sub vcl_backend_fetch {
 }
 
 sub vcl_backend_response {
-    if (beresp.ttl <= 0s ||
+    if ((beresp.ttl + beresp.grace) <= 0s ||
       beresp.http.Set-Cookie ||
       beresp.http.Surrogate-control ~ "no-store" ||
       (!beresp.http.Surrogate-Control &&

--- a/bin/varnishtest/tests/r01964.vtc
+++ b/bin/varnishtest/tests/r01964.vtc
@@ -1,0 +1,32 @@
+varnishtest "#1964: ttl, grace and automatic hit-for-pass"
+
+server s1 {
+	rxreq
+	txresp -hdr "Age: 6" -hdr "Foo: Bar"
+
+	rxreq
+	txresp -hdr "Age: 6" -hdr "Foo: Baz"
+} -start
+
+varnish v1 -arg "-p default_ttl=5 -p default_grace=5" -vcl+backend {
+	sub vcl_backend_response {
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.Foo == "Bar"
+
+	txreq
+	rxresp
+	expect resp.http.Foo == "Bar"
+
+	# Give the backend fetch which should have been done by the previous
+	# request time to finish
+	delay 1
+
+	txreq
+	rxresp
+	expect resp.http.Foo == "Baz"
+} -run


### PR DESCRIPTION
When checking for a non-positive TTL in vcl_backend_response, include
grace before creating a hit-for-pass object.

Fixes: #1964
