### PR TITLE
Add beresp.storage

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -507,6 +507,7 @@ struct busyobj {
 	struct acct_bereq	acct;
 
 	const char		*storage_hint;
+	const struct stevedore	*storage;
 	const struct director	*director_req;
 	const struct director	*director_resp;
 	enum director_state_e	director_state;
@@ -1083,7 +1084,7 @@ void RFC2616_Vary_AE(struct http *hp);
 
 /* stevedore.c */
 int STV_NewObject(struct worker *, struct objcore *,
-    const char *hint, unsigned len);
+    const struct stevedore *, unsigned len);
 
 /*
  * A normal pointer difference is signed, but we never want a negative value

--- a/bin/varnishd/cache/cache_priv.h
+++ b/bin/varnishd/cache/cache_priv.h
@@ -127,6 +127,8 @@ void V1P_Init(void);
 /* stevedore.c */
 void STV_open(void);
 void STV_close(void);
+const struct stevedore *STV_find(const char *);
+const struct stevedore *STV_next(void);
 int STV_BanInfoDrop(const uint8_t *ban, unsigned len);
 int STV_BanInfoNew(const uint8_t *ban, unsigned len);
 void STV_BanExport(const uint8_t *banlist, unsigned len);

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -36,6 +36,7 @@
 #include "cache_filter.h"
 #include "vtim.h"
 #include "hash/hash_slinger.h"
