### PR TITLE
Vmodtool last arg default

### DIFF
--- a/bin/varnishtest/tests/m00019.vtc
+++ b/bin/varnishtest/tests/m00019.vtc
@@ -22,12 +22,12 @@ client c1 {
 	txreq
 	rxresp
 	expect resp.bodylen == "6"
-	expect resp.http.foo1 == "1 2 3 ,"
-	expect resp.http.foo2 == "1 2 3 ,"
-	expect resp.http.foo3 == "1 2 3 ,"
-	expect resp.http.foo4 == "1 2 3 ,"
-	expect resp.http.foo5 == "1 2 3 ,"
-	expect resp.http.foo6 == "1 2 3 ,"
+	expect resp.http.foo1 == "1 2 3 , 4"
+	expect resp.http.foo2 == "1 2 3 , 4"
+	expect resp.http.foo3 == "1 2 3 , 4"
+	expect resp.http.foo4 == "1 2 3 , 4"
+	expect resp.http.foo5 == "1 2 3 , 4"
+	expect resp.http.foo6 == "1 2 3 , 4"
 } -run
 
 delay .1
@@ -48,10 +48,10 @@ varnish v1 -errvcl {Argument 'one' missing} {
 	}
 }
 
-varnish v1 -errvcl {Unknown argument 'four'} {
+varnish v1 -errvcl {Unknown argument 'five'} {
 	import debug;
 	backend b1 {.host = "127.0.0.1";}
 	sub vcl_deliver {
-		set resp.http.foo5 = debug.argtest("1", two=2.0, four="3");
+		set resp.http.foo5 = debug.argtest("1", two=2.0, five="3");
 	}
 }

--- a/bin/varnishtest/tests/m00019.vtc
+++ b/bin/varnishtest/tests/m00019.vtc
@@ -9,12 +9,12 @@ varnish v1 -vcl+backend {
 	import debug;
 
 	sub vcl_deliver {
-		set resp.http.foo1 = debug.argtest("1", 2.0, "3");
-		set resp.http.foo2 = debug.argtest("1", two=2.0, three="3");
-		set resp.http.foo3 = debug.argtest("1", three="3", two=2.0);
-		set resp.http.foo4 = debug.argtest("1", 2.0, three="3");
-		set resp.http.foo5 = debug.argtest("1", 2.0);
-		set resp.http.foo6 = debug.argtest("1");
+		set resp.http.foo1 = debug.argtest("1", 2.1, "3a");
+		set resp.http.foo2 = debug.argtest("1", two=2.2, three="3b");
+		set resp.http.foo3 = debug.argtest("1", three="3c", two=2.3);
+		set resp.http.foo4 = debug.argtest("1", 2.4, three="3d");
+		set resp.http.foo5 = debug.argtest("1", 2.5);
+		set resp.http.foo6 = debug.argtest("1", four=6);
 	}
 } -start
 
@@ -22,12 +22,12 @@ client c1 {
 	txreq
 	rxresp
 	expect resp.bodylen == "6"
-	expect resp.http.foo1 == "1 2 3 , 4"
-	expect resp.http.foo2 == "1 2 3 , 4"
-	expect resp.http.foo3 == "1 2 3 , 4"
-	expect resp.http.foo4 == "1 2 3 , 4"
-	expect resp.http.foo5 == "1 2 3 , 4"
-	expect resp.http.foo6 == "1 2 3 , 4"
+	expect resp.http.foo1 == "1 2.1 3a , 4"
+	expect resp.http.foo2 == "1 2.2 3b , 4"
+	expect resp.http.foo3 == "1 2.3 3c , 4"
+	expect resp.http.foo4 == "1 2.4 3d , 4"
+	expect resp.http.foo5 == "1 2.5 3 , 4"
+	expect resp.http.foo6 == "1 2 3 , 6"
 } -run
 
 delay .1

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -235,7 +235,9 @@ def arg(txt):
 
 	i = s.find('=')
 	j = s.find(',')
-	if j >= 0 and j < i:
+	if j < 0:
+		j = len(s)
+	if j < i:
 		i = -1
 	if i < 0:
 		i = s.find(',')
@@ -255,11 +257,14 @@ def arg(txt):
 		s = s[m.end():]
 	else:
 		i = s.find(',')
+		if i < 0:
+			i = len(s)
 		a.defval = s[:i]
 		s = s[i:]
 
 	return a,s
 
+# XXX cant have ( or ) in an argument default value
 class prototype(object):
 	def __init__(self, st, retval=True, prefix=""):
 		l = st.line[1]

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -95,7 +95,7 @@ Encrypt the HTTP header with quad-ROT13 encryption,
 (this is approx 33% better than triple-DES).
 
 $Function STRING argtest(STRING one, REAL two=2, STRING three="3",
-	  STRING comma=",")
+	  STRING comma=",", INT four=4)
 
 $Function INT vre_limit()
 

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -123,7 +123,8 @@ $Method VOID .refresh(STRING addr, STRING port)
 
 Dynamically refresh & (always!) replace the backend by a new one.
 
-$Function VOID workspace_allocate(ENUM { client, backend, session, thread }, INT SIZE)
+$Function VOID workspace_allocate(ENUM { client, backend, session, thread },
+	  INT size)
 
 Allocate and zero out SIZE bytes from a workspace.
 

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -186,11 +186,11 @@ vmod_rot52(VRT_CTX, VCL_HTTP hp)
 
 VCL_STRING
 vmod_argtest(VRT_CTX, VCL_STRING one, VCL_REAL two, VCL_STRING three,
-    VCL_STRING comma)
+    VCL_STRING comma, VCL_INT four)
 {
 	char buf[100];
 
-	bprintf(buf, "%s %g %s %s", one, two, three, comma);
+	bprintf(buf, "%s %g %s %s %ld", one, two, three, comma, four);
 	return (WS_Copy(ctx->ws, buf, -1));
 }
 


### PR DESCRIPTION
Fix a regression from a78efad8002895e6097aeb6b1daeac0f6108b9a9:
the following vcc from `vmod_vslp` was failing:
`$Method BACKEND .backend(INT nte=0, BOOL altsrv_p=1, BOOL healthy=1, INT hash=0)`
d0067f440ebc4990a7ac058f40eae2314f8271f4 is relevant, the other patches are just cosmetics