### PR TITLE
vcl_deliver read-only access to obj.ttl, obj.age, obj.grace and obj.keep

### DIFF
--- a/bin/varnishtest/tests/c00011.vtc
+++ b/bin/varnishtest/tests/c00011.vtc
@@ -13,6 +13,13 @@ varnish v1 -vcl+backend {
 	sub vcl_backend_response {
 		set beresp.uncacheable = true;
 	}
+	sub vcl_deliver {
+		set resp.http.o_uncacheable = obj.uncacheable;
+		set resp.http.o_age = obj.age;
+		set resp.http.o_ttl = obj.ttl;
+		set resp.http.o_grace = obj.grace;
+		set resp.http.o_keep = obj.keep;
+	}
 } -start
 
 client c1 {
@@ -21,11 +28,20 @@ client c1 {
 	expect resp.status == 200
 	expect resp.bodylen == 6
 	expect resp.http.x-varnish == "1001"
+	expect resp.http.o_age == "0.000"
+	expect resp.http.o_ttl == "120.000"
+	expect resp.http.o_grace == "10.000"
+	expect resp.http.o_keep == "0.000"
+
 	txreq -url "/foo"
 	rxresp
 	expect resp.status == 200
 	expect resp.bodylen == 7
 	expect resp.http.x-varnish == "1003"
+	expect resp.http.o_age == "0.000"
+	expect resp.http.o_ttl == "120.000"
+	expect resp.http.o_grace == "10.000"
+	expect resp.http.o_keep == "0.000"
 }
 
 client c1 -run

--- a/bin/varnishtest/tests/c00012.vtc
+++ b/bin/varnishtest/tests/c00012.vtc
@@ -13,6 +13,13 @@ varnish v1 -vcl+backend {
 	sub vcl_miss {
 		return(pass);
 	}
+	sub vcl_deliver {
+		set resp.http.o_uncacheable = obj.uncacheable;
+		set resp.http.o_age = obj.age;
+		set resp.http.o_ttl = obj.ttl;
+		set resp.http.o_grace = obj.grace;
+		set resp.http.o_keep = obj.keep;
+	}
 } -start
 
 client c1 {
@@ -21,11 +28,20 @@ client c1 {
 	expect resp.status == 200
 	expect resp.bodylen == 6
 	expect resp.http.x-varnish == "1001"
+	expect resp.http.o_age == "0.000"
+	expect resp.http.o_ttl == "-0.000"
+	expect resp.http.o_grace == "0.000"
+	expect resp.http.o_keep == "0.000"
+
 	txreq -url "/foo"
 	rxresp
 	expect resp.status == 200
 	expect resp.bodylen == 7
 	expect resp.http.x-varnish == "1003"
+	expect resp.http.o_age == "0.000"
+	expect resp.http.o_ttl == "-0.000"
+	expect resp.http.o_grace == "0.000"
+	expect resp.http.o_keep == "0.000"
 }
 
 client c1 -run

--- a/bin/varnishtest/tests/v00025.vtc
+++ b/bin/varnishtest/tests/v00025.vtc
@@ -25,6 +25,10 @@ varnish v1 -arg "-i J.F.Nobody" -vcl+backend {
 		set resp.http.l_ip = local.ip;
 		set resp.http.r_ip = remote.ip;
 		if (obj.uncacheable) { }
+		set resp.http.o_age = obj.age;
+		set resp.http.o_ttl = obj.ttl;
+		set resp.http.o_grace = obj.grace;
+		set resp.http.o_keep = obj.keep;
 	}
 
 	sub vcl_backend_response {

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -654,28 +654,28 @@ sp_variables = [
 	),
 	('obj.ttl',
 		'DURATION',
-		('hit',),
+		('hit', 'deliver'),
 		(), """
 		The object's remaining time to live, in seconds.
 		"""
 	),
 	('obj.age',
 		'DURATION',
-		('hit',),
+		('hit', 'deliver'),
 		(), """
 		The age of the object.
 		"""
 	),
 	('obj.grace',
 		'DURATION',
-		('hit',),
+		('hit', 'deliver'),
 		(), """
 		The object's remaining grace period in seconds.
 		"""
 	),
 	('obj.keep',
 		'DURATION',
-		('hit',),
+		('hit', 'deliver'),
 		(), """
 		The object's remaining keep period in seconds.
 		"""


### PR DESCRIPTION
Noticed that I've been missing this since the beginning of time when
porting some ancient inline-C.

We already have obj.uncacheable und obj.hits in vcl_deliver, so not
having these seems arbitrary. Copying out the values in vcl_hit just
to have them available in vcl_deliver, as it was possible previously,
implies unnecessary overhead.

One use case is to extend object lifetime downstream when delivering a
stale object, e.g.

```
sub vcl_deliver {
    if (! obj.uncacheable && obj.ttl < 0s) {
	set resp.http.Expires = now + 1m;
	set resp.http.Cache-Control = "public, max-age=60";
	unset req.http.Age;
    }
}
```