### PR TITLE
Add a "key" field to each backend.

### DIFF
--- a/bin/varnishd/cache/cache_backend.h
+++ b/bin/varnishd/cache/cache_backend.h
@@ -120,7 +120,7 @@ void VBP_Status(struct cli *cli, const struct backend *, int details);
 
 /* cache_backend_tcp.c */
 struct tcp_pool *VBT_Ref(const struct suckaddr *ip4,
-    const struct suckaddr *ip6);
+    const struct suckaddr *ip6, const char *key);
 void VBT_Rel(struct tcp_pool **tpp);
 int VBT_Open(const struct tcp_pool *tp, double tmo, const struct suckaddr **sa);
 void VBT_Recycle(const struct worker *, struct tcp_pool *, struct vbc **);

--- a/bin/varnishd/cache/cache_backend_cfg.c
+++ b/bin/varnishd/cache/cache_backend_cfg.c
@@ -112,9 +112,9 @@ VRT_new_backend(VRT_CTX, const struct vrt_backend *vrt)
 	Lck_Lock(&backends_mtx);
 	VTAILQ_INSERT_TAIL(&backends, b, list);
 	VSC_C_main->n_backend++;
-	b->tcp_pool = VBT_Ref(vrt->ipv4_suckaddr, vrt->ipv6_suckaddr);
+	b->tcp_pool = VBT_Ref(vrt->ipv4_suckaddr, vrt->ipv6_suckaddr, vrt->key);
 	if (vbp != NULL) {
-		tp = VBT_Ref(vrt->ipv4_suckaddr, vrt->ipv6_suckaddr);
+		tp = VBT_Ref(vrt->ipv4_suckaddr, vrt->ipv6_suckaddr, vrt->key);
 		assert(b->tcp_pool == tp);
 	}
 	Lck_Unlock(&backends_mtx);

--- a/doc/sphinx/reference/vcl.rst
+++ b/doc/sphinx/reference/vcl.rst
@@ -213,6 +213,14 @@ are available:
   host_header
     A host header to add.
 
+  key
+    An opaque key identifying this backend. Normally, backends with the
+    same host (as determined by IPv4/IPv6 address pair) and port will
+    share TCP connections, but if you give them different keys, they will
+    not. This is useful if your HTTP connections have some kind of state
+    (e.g. for security) which makes it impossible to reuse them across
+    backends.
+
   connect_timeout
     Timeout for connections.
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -186,6 +186,7 @@ extern const void * const vrt_magic_string_unset;
 	rigid char			*ipv6_addr;		\
 	rigid char			*port;			\
 	rigid char			*hosthdr;		\
+	rigid char			*key;			\
 	double				connect_timeout;	\
 	double				first_byte_timeout;	\
 	double				between_bytes_timeout;	\

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -299,6 +299,7 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	    "?probe",
 	    "?max_connections",
 	    "?proxy_header",
+	    "?key",
 	    NULL);
 
 	SkipToken(tl, '{');
@@ -346,6 +347,14 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 			ExpectErr(tl, CSTR);
 			assert(tl->t->dec != NULL);
 			t_hosthdr = tl->t;
+			vcc_NextToken(tl);
+			SkipToken(tl, ';');
+		} else if (vcc_IdIs(t_field, "key")) {
+			ERRCHK(tl);
+			ExpectErr(tl, CSTR);
+			Fb(tl, 0, "\t.key = ");
+			EncToken(tl->fb, tl->t);
+			Fb(tl, 0, ",\n");
 			vcc_NextToken(tl);
 			SkipToken(tl, ';');
 		} else if (vcc_IdIs(t_field, "connect_timeout")) {


### PR DESCRIPTION
Normally, backends with the same host (as determined by IPv4/IPv6 address pair)
and port will share TCP connections, but if you give them different keys,
they will not. This is useful if your HTTP connections have some kind of state
(e.g. for security) which makes it impossible to reuse them across backends.

This is a (trivial) forward-port of a 4.1 patch we've been running in production.