### PR TITLE
streamline ttl handling for passes

### DIFF
--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -156,15 +156,15 @@ sub vcl_backend_fetch {
 }
 
 sub vcl_backend_response {
-    if (beresp.ttl <= 0s ||
+    if (beresp.uncacheable) {
+        return (deliver);
+    } else if (beresp.ttl <= 0s ||
       beresp.http.Set-Cookie ||
       beresp.http.Surrogate-control ~ "no-store" ||
       (!beresp.http.Surrogate-Control &&
         beresp.http.Cache-Control ~ "no-cache|no-store|private") ||
       beresp.http.Vary == "*") {
-        /*
-        * Mark as "Hit-For-Pass" for the next 2 minutes
-        */
+        # Mark as "Hit-For-Pass" for the next 2 minutes
         set beresp.ttl = 120s;
         set beresp.uncacheable = true;
     }

--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -156,7 +156,7 @@ sub vcl_backend_fetch {
 }
 
 sub vcl_backend_response {
-    if (beresp.uncacheable) {
+    if (bereq.uncacheable) {
         return (deliver);
     } else if (beresp.ttl <= 0s ||
       beresp.http.Set-Cookie ||

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -379,19 +379,21 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 		return (F_STP_ERROR);
 	}
 
-	/*
-	 * What does RFC2616 think about TTL ?
-	 */
-	RFC2616_Ttl(bo, now,
-	    &bo->fetch_objcore->t_origin,
-	    &bo->fetch_objcore->ttl,
-	    &bo->fetch_objcore->grace,
-	    &bo->fetch_objcore->keep
-	);
-
-	/* private objects have negative TTL */
-	if (bo->fetch_objcore->flags & OC_F_PRIVATE)
+	if (bo->fetch_objcore->flags & OC_F_PRIVATE) {
+		/* private objects have negative TTL */
+		bo->fetch_objcore->t_origin = now;
 		bo->fetch_objcore->ttl = -1.;
+		bo->fetch_objcore->grace = 0;
+		bo->fetch_objcore->keep = 0;
+	} else {
+		/* What does RFC2616 think about TTL ? */
+		RFC2616_Ttl(bo, now,
+		    &bo->fetch_objcore->t_origin,
+		    &bo->fetch_objcore->ttl,
+		    &bo->fetch_objcore->grace,
+		    &bo->fetch_objcore->keep
+		    );
+	}
 
 	AZ(bo->do_esi);
 	AZ(bo->was_304);

--- a/bin/varnishtest/tests/b00002.vtc
+++ b/bin/varnishtest/tests/b00002.vtc
@@ -2,19 +2,33 @@ varnishtest "Check that a pass transaction works"
 
 server s1 {
 	rxreq
-	txresp -hdr "Connection: close" -body "012345\n"
+	txresp -hdr "Cache-Control: max-age=120" -hdr "Connection: close" -body "012345\n"
 } -start
 
 varnish v1 -vcl+backend {
 	sub vcl_recv {
 		return(pass);
 	}
+	sub vcl_backend_response {
+		set beresp.http.x-ttl = beresp.ttl;
+	}
+} -start
+
+# check that there are no TTL LogTags between the
+# last header and VCL_return b deliver
+logexpect l1 -v v1 -g request {
+	  expect * 1002 Begin
+	  expect * =	BerespHeader	^Date:
+	  expect 0 =	VCL_call	^BACKEND_RESPONSE
+	  expect 0 =	BerespHeader	^x-ttl: 0.000
+	  expect 0 =	VCL_return	^deliver
 } -start
 
 client c1 {
 	txreq -url "/"
 	rxresp
 	expect resp.status == 200
+	expect resp.http.x-ttl == 0.000
 } -run
 
 # Give varnish a chance to update stats
@@ -27,3 +41,5 @@ varnish v1 -expect client_req == 1
 varnish v1 -expect s_sess == 1
 varnish v1 -expect s_req == 1
 varnish v1 -expect s_pass == 1
+
+logexpect l1 -wait


### PR DESCRIPTION
It was counter-intuitive that, for pass objects, we logged the
parsed TTL when in fact the ttl visible from vcl was always 0.
In the builtin.vcl the Hit-For-Pass check was also called
for objects already classified as uncacheable.

Now, for passes, we

- do not parse Cache-Control / Expires
  - and, consequently, do not log TTL RFC
- do not call the hfp-code in builtin.vcl
  - and, consequently, do not log TTL VCL

Reflect this in b2.vtc