### PR TITLE
RFC: add va_args interface to varargisch vrt api functions

### DIFF
--- a/include/vrt.h
+++ b/include/vrt.h
@@ -39,6 +39,8 @@
  * binary/load-time compatible, increment MAJOR version
  *
  *
+ * 5.1:
+ *	Added va_list interfaces for varargish vrt functions
  * 5.0:
  *	Varnish 5.0 release "better safe than sorry" bump
  * 4.0:
@@ -59,6 +61,8 @@
 
 #define VRT_MINOR_VERSION	0U
 
+
+#include <stdarg.h>
 
 /***********************************************************************/
 
@@ -290,9 +294,11 @@ void VRT_synth(VRT_CTX, unsigned, const char *);
 
 struct http *VRT_selecthttp(VRT_CTX, enum gethdr_e);
 const char *VRT_GetHdr(VRT_CTX, const struct gethdr_s *);
+void VRT_SetHdrv(VRT_CTX, const struct gethdr_s *, const char *, va_list);
 void VRT_SetHdr(VRT_CTX, const struct gethdr_s *, const char *, ...);
 void VRT_handling(VRT_CTX, unsigned hand);
 
+void VRT_hashdatav(VRT_CTX, const char *str, va_list);
 void VRT_hashdata(VRT_CTX, const char *str, ...);
 
 /* Simple stuff */
@@ -302,6 +308,7 @@ void VRT_memmove(void *dst, const void *src, unsigned len);
 void VRT_Rollback(VRT_CTX, const struct http *);
 
 /* Synthetic pages */
+void VRT_synth_pagev(VRT_CTX, const char *, va_list);
 void VRT_synth_page(VRT_CTX, const char *, ...);
 
 /* Backend related */

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -1198,11 +1198,16 @@ def one_var(nm, spec):
 	else:
 		fo.write('\t    "VRT_l_%s(ctx, ",\n' % cnam)
 		if nm == i[0]:
-			fh.write("void VRT_l_%s(VRT_CTX, " % cnam)
 			if typ != "STRING" and typ != "BODY":
-				fh.write("VCL_" + typ + ");\n")
+				fh.write("void VRT_l_%s(VRT_CTX, VCL_%s);\n" %
+					 (cnam, typ))
 			else:
-				fh.write(ctyp + ", ...);\n")
+				fh.write("void VRT_l_%sv"
+					 "(VRT_CTX, VCL_%s, va_list);\n" %
+					 (cnam, typ))
+				fh.write("void VRT_l_%s"
+					 "(VRT_CTX, VCL_%s, ...);\n" %
+					 (cnam, typ))
 	restrict(fo, spec[3])
 
 	fo.write("\t},\n")


### PR DESCRIPTION
currently, vmods cannot use the varargish VRT functions for own varargs because we do not yet have the `va_list` variants.

RFC, some thoughts about this:
- this would be the first `#include` in `vrt.h`. I understand we want to avoid creating additional dependencies, but we require the C compiler, so can't we also require some basic system includes?
  - if we wanted to avoid this, starting another `vrt_vmod.h` would be an option
- we'd not need to wrap all the `VRT_l_*_*()` functions, we could also export `vrt_do_string`. For now I think that the first option may be POLA  though
  comments?
