### PR TITLE
be friendly to Sun CC aka Solaris Studio

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -543,7 +543,7 @@ vca_acct(void *arg)
 		now = VTIM_real();
 		VSC_C_main->uptime = (uint64_t)(now - t0);
 	}
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -384,8 +384,8 @@ vbp_thread(struct worker *wrk, void *priv)
 			binheap_insert(vbp_heap, vt);
 		}
 	}
-	Lck_Unlock(&vbp_mtx);
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(Lck_Unlock(&vbp_mtx));
+	NEEDLESS(return NULL);
 }
 
 

--- a/bin/varnishd/cache/cache_ban_lurker.c
+++ b/bin/varnishd/cache/cache_ban_lurker.c
@@ -368,5 +368,5 @@ ban_lurker(struct worker *wrk, void *priv)
 		Lck_Unlock(&ban_mtx);
 	}
 	pthread_exit(0);
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }

--- a/bin/varnishd/cache/cache_expire.c
+++ b/bin/varnishd/cache/cache_expire.c
@@ -341,7 +341,7 @@ exp_thread(struct worker *wrk, void *priv)
 		else
 			tnext = exp_expire(ep, t);
 	}
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/cache/cache_pool.c
+++ b/bin/varnishd/cache/cache_pool.c
@@ -226,7 +226,7 @@ pool_poolherder(void *priv)
 		Lck_Unlock(&pool_mtx);
 		VSC_C_main->thread_queue_len = u;
 	}
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/cache/cache_shmlog.c
+++ b/bin/varnishd/cache/cache_shmlog.c
@@ -478,7 +478,7 @@ vsm_cleaner(void *priv)
 		AZ(pthread_mutex_unlock(&vsm_mtx));
 		VTIM_sleep(1.1);
 	}
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -149,7 +149,7 @@ VRT_priv_top(VRT_CTX, void *vmod_id)
 		return (vrt_priv_dynamic(ctx, id, (uintptr_t)vmod_id));
 	} else
 		WRONG("PRIV_TOP is only accessible in client VCL context");
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -70,7 +70,7 @@ wrk_bgthread(void *arg)
 
 	WRONG("BgThread terminated");
 
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }
 
 void
@@ -539,5 +539,5 @@ pool_herder(void *priv)
 		}
 		Lck_Unlock(&pp->mtx);
 	}
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }

--- a/bin/varnishd/hash/hash_critbit.c
+++ b/bin/varnishd/hash/hash_critbit.c
@@ -327,7 +327,7 @@ hcb_cleaner(struct worker *wrk, void *priv)
 		Pool_Sumstat(wrk);
 		VTIM_sleep(cache_param->critbit_cooloff);
 	}
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/hpack/vhp_decode.c
+++ b/bin/varnishd/hpack/vhp_decode.c
@@ -733,7 +733,7 @@ decode(struct vhd_decode *d, struct vht_table *tbl, uint8_t *in, size_t in_l,
 		}
 	}
 
-	NEEDLESS_RETURN(0);
+	NEEDLESS(return (VHD_OK));
 }
 
 #define CHECK_RET(r, e)					\

--- a/bin/varnishd/storage/storage_persistent.c
+++ b/bin/varnishd/storage/storage_persistent.c
@@ -313,7 +313,7 @@ smp_thread(struct worker *wrk, void *priv)
 	Lck_Unlock(&sc->mtx);
 	pthread_exit(0);
 
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/waiter/cache_waiter_poll.c
+++ b/bin/varnishd/waiter/cache_waiter_poll.c
@@ -206,7 +206,7 @@ VSL(SLT_Debug, vwp->pollfd[i].fd, "POLL loop i=%d revents=0x%x", i, vwp->pollfd[
 		if (vwp->pollfd[0].revents)
 			vwp_dopipe(vwp);
 	}
-	NEEDLESS_RETURN(NULL);
+	NEEDLESS(return NULL);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishhist/varnishhist.c
+++ b/bin/varnishhist/varnishhist.c
@@ -457,7 +457,7 @@ do_curses(void *arg)
 			pthread_mutex_unlock(&mtx);
 		}
 	}
-	pthread_exit(NULL);
+	NEEDLESS(pthread_exit(NULL));
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishtest/vtc_server.c
+++ b/bin/varnishtest/vtc_server.c
@@ -255,7 +255,7 @@ server_dispatch_thread(void *priv)
 		s2->run = 1;
 		AZ(pthread_create(&s2->tp, NULL, server_dispatch_wrk, s2));
 	}
-	return(NULL);
+	NEEDLESS(return(NULL));
 }
 
 static void

--- a/bin/varnishtop/varnishtop.c
+++ b/bin/varnishtop/varnishtop.c
@@ -293,8 +293,7 @@ do_curses(void *arg)
 			break;
 		}
 	}
-	return NULL;
-
+	NEEDLESS(return NULL);
 }
 
 static void

--- a/configure.ac
+++ b/configure.ac
@@ -518,16 +518,21 @@ AX_CHECK_COMPILE_FLAG([-Wall],
      [CFLAGS="${CFLAGS} -Wall"
       OCFLAGS="${OCFLAGS} -Wall"])
 
