### PR TITLE
Add req.storage_hint

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -566,6 +566,7 @@ struct req {
 
 	ssize_t			req_bodybytes;	/* Parsed req bodybytes */
 
+	const char		*storage_hint;
 	const struct director	*director_hint;
 	struct vcl		*vcl;
 

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -51,6 +51,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	struct vfp_ctx *vfc;
 	uint8_t *ptr;
 	enum vfp_status vfps = VFP_ERROR;
+	const char *storage_hint;
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 
@@ -60,7 +61,15 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 
 	req->body_oc = HSH_Private(req->wrk);
 	AN(req->body_oc);
-	XXXAN(STV_NewObject(req->wrk, req->body_oc, TRANSIENT_STORAGE, 8));
+
+	if (req->storage_hint == NULL || req->storage_hint[0] == '\0')
+		storage_hint = TRANSIENT_STORAGE;
+	else
+		storage_hint = req->storage_hint;
+
+	req->storage_hint = NULL;
+
+	XXXAN(STV_NewObject(req->wrk, req->body_oc, storage_hint, 8));
 
 	vfc->oc = req->body_oc;
 

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -320,6 +320,36 @@ VRT_r_beresp_backend_ip(VRT_CTX)
 /*--------------------------------------------------------------------*/
 
 const char *
+VRT_r_req_storage_hint(VRT_CTX)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+	if (ctx->req->storage_hint != NULL)
+		return (ctx->req->storage_hint);
+	else
+		return (NULL);
+}
+
+void
+VRT_l_req_storage_hint(VRT_CTX, const char *str, ...)
+{
+	va_list ap;
+	const char *b;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+	va_start(ap, str);
+	b = VRT_String(ctx->req->ws, NULL, str, ap);	// XXX: ctx->ws ?
+	va_end(ap);
+	if (b == NULL) {
+		VSLb(ctx->vsl, SLT_LostHeader, "storage_hint");
+		WS_MarkOverflow(ctx->req->ws);
+		return;
+	}
+	ctx->req->storage_hint = b;
+}
+
+const char *
 VRT_r_beresp_storage_hint(VRT_CTX)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);

--- a/bin/varnishtest/tests/r01914.vtc
+++ b/bin/varnishtest/tests/r01914.vtc
@@ -1,0 +1,44 @@
+varnishtest "Set the storage backend for the request body"
+
+server s1 {
+	rxreq
+	expect req.bodylen == 100
+	txresp
+	rxreq
+	expect req.bodylen == 100
+	txresp
+} -start
+
+varnish v1 -arg "-s malloc,1MB" -arg "-s malloc,1MB" -vcl+backend {
+	import std;
+	sub vcl_recv {
+		if (req.url == "/1") {
+			set req.storage_hint = "s1";
+		}
+		std.cache_req_body(1KB);
+	}
+	sub vcl_backend_fetch {
+		return (fetch);
+	}
+	sub vcl_backend_response {
+		set beresp.storage_hint = "s0";
+	}
+} -start
+
+client c1 {
+	txreq -url /0 -bodylen 100
+	rxresp
+} -run
+
+varnish v1 -expect SMA.s0.c_bytes > 0
+varnish v1 -expect SMA.s1.c_bytes == 0
+varnish v1 -expect SMA.Transient.c_bytes > 0
+
+client c1 {
+	txreq -url /1 -bodylen 100
+	rxresp
+} -run
+
+varnish v1 -expect SMA.s0.c_bytes > 0
+varnish v1 -expect SMA.s1.c_bytes > 0
+varnish v1 -expect SMA.Transient.c_bytes > 0

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -306,6 +306,14 @@ sp_variables = [
 		or backend, respectively.
 		"""
 	),
+	('req.storage_hint',
+		'STRING',
+		('recv', ),
+		('recv', ), """
+		Hint to Varnish that you want to save the request body
+		to a particular storage backend.
+		"""
+	),
 	('req.hash_ignore_busy',
 		'BOOL',
 		('recv',),


### PR DESCRIPTION
This hints Varnish which storage backend it should use when dealing with the request body (if any).

Supersedes to #2108. Fixes #1914.