### PR TITLE
move workspace functions to libvarnish

### DIFF
--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -51,7 +51,6 @@ varnishd_SOURCES = \
 	cache/cache_vrt_var.c \
 	cache/cache_vrt_vmod.c \
 	cache/cache_wrk.c \
-	cache/cache_ws.c \
 	common/common_vsm.c \
 	common/common_vsc.c \
 	hash/hash_classic.c \

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -55,6 +55,7 @@
 #include <math.h>
 
 #include "common/params.h"
+#include "ws.h"
 
 /*--------------------------------------------------------------------*/
 
@@ -150,20 +151,6 @@ enum fetch_step {
 
 /*--------------------------------------------------------------------*/
 struct lock { void *priv; };	// Opaque
-
-/*--------------------------------------------------------------------
- * Workspace structure for quick memory allocation.
- */
-
-struct ws {
-	unsigned		magic;
-#define WS_MAGIC		0x35fac554
-	char			id[4];		/* identity */
-	char			*s;		/* (S)tart of buffer */
-	char			*f;		/* (F)ree/front pointer */
-	char			*r;		/* (R)eserved length */
-	char			*e;		/* (E)nd of buffer */
-};
 
 /*--------------------------------------------------------------------
  *
@@ -1058,21 +1045,6 @@ typedef void *bgthread_t(struct worker *, void *priv);
 void WRK_BgThread(pthread_t *thr, const char *name, bgthread_t *func,
     void *priv);
 
-/* cache_ws.c */
-
-void WS_Init(struct ws *ws, const char *id, void *space, unsigned len);
-unsigned WS_Reserve(struct ws *ws, unsigned bytes);
-void WS_MarkOverflow(struct ws *ws);
-void WS_Release(struct ws *ws, unsigned bytes);
-void WS_ReleaseP(struct ws *ws, char *ptr);
-void WS_Assert(const struct ws *ws);
-void WS_Reset(struct ws *ws, char *p);
-void *WS_Alloc(struct ws *ws, unsigned bytes);
-void *WS_Copy(struct ws *ws, const void *str, int len);
-char *WS_Snapshot(struct ws *ws);
-int WS_Overflowed(const struct ws *ws);
-void *WS_Printf(struct ws *ws, const char *fmt, ...) __v_printflike(2, 3);
-
 /* cache_rfc2616.c */
 void RFC2616_Ttl(struct busyobj *, double now, double *t_origin,
     float *ttl, float *grace, float *keep);
@@ -1084,20 +1056,6 @@ void RFC2616_Vary_AE(struct http *hp);
 /* stevedore.c */
 int STV_NewObject(struct worker *, struct objcore *,
     const char *hint, unsigned len);
-
-/*
- * A normal pointer difference is signed, but we never want a negative value
- * so this little tool will make sure we don't get that.
- */
-
-static inline unsigned
-pdiff(const void *b, const void *e)
-{
-
-	assert(b <= e);
-	return
-	    ((unsigned)((const unsigned char *)e - (const unsigned char *)b));
-}
 
 #define Tcheck(t) do {						\
 		AN((t).b);					\
@@ -1142,6 +1100,18 @@ DO_DEBUG(enum debug_bits x)
 		if (DO_DEBUG(debug_bit))			\
 			VSL(SLT_Debug, (id), __VA_ARGS__);	\
 	} while (0)
