### PR TITLE
Fixes for the VCL temperature engine

### DIFF
--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -127,7 +127,7 @@ VCL_Panic(struct vsb *vsb, const struct vcl *vcl)
 	VSB_printf(vsb, "busy = %u\n", vcl->busy);
 	VSB_printf(vsb, "discard = %u,\n", vcl->discard);
 	VSB_printf(vsb, "state = %s,\n", vcl->state);
-	VSB_printf(vsb, "temp = %s,\n", vcl->temp);
+	VSB_printf(vsb, "temp = %s,\n", (const volatile char *)vcl->temp);
 	VSB_printf(vsb, "conf = {\n");
 	VSB_indent(vsb, 2);
 	if (vcl->conf == NULL) {

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -510,8 +510,12 @@ VRT_rel_vcl(VRT_CTX, struct vclref **refp)
 	vcl = ctx->vcl;
 	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
 	assert(vcl == ref->vcl);
-	assert(vcl->temp == VCL_TEMP_WARM || vcl->temp == VCL_TEMP_BUSY ||
-	    vcl->temp == VCL_TEMP_COOLING);
+
+	/* NB: A VCL may be released by a VMOD at any time, but it must happen
+	 * after a warmup and before the end of a cooldown. The release may or
+	 * may not happen while the same thread holds the temperature lock, so
+	 * instead we check that all references are gone in VCL_Nuke.
+	 */
 
 	Lck_Lock(&vcl_mtx);
 	assert(!VTAILQ_EMPTY(&vcl->ref_list));

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -184,7 +184,9 @@ vcl_get(struct vcl **vcc, struct vcl *vcl)
 {
 
 	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
+	AZ(pthread_rwlock_rdlock(&vcl->temp_rwl));
 	assert(VCL_WARM(vcl));
+	AZ(pthread_rwlock_unlock(&vcl->temp_rwl));
 	Lck_Lock(&vcl_mtx);
 	AN(vcl);
 	if (vcl->label == NULL)
@@ -212,7 +214,9 @@ void
 VCL_Refresh(struct vcl **vcc)
 {
 	CHECK_OBJ_NOTNULL(vcl_active, VCL_MAGIC);
+	AZ(pthread_rwlock_rdlock(&vcl_active->temp_rwl));
 	assert(VCL_WARM(vcl_active));
+	AZ(pthread_rwlock_unlock(&vcl_active->temp_rwl));
 	if (*vcc == vcl_active)
 		return;
 	if (*vcc != NULL)
@@ -225,7 +229,9 @@ VCL_Ref(struct vcl *vcl)
 {
 
 	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
+	AZ(pthread_rwlock_rdlock(&vcl->temp_rwl));
 	assert(!VCL_COLD(vcl));
+	AZ(pthread_rwlock_unlock(&vcl->temp_rwl));
 	Lck_Lock(&vcl_mtx);
 	assert(vcl->busy > 0);
 	vcl->busy++;
@@ -261,8 +267,11 @@ VCL_AddBackend(struct vcl *vcl, struct backend *be)
 	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
 	CHECK_OBJ_NOTNULL(be, BACKEND_MAGIC);
 
-	if (vcl->temp == VCL_TEMP_COOLING)
+	AZ(pthread_rwlock_rdlock(&vcl->temp_rwl));
+	if (vcl->temp == VCL_TEMP_COOLING) {
+		AZ(pthread_rwlock_unlock(&vcl->temp_rwl));
 		return (1);
+	}
 
 	Lck_Lock(&vcl_mtx);
 	VTAILQ_INSERT_TAIL(&vcl->backend_list, be, vcl_list);
@@ -273,6 +282,7 @@ VCL_AddBackend(struct vcl *vcl, struct backend *be)
 		VBE_Event(be, VCL_EVENT_WARM);
 	else if (vcl->temp != VCL_TEMP_INIT)
 		WRONG("Dynamic Backends can only be added to warm VCLs");
+	AZ(pthread_rwlock_unlock(&vcl->temp_rwl));
 
 	return (0);
 }
@@ -288,8 +298,11 @@ VCL_DelBackend(struct backend *be)
 	Lck_Lock(&vcl_mtx);
 	VTAILQ_REMOVE(&vcl->backend_list, be, vcl_list);
 	Lck_Unlock(&vcl_mtx);
-	if (vcl->temp == VCL_TEMP_WARM)
+
+	AZ(pthread_rwlock_rdlock(&vcl->temp_rwl));
+	if (VCL_WARM(vcl))
 		VBE_Event(be, VCL_EVENT_COLD);
+	AZ(pthread_rwlock_unlock(&vcl->temp_rwl));
 }
 
 static void
@@ -591,6 +604,7 @@ vcl_set_state(VRT_CTX, const char *state)
 	assert(ctx->msg != NULL || *state == '0');
 
 	vcl = ctx->vcl;
+	AZ(pthread_rwlock_wrlock(&vcl->temp_rwl));
 	AN(vcl->temp);
 
 	switch(state[0]) {
@@ -632,6 +646,8 @@ vcl_set_state(VRT_CTX, const char *state)
 	default:
 		WRONG("Wrong enum state");
 	}
+	AZ(pthread_rwlock_unlock(&vcl->temp_rwl));
+
 	return (i);
 }
 


### PR DESCRIPTION
This is a series of fixes for #2008 going after temperature asserts and locking. See individual commits for better context.

@rnsanchez, could you please give it a try with your thousands of backends? The backport to 4.1 is not as easy as a cherry-pick of these commits but I will take care of it if this PR gets merged and ping you again to perform similar testing on the 4.1 branch.