### PR TITLE
WIP mcf auto-limiting by min/max

### DIFF
--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -443,12 +443,12 @@ init_params(struct cli *cli)
 #endif
 
 	low = sysconf(_SC_THREAD_STACK_MIN);
-	MCF_ParamConf(MCF_MINIMUM, "thread_pool_stack", "%jd", (intmax_t)low);
+	MCF_ParamConf(MCF_MINIMUM, "thread_pool_stack", "%jdb", (intmax_t)low);
 
 	def = 48 * 1024;
 	if (def < low)
 		def = low;
-	MCF_ParamConf(MCF_DEFAULT, "thread_pool_stack", "%jd", (intmax_t)def);
+	MCF_ParamConf(MCF_DEFAULT, "thread_pool_stack", "%jdb", (intmax_t)def);
 
 	MCF_ParamConf(MCF_MAXIMUM, "thread_pools", "%d", MAX_THREAD_POOLS);
 

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -231,7 +231,7 @@ mcf_param_show(struct cli *cli, const char * const *av, void *priv)
 {
 	int n;
 	struct plist *pl;
-	const struct parspec *pp;
+	struct parspec *pp;
 	int lfmt = 0, chg = 0;
 	struct vsb *vsb;
 
@@ -343,7 +343,7 @@ MCF_ParamProtect(struct cli *cli, const char *args)
 void
 MCF_ParamSet(struct cli *cli, const char *param, const char *val)
 {
-	const struct parspec *pp;
+	struct parspec *pp;
 
 	pp = mcf_findpar(param);
 	if (pp == NULL) {
@@ -527,7 +527,7 @@ void
 MCF_DumpRstParam(void)
 {
 	struct plist *pl;
-	const struct parspec *pp;
+	struct parspec *pp;
 	const char *p, *q, *t1, *t2;
 	int j;
 

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -535,8 +535,10 @@ mcf_limit(struct parspec *pp, struct vsb *vsb) {
 		return;
 
 	AN(why);
+#if 0
 	printf("%s %s too %s - limiting to %s\n", pp->name,
 	    VSB_data(vsb), why, lim);
+#endif
 	err = pp->func(vsb2, pp, lim);
 	assert(err == TWOK);
 

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -417,7 +417,7 @@ static void
 mcf_wash_param(struct cli *cli, const struct parspec *pp, const char **val,
     const char *name, struct vsb *vsb)
 {
-	int err;
+	enum tweak_r_e err;
 
 	AN(*val);
 	VSB_clear(vsb);
@@ -425,14 +425,14 @@ mcf_wash_param(struct cli *cli, const struct parspec *pp, const char **val,
 	    name, pp->name, *val);
 	err = pp->func(vsb, pp, *val);
 	AZ(VSB_finish(vsb));
-	if (err) {
+	if (err != TWOK) {
 		VCLI_Out(cli, "%s\n", VSB_data(vsb));
 		VCLI_SetResult(cli, CLIS_CANT);
 		return;
 	}
 	VSB_clear(vsb);
 	err = pp->func(vsb, pp, NULL);
-	AZ(err);
+	assert(err == TWOK);
 	AZ(VSB_finish(vsb));
 	if (strcmp(*val, VSB_data(vsb))) {
 		*val = strdup(VSB_data(vsb));

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -56,6 +56,7 @@ struct parspec {
 #define PROTECTED	(1<<5)
 #define OBJ_STICKY	(1<<6)
 #define ONLY_ROOT	(1<<7)
+#define _LIMITING	(1<<8)
 	const char	*def;
 	const char	*units;
 };

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -30,7 +30,15 @@
 
 struct parspec;
 
-typedef int tweak_t(struct vsb *, const struct parspec *, const char *arg);
+enum tweak_r_e __match_proto__(tweak_t) {
+	TWOK		= 0,
+	TWEFMT		= -1,
+	TWESMALL	= -2,
+	TWEBIG		= -3
+};
+
+typedef enum tweak_r_e tweak_t(struct vsb *, const struct parspec *,
+    const char *arg);
 
 struct parspec {
 	const char	*name;
@@ -64,7 +72,7 @@ tweak_t tweak_waiter;
 tweak_t tweak_vsl_buffer;
 tweak_t tweak_vsl_reclen;
 
-int tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest,
+enum tweak_r_e tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest,
     const char *arg, const char *min, const char *max);
 
 extern struct parspec mgt_parspec[]; /* mgt_param_tbl.c */

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -37,7 +37,7 @@ enum tweak_r_e __match_proto__(tweak_t) {
 	TWEBIG		= -3
 };
 
-typedef enum tweak_r_e tweak_t(struct vsb *, const struct parspec *,
+typedef enum tweak_r_e tweak_t(struct vsb *, struct parspec *,
     const char *arg);
 
 struct parspec {

--- a/bin/varnishd/mgt/mgt_param_bits.c
+++ b/bin/varnishd/mgt/mgt_param_bits.c
@@ -116,7 +116,7 @@ static const char * const VSL_tags[256] = {
 };
 
 static int
-tweak_vsl_mask(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_vsl_mask(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	unsigned j;
 	const char *s;
@@ -161,7 +161,7 @@ static const char * const debug_tags[] = {
 };
 
 static int
-tweak_debug(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_debug(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	const char *s;
 	unsigned j;
@@ -201,7 +201,7 @@ static const char * const feature_tags[] = {
 };
 
 static int
-tweak_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_feature(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	const char *s;
 	unsigned j;

--- a/bin/varnishd/mgt/mgt_param_bits.c
+++ b/bin/varnishd/mgt/mgt_param_bits.c
@@ -62,7 +62,7 @@ bit(uint8_t *p, unsigned no, enum bit_do act)
 /*--------------------------------------------------------------------
  */
 
-static int
+static enum tweak_r_e __match_proto__(tweak_t)
 bit_tweak(struct vsb *vsb, uint8_t *p, unsigned l, const char *arg,
     const char * const *tags, const char *desc, const char *sign)
 {
@@ -75,14 +75,14 @@ bit_tweak(struct vsb *vsb, uint8_t *p, unsigned l, const char *arg,
 	if (av[0] != NULL) {
 		VSB_printf(vsb, "Cannot parse: %s\n", av[0]);
 		VAV_Free(av);
-		return (-1);
+		return (TWEFMT);
 	}
 	for (i = 1; av[i] != NULL; i++) {
 		s = av[i];
 		if (*s != '-' && *s != '+') {
 			VSB_printf(vsb, "Missing '+' or '-' (%s)\n", s);
 			VAV_Free(av);
-			return (-1);
+			return (TWEFMT);
 		}
 		for (j = 0; j < l; j++) {
 			if (tags[j] != NULL && !strcasecmp(s + 1, tags[j]))
@@ -91,7 +91,7 @@ bit_tweak(struct vsb *vsb, uint8_t *p, unsigned l, const char *arg,
 		if (tags[j] == NULL) {
 			VSB_printf(vsb, "Unknown %s (%s)\n", desc, s);
 			VAV_Free(av);
-			return (-1);
+			return (TWEFMT);
 		}
 		assert(j < l);
 		if (s[0] == *sign)
@@ -100,7 +100,7 @@ bit_tweak(struct vsb *vsb, uint8_t *p, unsigned l, const char *arg,
 			(void)bit(p, j, BCLR);
 	}
 	VAV_Free(av);
-	return (0);
+	return (TWOK);
 }
 
 
@@ -146,7 +146,7 @@ tweak_vsl_mask(struct vsb *vsb, const struct parspec *par, const char *arg)
 		if (*s == '\0')
 			VSB_printf(vsb, "(all enabled)");
 	}
-	return (0);
+	return (TWOK);
 }
 
 /*--------------------------------------------------------------------
@@ -186,7 +186,7 @@ tweak_debug(struct vsb *vsb, const struct parspec *par, const char *arg)
 		if (*s == '\0')
 			VSB_printf(vsb, "none");
 	}
-	return (0);
+	return (TWOK);
 }
 
 /*--------------------------------------------------------------------
@@ -227,7 +227,7 @@ tweak_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
 		if (*s == '\0')
 			VSB_printf(vsb, "none");
 	}
-	return (0);
+	return (TWOK);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -95,7 +95,7 @@ tweak_generic_double(struct vsb *vsb, volatile double *dest,
 /*--------------------------------------------------------------------*/
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_timeout(struct vsb *vsb, const struct parspec *par,
+tweak_timeout(struct vsb *vsb, struct parspec *par,
     const char *arg)
 {
 	volatile double *dest;
@@ -108,7 +108,7 @@ tweak_timeout(struct vsb *vsb, const struct parspec *par,
 /*--------------------------------------------------------------------*/
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_double(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_double(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	volatile double *dest;
 
@@ -120,7 +120,7 @@ tweak_double(struct vsb *vsb, const struct parspec *par, const char *arg)
 /*--------------------------------------------------------------------*/
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_bool(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_bool(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	volatile unsigned *dest;
 
@@ -208,7 +208,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 /*--------------------------------------------------------------------*/
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_uint(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_uint(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	volatile unsigned *dest;
 
@@ -296,7 +296,7 @@ tweak_generic_bytes(struct vsb *vsb, volatile ssize_t *dest, const char *arg,
 /*--------------------------------------------------------------------*/
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_bytes(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_bytes(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	volatile ssize_t *dest;
 
@@ -307,7 +307,7 @@ tweak_bytes(struct vsb *vsb, const struct parspec *par, const char *arg)
 /*--------------------------------------------------------------------*/
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_bytes_u(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_bytes_u(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	volatile unsigned *d1;
 	volatile ssize_t dest;
@@ -326,7 +326,7 @@ tweak_bytes_u(struct vsb *vsb, const struct parspec *par, const char *arg)
  */
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_vsl_buffer(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_vsl_buffer(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	volatile unsigned *d1;
 	volatile ssize_t dest;
@@ -344,7 +344,7 @@ tweak_vsl_buffer(struct vsb *vsb, const struct parspec *par, const char *arg)
 }
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_vsl_reclen(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_vsl_reclen(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	volatile unsigned *d1;
 	volatile ssize_t dest;
@@ -363,7 +363,7 @@ tweak_vsl_reclen(struct vsb *vsb, const struct parspec *par, const char *arg)
 /*--------------------------------------------------------------------*/
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_string(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_string(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	char **p = TRUST_ME(par->priv);
 
@@ -380,7 +380,7 @@ tweak_string(struct vsb *vsb, const struct parspec *par, const char *arg)
 /*--------------------------------------------------------------------*/
 
 enum tweak_r_e __match_proto__(tweak_t)
-tweak_poolparam(struct vsb *vsb, const struct parspec *par, const char *arg)
+tweak_poolparam(struct vsb *vsb, struct parspec *par, const char *arg)
 {
 	volatile struct poolparam *pp, px;
 	char **av;

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -49,7 +49,7 @@
  * Generic handling of double typed parameters
  */
 
-static int
+static enum tweak_r_e __match_proto__(tweak_t)
 tweak_generic_double(struct vsb *vsb, volatile double *dest,
     const char *arg, const char *min, const char *max, const char *fmt)
 {
@@ -60,41 +60,41 @@ tweak_generic_double(struct vsb *vsb, volatile double *dest,
 			minv = VNUM(min);
 			if (isnan(minv)) {
 				VSB_printf(vsb, "Illegal Min: %s\n", min);
-				return (-1);
+				return (TWEFMT);
 			}
 		}
 		if (max != NULL) {
 			maxv = VNUM(max);
 			if (isnan(maxv)) {
 				VSB_printf(vsb, "Illegal Max: %s\n", max);
-				return (-1);
+				return (TWEFMT);
 			}
 		}
 
 		u = VNUM(arg);
 		if (isnan(u)) {
 			VSB_printf(vsb, "Not a number(%s)\n", arg);
-			return (-1);
+			return (TWEFMT);
 		}
 		if (min != NULL && u < minv) {
 			VSB_printf(vsb,
 			    "Must be greater or equal to %s\n", min);
-			return (-1);
+			return (TWESMALL);
 		}
 		if (max != NULL && u > maxv) {
 			VSB_printf(vsb,
 			    "Must be less than or equal to %s\n", max);
-			return (-1);
+			return (TWEBIG);
 		}
 		*dest = u;
 	} else
 		VSB_printf(vsb, fmt, *dest);
-	return (0);
+	return (TWOK);
 }
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_timeout(struct vsb *vsb, const struct parspec *par,
     const char *arg)
 {
@@ -107,7 +107,7 @@ tweak_timeout(struct vsb *vsb, const struct parspec *par,
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_double(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile double *dest;
@@ -119,7 +119,7 @@ tweak_double(struct vsb *vsb, const struct parspec *par, const char *arg)
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_bool(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile unsigned *dest;
@@ -144,17 +144,17 @@ tweak_bool(struct vsb *vsb, const struct parspec *par, const char *arg)
 			*dest = 1;
 		else {
 			VSB_printf(vsb, "use \"on\" or \"off\"\n");
-			return (-1);
+			return (TWEFMT);
 		}
 	} else {
 		VSB_printf(vsb, "%s", *dest ? "on" : "off");
 	}
-	return (0);
+	return (TWOK);
 }
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_r_e
 tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
     const char *min, const char *max)
 {
@@ -167,7 +167,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			minv = strtoul(min, &p, 0);
 			if (*arg == '\0' || *p != '\0') {
 				VSB_printf(vsb, "Illegal Min: %s\n", min);
-				return (-1);
+				return (TWEFMT);
 			}
 		}
 		if (max != NULL) {
@@ -175,7 +175,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			maxv = strtoul(max, &p, 0);
 			if (*arg == '\0' || *p != '\0') {
 				VSB_printf(vsb, "Illegal Max: %s\n", max);
-				return (-1);
+				return (TWEFMT);
 			}
 		}
 		p = NULL;
@@ -185,16 +185,16 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			u = strtoul(arg, &p, 0);
 			if (*arg == '\0' || *p != '\0') {
 				VSB_printf(vsb, "Not a number (%s)\n", arg);
-				return (-1);
+				return (TWEFMT);
 			}
 		}
 		if (min != NULL && u < minv) {
 			VSB_printf(vsb, "Must be at least %s\n", min);
-			return (-1);
+			return (TWESMALL);
 		}
 		if (max != NULL && u > maxv) {
 			VSB_printf(vsb, "Must be no more than %s\n", max);
-			return (-1);
+			return (TWEBIG);
 		}
 		*dest = u;
 	} else if (*dest == UINT_MAX) {
@@ -202,12 +202,12 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 	} else {
 		VSB_printf(vsb, "%u", *dest);
 	}
-	return (0);
+	return (TWOK);
 }
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_uint(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile unsigned *dest;
@@ -241,7 +241,7 @@ fmt_bytes(struct vsb *vsb, uintmax_t t)
 	VSB_printf(vsb, "(bogus number)");
 }
 
-static int
+static enum tweak_r_e __match_proto__(tweak_t)
 tweak_generic_bytes(struct vsb *vsb, volatile ssize_t *dest, const char *arg,
     const char *min, const char *max)
 {
@@ -253,14 +253,14 @@ tweak_generic_bytes(struct vsb *vsb, volatile ssize_t *dest, const char *arg,
 			p = VNUM_2bytes(min, &rmin, 0);
 			if (p != NULL) {
 				VSB_printf(vsb, "Invalid min-val: %s\n", min);
-				return (-1);
+				return (TWEFMT);
 			}
 		}
 		if (max != NULL) {
 			p = VNUM_2bytes(max, &rmax, 0);
 			if (p != NULL) {
 				VSB_printf(vsb, "Invalid max-val: %s\n", max);
-				return (-1);
+				return (TWEFMT);
 			}
 		}
 		p = VNUM_2bytes(arg, &r, 0);
@@ -269,33 +269,33 @@ tweak_generic_bytes(struct vsb *vsb, volatile ssize_t *dest, const char *arg,
 			VSB_printf(vsb, "%s\n", p);
 			VSB_printf(vsb,
 			    "  Try something like '80k' or '120M'\n");
-			return (-1);
+			return (TWEFMT);
 		}
 		if ((uintmax_t)((ssize_t)r) != r) {
 			fmt_bytes(vsb, r);
 			VSB_printf(vsb,
 			    " is too large for this architecture.\n");
-			return (-1);
+			return (TWEFMT);
 		}
 		if (max != NULL && r > rmax) {
 			VSB_printf(vsb, "Must be no more than %s\n", max);
 			VSB_printf(vsb, "\n");
-			return (-1);
+			return (TWEBIG);
 		}
 		if (min != NULL && r < rmin) {
 			VSB_printf(vsb, "Must be at least %s\n", min);
-			return (-1);
+			return (TWESMALL);
 		}
 		*dest = r;
 	} else {
 		fmt_bytes(vsb, *dest);
 	}
-	return (0);
+	return (TWOK);
 }
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_bytes(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile ssize_t *dest;
@@ -306,58 +306,63 @@ tweak_bytes(struct vsb *vsb, const struct parspec *par, const char *arg)
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_bytes_u(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile unsigned *d1;
 	volatile ssize_t dest;
+	enum tweak_r_e r;
 
 	d1 = par->priv;
 	dest = *d1;
-	if (tweak_generic_bytes(vsb, &dest, arg, par->min, par->max))
-		return (-1);
-	*d1 = dest;
-	return (0);
+	r = tweak_generic_bytes(vsb, &dest, arg, par->min, par->max);
+	if (r == TWOK)
+		*d1 = dest;
+	return (r);
 }
 
 /*--------------------------------------------------------------------
  * vsl_buffer and vsl_reclen have dependencies.
  */
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_vsl_buffer(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile unsigned *d1;
 	volatile ssize_t dest;
+	enum tweak_r_e r;
 
 	d1 = par->priv;
 	dest = *d1;
-	if (tweak_generic_bytes(vsb, &dest, arg, par->min, par->max))
-		return (-1);
-	*d1 = dest;
-	MCF_ParamConf(MCF_MAXIMUM, "vsl_reclen", "%u", *d1 - 12);
-	MCF_ParamConf(MCF_MAXIMUM, "shm_reclen", "%u", *d1 - 12);
-	return (0);
+	r = tweak_generic_bytes(vsb, &dest, arg, par->min, par->max);
+	if (r == TWOK) {
+		*d1 = dest;
+		MCF_ParamConf(MCF_MAXIMUM, "vsl_reclen", "%u", *d1 - 12);
+		MCF_ParamConf(MCF_MAXIMUM, "shm_reclen", "%u", *d1 - 12);
+	}
+	return (r);
 }
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_vsl_reclen(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile unsigned *d1;
 	volatile ssize_t dest;
+	enum tweak_r_e r;
 
 	d1 = par->priv;
 	dest = *d1;
-	if (tweak_generic_bytes(vsb, &dest, arg, par->min, par->max))
-		return (-1);
-	*d1 = dest;
-	MCF_ParamConf(MCF_MINIMUM, "vsl_buffer", "%u", *d1 + 12);
-	return (0);
+	r = tweak_generic_bytes(vsb, &dest, arg, par->min, par->max);
+	if (r == TWOK) {
+		*d1 = dest;
+		MCF_ParamConf(MCF_MINIMUM, "vsl_buffer", "%u", *d1 + 12);
+	}
+	return (r);
 }
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_string(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	char **p = TRUST_ME(par->priv);
@@ -369,17 +374,17 @@ tweak_string(struct vsb *vsb, const struct parspec *par, const char *arg)
 	} else {
 		REPLACE(*p, arg);
 	}
-	return (0);
+	return (TWOK);
 }
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_r_e __match_proto__(tweak_t)
 tweak_poolparam(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile struct poolparam *pp, px;
 	char **av;
-	int retval = 0;
+	enum tweak_r_e retval = TWOK;
 
 	pp = par->priv;
 	if (arg == NULL) {
@@ -390,14 +395,14 @@ tweak_poolparam(struct vsb *vsb, const struct parspec *par, const char *arg)
 		do {
 			if (av[0] != NULL) {
 				VSB_printf(vsb, "Parse error: %s", av[0]);
-				retval = -1;
+				retval = TWEFMT;
 				break;
 			}
 			if (av[1] == NULL || av[2] == NULL || av[3] == NULL) {
 				VSB_printf(vsb,
 				    "Three fields required:"
 				    " min_pool, max_pool and max_age\n");
-				retval = -1;
+				retval = TWEFMT;
 				break;
 			}
 			px = *pp;
@@ -417,7 +422,7 @@ tweak_poolparam(struct vsb *vsb, const struct parspec *par, const char *arg)
 				VSB_printf(vsb,
 				    "min_pool cannot be larger"
 				    " than max_pool\n");
-				retval = -1;
+				retval = TWEFMT;
 				break;
 			}
 			*pp = px;

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -340,7 +340,6 @@ tweak_vsl_buffer(struct vsb *vsb, struct parspec *par, const char *arg)
 	if (r == TWOK) {
 		*d1 = dest;
 		MCF_ParamConf(MCF_MAXIMUM, "vsl_reclen", "%ub", *d1 - 12);
-		MCF_ParamConf(MCF_MAXIMUM, "shm_reclen", "%ub", *d1 - 12);
 	}
 
 	par->flags &= ~_LIMITING;

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -223,7 +223,7 @@ fmt_bytes(struct vsb *vsb, uintmax_t t)
 {
 	const char *p;
 
-	if (t & 0xff) {
+	if (t == 0 || t & 0xff) {
 		VSB_printf(vsb, "%jub", t);
 		return;
 	}
@@ -339,8 +339,8 @@ tweak_vsl_buffer(struct vsb *vsb, struct parspec *par, const char *arg)
 	r = tweak_generic_bytes(vsb, &dest, arg, par->min, par->max);
 	if (r == TWOK) {
 		*d1 = dest;
-		MCF_ParamConf(MCF_MAXIMUM, "vsl_reclen", "%u", *d1 - 12);
-		MCF_ParamConf(MCF_MAXIMUM, "shm_reclen", "%u", *d1 - 12);
+		MCF_ParamConf(MCF_MAXIMUM, "vsl_reclen", "%ub", *d1 - 12);
+		MCF_ParamConf(MCF_MAXIMUM, "shm_reclen", "%ub", *d1 - 12);
 	}
 
 	par->flags &= ~_LIMITING;
@@ -362,7 +362,7 @@ tweak_vsl_reclen(struct vsb *vsb, struct parspec *par, const char *arg)
 	r = tweak_generic_bytes(vsb, &dest, arg, par->min, par->max);
 	if (r == TWOK) {
 		*d1 = dest;
-		MCF_ParamConf(MCF_MINIMUM, "vsl_buffer", "%u", *d1 + 12);
+		MCF_ParamConf(MCF_MINIMUM, "vsl_buffer", "%ub", *d1 + 12);
 	}
 
 	par->flags &= ~_LIMITING;

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -332,6 +332,8 @@ tweak_vsl_buffer(struct vsb *vsb, struct parspec *par, const char *arg)
 	volatile ssize_t dest;
 	enum tweak_r_e r;
 
+	par->flags |= _LIMITING;
+
 	d1 = par->priv;
 	dest = *d1;
 	r = tweak_generic_bytes(vsb, &dest, arg, par->min, par->max);
@@ -340,6 +342,9 @@ tweak_vsl_buffer(struct vsb *vsb, struct parspec *par, const char *arg)
 		MCF_ParamConf(MCF_MAXIMUM, "vsl_reclen", "%u", *d1 - 12);
 		MCF_ParamConf(MCF_MAXIMUM, "shm_reclen", "%u", *d1 - 12);
 	}
+
+	par->flags &= ~_LIMITING;
+
 	return (r);
 }
 
@@ -350,6 +355,8 @@ tweak_vsl_reclen(struct vsb *vsb, struct parspec *par, const char *arg)
 	volatile ssize_t dest;
 	enum tweak_r_e r;
 
+	par->flags |= _LIMITING;
+
 	d1 = par->priv;
 	dest = *d1;
 	r = tweak_generic_bytes(vsb, &dest, arg, par->min, par->max);
@@ -357,6 +364,9 @@ tweak_vsl_reclen(struct vsb *vsb, struct parspec *par, const char *arg)
 		*d1 = dest;
 		MCF_ParamConf(MCF_MINIMUM, "vsl_buffer", "%u", *d1 + 12);
 	}
+
+	par->flags &= ~_LIMITING;
+
 	return (r);
 }
 

--- a/bin/varnishd/mgt/mgt_pool.c
+++ b/bin/varnishd/mgt/mgt_pool.c
@@ -53,30 +53,34 @@
  * limit, so they don't end up crossing.
  */
 
-static int
+static enum tweak_r_e __match_proto__(tweak_t)
 tweak_thread_pool_min(struct vsb *vsb, const struct parspec *par,
     const char *arg)
 {
+	enum tweak_r_e r;
 
-	if (tweak_generic_uint(vsb, par->priv, arg, par->min, par->max))
-		return (-1);
-	MCF_ParamConf(MCF_MINIMUM, "thread_pool_max",
-	    "%u", mgt_param.wthread_min);
-	MCF_ParamConf(MCF_MAXIMUM, "thread_pool_reserve",
-	    "%u", mgt_param.wthread_min * 950 / 1000);
-	return (0);
+	r = tweak_generic_uint(vsb, par->priv, arg, par->min, par->max);
+	if (r == TWOK) {
+		MCF_ParamConf(MCF_MINIMUM, "thread_pool_max",
+		    "%u", mgt_param.wthread_min);
+		MCF_ParamConf(MCF_MAXIMUM, "thread_pool_reserve",
+		    "%u", mgt_param.wthread_min * 950 / 1000);
+	}
+	return (r);
 }
 
-static int
+static enum tweak_r_e __match_proto__(tweak_t)
 tweak_thread_pool_max(struct vsb *vsb, const struct parspec *par,
     const char *arg)
 {
+	enum tweak_r_e r;
 
-	if (tweak_generic_uint(vsb, par->priv, arg, par->min, par->max))
-		return (-1);
-	MCF_ParamConf(MCF_MAXIMUM, "thread_pool_min",
-	    "%u", mgt_param.wthread_max);
-	return (0);
+	r = tweak_generic_uint(vsb, par->priv, arg, par->min, par->max);
+	if (r == TWOK) {
+		MCF_ParamConf(MCF_MAXIMUM, "thread_pool_min",
+		    "%u", mgt_param.wthread_max);
+	}
+	return (r);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/mgt/mgt_pool.c
+++ b/bin/varnishd/mgt/mgt_pool.c
@@ -54,7 +54,7 @@
  */
 
 static enum tweak_r_e __match_proto__(tweak_t)
-tweak_thread_pool_min(struct vsb *vsb, const struct parspec *par,
+tweak_thread_pool_min(struct vsb *vsb, struct parspec *par,
     const char *arg)
 {
 	enum tweak_r_e r;
@@ -70,7 +70,7 @@ tweak_thread_pool_min(struct vsb *vsb, const struct parspec *par,
 }
 
 static enum tweak_r_e __match_proto__(tweak_t)
-tweak_thread_pool_max(struct vsb *vsb, const struct parspec *par,
+tweak_thread_pool_max(struct vsb *vsb, struct parspec *par,
     const char *arg)
 {
 	enum tweak_r_e r;

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1394,7 +1394,7 @@ PARAM(
 	/* typ */	string,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	/opt/varnish/etc/varnish,
+	/* default */	"/opt/varnish/etc/varnish",
 	/* units */	NULL,
 	/* flags */	0,
 	/* s-text */
@@ -1410,7 +1410,7 @@ PARAM(
 	/* typ */	string,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	/opt/varnish/lib/varnish/vmods,
+	/* default */	"/opt/varnish/lib/varnish/vmods",
 	/* units */	NULL,
 	/* flags */	0,
 	/* s-text */
@@ -1515,7 +1515,7 @@ PARAM(
 	/* typ */	waiter,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	kqueue (possible values: kqueue, poll),
+	/* default */	"kqueue (possible values: kqueue, poll)",
 	/* units */	NULL,
 	/* flags */	MUST_RESTART| WIZARD,
 	/* s-text */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -921,20 +921,6 @@ PARAM(
 )
 
 PARAM(
-	/* name */	shm_reclen,
-	/* typ */	vsl_reclen,
-	/* min */	"16b",
-	/* max */	NULL,
-	/* default */	"255b",
-	/* units */	"bytes",
-	/* flags */	0,
-	/* s-text */
-	"Old name for vsl_reclen, use that instead.",
-	/* l-text */	"",
-	/* func */	NULL
-)
-
-PARAM(
 	/* name */	shortlived,
 	/* typ */	timeout,
 	/* min */	"0.000",


### PR DESCRIPTION
Limit parameter values by the min/max
open questions:
* Do we want the "this parameter has been limited" warning andwhere?
* I am not particularly fond of the recursion cut off using the {{_LIMITING}} flag - any better ideas?

more todos:
* normalize min/max values not just when washing, but always (for those adjusted automatically)
* check for (more) races between interlocked params as in ee4ae94cb53a481afdc0222b7a17feec9155df37
* we leak a bit of memory every time we change a min/max - maybe just replace all compiled-in defaults once with strdups and free every time?