+#include "storage/storage.h"
 
 /*----------------------------------------------------------------------
  * Pull the req.body in via/into a objcore
@@ -60,7 +61,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 
 	req->body_oc = HSH_Private(req->wrk);
 	AN(req->body_oc);
-	XXXAN(STV_NewObject(req->wrk, req->body_oc, TRANSIENT_STORAGE, 8));
+	XXXAN(STV_NewObject(req->wrk, req->body_oc, stv_transient, 8));
 
 	vfc->oc = req->body_oc;
 

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -44,6 +44,7 @@
 #include "cache_transport.h"
 
 #include "hash/hash_slinger.h"
+#include "storage/storage.h"
 #include "vcl.h"
 #include "vsha256.h"
 #include "vtim.h"
@@ -194,7 +195,7 @@ cnt_synth(struct worker *wrk, struct req *req)
 	req->objcore = HSH_Private(wrk);
 	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
 	szl = -1;
-	if (STV_NewObject(wrk, req->objcore, TRANSIENT_STORAGE, 1024)) {
+	if (STV_NewObject(wrk, req->objcore, stv_transient, 1024)) {
 		szl = VSB_len(synth_body);
 		assert(szl >= 0);
 		sz = szl;

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -333,6 +333,7 @@ VRT_r_beresp_storage_hint(VRT_CTX)
 void
 VRT_l_beresp_storage_hint(VRT_CTX, const char *str, ...)
 {
+	const struct stevedore *stv;
 	va_list ap;
 	const char *b;
 
@@ -347,6 +348,27 @@ VRT_l_beresp_storage_hint(VRT_CTX, const char *str, ...)
 		return;
 	}
 	ctx->bo->storage_hint = b;
+	stv = STV_find(b);
+	if (stv != NULL)
+		ctx->bo->storage = stv;
+}
+
+/*--------------------------------------------------------------------*/
+
+VCL_STEVEDORE
+VRT_r_beresp_storage(VRT_CTX)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+	return (ctx->bo->storage);
+}
+
+void
+VRT_l_beresp_storage(VRT_CTX, VCL_STEVEDORE stv)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+	ctx->bo->storage = stv;
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishtest/tests/c00044.vtc
+++ b/bin/varnishtest/tests/c00044.vtc
@@ -24,7 +24,6 @@ varnish v1 \
 	-vcl+backend {
 	sub vcl_backend_response {
 		set beresp.do_stream = false;
-		set beresp.storage_hint = "invalid";
 		# Unset Date header to not change the object sizes
 		unset beresp.http.Date;
 	}

--- a/bin/varnishtest/tests/c00045.vtc
+++ b/bin/varnishtest/tests/c00045.vtc
@@ -1,4 +1,4 @@
-varnishtest	"Object/LRU/Stevedores with hinting"
+varnishtest	"Object/LRU/Stevedores with storage set"
 
 server s1 {
 	rxreq
@@ -16,7 +16,7 @@ varnish v1 \
 	-vcl+backend {
 	sub vcl_backend_response {
 		set beresp.do_stream = false;
-		set beresp.storage_hint = "s0";
+		set beresp.storage = storage.s0;
 		# Unset Date header to not change the object sizes
 		unset beresp.http.Date;
 	}

--- a/bin/varnishtest/tests/c00046.vtc
+++ b/bin/varnishtest/tests/c00046.vtc
@@ -1,4 +1,4 @@
-varnishtest	"Object/LRU/Stevedores with hinting and body alloc failures"
+varnishtest	"Object/LRU/Stevedores with storage set and body alloc failures"
 
 server s1 {
 	rxreq
@@ -11,7 +11,7 @@ varnish v1 \
 	-arg "-smalloc,1m" \
 	-vcl+backend {
 	sub vcl_backend_response {
-		set beresp.storage_hint = "s0";
+		set beresp.storage = storage.s0;
 	}
 } -start
 

--- a/bin/varnishtest/tests/c00078.vtc
+++ b/bin/varnishtest/tests/c00078.vtc
@@ -1,0 +1,42 @@
+varnishtest "Stevedores RR, beresp.storage and beresp.storage_hint"
+
+server s1 -repeat 6 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-smalloc,1m" -arg "-smalloc,1m" \
+    -arg "-smalloc,1m" -vcl+backend {
+	import debug;
+	sub vcl_backend_response {
+		if (bereq.url == "/1") {
+			set beresp.storage_hint = "invalid";
+		} else if (bereq.url == "/2") {
+			set beresp.storage_hint = "s1";
+		} else if (bereq.url == "/6") {
+			set beresp.storage = debug.no_stevedore();
+		}
+		set beresp.http.storage = beresp.storage;
+	}
+} -start
+
+client c1 {
+	txreq -url /1
+	rxresp
+	expect resp.http.storage == "storage.s1"
+	txreq -url /2
+	rxresp
+	expect resp.http.storage == "storage.s1"
+	txreq -url /3
+	rxresp
+	expect resp.http.storage == "storage.s0"
+	txreq -url /4
+	rxresp
+	expect resp.http.storage == "storage.s1"
+	txreq -url /5
+	rxresp
+	expect resp.http.storage == "storage.s2"
+	txreq -url /6
+	rxresp
+	expect resp.http.storage == <undef>
+} -run

--- a/bin/varnishtest/tests/p00008.vtc
+++ b/bin/varnishtest/tests/p00008.vtc
@@ -20,9 +20,9 @@ varnish v1 \
 	-arg "-sper2=deprecated_persistent,${tmpdir}/_.per2,10m" \
 	-vcl+backend {
 		sub vcl_backend_response {
-			set beresp.storage_hint = "per1";
+			set beresp.storage = storage.per1;
 			if (bereq.url ~ "silo2") {
-				set beresp.storage_hint = "per2";
+				set beresp.storage = storage.per2;
 			}
 		}
 	} -start

--- a/bin/varnishtest/tests/r00962.vtc
+++ b/bin/varnishtest/tests/r00962.vtc
@@ -16,7 +16,7 @@ varnish v1 \
 	-arg "-sdeprecated_persistent,${tmpdir}/_.per2,10m" \
 	-vcl+backend {
 	sub vcl_backend_response {
-		set beresp.storage_hint = "s0";
+		set beresp.storage = storage.s0;
 	}
 } -start
 

--- a/bin/varnishtest/tests/r01175.vtc
+++ b/bin/varnishtest/tests/r01175.vtc
@@ -7,7 +7,7 @@ server s1 {
 
 varnish v1 -arg "-s test=malloc,1M" -vcl+backend {
 	sub vcl_backend_response {
-		set beresp.storage_hint = "test";
+		set beresp.storage = storage.test;
 		set beresp.do_stream = false;
 	}
 } -start

--- a/bin/varnishtest/tests/r01284.vtc
+++ b/bin/varnishtest/tests/r01284.vtc
@@ -15,7 +15,7 @@ varnish v1 \
 	-vcl+backend {
 	sub vcl_backend_response {
 		set beresp.do_stream = false;
-		set beresp.storage_hint = "Transient";
+		set beresp.storage = storage.Transient;
 		# Unset Date header to not change the object sizes
 		unset beresp.http.Date;
 	}

--- a/bin/varnishtest/tests/v00020.vtc
+++ b/bin/varnishtest/tests/v00020.vtc
@@ -300,3 +300,11 @@ varnish v1 -errvcl {INT * BLOB not possible.} {
 		set resp.status = 100 * debug.str2blob("a");
 	}
 }
+
+# XXX: should spot nonexistent storage
+varnish v1 -errvcl {Symbol not found: 'storage.foo' (expected type STEVEDORE):} {
+	backend b { .host = "127.0.0.1"; }
+	sub vcl_backend_response {
+		set beresp.storage = storage.foo;
+	}
+}

--- a/bin/varnishtest/tests/v00025.vtc
+++ b/bin/varnishtest/tests/v00025.vtc
@@ -42,6 +42,7 @@ varnish v1 -arg "-i J.F.Nobody" -vcl+backend {
 		set beresp.http.bereq_backend = bereq.backend;
 		set beresp.http.beresp_backend = beresp.backend;
 		set beresp.http.keep = beresp.keep;
+		set beresp.http.stv = beresp.storage;
 		set beresp.http.hint = beresp.storage_hint;
 		set beresp.http.be_ip = beresp.backend.ip;
 		set beresp.http.be_nm = beresp.backend.name;

--- a/bin/varnishtest/tests/v00033.vtc
+++ b/bin/varnishtest/tests/v00033.vtc
@@ -15,7 +15,7 @@ varnish v1 -vcl+backend {
 		    storage.Transient.used_space +
 		    1 B + 1 KB + 1 MB + 1GB + 1TB;
 		if (bereq.url == "/foo") {
-			set beresp.storage_hint = "Transient";
+			set beresp.storage = storage.Transient;
 		}
 	}
 	sub vcl_deliver {

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -620,12 +620,20 @@ sp_variables = [
 		IP of the backend this response was fetched from.
 		"""
 	),
+	('beresp.storage',
+		'STEVEDORE',
+		('backend_response', 'backend_error'),
+		('backend_response', 'backend_error'), """
+		The storage backend to use to save this object.
+		"""
+	),
 	('beresp.storage_hint',
 		'STRING',
 		('backend_response', 'backend_error'),
 		('backend_response', 'backend_error'), """
-		Hint to Varnish that you want to save this object to a
-		particular storage backend.
+		Deprecated. Hint to Varnish that you want to
+		save this object to a particular storage backend.
+		Use beresp.storage instead.
 		"""
 	),
 	('obj.proto',


### PR DESCRIPTION
This supersedes beresp.storage_hint but is kept around for backward
compatibility until the next major release.