### PR TITLE
Avoid copying in VRT_String if we can

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -252,7 +252,30 @@ const char *
 VRT_String(struct ws *ws, const char *h, const char *p, va_list ap)
 {
 	char *b, *e;
+	const char *q;
 	unsigned u, x;
+	va_list aq;
+
+	while (p == NULL ||
+	       (p != vrt_magic_string_end && *p == '\0'))
+		p = va_arg(ap, const char *);
+
+	if (h == NULL) {
+		q = p;
+
+		if (q == vrt_magic_string_end)
+			p = "";
+		else if (WS_Inside(ws, q, NULL)) {
+			va_copy(aq, ap);
+			do
+				q = va_arg(aq, const char *);
+			while (q == NULL ||
+			       (q != vrt_magic_string_end && *q == '\0'));
+			va_end(aq);
+		}
+		if (q == vrt_magic_string_end)
+			return (p);
+	}
 
 	u = WS_Reserve(ws, 0);
 	e = b = ws->f;

--- a/bin/varnishtest/tests/v00053.vtc
+++ b/bin/varnishtest/tests/v00053.vtc
@@ -1,0 +1,97 @@
+varnishtest "test that strings are only copied when necessary"
+
+server s1 {
+	rxreq
+	txresp -hdr "Connection: close" -body "012345\n"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+	import debug;
+
+	sub vcl_recv {
+	    # we try to make this work for 32 and 64 bit by having
+	    # all strings round up to a multiple of 8
+	    # 6 bytes: stringifying the 5-digit free integer
+	    # 14 bytes: wssnap: 12345 + null
+	    # we exploit the implementation detail that std.log does
+	    # not keep a reference to the passed string
+	    set req.http.wssnap = debug.workspace_free(client) - 24;
+	    debug.workspace_snap(client);
+	    std.log(std.integer(req.http.wssnap, 0) - debug.workspace_free(client));
+	    debug.workspace_reset(client);
+
+	    set req.url = req.url;
+	    debug.workspace_snap(client);
+	    std.log(std.integer(req.http.wssnap, 0) - debug.workspace_free(client));
+	    debug.workspace_reset(client);
+
+	    set req.url = "" + "" + req.url;
+	    debug.workspace_snap(client);
+	    std.log(std.integer(req.http.wssnap, 0) - debug.workspace_free(client));
+	    debug.workspace_reset(client);
+
+	    set req.url = "" + "" + req.url + "" + "";
+	    debug.workspace_snap(client);
+	    std.log(std.integer(req.http.wssnap, 0) - debug.workspace_free(client));
+	    debug.workspace_reset(client);
+
+	    set req.url = "/" + "new" + "/st";
+	    debug.workspace_snap(client);
+	    std.log(std.integer(req.http.wssnap, 0) - debug.workspace_free(client));
+	    debug.workspace_reset(client);
+
+	    set req.url = req.url;
+	    debug.workspace_snap(client);
+	    std.log(std.integer(req.http.wssnap, 0) - debug.workspace_free(client));
+	    debug.workspace_reset(client);
+
+	    set req.url = "" + "" + req.url;
+	    debug.workspace_snap(client);
+	    std.log(std.integer(req.http.wssnap, 0) - debug.workspace_free(client));
+	    debug.workspace_reset(client);
+
+	    set req.url = "" + req.url + "";
+	    debug.workspace_snap(client);
+	    std.log(std.integer(req.http.wssnap, 0) - debug.workspace_free(client));
+	    debug.workspace_reset(client);
+
+	    set req.url = req.url + req.url;
+	    debug.workspace_snap(client);
+	    std.log(std.integer(req.http.wssnap, 0) - debug.workspace_free(client));
+	    debug.workspace_reset(client);
+	}
+} -start
+
+logexpect l1 -v v1 -g raw -d 1 {
+	expect * 1001		VCL_call	{^RECV$}
+	expect 0 =		ReqHeader	{^wssnap: \d{5}$}
+	expect 0 =		VCL_Log	{^0$}
+	expect 0 =		ReqURL		{^/2345$}
+	expect 0 =		VCL_Log	{^0$}
+	expect 0 =		ReqURL		{^/2345$}
+	expect 0 =		VCL_Log	{^0$}
+	expect 0 =		ReqURL		{^/2345$}
+	expect 0 =		VCL_Log	{^0$}
+	expect 0 =		ReqURL		{^/new/st$}
+	expect 0 =		VCL_Log	{^8$}
+	expect 0 =		ReqURL		{^/new/st$}
+	expect 0 =		VCL_Log	{^8$}
+	expect 0 =		ReqURL		{^/new/st$}
+	expect 0 =		VCL_Log	{^8$}
+	expect 0 =		ReqURL		{^/new/st$}
+	expect 0 =		VCL_Log	{^8$}
+	expect 0 =		ReqURL		{^/new/st/new/st$}
+	expect 0 =		VCL_Log	{^24$}
+	expect 0 =		VCL_return	{^hash$}
+}
+
+logexpect l1 -start
+
+client c1 {
+	txreq -url "/2345"
+	rxresp
+	expect resp.status == 200
+} -run
+
+logexpect l1 -wait


### PR DESCRIPTION
If we neither need to prepend a header, nor need to concatinate and
the (single non-NULL non-empty) string is already on the correct
workspace, just return it rather than copying.

For the empty string, a const "" not from the workspace is returned.