### PR TITLE
Add restart of poll in read_tmo

### DIFF
--- a/lib/libvarnish/vcli_proto.c
+++ b/lib/libvarnish/vcli_proto.c
@@ -119,6 +119,10 @@ read_tmo(int fd, char *ptr, unsigned len, double tmo)
 	pfd.events = POLLIN;
 	for (j = 0; len > 0; ) {
 		i = poll(&pfd, 1, to);
+		if (i < 0) {
+			assert(errno == EINTR);
+			continue;
+		}
 		if (i == 0) {
 			errno = ETIMEDOUT;
 			return (-1);


### PR DESCRIPTION
Add check for negative return value from poll in read_tmo. A negative
return value can happen if a signal interupts poll(), and then the
correct behavior is to call poll() again.