### PR TITLE
Killing the child proces properly

### DIFF
--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -88,6 +88,7 @@ enum jail_master_e {
 	JAIL_MASTER_FILE,
 	JAIL_MASTER_STORAGE,
 	JAIL_MASTER_PRIVPORT,
+	JAIL_MASTER_KILL,
 };
 
 typedef int jail_init_f(char **);

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -455,10 +455,17 @@ mgt_launch_child(struct cli *cli)
 
 static int
 kill_child(void) {
+	int i, error;
+
+	VJ_master(JAIL_MASTER_KILL);
 	if (MGT_FEATURE(FEATURE_NO_COREDUMP))
-		return (kill(child_pid, SIGKILL));
+		i = kill(child_pid, SIGKILL);
 	else
-		return (kill(child_pid, SIGQUIT));
+		i = kill(child_pid, SIGQUIT);
+	error = errno;
+	VJ_master(JAIL_MASTER_LOW);
+	errno = error;
+	return (i);
 }
 
 static void

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -603,7 +603,7 @@ MGT_Child_Cli_Fail(void)
 		return;
 	if (kill_child() == 0)
 		MGT_complain(C_ERR, "Child (%jd) not responding to CLI,"
-		    " killing it.", (intmax_t)child_pid);
+		    " killed it.", (intmax_t)child_pid);
 	else
 		MGT_complain(C_ERR, "Failed to kill child with PID %jd: %s",
 		    (intmax_t)child_pid, strerror(errno));


### PR DESCRIPTION
When debugging #2010 we came to the conclusion that the mgt proces did not have rights to kill the child. The first patch, "Add error checking to confirm bug", was made, and the conclusion was confirmed by @thlc. The next two commits should fix the problem, but I need @nigoroll to look at the case for Sun OS derivates, and I welcome comments, as always.