### PR TITLE
Add req.storage

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -566,6 +566,7 @@ struct req {
 	double			d_ttl;
 
 	ssize_t			req_bodybytes;	/* Parsed req bodybytes */
+	const struct stevedore	*storage;
 
 	const struct director	*director_hint;
 	struct vcl		*vcl;

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -52,6 +52,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	struct vfp_ctx *vfc;
 	uint8_t *ptr;
 	enum vfp_status vfps = VFP_ERROR;
+	const struct stevedore *stv;
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 
@@ -61,7 +62,15 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 
 	req->body_oc = HSH_Private(req->wrk);
 	AN(req->body_oc);
-	XXXAN(STV_NewObject(req->wrk, req->body_oc, stv_transient, 8));
+
+	if (req->storage != NULL)
+		stv = req->storage;
+	else
+		stv = stv_transient;
+
+	req->storage = NULL;
+
+	XXXAN(STV_NewObject(req->wrk, req->body_oc, stv, 8));
 
 	vfc->oc = req->body_oc;
 

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -673,6 +673,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 	req->hash_always_miss = 0;
 	req->hash_ignore_busy = 0;
 	req->client_identity = NULL;
+	req->storage = NULL;
 
 	http_CollectHdr(req->http, H_Cache_Control);
 

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -356,6 +356,24 @@ VRT_l_beresp_storage_hint(VRT_CTX, const char *str, ...)
 /*--------------------------------------------------------------------*/
 
 VCL_STEVEDORE
+VRT_r_req_storage(VRT_CTX)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+	return (ctx->req->storage);
+}
+
+void
+VRT_l_req_storage(VRT_CTX, VCL_STEVEDORE stv)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+	ctx->req->storage = stv;
+}
+
+/*--------------------------------------------------------------------*/
+
+VCL_STEVEDORE
 VRT_r_beresp_storage(VRT_CTX)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);

--- a/bin/varnishtest/tests/r01914.vtc
+++ b/bin/varnishtest/tests/r01914.vtc
@@ -1,0 +1,44 @@
+varnishtest "Set the storage backend for the request body"
+
+server s1 {
+	rxreq
+	expect req.bodylen == 100
+	txresp
+	rxreq
+	expect req.bodylen == 100
+	txresp
+} -start
+
+varnish v1 -arg "-s malloc,1MB" -arg "-s malloc,1MB" -vcl+backend {
+	import std;
+	sub vcl_recv {
+		if (req.url == "/1") {
+			set req.storage = storage.s1;
+		}
+		std.cache_req_body(1KB);
+	}
+	sub vcl_backend_fetch {
+		return (fetch);
+	}
+	sub vcl_backend_response {
+		set beresp.storage = storage.s0;
+	}
+} -start
+
+client c1 {
+	txreq -url /0 -bodylen 100
+	rxresp
+} -run
+
+varnish v1 -expect SMA.s0.c_bytes > 0
+varnish v1 -expect SMA.s1.c_bytes == 0
+varnish v1 -expect SMA.Transient.c_bytes > 0
+
+client c1 {
+	txreq -url /1 -bodylen 100
+	rxresp
+} -run
+
+varnish v1 -expect SMA.s0.c_bytes > 0
+varnish v1 -expect SMA.s1.c_bytes > 0
+varnish v1 -expect SMA.Transient.c_bytes > 0

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -257,6 +257,13 @@ sp_variables = [
 		A count of how many times this request has been restarted.
 		"""
 	),
+	('req.storage',
+		'STEVEDORE',
+		('recv',),
+		('recv',), """
+		The storage backend to use to save this request body.
+		"""
+	),
 	('req.esi_level',
 		'INT',
 		('client',),


### PR DESCRIPTION
This tells Varnish which storage backend it should use when dealing with
the request body (if any).

Fixes #1914.