### PR TITLE
Append a default system-wide location to vcl_path

### DIFF
--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -136,7 +136,7 @@ varnishd_CFLAGS = \
 	-DVARNISHD_IS_NOT_A_VMOD \
 	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
 	-DVARNISH_VMOD_DIR='"${pkglibdir}/vmods"' \
-	-DVARNISH_VCL_DIR='"${varnishconfdir}"'
+	-DVARNISH_VCL_DIR='"${varnishconfdir}:$(datarootdir)/vcl"'
 
 varnishd_LDFLAGS = -export-dynamic
 

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -10,3 +10,7 @@ builtin.vcl:	$(top_srcdir)/bin/varnishd/builtin.vcl
 New users is recommended to use the example.vcl file as a starting point.\n\n";\
 	sed -n '/vcl_recv/,$$p' $(top_srcdir)/bin/varnishd/builtin.vcl ) | \
 	sed 's/^\(.*\)$$/# \1/' > builtin.vcl
+
+vcldir=$(datarootdir)/vcl
+
+dist_vcl_DATA = devicedetect.vcl


### PR DESCRIPTION
Of course it can still be removed via the varnish cli.

The *how* and the *why* are detailed in the first commit message.

The *when* dates to the discussions that lead to the replacement of `vcl_dir` by `vcl_path`.

After all the efforts it took me understanding autotools to produce #2054, this one became trivial. I've had ideas of VCL libraries that could fit this model in the past but never implemented any, the one I see fitting best in this model today is @comotion's VSF (Varnish Security Firewall).

In my own `querystring` VMOD I could ship VCL subroutines for turnkey integration with big players (eg. google analytics) or with web stacks that sometimes do cache-unfriendly things with query-strings (although it's been a while since I've last been confronted to a web stack luckily).

In my case it might be overkill since an absolute path would be enough, but in large libraries like VSF with transitive includes that would be a nice alternative to invading the `/etc` tree.

If merged, it needs to be documented and not just in the changelog.