### PR TITLE
A `cmd` feature for custom shell-based checks

### DIFF
--- a/bin/varnishtest/tests/a00014.vtc
+++ b/bin/varnishtest/tests/a00014.vtc
@@ -1,0 +1,6 @@
+varnishtest "Custom feature verification"
+
+feature cmd true
+feature cmd false
+
+this is an invalid varnishtest command

--- a/bin/varnishtest/vtc.c
+++ b/bin/varnishtest/vtc.c
@@ -611,60 +611,61 @@ cmd_random(CMD_ARGS)
 static void
 cmd_feature(CMD_ARGS)
 {
-	int i, r;
+	int r;
 
 	(void)priv;
 	(void)cmd;
+
 	if (av == NULL)
 		return;
 
-	for (i = 1; av[i] != NULL; i++) {
+	for (; *av != NULL; av++) {
 #ifdef SO_RCVTIMEO_WORKS
-		if (!strcmp(av[i], "SO_RCVTIMEO_WORKS"))
+		if (!strcmp(*av, "SO_RCVTIMEO_WORKS"))
 			continue;
 #endif
-		if (sizeof(void*) == 8 && !strcmp(av[i], "64bit"))
+		if (sizeof(void*) == 8 && !strcmp(*av, "64bit"))
 			continue;
 
-		if (!strcmp(av[i], "pcre_jit") && VRE_has_jit)
+		if (!strcmp(*av, "pcre_jit") && VRE_has_jit)
 			continue;
 
-		if (!strcmp(av[i], "!OSX")) {
+		if (!strcmp(*av, "!OSX")) {
 #if !defined(__APPLE__) || !defined(__MACH__)
 			continue;
 #endif
 		}
-		if (!strcmp(av[i], "dns") && feature_dns)
+		if (!strcmp(*av, "dns") && feature_dns)
 			continue;
 
-		if (!strcmp(av[i], "topbuild") && iflg)
+		if (!strcmp(*av, "topbuild") && iflg)
 			continue;
 
-		if (!strcmp(av[i], "root") && !geteuid())
+		if (!strcmp(*av, "root") && !geteuid())
 			continue;
 
-		if (!strcmp(av[i], "user_varnish") &&
+		if (!strcmp(*av, "user_varnish") &&
 		    getpwnam("varnish") != NULL)
 			continue;
 
-		if (!strcmp(av[i], "user_vcache") &&
+		if (!strcmp(*av, "user_vcache") &&
 		    getpwnam("vcache") != NULL)
 			continue;
 
-		if (!strcmp(av[i], "group_varnish") &&
+		if (!strcmp(*av, "group_varnish") &&
 		    getgrnam("varnish") != NULL)
 			continue;
 
-		if (!strcmp(av[i], "cmd")) {
-			i++;
-			if (av[i] == NULL)
+		if (!strcmp(*av, "cmd")) {
+			av++;
+			if (*av == NULL)
 				vtc_log(vl, 0, "Missing the command-line");
-			r = system(av[i]);
+			r = system(*av);
 			if (WEXITSTATUS(r) == 0)
 				continue;
 		}
 
-		vtc_log(vl, 1, "SKIPPING test, missing feature: %s", av[i]);
+		vtc_log(vl, 1, "SKIPPING test, missing feature: %s", *av);
 		vtc_stop = 1;
 		return;
 	}

--- a/bin/varnishtest/vtc.c
+++ b/bin/varnishtest/vtc.c
@@ -604,12 +604,14 @@ cmd_random(CMD_ARGS)
  *        The vcache user is present
  * group_varnish
  *        The varnish group is present
+ * cmd <command-line>
+ *        A command-line that should exit with zero
  */
 
 static void
 cmd_feature(CMD_ARGS)
 {
-	int i;
+	int i, r;
 
 	(void)priv;
 	(void)cmd;
@@ -652,6 +654,15 @@ cmd_feature(CMD_ARGS)
 		if (!strcmp(av[i], "group_varnish") &&
 		    getgrnam("varnish") != NULL)
 			continue;
+
+		if (!strcmp(av[i], "cmd")) {
+			i++;
+			if (av[i] == NULL)
+				vtc_log(vl, 0, "Missing the command-line");
+			r = system(av[i]);
+			if (WEXITSTATUS(r) == 0)
+				continue;
+		}
 
 		vtc_log(vl, 1, "SKIPPING test, missing feature: %s", av[i]);
 		vtc_stop = 1;


### PR DESCRIPTION
In addition to harcoded features in varnishtest, this opens a window for
out-of-tree uses of the test framework to skip test cases if an external
component (a database system, OS-specific capabilities, an environment
variable, a library, etc) is missing.

This feature takes an extra argument, a command-line that must exit with
a zero status. Complex feature testing can nicely be wrapped in scripts
at the user's discretion:

    feature cmd "my --command=line"

If the test is skipped, it is logged as:

    **   top   0.0 === feature cmd "my --command=line"
    *    top   0.0 SKIPPING test, missing feature: my --command=line