-SUNCC_CFLAGS=" \
-	-errwarn=%all,no%E_EMPTY_TRANSLATION_UNIT,no%E_ATTRIBUTE_UNKNOWN,no%E_STATEMENT_NOT_REACHED,no%E_EMPTY_DECLARATION \
+AC_CHECK_DECL([__SUNPRO_C], [SUNCC="yes"], [SUNCC="no"])
+
+if test "$SUNCC" = "yes" ; then
+    SUNCC_CFLAGS=" \
+	-errwarn=%all,no%E_EMPTY_TRANSLATION_UNIT \
 	-errtags=yes \
 	"
-AX_CHECK_COMPILE_FLAG([-Werror],
-     [CFLAGS="${CFLAGS} -Werror"
-      OCFLAGS="${OCFLAGS} -Werror"],
-     [AX_CHECK_COMPILE_FLAG([${SUNCC_CFLAGS}],
-      [CFLAGS="${CFLAGS} ${SUNCC_CFLAGS}"
-       OCFLAGS="${OCFLAGS} ${SUNCC_CFLAGS}"])])
+    AX_CHECK_COMPILE_FLAG([${SUNCC_CFLAGS}],
+	[CFLAGS="${CFLAGS} ${SUNCC_CFLAGS}"
+	 OCFLAGS="${OCFLAGS} ${SUNCC_CFLAGS}"])
+else
+    AX_CHECK_COMPILE_FLAG([-Werror],
+	[CFLAGS="${CFLAGS} -Werror"
+	 OCFLAGS="${OCFLAGS} -Werror"])
+fi
 
 AX_CHECK_COMPILE_FLAG([-Werror=unused-result],
     [CFLAGS="${CFLAGS} -Wno-error=unused-result"
@@ -586,7 +591,7 @@ AC_ARG_ENABLE(developer-warnings,
 	[],
 	[enable_developer_warnings=no])
 
-if test "x$enable_developer_warnings" != "xno"; then
+if test "x$SUNCC" != "xyes" && test "x$enable_developer_warnings" != "xno"; then
 	# compiler flags not available on gcc3
 	AX_CHECK_COMPILE_FLAG([-Wno-pointer-sign],
 		[DEVELOPER_CFLAGS="${DEVELOPER_CFLAGS} -Wno-pointer-sign"], [], [])
@@ -625,7 +630,11 @@ esac
 # --enable-debugging-symbols
 AC_ARG_ENABLE(debugging-symbols,
 	AS_HELP_STRING([--enable-debugging-symbols],[enable debugging symbols (default is NO)]),
-	CFLAGS="${CFLAGS} -O0 -g -fno-inline")
+	if test "x$SUNCC" = "xyes" ; then
+		CFLAGS="${CFLAGS} -O0 -g"
+	else
+		CFLAGS="${CFLAGS} -O0 -g -fno-inline"
+	fi)
 
 AC_SUBST(AM_LT_LDFLAGS)
 
@@ -644,7 +653,7 @@ else
 			break
 			;;
 		*cc)
-			VCC_CC="$PTHREAD_CC $OCFLAGS $PTHREAD_CFLAGS -Kpic -G -o %o %s"
+			VCC_CC="$PTHREAD_CC $OCFLAGS -errwarn=%all,no%E_STATEMENT_NOT_REACHED $PTHREAD_CFLAGS -Kpic -G -o %o %s"
 			;;
 		esac
 		;;

--- a/include/vdef.h
+++ b/include/vdef.h
@@ -111,6 +111,12 @@
  */
 #define __state_variable__(varname)	varname /*lint -esym(838,varname) */
 
+#ifdef __SUNPRO_C
+#define NEEDLESS_RETURN		{}
+#define NEEDLESS(s)		{}
+#else
 #define NEEDLESS_RETURN		return
+#define NEEDLESS(s)		s
+#endif
 
 #endif /* VDEF_H_INCLUDED */

--- a/include/vdef.h
+++ b/include/vdef.h
@@ -114,6 +114,7 @@
 #ifdef __SUNPRO_C
 #define NEEDLESS_RETURN		{}
 #define NEEDLESS(s)		{}
+#define __unused
 #else
 #define NEEDLESS_RETURN		return
 #define NEEDLESS(s)		s

--- a/lib/libvarnish/vcli_proto.c
+++ b/lib/libvarnish/vcli_proto.c
@@ -39,6 +39,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "vdef.h"
 #include "vas.h"
 #include "vcli.h"
 #include "vsha256.h"

--- a/lib/libvarnishapi/vsl_query.c
+++ b/lib/libvarnishapi/vsl_query.c
@@ -298,7 +298,7 @@ vslq_exec(const struct vex *vex, struct VSL_transaction * const ptrans[])
 	default:
 		return (vslq_test(vex, ptrans));
 	}
-	NEEDLESS_RETURN(0);
+	NEEDLESS(return 0);
 }
 
 struct vslq_query *


### PR DESCRIPTION
- use `NEEDLESS` macro to no-op code which is never reached
- use `SUNCCPRAGMA` macro to selectively silence warnings
  Not sure if there are better / less intrusive ways of achieving the same goal
