### PR TITLE
Don't emit multiple Age or Accept-Ranges headers

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -119,7 +119,7 @@ vbf_beresp2obj(struct busyobj *bo)
 	}
 
 	l2 = http_EstimateWS(bo->beresp,
-	    bo->uncacheable ? HTTPH_R_PASS : HTTPH_A_INS);
+	    bo->uncacheable ? HTTPH_A_PASS : HTTPH_A_INS);
 	l += l2;
 
 	if (bo->uncacheable)
@@ -143,7 +143,7 @@ vbf_beresp2obj(struct busyobj *bo)
 	bp = ObjSetAttr(bo->wrk, bo->fetch_objcore, OA_HEADERS, l2, NULL);
 	AN(bp);
 	HTTP_Encode(bo->beresp, bp, l2,
-	    bo->uncacheable ? HTTPH_R_PASS : HTTPH_A_INS);
+	    bo->uncacheable ? HTTPH_A_PASS : HTTPH_A_INS);
 
 	if (http_GetHdr(bo->beresp, H_Last_Modified, &b))
 		AZ(ObjSetDouble(bo->wrk, bo->fetch_objcore, OA_LASTMODIFIED,

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -278,7 +278,7 @@ cnt_transmit(struct worker *wrk, struct req *req)
 
 		if (cache_param->http_range_support &&
 		    http_IsStatus(req->resp, 200)) {
-			http_SetHeader(req->resp, "Accept-Ranges: bytes");
+			http_ForceHeader(req->resp, H_Accept_Ranges, "bytes");
 			if (sendbody && http_GetHdr(req->http, H_Range, &r))
 				VRG_dorange(req, r);
 		}

--- a/bin/varnishtest/tests/c00071.vtc
+++ b/bin/varnishtest/tests/c00071.vtc
@@ -14,7 +14,7 @@ server s1 {
 varnish v1 -vcl+backend {
 	import debug;
 	sub vcl_deliver {
-		debug.workspace_allocate(client, debug.workspace_free(client) - 150);
+		debug.workspace_allocate(client, debug.workspace_free(client) - 160);
 
 		if (req.url ~ "/bar") {
 			set resp.http.x-foo = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";

--- a/bin/varnishtest/tests/r01955.vtc
+++ b/bin/varnishtest/tests/r01955.vtc
@@ -1,0 +1,22 @@
+varnishtest "Correct handling multiple Age headers in pass mode"
+
+# This affects Accept-Range as well but it's not possible to test
+# for that.
+
+server s1 {
+	 rxreq
+	 txresp -hdr "Cache-Control: max-age=1" -hdr "Age: 2"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+	sub vcl_deliver {
+		std.collect(resp.http.age);
+	}
+} -start
+
+client c1 {
+	 txreq
+	 rxresp
+	 expect resp.http.age == "2"
+} -run

--- a/include/tbl/http_headers.h
+++ b/include/tbl/http_headers.h
@@ -43,75 +43,78 @@
 #define HTTPH_R_PASS	(1 << 0)	/* Request (c->b) in pass mode */
 #define HTTPH_R_FETCH	(1 << 1)	/* Request (c->b) for fetch */
 #define HTTPH_A_INS	(1 << 2)	/* Response (b->o) for insert */
+#define HTTPH_A_PASS	(1 << 3)	/* Response (b->o) for pass */
 #endif
 
 /* Shorthand for this file only, to keep table narrow */
 
-#if defined(P) || defined(F) || defined(I) || defined(H)
+#if defined(P) || defined(F) || defined(I) || defined(H) || defined(S)
 #error "Macro overloading"  // Trust but verify
 #endif
 
 #define P HTTPH_R_PASS
 #define F HTTPH_R_FETCH
 #define I HTTPH_A_INS
+#define S HTTPH_A_PASS
 #define H(s,e,f) HTTPH(s, e, f)
 
-H("Keep-Alive",		H_Keep_Alive,		P|F  )	// 2068
-H("Accept",		H_Accept,		0    )	// 2616 14.1
-H("Accept-Charset",	H_Accept_Charset,	0    )	// 2616 14.2
-H("Accept-Encoding",	H_Accept_Encoding,	0    )	// 2616 14.3
-H("Accept-Language",	H_Accept_Language,	0    )	// 2616 14.4
-H("Accept-Ranges",	H_Accept_Ranges,	  F|I)	// 2616 14.5
-H("Age",		H_Age,			    I)	// 2616 14.6
-H("Allow",		H_Allow,		0    )	// 2616 14.7
-H("Authorization",	H_Authorization,	0    )	// 2616 14.8
-H("Cache-Control",	H_Cache_Control,	  F  )	// 2616 14.9
-H("Connection",		H_Connection,		P|F|I)	// 2616 14.10
-H("Content-Encoding",	H_Content_Encoding,	0    )	// 2616 14.11
-H("Content-Language",	H_Content_Language,	0    )	// 2616 14.12
-H("Content-Length",	H_Content_Length,	  F  )	// 2616 14.13
-H("Content-Location",	H_Content_Location,	0    )	// 2616 14.14
-H("Content-MD5",	H_Content_MD5,		0    )	// 2616 14.15
-H("Content-Range",	H_Content_Range,	  F|I)	// 2616 14.16
-H("Content-Type",	H_Content_Type,		0    )	// 2616 14.17
-H("Cookie",		H_Cookie,		0    )	// 6265 4.2
-H("Date",		H_Date,			0    )	// 2616 14.18
-H("ETag",		H_ETag,			0    )	// 2616 14.19
-H("Expect",		H_Expect,		0    )	// 2616 14.20
-H("Expires",		H_Expires,		0    )	// 2616 14.21
-H("From",		H_From,			0    )	// 2616 14.22
-H("Host",		H_Host,			0    )	// 2616 14.23
-H("HTTP2-Settings",	H_HTTP2_Settings,	P|F|I)	// httpbis-http2-16.txt
-H("If-Match",		H_If_Match,		  F  )	// 2616 14.24
-H("If-Modified-Since",	H_If_Modified_Since,	  F  )	// 2616 14.25
-H("If-None-Match",	H_If_None_Match,	  F  )	// 2616 14.26
-H("If-Range",		H_If_Range,		  F  )	// 2616 14.27
-H("If-Unmodified-Since",H_If_Unmodified_Since,	  F  )	// 2616 14.28
-H("Last-Modified",	H_Last_Modified,	0    )	// 2616 14.29
-H("Location",		H_Location,		0    )	// 2616 14.30
-H("Max-Forwards",	H_Max_Forwards,		0    )	// 2616 14.31
-H("Pragma",		H_Pragma,		0    )	// 2616 14.32
-H("Proxy-Authenticate",	H_Proxy_Authenticate,	  F|I)	// 2616 14.33
-H("Proxy-Authorization",H_Proxy_Authorization,	  F|I)	// 2616 14.34
-H("Range",		H_Range,		  F|I)	// 2616 14.35
-H("Referer",		H_Referer,		0    )	// 2616 14.36
-H("Retry-After",	H_Retry_After,		0    )	// 2616 14.37
-H("Server",		H_Server,		0    )	// 2616 14.38
-H("Set-Cookie",		H_Set_Cookie,		0    )	// 6265 4.1
-H("TE",			H_TE,			P|F|I)	// 2616 14.39
-H("Trailer",		H_Trailer,		P|F|I)	// 2616 14.40
-H("Transfer-Encoding",	H_Transfer_Encoding,	P|F|I)	// 2616 14.41
-H("Upgrade",		H_Upgrade,		P|F|I)	// 2616 14.42
-H("User-Agent",		H_User_Agent,		0    )	// 2616 14.43
-H("Vary",		H_Vary,			0    )	// 2616 14.44
-H("Via",		H_Via,			0    )	// 2616 14.45
-H("Warning",		H_Warning,		0    )	// 2616 14.46
-H("WWW-Authenticate",	H_WWW_Authenticate,	0    )	// 2616 14.47
-H("X-Forwarded-For",	H_X_Forwarded_For,	0    )	// No RFC
+H("Keep-Alive",		H_Keep_Alive,		P|F  |S)	// 2068
+H("Accept",		H_Accept,		0      )	// 2616 14.1
+H("Accept-Charset",	H_Accept_Charset,	0      )	// 2616 14.2
+H("Accept-Encoding",	H_Accept_Encoding,	0      )	// 2616 14.3
+H("Accept-Language",	H_Accept_Language,	0      )	// 2616 14.4
+H("Accept-Ranges",	H_Accept_Ranges,	P|F|I  )	// 2616 14.5
+H("Age",		H_Age,			    I|S)	// 2616 14.6
+H("Allow",		H_Allow,		0      )	// 2616 14.7
+H("Authorization",	H_Authorization,	0      )	// 2616 14.8
+H("Cache-Control",	H_Cache_Control,	  F    )	// 2616 14.9
+H("Connection",		H_Connection,		P|F|I|S)	// 2616 14.10
+H("Content-Encoding",	H_Content_Encoding,	0      )	// 2616 14.11
+H("Content-Language",	H_Content_Language,	0      )	// 2616 14.12
+H("Content-Length",	H_Content_Length,	  F    )	// 2616 14.13
+H("Content-Location",	H_Content_Location,	0      )	// 2616 14.14
+H("Content-MD5",	H_Content_MD5,		0      )	// 2616 14.15
+H("Content-Range",	H_Content_Range,	  F|I  )	// 2616 14.16
+H("Content-Type",	H_Content_Type,		0      )	// 2616 14.17
+H("Cookie",		H_Cookie,		0      )	// 6265 4.2
+H("Date",		H_Date,			0      )	// 2616 14.18
+H("ETag",		H_ETag,			0      )	// 2616 14.19
+H("Expect",		H_Expect,		0      )	// 2616 14.20
+H("Expires",		H_Expires,		0      )	// 2616 14.21
+H("From",		H_From,			0      )	// 2616 14.22
+H("Host",		H_Host,			0      )	// 2616 14.23
+H("HTTP2-Settings",	H_HTTP2_Settings,	P|F|I|S)	// httpbis-http2-16.txt
+H("If-Match",		H_If_Match,		  F    )	// 2616 14.24
+H("If-Modified-Since",	H_If_Modified_Since,	  F    )	// 2616 14.25
+H("If-None-Match",	H_If_None_Match,	  F    )	// 2616 14.26
+H("If-Range",		H_If_Range,		  F    )	// 2616 14.27
+H("If-Unmodified-Since",H_If_Unmodified_Since,	  F    )	// 2616 14.28
+H("Last-Modified",	H_Last_Modified,	0      )	// 2616 14.29
+H("Location",		H_Location,		0      )	// 2616 14.30
+H("Max-Forwards",	H_Max_Forwards,		0      )	// 2616 14.31
+H("Pragma",		H_Pragma,		0      )	// 2616 14.32
+H("Proxy-Authenticate",	H_Proxy_Authenticate,	  F|I  )	// 2616 14.33
+H("Proxy-Authorization",H_Proxy_Authorization,	  F|I  )	// 2616 14.34
+H("Range",		H_Range,		  F|I  )	// 2616 14.35
+H("Referer",		H_Referer,		0      )	// 2616 14.36
+H("Retry-After",	H_Retry_After,		0      )	// 2616 14.37
+H("Server",		H_Server,		0      )	// 2616 14.38
+H("Set-Cookie",		H_Set_Cookie,		0      )	// 6265 4.1
+H("TE",			H_TE,			P|F|I|S)	// 2616 14.39
+H("Trailer",		H_Trailer,		P|F|I|S)	// 2616 14.40
+H("Transfer-Encoding",	H_Transfer_Encoding,	P|F|I|S)	// 2616 14.41
+H("Upgrade",		H_Upgrade,		P|F|I|S)	// 2616 14.42
+H("User-Agent",		H_User_Agent,		0      )	// 2616 14.43
+H("Vary",		H_Vary,			0      )	// 2616 14.44
+H("Via",		H_Via,			0      )	// 2616 14.45
+H("Warning",		H_Warning,		0      )	// 2616 14.46
+H("WWW-Authenticate",	H_WWW_Authenticate,	0      )	// 2616 14.47
+H("X-Forwarded-For",	H_X_Forwarded_For,	0      )	// No RFC
 
 #undef P
 #undef F
 #undef I
+#undef S
 #undef H
 
 /*lint -restore */


### PR DESCRIPTION
This might happen during pass'd requests or in a multi-tier setup.
Fixes #1955.