### PR TITLE
Use a switch-case for the fini sequence

### DIFF
--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -286,7 +286,7 @@ EmitCoordinates(const struct vcc *tl, struct vsb *vsb)
 static void
 EmitInitFini(const struct vcc *tl)
 {
-	struct inifin *p;
+	struct inifin *p, *q = NULL;
 	unsigned has_event = 0;
 
 	Fh(tl, 0, "\n");
@@ -325,6 +325,8 @@ EmitInitFini(const struct vcc *tl)
 	Fc(tl, 0, "\tswitch (vgc_inistep) {\n\n");
 	VTAILQ_FOREACH_REVERSE(p, &tl->inifin, inifinhead, list) {
 		AZ(VSB_finish(p->fin));
+		if (q)
+			assert(q->n > p->n);
 		if (VSB_len(p->fin)) {
 			Fc(tl, 0, "\t\tcase %u :\n", p->n);
 			Fc(tl, 0, "\t%s\n", VSB_data(p->fin));

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -321,16 +321,18 @@ EmitInitFini(const struct vcc *tl)
 	Fc(tl, 0, "\nstatic int\nVGC_Discard(VRT_CTX)\n{\n\n");
 
 	Fc(tl, 0, "\t(void)VGC_function_vcl_fini(ctx);\n\n");
+
+	Fc(tl, 0, "\tswitch (vgc_inistep) {\n\n");
 	VTAILQ_FOREACH_REVERSE(p, &tl->inifin, inifinhead, list) {
 		AZ(VSB_finish(p->fin));
 		if (VSB_len(p->fin)) {
-			Fc(tl, 0, "\t/* %u */\n", p->n);
-			Fc(tl, 0, "\tif (vgc_inistep >= %u) {\n", p->n);
-			Fc(tl, 0, "%s\n", VSB_data(p->fin));
-			Fc(tl, 0, "\t}\n\n");
+			Fc(tl, 0, "\t\tcase %u :\n", p->n);
+			Fc(tl, 0, "\t%s\n", VSB_data(p->fin));
+			Fc(tl, 0, "\t\t\t/* FALLTHROUGH */\n");
 		}
 		VSB_destroy(&p->fin);
 	}
+	Fc(tl, 0, "\t}\n\n");
 
 	Fc(tl, 0, "\treturn (0);\n");
 	Fc(tl, 0, "}\n");


### PR DESCRIPTION
This allows to test vgc_inistep only once and make it easier to work for
the compiler.

It doesn't seem to help gcc that's super slow, but clang get a 15% speed boost when compiling with clang on large VCLs (10000 backends).

Performance feedback is welcome.