### PR TITLE
Modernize the build system for out-of-tree vmods

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,10 +6,10 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = varnishapi.pc
 
 m4dir = $(datadir)/aclocal
-m4_DATA = varnish.m4
+m4_DATA = varnish.m4 varnish-deprecated.m4
 
 CLEANFILES = cscope.in.out cscope.out cscope.po.out
-EXTRA_DIST = README.rst README.Packaging LICENSE autogen.sh varnishapi.pc.in varnish.m4
+EXTRA_DIST = README.rst README.Packaging LICENSE autogen.sh varnishapi.pc.in varnish.m4 varnish-deprecated.m4
 
 DISTCHECK_CONFIGURE_FLAGS = \
     --enable-developer-warnings \

--- a/varnish-deprecated.m4
+++ b/varnish-deprecated.m4
@@ -1,0 +1,104 @@
+# varnish-deprecated.m4 - Macros to locate Varnish header files. -*- Autoconf -*-
+# serial 3 (varnish-4.0)
+
+# Copyright (c) 2013-2015 Varnish Software AS
+# All rights reserved.
+#
+# Author: Tollef Fog Heen <tfheen@varnish-software.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+# For compatibility with autoconf < 2.63b
+m4_ifndef([AS_VAR_COPY],
+  [m4_define([AS_VAR_COPY],
+     [AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])
+
+# VARNISH_VMOD_INCLUDE_DIR([])
+# ----------------------------
+
+AC_DEFUN([VARNISH_VMOD_INCLUDES],
+[
+m4_pattern_forbid([^_?VARNISH[A-Z_]+$])
+m4_pattern_allow([^VARNISH_VMOD(_INCLUDE_DIR|TOOL)$])
+# Check for pkg-config
+PKG_CHECK_EXISTS([varnishapi],[],[
+	if test -z "$PKG_CONFIG"; then
+		AC_MSG_FAILURE(
+[The pkg-config script could not be found or is too old.  Make sure it
+is in your PATH or set the PKG_CONFIG environment variable to the full
+path to pkg-config.
+
+To get pkg-config, see <http://www.freedesktop.org/wiki/Software/pkg-config/>.])
+	else
+		AC_MSG_FAILURE(
+[pkg-config was unable to locate the varnishapi configuration data.
+
+Please check config.log or adjust the PKG_CONFIG_PATH environment
+variable if you installed software in a non-standard prefix.])
+	fi
+])
+
+VARNISH_PKG_GET_VAR([VAPI_INCLUDE_DIR], [pkgincludedir])
+_CPPFLAGS="$CPPFLAGS"
+VMOD_INCLUDES="-I$VAPI_INCLUDE_DIR"
+CPPFLAGS="$VMOD_INCLUDES $CPPFLAGS"
+AC_CHECK_HEADERS([vsha256.h cache/cache.h])
+CPPFLAGS="$_CPPFLAGS"
+AC_SUBST([VMOD_INCLUDES])
+])# VARNISH_VMOD_INCLUDE_DIR
+
+# VARNISH_VMOD_DIR([])
+# --------------------
+
+AC_DEFUN([VARNISH_VMOD_DIR],
+[
+VARNISH_PKG_GET_VAR([VMOD_DIR], [vmoddir])
+AC_SUBST([VMOD_DIR])
+])
+
+# VARNISH_VMODTOOL([])
+# --------------------
+
+AC_DEFUN([VARNISH_VMODTOOL],
+[
+AC_CHECK_PROGS(PYTHON, [python3 python3.1 python3.2 python2.7 python2.6 python2.5 python2 python], "no")
+if test "x$PYTHON" = "xno"; then
+  AC_MSG_ERROR([Python is needed to build, please install python.])
+fi
+VARNISH_PKG_GET_VAR([VMODTOOL], [vmodtool])
+AC_SUBST([VMODTOOL])
+])
+
+# VARNISH_PKG_GET_VAR([VARIABLE, PC_VAR_NAME])
+# -------------------------------
+
+AC_DEFUN([VARNISH_PKG_GET_VAR],
+[
+# Uses internal function for now..
+pkg_failed=no
+_PKG_CONFIG([$1], [variable=][$2], [varnishapi])
+if test "$pkg_failed" = "yes"; then
+   AC_MSG_FAILURE([$2][ not defined, too old Varnish?])
+fi
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+])

--- a/varnish.m4
+++ b/varnish.m4
@@ -1,104 +1,177 @@
 # varnish.m4 - Macros to locate Varnish header files.            -*- Autoconf -*-
-# serial 3 (varnish-4.0)
+# serial 4 (varnish-4.1.4)
 
 # Copyright (c) 2013-2015 Varnish Software AS
 # All rights reserved.
 #
-# Author: Tollef Fog Heen <tfheen@varnish-software.com>
+# Author: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-# SUCH DAMAGE.
+# 1. Redistributions of source code must retain the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer.
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials
+#    provided with the distribution.
 #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# For compatibility with autoconf < 2.63b
-m4_ifndef([AS_VAR_COPY],
-  [m4_define([AS_VAR_COPY],
-     [AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])
-
-# VARNISH_VMOD_INCLUDE_DIR([])
-# ----------------------------
-
-AC_DEFUN([VARNISH_VMOD_INCLUDES],
-[
-m4_pattern_forbid([^_?VARNISH[A-Z_]+$])
-m4_pattern_allow([^VARNISH_VMOD(_INCLUDE_DIR|TOOL)$])
-# Check for pkg-config
-PKG_CHECK_EXISTS([varnishapi],[],[
-	if test -z "$PKG_CONFIG"; then
-		AC_MSG_FAILURE(
-[The pkg-config script could not be found or is too old.  Make sure it
-is in your PATH or set the PKG_CONFIG environment variable to the full
-path to pkg-config.
-
-To get pkg-config, see <http://www.freedesktop.org/wiki/Software/pkg-config/>.])
-	else
-		AC_MSG_FAILURE(
-[pkg-config was unable to locate the varnishapi configuration data.
-
-Please check config.log or adjust the PKG_CONFIG_PATH environment
-variable if you installed software in a non-standard prefix.])
-	fi
-])
-
-VARNISH_PKG_GET_VAR([VAPI_INCLUDE_DIR], [pkgincludedir])
-_CPPFLAGS="$CPPFLAGS"
-VMOD_INCLUDES="-I$VAPI_INCLUDE_DIR"
-CPPFLAGS="$VMOD_INCLUDES $CPPFLAGS"
-AC_CHECK_HEADERS([vsha256.h cache/cache.h])
-CPPFLAGS="$_CPPFLAGS"
-AC_SUBST([VMOD_INCLUDES])
-])# VARNISH_VMOD_INCLUDE_DIR
-
-# VARNISH_VMOD_DIR([])
+# _VARNISH_PKG_CONFIG
 # --------------------
+AC_DEFUN([_VARNISH_PKG_CONFIG], [
+	PKG_PROG_PKG_CONFIG([0.21])
 
-AC_DEFUN([VARNISH_VMOD_DIR],
-[
-VARNISH_PKG_GET_VAR([VMOD_DIR], [vmoddir])
-AC_SUBST([VMOD_DIR])
+	PKG_CHECK_MODULES([VARNISHAPI], [varnishapi])
+	AC_SUBST([VARNISH_VERSION], [$($PKG_CONFIG --modversion varnishapi)])
+
+	PKG_CHECK_VAR([VARNISHAPI_PREFIX], [varnishapi], [prefix])
+	PKG_CHECK_VAR([VARNISHAPI_DATAROOTDIR], [varnishapi], [datarootdir])
+	PKG_CHECK_VAR([VARNISHAPI_BINDIR], [varnishapi], [bindir])
+	PKG_CHECK_VAR([VARNISHAPI_SBINDIR], [varnishapi], [sbindir])
+	PKG_CHECK_VAR([VARNISHAPI_VMODDIR], [varnishapi], [vmoddir])
+
+	PKG_CHECK_VAR([VMODTOOL], [varnishapi], [vmodtool])
 ])
 
-# VARNISH_VMODTOOL([])
+# _VARNISH_CHECK_DEVEL
 # --------------------
+AC_DEFUN([_VARNISH_CHECK_DEVEL], [
 
-AC_DEFUN([VARNISH_VMODTOOL],
-[
-AC_CHECK_PROGS(PYTHON, [python3 python3.1 python3.2 python2.7 python2.6 python2.5 python2 python], "no")
-if test "x$PYTHON" = "xno"; then
-  AC_MSG_ERROR([Python is needed to build, please install python.])
-fi
-VARNISH_PKG_GET_VAR([VMODTOOL], [vmodtool])
-AC_SUBST([VMODTOOL])
+	AC_REQUIRE([_VARNISH_PKG_CONFIG])
+
+	[_orig_cppflags=$CPPFLAGS]
+	[CPPFLAGS=$VARNISHAPI_CFLAGS]
+
+	AC_CHECK_HEADERS([vsha256.h cache/cache.h], [],
+		[AC_MSG_ERROR([Missing Varnish development files.])])
+
+	[CPPFLAGS=$_orig_cppflags]
 ])
 
-# VARNISH_PKG_GET_VAR([VARIABLE, PC_VAR_NAME])
-# -------------------------------
+# _VARNISH_VMOD_CONFIG
+# --------------------
+AC_DEFUN([_VARNISH_VMOD_CONFIG], [
 
-AC_DEFUN([VARNISH_PKG_GET_VAR],
-[
-# Uses internal function for now..
-pkg_failed=no
-_PKG_CONFIG([$1], [variable=][$2], [varnishapi])
-if test "$pkg_failed" = "yes"; then
-   AC_MSG_FAILURE([$2][ not defined, too old Varnish?])
-fi
-AS_VAR_COPY([$1], [pkg_cv_][$1])
+	AC_REQUIRE([_VARNISH_PKG_CONFIG])
+	AC_REQUIRE([_VARNISH_CHECK_DEVEL])
+
+	dnl Check the VMOD toolchain
+	AC_REQUIRE([AC_LANG_C])
+	AC_REQUIRE([AC_PROG_CC_C99])
+	AC_REQUIRE([AC_PROG_CPP])
+	AC_REQUIRE([AC_PROG_CPP_WERROR])
+
+	AM_PATH_PYTHON([2.6], [], [
+		AC_MSG_ERROR([Python is needed to build VMODs.])
+	])
+
+	AS_IF([test -z "$RST2MAN"], [
+		AC_MSG_ERROR([rst2man is needed to build VMOD manuals.])
+	])
+
+	dnl Expose the location of the std and directors VMODs
+	AC_SUBST([VARNISHAPI_VMODDIR])
+
+	dnl Expose Varnish's aclocal directory to automake
+	AC_SUBST([VARNISHAPI_DATAROOTDIR])
+
+	dnl Define the VMOD directory for libtool
+	AS_CASE([$prefix],
+		[NONE], [
+			vmoddir=$VARNISHAPI_VMODDIR
+			ac_default_prefix=$VARNISHAPI_PREFIX],
+		[vmoddir=$libdir/varnish/vmods]
+	)
+	AC_SUBST([vmoddir])
+
+	dnl Define an automake silent execution for vmodtool
+	[am__v_VMODTOOL_0='@echo "  VMODTOOL" $<;']
+	[am__v_VMODTOOL_1='']
+	[am__v_VMODTOOL_='$(am__v_VMODTOOL_$(AM_DEFAULT_VERBOSITY))']
+	[AM_V_VMODTOOL='$(am__v_VMODTOOL_$(V))']
+	AC_SUBST([am__v_VMODTOOL_0])
+	AC_SUBST([am__v_VMODTOOL_1])
+	AC_SUBST([am__v_VMODTOOL_])
+	AC_SUBST([AM_V_VMODTOOL])
+
+	dnl Define VMODs LDFLAGS
+	AC_SUBST([VMOD_LDFLAGS],
+		"-module -export-dynamic -avoid-version -shared")
+
+	dnl Define the PATH for the test suite
+	AC_SUBST([VMOD_TEST_PATH],
+		[$VARNISHAPI_SBINDIR:$VARNISHAPI_BINDIR:$PATH])
+])
+
+# _VARNISH_VMOD(NAME)
+# -------------------
+AC_DEFUN([_VARNISH_VMOD], [
+
+	AC_REQUIRE([_VARNISH_VMOD_CONFIG])
+
+	VMOD_FILE="\$(abs_builddir)/.libs/libvmod_$1.so"
+	AC_SUBST(m4_toupper(VMOD_$1_FILE), [$VMOD_FILE])
+
+	VMOD_IMPORT="querystring from \\\"$VMOD_FILE\\\""
+	AC_SUBST(m4_toupper(VMOD_$1), [$VMOD_IMPORT])
+
+	VMOD_RULES="
+
+vmod_$1.lo: vcc_$1_if.c vcc_$1_if.h
+
+vcc_$1_if.c vcc_$1_if.h vmod_$1.rst vmod_$1.man.rst: .vcc_$1
+
+.vcc_$1: vmod_$1.vcc
+	\$(AM_V_VMODTOOL) $PYTHON $VMODTOOL -o vcc_$1_if \$(srcdir)/vmod_$1.vcc
+	@touch .vcc_$1
+
+vmod_$1.3: vmod_$1.man.rst
+	$RST2MAN vmod_$1.man.rst vmod_$1.3
+
+clean: clean-vmod-$1
+
+distclean: clean-vmod-$1
+
+clean-vmod-$1:
+	rm -f vcc_$1_if.c vcc_$1_if.h
+	rm -f vmod_$1.rst vmod_$1.man.rst vmod_$1.3
+	rm -f .vcc_$1
+
+"
+
+	AC_SUBST(m4_toupper(BUILD_VMOD_$1), [$VMOD_RULES])
+	m4_ifdef([_AM_SUBST_NOTMAKE],
+		[_AM_SUBST_NOTMAKE(m4_toupper(BUILD_VMOD_$1))])
+])
+
+# VARNISH_VMODS(NAMES)
+# --------------------
+AC_DEFUN([VARNISH_VMODS], [
+	m4_foreach([_vmod_name],
+		m4_split(m4_normalize([$1])),
+		[_VARNISH_VMOD(_vmod_name)])
+])
+
+# VARNISH_PREREQ(VERSION)
+# -----------------------
+AC_DEFUN([VARNISH_PREREQ], [
+	AC_REQUIRE([_VARNISH_PKG_CONFIG])
+	AS_VERSION_COMPARE([$VARNISH_VERSION], [$1], [
+		AC_MSG_ERROR([Varnish version $1 or higher is required.])
+	])
 ])

--- a/varnish.m4
+++ b/varnish.m4
@@ -134,11 +134,10 @@ AC_DEFUN([_VARNISH_VMOD], [
 
 vmod_$1.lo: vcc_$1_if.c vcc_$1_if.h
 
-vcc_$1_if.c vcc_$1_if.h vmod_$1.rst vmod_$1.man.rst: .vcc_$1
+vcc_$1_if.h vmod_$1.rst vmod_$1.man.rst: vcc_$1_if.c
 
-.vcc_$1: vmod_$1.vcc
+vcc_$1_if.c: vmod_$1.vcc
 	\$(AM_V_VMODTOOL) $PYTHON $VMODTOOL -o vcc_$1_if \$(srcdir)/vmod_$1.vcc
-	@touch .vcc_$1
 
 vmod_$1.3: vmod_$1.man.rst
 	$RST2MAN vmod_$1.man.rst vmod_$1.3
@@ -150,7 +149,6 @@ distclean: clean-vmod-$1
 clean-vmod-$1:
 	rm -f vcc_$1_if.c vcc_$1_if.h
 	rm -f vmod_$1.rst vmod_$1.man.rst vmod_$1.3
-	rm -f .vcc_$1
 
 "
 

--- a/varnish.m4
+++ b/varnish.m4
@@ -127,7 +127,7 @@ AC_DEFUN([_VARNISH_VMOD], [
 	VMOD_FILE="\$(abs_builddir)/.libs/libvmod_$1.so"
 	AC_SUBST(m4_toupper(VMOD_$1_FILE), [$VMOD_FILE])
 
-	VMOD_IMPORT="querystring from \\\"$VMOD_FILE\\\""
+	VMOD_IMPORT="$1 from \\\"$VMOD_FILE\\\""
 	AC_SUBST(m4_toupper(VMOD_$1), [$VMOD_IMPORT])
 
 	VMOD_RULES="


### PR DESCRIPTION
> It should make the life of VMOD maintainers a lot easier without forcing
them to migrate their build systems right away.  The old macros could be
killed with the next major release.  Ideally they should also build the
`std` and `directors` module because dogfooding. &lt;insert promises of a
unicorns and rainbows and happy princesses here&gt;