### PR TITLE
Introduce the parameter vsm_free_cooldown

### DIFF
--- a/bin/varnishd/common/common_vsm.c
+++ b/bin/varnishd/common/common_vsm.c
@@ -41,10 +41,13 @@
 #include <unistd.h>
 
 #include "common.h"
+#include "common/params.h"
 
 #include "vsm_priv.h"
 #include "vmb.h"
 #include "vtim.h"
+
+extern volatile struct params * cache_param;
 
 /*--------------------------------------------------------------------*/
 
@@ -299,7 +302,7 @@ VSM_common_free(struct vsm_sc *sc, void *ptr)
 		vr2 = VTAILQ_NEXT(vr, list);
 		VTAILQ_REMOVE(&sc->r_used, vr, list);
 		VTAILQ_INSERT_TAIL(&sc->r_cooling, vr, list);
-		vr->cool = VTIM_real() + 60;	/* XXX: param ? */
+		vr->cool = VTIM_real() + cache_param->vsm_free_cooldown;
 		if (vr2 != NULL)
 			vr2->chunk->next = vr->chunk->next;
 		else

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1332,6 +1332,21 @@ PARAM(
 	/* func */	NULL
 )
 
+PARAM(
+	/* name */	vsm_free_cooldown,
+	/* typ */	timeout,
+	/* min */	"10.000",
+	/* max */	"600.000",
+	/* default */	"60.000",
+	/* units */	"seconds",
+	/* flags */	0,
+	/* s-text */
+	"How long VSM memory is kept warm after a deallocation "
+	"(granularity approximately 2 seconds).",
+	/* l-text */	"",
+	/* func */	NULL
+)
+
 #if 0
 PARAM(
 	/* name */	vcl_dir,


### PR DESCRIPTION
This new parameter specifies how long freed VSM memory is on the
cooling list before it is actually freed.

This parameter is proposed partly because I want to make a better
VTC for an issue I am submitting soon.