### PR TITLE
Parameter ban_cutoff to limit the number of active (incomplete) bans

### DIFF
--- a/bin/varnishtest/tests/c00049.vtc
+++ b/bin/varnishtest/tests/c00049.vtc
@@ -188,3 +188,38 @@ varnish v1 -expect bans_lurker_obj_killed == 4
 varnish v1 -expect bans_dups == 0
 
 varnish v1 -expect n_object == 3
+
+# adding more bans than the cutoff purges all untested objects
+# (here: all objects)
+
+varnish v1 -cliok "param.set ban_lurker_age 2"
+varnish v1 -cliok "param.set ban_cutoff 4"
+
+varnish v1 -cliok "ban.list"
+varnish v1 -cliok "ban obj.http.nomatch == 1"
+varnish v1 -cliok "ban obj.http.nomatch == 2"
+varnish v1 -cliok "ban obj.http.nomatch == 3"
+varnish v1 -cliok "ban obj.http.nomatch == 4"
+varnish v1 -cliok "ban obj.http.nomatch == 5"
+varnish v1 -cliok "ban.list"
+varnish v1 -cliok "param.set ban_lurker_age .1"
+delay 3
+
+varnish v1 -cliok "ban.list"
+
+varnish v1 -expect bans == 1
+varnish v1 -expect bans_completed == 1
+varnish v1 -expect bans_req == 0
+varnish v1 -expect bans_obj == 1
+varnish v1 -expect bans_added == 11
+varnish v1 -expect bans_deleted == 10
+varnish v1 -expect bans_tested == 2
+varnish v1 -expect bans_tests_tested == 2
+varnish v1 -expect bans_obj_killed == 1
+varnish v1 -expect bans_lurker_tested == 8
+varnish v1 -expect bans_lurker_tests_tested == 9
+varnish v1 -expect bans_lurker_obj_killed == 4
+varnish v1 -expect bans_lurker_obj_killed_cutoff == 3
+varnish v1 -expect bans_dups == 0
+
+varnish v1 -expect n_object == 0

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -137,6 +137,30 @@ PARAM(
 )
 
 PARAM(
+	/* name */	ban_cutoff,
+	/* typ */	uint,
+	/* min */	"0",
+	/* max */	NULL,
+	/* default */	"0",
+	/* units */	"bans",
+	/* flags */	EXPERIMENTAL,
+	/* s-text */
+	"Expurge long tail content from the cache to keep the number of bans "
+	"below this value. 0 disables.\n"
+	"This is a safety net to avoid bad response times due to bans being "
+	"tested at lookup time. Setting a cutoff trades response time for "
+	"cache efficiency. The recommended value is proportional to "
+	"rate(bans_lurker_tests_tested) / n_objects while the ban lurker is "
+	"working, which is the number of bans the system can sustain. The "
+	"additional latency due to request ban testing is in the order of "
+	"ban_cutoff / rate(bans_lurker_tests_tested). For example, for "
+	"rate(bans_lurker_tests_tested) = 2M/s and a tolerable latency of "
+	"100ms, a good value for ban_cutoff may be 200K.",
+	/* l-text */	"",
+	/* func */	NULL
+)
+
+PARAM(
 	/* name */	ban_lurker_age,
 	/* typ */	timeout,
 	/* min */	"0",

--- a/include/tbl/vsc_f_main.h
+++ b/include/tbl/vsc_f_main.h
@@ -571,7 +571,13 @@ VSC_FF(bans_lurker_tests_tested,	uint64_t, 0, 'c', 'i', diag,
 
 VSC_FF(bans_lurker_obj_killed,	uint64_t, 0, 'c', 'i', diag,
     "Objects killed by bans (lurker)",
-	"Number of objects killed by ban-lurker."
+	"Number of objects killed by the ban-lurker."
+)
+
+VSC_FF(bans_lurker_obj_killed_cutoff,	uint64_t, 0, 'c', 'i', diag,
+    "Objects killed by bans for cutoff (lurker)",
+	"Number of objects killed by the ban-lurker to keep the number of"
+	" bans below ban_cutoff."
 )
 
 VSC_FF(bans_dups,		uint64_t, 0, 'c', 'i', diag,


### PR DESCRIPTION
Expurge long tail content from the cache to keep the number of bans
below this value. 0 disables.

This is a safety net to avoid bad response times due to bans being
tested at lookup time. Setting a cutoff trades response time for cache
efficiency. The recommended value is proportional to
rate(bans_lurker_tests_tested) / n_objects while the ban lurker is
working, which is the number of bans the system can sustain. The
additional latency due to request ban testing is in the order of
ban_cutoff / rate(bans_lurker_tests_tested). For example, for
rate(bans_lurker_tests_tested) = 2M/s and a tolerable latency of
100ms, a good value for ban_cutoff may be 200K.