### PR TITLE
Make the counter vsm_cooling act according to spec

### DIFF
--- a/bin/varnishd/common/common_vsm.c
+++ b/bin/varnishd/common/common_vsm.c
@@ -179,6 +179,7 @@ VSM_common_cleaner(struct vsm_sc *sc, struct VSC_C_main *stats)
 		if (vr->cool > now)
 			break;
 		VTAILQ_REMOVE(&sc->r_cooling, vr, list);
+		sc->g_cooling -= vr->len;
 		vsm_common_insert_free(sc, vr);
 	}
 	stats->vsm_free = sc->g_free;

--- a/bin/varnishtest/tests/r01984.vtc
+++ b/bin/varnishtest/tests/r01984.vtc
@@ -1,0 +1,18 @@
+varnishtest "g_cooldown counter test"
+
+server s1 {} -start
+varnish v1 -vcl+backend {} -start
+varnish v1 -cliok "param.set vsm_free_cooldown 10.0"
+
+# Load and use a new VCL, freeze the first
+varnish v1 -vcl+backend {}
+varnish v1 -cliok "vcl.state vcl1 cold"
+
+# the VSM_common_cleaner runs every 1.1 seconds.
+# Wait for it to update vsm_cooling
+delay 2
+varnish v1 -expect vsm_cooling > 0
+
+# Wait long enough for all the cooling vsm memory to be transfered to the free list:
+delay 12
+varnish v1 -expect vsm_cooling == 0


### PR DESCRIPTION
The counter g_cooling variable is now decremented when memory from the
cooling list is freed, making the counter vsm_cooling update
accordingly.

The test case requires #1983 to work. See #1984 for a test case that
works without #1983.

Fixes: #1984