+
+static inline void __match_proto__(ws_debug_f)
+debug_ws(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	VSLv(SLT_Debug, 0, fmt, ap);
+	va_end(ap);
+}
+
+#define IF_DEBUG(bit, ptr) (DO_DEBUG(bit) ? (ptr) : NULL)
 
 #define PAN_CheckMagic(vsb, ptr, exp)					\
 	do {								\

--- a/bin/varnishd/cache/cache_busyobj.c
+++ b/bin/varnishd/cache/cache_busyobj.c
@@ -123,7 +123,8 @@ VBO_GetBusyObj(struct worker *wrk, const struct req *req)
 	p = (void*)PRNDUP(p);
 	assert(p < bo->end);
 
-	WS_Init(bo->ws, "bo", p, bo->end - p);
+	WS_Init(bo->ws, "bo", p, bo->end - p,
+	    IF_DEBUG(DBG_WORKSPACE, debug_ws));
 
 	bo->do_stream = 1;
 

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -100,7 +100,8 @@ Req_New(const struct worker *wrk, struct sess *sp)
 
 	assert(p < e);
 
-	WS_Init(req->ws, "req", p, e - p);
+	WS_Init(req->ws, "req", p, e - p,
+	    IF_DEBUG(DBG_WORKSPACE, debug_ws));
 
 	req->req_bodybytes = 0;
 

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -333,7 +333,8 @@ SES_New(struct pool *pp)
 	p = (char*)(sp + 1);
 	p = (void*)PRNDUP(p);
 	assert(p < e);
-	WS_Init(sp->ws, "ses", p, e - p);
+	WS_Init(sp->ws, "ses", p, e - p,
+	    IF_DEBUG(DBG_WORKSPACE, debug_ws));
 
 	sp->t_open = NAN;
 	sp->t_idle = NAN;

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -106,7 +106,8 @@ WRK_Thread(struct pool *qp, size_t stacksize, unsigned thread_workspace)
 	w->lastused = NAN;
 	AZ(pthread_cond_init(&w->cond, NULL));
 
-	WS_Init(w->aws, "wrk", ws, thread_workspace);
+	WS_Init(w->aws, "wrk", ws, thread_workspace,
+	    IF_DEBUG(DBG_WORKSPACE, debug_ws));
 
 	u = getpagesize();
 	AN(u);

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -73,7 +73,8 @@ nobase_pkginclude_HEADERS += \
 	vsha256.h \
 	vtcp.h \
 	vtim.h \
-	vrnd.h
+	vrnd.h \
+	ws.h
 
 # Private headers
 nobase_noinst_HEADERS = \

--- a/include/vdef.h
+++ b/include/vdef.h
@@ -35,6 +35,9 @@
 #ifndef VDEF_H_INCLUDED
 #define VDEF_H_INCLUDED
 
+#include <stdint.h>
+#include "vas.h"
+
 /* Safe printf into a fixed-size buffer */
 #define bprintf(buf, fmt, ...)						\
 	do {								\
@@ -80,6 +83,20 @@
 #define PAOK(p)	    (((uintptr_t)(p) & PALGN) == 0)	/* is aligned */
 #define PRNDDN(p)   ((uintptr_t)(p) & ~PALGN)		/* Round down */
 #define PRNDUP(p)   (((uintptr_t)(p) + PALGN) & ~PALGN)	/* Round up */
+
+/*
+ * A normal pointer difference is signed, but we never want a negative value
+ * so this little tool will make sure we don't get that.
+ */
+
+static inline unsigned
+pdiff(const void *b, const void *e)
+{
+	assert(b <= e);
+	return
+	    ((unsigned)((const unsigned char *)e - (const unsigned char *)b));
+}
+
 
 /*********************************************************************
  * To be used as little as possible to wash off const/volatile etc.

--- a/include/ws.h
+++ b/include/ws.h
@@ -1,0 +1,63 @@
+/*-
+ * Copyright (c) 2006 Verdens Gang AS
+ * Copyright (c) 2006-2015 Varnish Software AS
+ * All rights reserved.
+ *
+ * Author: Poul-Henning Kamp <phk@phk.freebsd.dk>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/*--------------------------------------------------------------------
+ * Workspace structure for quick memory allocation.
+ */
+
+#include "vdef.h"
+
+typedef void ws_debug_f(const char *, ...) __v_printflike(1, 2);
+
+/* TODO make private */
+struct ws {
+	unsigned		magic;
+#define WS_MAGIC		0x35fac554
+	ws_debug_f		*debug_f;
+	char			id[4];		/* identity */
+	char			*s;		/* (S)tart of buffer */
+	char			*f;		/* (F)ree/front pointer */
+	char			*r;		/* (R)eserved length */
+	char			*e;		/* (E)nd of buffer */
+};
+
+void WS_Init(struct ws *ws, const char *id, void *space, unsigned len,
+    ws_debug_f *debug_f);
+unsigned WS_Reserve(struct ws *ws, unsigned bytes);
+void WS_MarkOverflow(struct ws *ws);
+void WS_Release(struct ws *ws, unsigned bytes);
+void WS_ReleaseP(struct ws *ws, char *ptr);
+void WS_Assert(const struct ws *ws);
+void WS_Reset(struct ws *ws, char *p);
+void *WS_Alloc(struct ws *ws, unsigned bytes);
+void *WS_Copy(struct ws *ws, const void *str, int len);
+char *WS_Snapshot(struct ws *ws);
+int WS_Overflowed(const struct ws *ws);
+void *WS_Printf(struct ws *ws, const char *fmt, ...) __v_printflike(2, 3);

--- a/lib/libvarnish/Makefile.am
+++ b/lib/libvarnish/Makefile.am
@@ -33,7 +33,8 @@ libvarnish_la_SOURCES = \
 	vss.c \
 	vsub.c \
 	vtcp.c \
-	vtim.c
+	vtim.c \
+	ws.c
 
 libvarnish_la_CFLAGS = \
 	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \

--- a/lib/libvarnish/ws.c
+++ b/lib/libvarnish/ws.c
@@ -31,15 +31,24 @@
 #include "config.h"
 
 #include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
 
-#include "cache.h"
+#include "ws.h"
+#include "vas.h"
+#include "miniobj.h"
+
+#define DBG(ws, fmt, ...) do {					\
+		if ((ws)->debug_f != NULL)			\
+			(ws)->debug_f((fmt), __VA_ARGS__);	\
+	} while (0);
 
 void
 WS_Assert(const struct ws *ws)
 {
 
 	CHECK_OBJ_NOTNULL(ws, WS_MAGIC);
-	DSL(DBG_WORKSPACE, 0, "WS(%p) = (%s, %p %u %u %u)",
+	DBG(ws, "WS(%p) = (%s, %p %u %u %u)",
 	    ws, ws->id, ws->s, pdiff(ws->s, ws->f),
 	    ws->r == NULL ? 0 : pdiff(ws->f, ws->r),
 	    pdiff(ws->s, ws->e));
@@ -65,11 +74,10 @@ WS_Assert(const struct ws *ws)
  */
 
 void
-WS_Init(struct ws *ws, const char *id, void *space, unsigned len)
+WS_Init(struct ws *ws, const char *id, void *space, unsigned len,
+    ws_debug_f *debug_f)
 {
 
-	DSL(DBG_WORKSPACE, 0,
-	    "WS_Init(%p, \"%s\", %p, %u)", ws, id, space, len);
 	assert(space != NULL);
 	INIT_OBJ(ws, WS_MAGIC);
 	ws->s = space;
@@ -81,6 +89,8 @@ WS_Init(struct ws *ws, const char *id, void *space, unsigned len)
 	assert(id[0] & 0x20);
 	assert(strlen(id) < sizeof ws->id);
 	strcpy(ws->id, id);
+	ws->debug_f = debug_f;
+	DBG(ws, "WS_Init(%p, \"%s\", %p, %u)", ws, id, space, len);
 	WS_Assert(ws);
 }
 
@@ -110,7 +120,7 @@ WS_Reset(struct ws *ws, char *p)
 {
 
 	WS_Assert(ws);
-	DSL(DBG_WORKSPACE, 0, "WS_Reset(%p, %p)", ws, p);
+	DBG(ws, "WS_Reset(%p, %p)", ws, p);
 	assert(ws->r == NULL);
 	if (p == NULL)
 		ws->f = ws->s;
@@ -138,7 +148,7 @@ WS_Alloc(struct ws *ws, unsigned bytes)
 	}
 	r = ws->f;
 	ws->f += bytes;
-	DSL(DBG_WORKSPACE, 0, "WS_Alloc(%p, %u) = %p", ws, bytes, r);
+	DBG(ws, "WS_Alloc(%p, %u) = %p", ws, bytes, r);
 	WS_Assert(ws);
 	return (r);
 }
@@ -164,7 +174,7 @@ WS_Copy(struct ws *ws, const void *str, int len)
 	r = ws->f;
 	ws->f += bytes;
 	memcpy(r, str, len);
-	DSL(DBG_WORKSPACE, 0, "WS_Copy(%p, %d) = %p", ws, len, r);
+	DBG(ws, "WS_Copy(%p, %d) = %p", ws, len, r);
 	WS_Assert(ws);
 	return (r);
 }
@@ -199,7 +209,7 @@ WS_Snapshot(struct ws *ws)
 
 	WS_Assert(ws);
 	assert(ws->r == NULL);
-	DSL(DBG_WORKSPACE, 0, "WS_Snapshot(%p) = %p", ws, ws->f);
+	DBG(ws, "WS_Snapshot(%p) = %p", ws, ws->f);
 	return (ws->f);
 }
 
