### PR TITLE
Master r01874

### DIFF
--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -39,6 +39,8 @@
 #include <stdlib.h>
 #include <signal.h>
 
+#include "vtim.h"
+
 #include "cache.h"
 #include "cache_transport.h"
 
@@ -629,6 +631,8 @@ pan_ic(const char *func, const char *file, int line, const char *cond,
 	VSB_printf(pan_vsb, "version = %s\n", VCS_version);
 	VSB_printf(pan_vsb, "ident = %s,%s\n",
 	    VSB_data(vident) + 1, Waiter_GetName());
+	VSB_printf(pan_vsb, "now = %f (mono), %f (real)\n",
+	    VTIM_mono(), VTIM_real());
 
 	pan_backtrace(pan_vsb);
 

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -518,11 +518,15 @@ SES_Delete(struct sess *sp, enum sess_close reason, double now)
 	if (isnan(now))
 		now = VTIM_real();
 	AZ(isnan(sp->t_open));
+	if (now < sp->t_open) {
+		if (now + cache_param->clock_step < sp->t_open)
+			WRONG("Clock step detected");
+		now = sp->t_open; /* Do not log negatives */
+	}
 
 	if (reason == SC_NULL)
 		reason = (enum sess_close)-sp->fd;
 
-	assert(now >= sp->t_open);
 	assert(VTAILQ_EMPTY(&sp->privs->privs));
 	VSL(SLT_SessClose, sp->vxid, "%s %.3f",
 	    sess_close_2str(reason, 0), now - sp->t_open);

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -307,6 +307,21 @@ PARAM(
 )
 
 PARAM(
+	/* name */	clock_step,
+	/* typ */	timeout,
+	/* min */	"0.000",
+	/* max */	NULL,
+	/* default */	"1.000",
+	/* units */	"seconds",
+	/* flags */	0,
+	/* s-text */
+	"How much observed clock step we are willing to accept before "
+	"we panic.",
+	/* l-text */	"",
+	/* func */	NULL
+)
+
+PARAM(
 	/* name */	connect_timeout,
 	/* typ */	timeout,
 	/* min */	"0.000",


### PR DESCRIPTION
This pull request adds a runtime parameter to control how much clock step we tolerate before panicking. Also changes the session timestamps checks to take this into account.

Ref: #1874 
