### PR TITLE
varnishtest: retire -msg

### DIFF
--- a/bin/varnishtest/tests/a00002.vtc
+++ b/bin/varnishtest/tests/a00002.vtc
@@ -5,7 +5,7 @@ server s1 {
 	expect req.method == PUT
 	expect req.proto == HTTP/1.0
 	expect req.url == "/foo"
-	txresp -proto HTTP/1.2 -status 201 -msg Foo
+	txresp -proto HTTP/1.2 -status 201 -reason Foo
 }
 
 server s1 -start

--- a/bin/varnishtest/tests/a00003.vtc
+++ b/bin/varnishtest/tests/a00003.vtc
@@ -5,7 +5,7 @@ server s1 {
 	expect req.method == PUT
 	expect req.proto == HTTP/1.0
 	expect req.url == "/foo"
-	txresp -proto HTTP/1.2 -status 201 -msg Foo
+	txresp -proto HTTP/1.2 -status 201 -reason Foo
 }
 
 server s2 {

--- a/bin/varnishtest/tests/a00004.vtc
+++ b/bin/varnishtest/tests/a00004.vtc
@@ -5,7 +5,7 @@ server s1 -repeat 2 {
 	expect req.method == PUT
 	expect req.proto == HTTP/1.0
 	expect req.url == "/foo"
-	txresp -proto HTTP/1.2 -status 201 -msg Foo
+	txresp -proto HTTP/1.2 -status 201 -reason Foo
 }
 
 server s1 -start

--- a/bin/varnishtest/tests/a00005.vtc
+++ b/bin/varnishtest/tests/a00005.vtc
@@ -5,7 +5,7 @@ server s1 {
 	expect req.method == PUT
 	expect req.proto == HTTP/1.0
 	expect req.url == "/foo"
-	txresp -proto HTTP/1.2 -status 201 -msg Foo
+	txresp -proto HTTP/1.2 -status 201 -reason Foo
 }
 
 server s2 {

--- a/bin/varnishtest/tests/a00006.vtc
+++ b/bin/varnishtest/tests/a00006.vtc
@@ -5,7 +5,7 @@ server s1 {
 	expect req.method == PUT
 	expect req.proto == HTTP/1.0
 	expect req.url == "/foo"
-	txresp -proto HTTP/1.2 -status 201 -msg Foo \
+	txresp -proto HTTP/1.2 -status 201 -reason Foo \
 		-body "987654321\n"
 }
 

--- a/bin/varnishtest/tests/r00962.vtc
+++ b/bin/varnishtest/tests/r00962.vtc
@@ -38,7 +38,7 @@ varnish v1 -stop
 
 server s1 {
 	rxreq
-	txresp -status 400 -msg "Persistent Object Not Found"
+	txresp -status 400 -reason "Persistent Object Not Found"
 } -start
 
 

--- a/bin/varnishtest/tests/r01485.vtc
+++ b/bin/varnishtest/tests/r01485.vtc
@@ -6,7 +6,7 @@ server s1 {
 
 	rxreq
 	expect req.http.If-None-Match == {"foo"}
-	txresp -status 304 -msg "Not Modified"
+	txresp -status 304 -reason "Not Modified"
 } -start
 
 varnish v1 -vcl+backend {

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -948,9 +948,6 @@ http_tx_parse_args(char * const *av, struct vtclog *vl, struct http *hp,
  *         \-reason STRING (txresp only)
  *                 What message to put in the status line (default: "OK").
  *
- *         \-msg STRING (txresp only)
- *                 An alias to -reason.
- *
  *         These three switches can appear in any order but must come before the
  *         following ones.
  *
@@ -1013,7 +1010,7 @@ cmd_http_txresp(CMD_ARGS)
 		} else if (!strcmp(*av, "-status")) {
 			status = av[1];
 			av++;
-		} else if (!strcmp(*av, "-reason") || !strcmp(*av, "-msg")) {
+		} else if (!strcmp(*av, "-reason")) {
 			reason = av[1];
 			av++;
 			continue;

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -945,8 +945,11 @@ http_tx_parse_args(char * const *av, struct vtclog *vl, struct http *hp,
  *         \-status NUMBER (txresp only)
  *                 What status code to return (default 200).
  *
- *         \-msg STRING (txresp only)
+ *         \-reason STRING (txresp only)
  *                 What message to put in the status line (default: "OK").
+ *
+ *         \-msg STRING (txresp only)
+ *                 An alias to -reason.
  *
  *         These three switches can appear in any order but must come before the
  *         following ones.
@@ -991,7 +994,7 @@ cmd_http_txresp(CMD_ARGS)
 	struct http *hp;
 	const char *proto = "HTTP/1.1";
 	const char *status = "200";
-	const char *msg = "OK";
+	const char *reason = "OK";
 	char* body = NULL;
 
 	(void)cmd;
@@ -1010,15 +1013,15 @@ cmd_http_txresp(CMD_ARGS)
 		} else if (!strcmp(*av, "-status")) {
 			status = av[1];
 			av++;
-		} else if (!strcmp(*av, "-msg")) {
-			msg = av[1];
+		} else if (!strcmp(*av, "-reason") || !strcmp(*av, "-msg")) {
+			reason = av[1];
 			av++;
 			continue;
 		} else
 			break;
 	}
 
-	VSB_printf(hp->vsb, "%s %s %s%s", proto, status, msg, nl);
+	VSB_printf(hp->vsb, "%s %s %s%s", proto, status, reason, nl);
 
 	/* send a "Content-Length: 0" header unless something else happens */
 	REPLACE(body, "");


### PR DESCRIPTION
Split in two commits, to make the first one back-portable.