### PR TITLE
Implicit backend cast to boolean

### DIFF
--- a/bin/varnishtest/tests/d00014.vtc
+++ b/bin/varnishtest/tests/d00014.vtc
@@ -1,0 +1,20 @@
+varnishtest "Backend as a boolean expression"
+
+server s1 -start
+
+varnish v1 -vcl+backend {
+	import debug;
+
+	sub vcl_recv {
+		set req.backend_hint = debug.no_backend();
+		if (!req.backend_hint) {
+			return (synth(404));
+		}
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 404
+} -run

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1191,7 +1191,7 @@ vcc_expr_cmp(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 	default:
 		break;
 	}
-	if (fmt == BOOL && (*e)->fmt == STRING) {
+	if (fmt == BOOL && ((*e)->fmt == STRING || (*e)->fmt == BACKEND)) {
 		*e = vcc_expr_edit(BOOL, "(\v1 != 0)", *e, NULL);
 		return;
 	}


### PR DESCRIPTION
Inspired by a VMOD [1] that does two lookups where one could be enough when there is no backend.

```vcl
sub vcl_recv {
  if (!sd.contains(req.http.host)) {
    return(synth(404));
  } else {
    set req.backend_hint = sd.backend(req.http.host);
  }
}
```

Instead one could do:

```vcl
sub vcl_recv {
  set req.backend_hint = sd.backend(req.http.host);
  if (!req.backend_hint) {
    return(synth(404));
  }
}
```

[1] https://github.com/gquintard/libvmod-stendhal#varnish-stendhal-module