### PR TITLE
Add optional storage parameter to cache_req_body.

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -935,7 +935,7 @@ void Req_Fail(struct req *req, enum sess_close reason);
 
 /* cache_req_body.c */
 int VRB_Ignore(struct req *);
-ssize_t VRB_Cache(struct req *, ssize_t maxsize);
+ssize_t VRB_Cache(struct req *, ssize_t maxsize, const char *hint);
 ssize_t VRB_Iterate(struct req *, objiterate_f *func, void *priv);
 void VRB_Free(struct req *);
 

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -45,7 +45,7 @@
  */
 
 static ssize_t
-vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
+vrb_pull(struct req *req, ssize_t maxsize, const char *hint, objiterate_f *func, void *priv)
 {
 	ssize_t l, r = 0, yet;
 	struct vfp_ctx *vfc;
@@ -60,7 +60,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 
 	req->body_oc = HSH_Private(req->wrk);
 	AN(req->body_oc);
-	XXXAN(STV_NewObject(req->wrk, req->body_oc, TRANSIENT_STORAGE, 8));
+	XXXAN(STV_NewObject(req->wrk, req->body_oc, hint, 8));
 
 	vfc->oc = req->body_oc;
 
@@ -197,7 +197,7 @@ VRB_Iterate(struct req *req, objiterate_f *func, void *priv)
 		    "Multiple attempts to access non-cached req.body");
 		return (i);
 	}
-	return (vrb_pull(req, -1, func, priv));
+	return (vrb_pull(req, -1, TRANSIENT_STORAGE, func, priv));
 }
 
 /*----------------------------------------------------------------------
@@ -250,7 +250,7 @@ VRB_Free(struct req *req)
  */
 
 ssize_t
-VRB_Cache(struct req *req, ssize_t maxsize)
+VRB_Cache(struct req *req, ssize_t maxsize, const char *hint)
 {
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
@@ -286,5 +286,5 @@ VRB_Cache(struct req *req, ssize_t maxsize)
 		return (-1);
 	}
 
-	return (vrb_pull(req, maxsize, NULL, NULL));
+	return (vrb_pull(req, maxsize, hint, NULL, NULL));
 }

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -475,7 +475,7 @@ VRT_ban_string(VRT_CTX, const char *str)
 }
 
 VCL_BYTES
-VRT_CacheReqBody(VRT_CTX, VCL_BYTES maxsize)
+VRT_CacheReqBody(VRT_CTX, VCL_BYTES maxsize, VCL_STEVEDORE storage)
 {
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
@@ -485,7 +485,7 @@ VRT_CacheReqBody(VRT_CTX, VCL_BYTES maxsize)
 		    "req.body can only be cached in vcl_recv{}");
 		return (-1);
 	}
-	return (VRB_Cache(ctx->req, maxsize));
+	return (VRB_Cache(ctx->req, maxsize, VRT_STEVEDORE_string(storage)));
 }
 
 /*--------------------------------------------------------------------

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -274,7 +274,7 @@ int VRT_acl_match(VRT_CTX, VCL_ACL, VCL_IP);
 
 /* req related */
 
-VCL_BYTES VRT_CacheReqBody(VRT_CTX, VCL_BYTES maxsize);
+VCL_BYTES VRT_CacheReqBody(VRT_CTX, VCL_BYTES maxsize, VCL_STEVEDORE storage);
 
 /* Regexp related */
 void VRT_re_init(void **, const char *);

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -68,6 +68,7 @@ ctypes = {
 	'PRIV_TOP':	"struct vmod_priv *",
 	'PROBE':	"VCL_PROBE",
 	'REAL':		"VCL_REAL",
+	'STEVEDORE':	"VCL_STEVEDORE",
 	'STRING':	"VCL_STRING",
 	'STRING_LIST':	"const char *, ...",
 	'TIME':		"VCL_TIME",

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -226,11 +226,12 @@ Description
 Example
 	set req.url = std.querysort(req.url);
 
-$Function BOOL cache_req_body(BYTES size)
+$Function BOOL cache_req_body(BYTES size, STEVEDORE storage=VRT_stevedore("Transient"))
 
 Description
 	Caches the request body if it is smaller than *size*.  Returns
 	`true` if the body was cached, `false` otherwise.
+	An optional parameter can be used to change the storage.
 
 	Normally the request body is not available after sending it to
 	the backend.  By caching it is possible to retry pass operations,

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -230,12 +230,12 @@ vmod_timestamp(VRT_CTX, VCL_STRING label)
 }
 
 VCL_BOOL __match_proto__(td_std_cache_req_body)
-vmod_cache_req_body(VRT_CTX, VCL_BYTES size)
+vmod_cache_req_body(VRT_CTX, VCL_BYTES size, VCL_STEVEDORE storage)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (size < 0)
 		size = 0;
-	if (VRT_CacheReqBody(ctx, (size_t)size) < 0)
+	if (VRT_CacheReqBody(ctx, (size_t)size, storage) < 0)
 		return (0);
 	return (1);
 }


### PR DESCRIPTION
Cache big req body should not eat the Transient storage.
The use case is to store the body on a dedicated sfile when CL is big.

This PR add an optional VCL_STEVEDORE  parameter to cache_req_body.

Related to: https://github.com/varnishcache/varnish-cache/pull/1914