@@ -220,7 +230,7 @@ WS_Reserve(struct ws *ws, unsigned bytes)
 		return (0);
 	}
 	ws->r = ws->f + b2;
-	DSL(DBG_WORKSPACE, 0, "WS_Reserve(%p, %u/%u) = %u",
+	DBG(ws, "WS_Reserve(%p, %u/%u) = %u",
 	    ws, b2, bytes, pdiff(ws->f, ws->r));
 	WS_Assert(ws);
 	return (pdiff(ws->f, ws->r));
@@ -232,7 +242,7 @@ WS_Release(struct ws *ws, unsigned bytes)
 	WS_Assert(ws);
 	bytes = PRNDUP(bytes);
 	assert(bytes <= ws->e - ws->f);
-	DSL(DBG_WORKSPACE, 0, "WS_Release(%p, %u)", ws, bytes);
+	DBG(ws, "WS_Release(%p, %u)", ws, bytes);
 	assert(ws->r != NULL);
 	assert(ws->f + bytes <= ws->r);
 	ws->f += bytes;
@@ -244,7 +254,7 @@ void
 WS_ReleaseP(struct ws *ws, char *ptr)
 {
 	WS_Assert(ws);
-	DSL(DBG_WORKSPACE, 0, "WS_ReleaseP(%p, %p (%zd))", ws, ptr, ptr - ws->f);
+	DBG(ws, "WS_ReleaseP(%p, %p (%zd))", ws, ptr, ptr - ws->f);
 	assert(ws->r != NULL);
 	assert(ptr >= ws->f);
 	assert(ptr <= ws->r);


### PR DESCRIPTION
Context: #2063 

Checking for possible ways to implement this, I came to the point that any sensible way needs
the ws code outside cache. Reality for most vmods probably is that they rely on the ws functions
anyway, so opening the interface seems the right thing to do.