### PR TITLE
Add record-prefix to varnishncsa.(%{VSL}x)

### DIFF
--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -131,7 +131,7 @@ struct vsl_watch {
 	VTAILQ_ENTRY(vsl_watch)	list;
 	enum VSL_tag_e		tag;
 	int			idx;
-	char		*prefix;
+	char			*prefix;
 	int			prefixlen;
 	struct fragment		frag;
 };

--- a/doc/sphinx/reference/varnishncsa.rst
+++ b/doc/sphinx/reference/varnishncsa.rst
@@ -172,11 +172,14 @@ Supported formatters are:
   VCL_Log:key
     Output value set by std.log("key:value") in VCL.
 
-  VSL:tag or VSL:tag[field]
-    The value of the VSL entry for the given tag.  If field is specified,
-    only the selected part is shown.  Defaults to '-' when the tag is not
-    seen, or when the field is out of bounds.  If a tag appears several
-    times in a single transaction, only the first occurrence is used.
+  VSL:tag or VSL:tag[field] or VSL:tag:record-prefix or VSL:tag:record-prefix[field]
+    The value of the VSL entry for the given tag.  If record-prefix
+    is specified, limit the matches to those records that has this prefix
+    as it's first part of the record content followed by a colon.
+    If field is specified, only the selected part is shown.
+    Defaults to '-' when the tag is not seen, or when the field
+    is out of bounds.  If a tag appears several times in
+    a single transaction, only the first occurrence is used.
 
 SIGNALS
 =======


### PR DESCRIPTION
Current Version %{VSL}x formatter is only output the Start event in TimeStamp tag. 
Can't get the Resp, Fetch...other event.
This PR supports record-prefix in %{VSL}x formatter.
Can select all event in TimeStamp tag.

Output sample

```
#Raw log
$ sudo /opt/trunk-varnish/bin/varnishlog -graw -itimestamp
     65542 Timestamp      c Start: 1473174473.455523 0.000000 0.000000
     65542 Timestamp      c Req: 1473174473.455523 0.000000 0.000000
     65542 Timestamp      c Fetch: 1473174473.456650 0.001127 0.001127
     65542 Timestamp      c Process: 1473174473.456665 0.001143 0.000015
     65542 Timestamp      c Resp: 1473174473.456773 0.001251 0.000108
     65545 Timestamp      c Start: 1473174507.979415 0.000000 0.000000
     65545 Timestamp      c Req: 1473174507.979415 0.000000 0.000000
     65545 Timestamp      c Process: 1473174507.979477 0.000063 0.000063
     65545 Timestamp      c Resp: 1473174507.979630 0.000215 0.000152

#patched varnishncsa
$ sudo /opt/trunk-varnish/bin/varnishncsa  -F "TimeStamp: %{VSL:TimeStamp}x\nTimpStamp[2]: %{VSL:TimeStamp[2]}x\nTimeStamp:Resp: %{VSL:TimeStamp:resp}x\nTimeStamp:Resp[2]: %{VSL:TimeStamp:resp[2]}x\nTitamp:foo: %{VSL:TimeStamp:foo}x\nvxid: %{Varnish:vxid}x\n------"
TimeStamp: Start: 1473174473.455523 0.000000 0.000000
TimpStamp[2]: 1473174473.455523
TimeStamp:Resp: 1473174473.456773 0.001251 0.000108
TimeStamp:Resp[2]: 0.001251
TimeStamp:foo: -
vxid: 65542
------
TimeStamp: Start: 1473174507.979415 0.000000 0.000000
TimpStamp[2]: 1473174507.979415
TimeStamp:Resp: 1473174507.979630 0.000215 0.000152
TimeStamp:Resp[2]: 0.000215
TimeStamp:foo: -
vxid: 65545
------
```
