### PR TITLE
New assert-like macros `require`, `RN` and `RZ`

### DIFF
--- a/bin/varnishd/cache/cache_ban.c
+++ b/bin/varnishd/cache/cache_ban.c
@@ -380,7 +380,7 @@ ban_reload(const uint8_t *ban, unsigned len)
 	b2 = ban_alloc();
 	AN(b2);
 	b2->spec = malloc(len);
-	AN(b2->spec);
+	RN(b2->spec);
 	memcpy(b2->spec, ban, len);
 	if (ban[BANS_FLAGS] & BANS_FLAG_REQ) {
 		VSC_C_main->bans_req++;

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -611,6 +611,12 @@ pan_ic(const char *func, const char *file, int line, const char *cond,
 		    "Incomplete code in %s(), %s line %d:\n",
 		    func, file, line);
 		break;
+	case VAS_REQUIRE:
+		VSB_printf(pan_vsb,
+		    "Unmet requirement in %s(), %s line %d:\n"
+		    "  Condition(%s) not true.\n",
+		    func, file, line, cond);
+		break;
 	default:
 	case VAS_ASSERT:
 		VSB_printf(pan_vsb,

--- a/bin/varnishd/cache/cache_shmlog.c
+++ b/bin/varnishd/cache/cache_shmlog.c
@@ -389,7 +389,7 @@ VSL_Setup(struct vsl_log *vsl, void *ptr, size_t len)
 	if (ptr == NULL) {
 		len = cache_param->vsl_buffer;
 		ptr = malloc(len);
-		AN(ptr);
+		RN(ptr);
 	}
 	vsl->wlp = ptr;
 	vsl->wlb = ptr;

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -337,7 +337,7 @@ Symbol_hack(const char *a0)
 		if (i != 4)
 			continue;
 		s = malloc(sizeof *s + strlen(name) + 1);
-		AN(s);
+		RN(s);
 		s->a = aa;
 		s->l = ll;
 		s->n = (void*)(s + 1);

--- a/bin/varnishd/mgt/mgt_shmem.c
+++ b/bin/varnishd/mgt/mgt_shmem.c
@@ -107,7 +107,7 @@ vsm_n_check(void)
 	if (fd < 0)
 		return (0);
 
-	AZ(fstat(fd, &st));
+	RZ(fstat(fd, &st));
 	if (!S_ISREG(st.st_mode)) {
 		fprintf(stderr,
 		    "VSM (%s) not a regular file.\n", VSM_FILENAME);

--- a/bin/varnishd/storage/stevedore_utils.c
+++ b/bin/varnishd/storage/stevedore_utils.c
@@ -128,7 +128,7 @@ STV_GetFile(const char *fn, int *fdp, const char **fnp, const char *ctx)
 		ARGV_ERR(
 		    "(%s) \"%s\" is neither file nor directory\n", ctx, fn);
 
-	AZ(fstat(fd, &st));
+	RZ(fstat(fd, &st));
 	if (!S_ISREG(st.st_mode))
 		ARGV_ERR("(%s) \"%s\" was not a file after opening\n",
 		    ctx, fn);
@@ -161,7 +161,7 @@ STV_FileSize(int fd, const char *size, unsigned *granularity, const char *ctx)
 	AN(granularity);
 	AN(ctx);
 
-	AZ(fstat(fd, &st));
+	RZ(fstat(fd, &st));
 	xxxassert(S_ISREG(st.st_mode));
 
 	AZ(VFIL_fsinfo(fd, &bs, &fssize, NULL));

--- a/bin/varnishtest/vtc.c
+++ b/bin/varnishtest/vtc.c
@@ -190,7 +190,7 @@ macro_get(const char *b, const char *e)
 	if (l == 4 && !memcmp(b, "date", l)) {
 		double t = VTIM_real();
 		retval = malloc(64);
-		AN(retval);
+		RN(retval);
 		VTIM_format(t, retval);
 		return (retval);
 	}

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -184,7 +184,7 @@ synth_body(const char *len, int rnd)
 	i = strtoul(len, NULL, 0);
 	assert(i > 0);
 	b = malloc(i + 1L);
-	AN(b);
+	RN(b);
 	l = k = '!';
 	for (j = 0; j < i; j++) {
 		if ((j % 64) == 63) {
@@ -1337,7 +1337,7 @@ cmd_http_sendhex(CMD_ARGS)
 	AZ(av[2]);
 	l = strlen(av[1]) / 2;
 	p = malloc(l);
-	AN(p);
+	RN(p);
 	q = av[1];
 	for (i = 0; i < l; i++) {
 		while (vct_issp(*q))
@@ -1646,7 +1646,7 @@ http_process(struct vtclog *vl, const char *spec, int sock, int *sfd)
 
 	hp->nrxbuf = 2048*1024;
 	hp->rxbuf = malloc(hp->nrxbuf);		/* XXX */
-	AN(hp->rxbuf);
+	RN(hp->rxbuf);
 
 	hp->vsb = VSB_new_auto();
 	AN(hp->vsb);
@@ -1654,10 +1654,10 @@ http_process(struct vtclog *vl, const char *spec, int sock, int *sfd)
 	hp->sfd = sfd;
 
 	hp->rem_ip = malloc(VTCP_ADDRBUFSIZE);
-	AN(hp->rem_ip);
+	RN(hp->rem_ip);
 
 	hp->rem_port = malloc(VTCP_PORTBUFSIZE);
-	AN(hp->rem_port);
+	RN(hp->rem_port);
 
 	hp->vl = vl;
 	hp->gziplevel = 0;

--- a/include/vas.h
+++ b/include/vas.h
@@ -42,6 +42,7 @@ enum vas_e {
 	VAS_WRONG,
 	VAS_MISSING,
 	VAS_ASSERT,
+	VAS_REQUIRE,
 	VAS_INCOMPLETE,
 	VAS_VCL,
 };
@@ -62,6 +63,14 @@ do {									\
 } while (0)
 #endif
 
+#define require(e)							\
+do {									\
+	if (!(e)) {							\
+		VAS_Fail(__func__, __FILE__, __LINE__,			\
+		    #e, VAS_REQUIRE);					\
+	}								\
+} while (0)
+
 #define xxxassert(e)							\
 do {									\
 	if (!(e)) {							\
@@ -73,6 +82,8 @@ do {									\
 /* Assert zero return value */
 #define AZ(foo)		do { assert((foo) == 0); } while (0)
 #define AN(foo)		do { assert((foo) != 0); } while (0)
+#define RZ(foo)		do { require((foo) == 0); } while (0)
+#define RN(foo)		do { require((foo) != 0); } while (0)
 #define XXXAZ(foo)	do { xxxassert((foo) == 0); } while (0)
 #define XXXAN(foo)	do { xxxassert((foo) != 0); } while (0)
 #define diagnostic(foo)	assert(foo)

--- a/lib/libvarnish/vas.c
+++ b/lib/libvarnish/vas.c
@@ -57,6 +57,11 @@ VAS_Fail_default(const char *func, const char *file, int line,
 		fprintf(stderr,
 		    "Wrong turn in %s(), %s line %d: %s\n",
 		    func, file, line, cond);
+	} else if (kind == VAS_REQUIRE) {
+		fprintf(stderr,
+		    "Unmet requirement in %s(), %s line %d:\n"
+		    "  Condition(%s) not true.\n",
+		    func, file, line, cond);
 	} else {
 		fprintf(stderr,
 		    "Assert error in %s(), %s line %d:\n"

--- a/lib/libvarnish/vfil.c
+++ b/lib/libvarnish/vfil.c
@@ -70,7 +70,7 @@ vfil_readfd(int fd, ssize_t *sz)
 	char *f;
 	int i;
 
-	AZ(fstat(fd, &st));
+	RZ(fstat(fd, &st));
 	if (!S_ISREG(st.st_mode))
 		return (NULL);
 	f = malloc(st.st_size + 1);

--- a/lib/libvarnishapi/vsc.c
+++ b/lib/libvarnishapi/vsc.c
@@ -203,7 +203,7 @@ vsc_f_arg(struct VSM_data *vd, const char *opt)
 				q++;
 		if (i < 3) {
 			parts[i] = malloc(1 + q - p);
-			AN(parts[i]);
+			RN(parts[i]);
 			memcpy(parts[i], p, q - p);
 			parts[i][q - p] = '\0';
 			p = r = parts[i];

--- a/lib/libvarnishapi/vsl_cursor.c
+++ b/lib/libvarnishapi/vsl_cursor.c
@@ -442,7 +442,7 @@ VSL_CursorFile(struct VSL_data *vsl, const char *name, unsigned options)
 	c->close_fd = close_fd;
 	c->buflen = VSL_WORDS(BUFSIZ);
 	c->buf = malloc(VSL_BYTES(c->buflen));
-	AN(c->buf);
+	RN(c->buf);
 
 	return (&c->cursor);
 }

--- a/lib/libvarnishapi/vsl_dispatch.c
+++ b/lib/libvarnishapi/vsl_dispatch.c
@@ -354,7 +354,7 @@ chunk_newbuf(struct vtx *vtx, const uint32_t *ptr, size_t len)
 	while (chunk->buf.space < len)
 		chunk->buf.space *= 2;
 	chunk->buf.data = malloc(sizeof (uint32_t) * chunk->buf.space);
-	AN(chunk->buf.data);
+	RN(chunk->buf.data);
 	memcpy(chunk->buf.data, ptr, sizeof (uint32_t) * len);
 	chunk->len = len;
 	return (chunk);

--- a/lib/libvarnishapi/vsm.c
+++ b/lib/libvarnishapi/vsm.c
@@ -237,7 +237,7 @@ VSM_Open(struct VSM_data *vd)
 		return (vsm_diag(vd, "Cannot open %s: %s\n",
 		    vd->fname, strerror(errno)));
 
-	AZ(fstat(vd->vsm_fd, &vd->fstat));
+	RZ(fstat(vd->vsm_fd, &vd->fstat));
 	if (!S_ISREG(vd->fstat.st_mode)) {
 		AZ(close(vd->vsm_fd));
 		vd->vsm_fd = -1;


### PR DESCRIPTION
There are many places in the code base where assertions are used to
verify an operation relying on a dependency where there is no path for
recovery.

For instance, many `malloc` calls are followed by an `AN` check because
there is no recovery path when the child runs out of memory.  So instead
the classic course of action is to let it panic and rely on the manager
for spawning a new child.

However, `assert` can be turned into a no-op, meaning that an allocation
failure would likely be followed by a segmentation fault slightly harder
to diagnose.  Instead of assimilating dependencies to invariant checks
(assert) the new macros ensure a systematic failures.

These macros should be used for checks on foreign code, free of context.
Assuming that the underlying allocator is bug-free, the only reason to
return a NULL pointer is the lack of memory whereas a failure on a lock
operation would more likely be caused by a misuse of a pthread object
and thus better fits assertions.

Once such patterns are identified they can be applied to the whole code
base conveniently with a Coccinelle semantic patch.