### PR TITLE
Add a `std.boolean` function

### DIFF
--- a/bin/varnishtest/tests/m00025.vtc
+++ b/bin/varnishtest/tests/m00025.vtc
@@ -1,0 +1,40 @@
+varnishtest "test vmod_std.boolean()"
+
+server s1 {
+    rxreq
+    txresp
+} -start
+
+varnish v1 -vcl+backend {
+    import std;
+
+    sub vcl_deliver {
+        set resp.http.foo = std.boolean(req.http.foo, false);
+    }
+} -start
+
+client c1 {
+    txreq -hdr "Foo: true"
+    rxresp
+    expect resp.http.foo == true
+
+    txreq -hdr "Foo: TRUE"
+    rxresp
+    expect resp.http.foo == true
+
+    txreq -hdr "Foo: false"
+    rxresp
+    expect resp.http.foo == false
+
+    txreq -hdr "Foo: FALSE"
+    rxresp
+    expect resp.http.foo == false
+
+    txreq -hdr "Foo: 0"
+    rxresp
+    expect resp.http.foo == false
+
+    txreq -hdr "Foo: 1"
+    rxresp
+    expect resp.http.foo == true
+} -run

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -139,6 +139,16 @@ Example
 	|	...
 	| }
 
+$Function BOOL boolean(STRING s, BOOL fallback)
+
+Description
+	Converts the string *s* to a boolean. If conversion fails,
+	*fallback* will be returned.
+Example
+	| if (std.boolean(req.http.foo, true)) {
+	|	...
+	| }
+
 $Function IP ip(STRING s, IP fallback)
 
 Description

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -32,6 +32,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -124,6 +125,39 @@ vmod_integer(VRT_CTX, VCL_STRING p, VCL_INT i)
 		return (i);
 
 	return (r);
+}
+
+VCL_BOOL __match_proto__(td_std_boolean)
+vmod_boolean(VRT_CTX, VCL_STRING p, VCL_BOOL b)
+{
+	char *e;
+	long r;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	if (p == NULL)
+		return (b);
+
+	while(isspace(*p))
+		p++;
+
+	if (strcasecmp("false", p) == 0) {
+		return (0);
+	} else if (strcasecmp("true", p) == 0) {
+		return (1);
+	}
+
+	if (*p != '+' && *p != '-' && !isdigit(*p))
+		return (b);
+
+	e = NULL;
+
+	r = strtol(p, &e, 0);
+
+	if (e == NULL || *e != '\0')
+		return (b);
+
+	return (r == 0 ? 0 : 1);
 }
 
 VCL_IP


### PR DESCRIPTION
Adds a `boolean` function to `vmod_std`. This function is quite similar to `std.integer`, but is used for parsing boolean values rather than integers.