### PR TITLE
Check if events we received are actually being waited for

### DIFF
--- a/bin/varnishd/waiter/cache_waiter.c
+++ b/bin/varnishd/waiter/cache_waiter.c
@@ -97,13 +97,15 @@ Wait_HeapInsert(const struct waiter *w, struct waited *wp)
  * XXX: any harm to come from it.  Caveat Emptor.
  */
 
-void
+int
 Wait_HeapDelete(const struct waiter *w, const struct waited *wp)
 {
 	CHECK_OBJ_NOTNULL(w, WAITER_MAGIC);
 	CHECK_OBJ_NOTNULL(wp, WAITED_MAGIC);
-	if (wp->idx != BINHEAP_NOIDX)
-		binheap_delete(w->heap, wp->idx);
+	if (wp->idx == BINHEAP_NOIDX)
+		return (0);
+	binheap_delete(w->heap, wp->idx);
+	return (1);
 }
 
 double

--- a/bin/varnishd/waiter/cache_waiter_kqueue.c
+++ b/bin/varnishd/waiter/cache_waiter_kqueue.c
@@ -98,7 +98,7 @@ vwk_thread(void *priv)
 			CHECK_OBJ_NOTNULL(wp, WAITED_MAGIC);
 			EV_SET(ke, wp->fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
 			AZ(kevent(vwk->kq, ke, 1, NULL, 0, NULL));
-			Wait_HeapDelete(w, wp);
+			AN(Wait_HeapDelete(w, wp));
 			Lck_Unlock(&vwk->mtx);
 			Wait_Call(w, wp, WAITER_TIMEOUT, now);
 		}
@@ -118,7 +118,7 @@ vwk_thread(void *priv)
 			}
 			CAST_OBJ_NOTNULL(wp, ke[j].udata, WAITED_MAGIC);
 			Lck_Lock(&vwk->mtx);
-			Wait_HeapDelete(w, wp);
+			AN(Wait_HeapDelete(w, wp));
 			Lck_Unlock(&vwk->mtx);
 			vwk->nwaited--;
 			if (kp->flags & EV_EOF)

--- a/bin/varnishd/waiter/cache_waiter_poll.c
+++ b/bin/varnishd/waiter/cache_waiter_poll.c
@@ -190,13 +190,13 @@ VSL(SLT_Debug, vwp->pollfd[i].fd, "POLL loop i=%d revents=0x%x", i, vwp->pollfd[
 				v--;
 			then = Wait_When(wp);
 			if (then <= now) {
-				Wait_HeapDelete(w, wp);
+				AN(Wait_HeapDelete(w, wp));
 				Wait_Call(w, wp, WAITER_TIMEOUT, now);
 				vwp_del(vwp, i);
 			} else if (vwp->pollfd[i].revents & POLLIN) {
 				assert(wp->fd > 0);
 				assert(wp->fd == vwp->pollfd[i].fd);
-				Wait_HeapDelete(w, wp);
+				AN(Wait_HeapDelete(w, wp));
 				Wait_Call(w, wp, WAITER_ACTION, now);
 				vwp_del(vwp, i);
 			} else {

--- a/bin/varnishd/waiter/cache_waiter_ports.c
+++ b/bin/varnishd/waiter/cache_waiter_ports.c
@@ -128,7 +128,7 @@ vws_port_ev(struct vws *vws, struct waiter *w, port_event_t *ev, double now)
 		 *          threadID=129476&tstart=0
 		 */
 		vws_del(vws, wp->fd);
-		Wait_HeapDelete(w, wp);
+		AN(Wait_HeapDelete(w, wp));
 		Wait_Call(w, wp, ev->portev_events & POLLERR ?
 		    WAITER_REMCLOSE : WAITER_ACTION,
 		    now);
@@ -167,7 +167,7 @@ vws_thread(void *priv)
 			}
 			CHECK_OBJ_NOTNULL(wp, WAITED_MAGIC);
 			vws_del(vws, wp->fd);
-			Wait_HeapDelete(w, wp);
+			AN(Wait_HeapDelete(w, wp));
 			Wait_Call(w, wp, WAITER_TIMEOUT, now);
 		}
 		then = vws->next - now;

--- a/bin/varnishd/waiter/waiter_priv.h
+++ b/bin/varnishd/waiter/waiter_priv.h
@@ -78,5 +78,5 @@ Wait_When(const struct waited *wp)
 void Wait_Call(const struct waiter *, struct waited *,
     enum wait_event ev, double now);
 void Wait_HeapInsert(const struct waiter *, struct waited *);
-void Wait_HeapDelete(const struct waiter *, const struct waited *);
+int Wait_HeapDelete(const struct waiter *, const struct waited *);
 double Wait_HeapDue(const struct waiter *, struct waited **);


### PR DESCRIPTION
For epoll, we tolerate spurious reports, for all other waiters
we assert.

fixes #2117

This has been running in production on two systems for a couple of days without any issues:
### linux epoll
```
# /opt/varnish/compiled/current/bin/varnishstat -1 | head
MAIN.uptime             256272         1.00 Child process uptime
MAIN.sess_conn        14528084        56.69 Sessions accepted
MAIN.sess_drop               0         0.00 Sessions dropped
MAIN.sess_fail               0         0.00 Session accept failures
MAIN.client_req_400         1890         0.01 Client requests received, subject to 400 errors
MAIN.client_req_417            0         0.00 Client requests received, subject to 417 errors
MAIN.client_req         33043064       128.94 Good client requests received
MAIN.cache_hit          36943051       144.16 Cache hits
MAIN.cache_hitpass        158334         0.62 Cache hits for pass.
MAIN.cache_miss          1663757         6.49 Cache misses
```
### smartos ports
```
$ varnishstat -1|head
MAIN.uptime             408337         1.00 Child process uptime
MAIN.sess_conn         4492394        11.00 Sessions accepted
MAIN.sess_drop              37         0.00 Sessions dropped
MAIN.sess_fail               1         0.00 Session accept failures
MAIN.client_req_400           29         0.00 Client requests received, subject to 400 errors
MAIN.client_req_417            0         0.00 Client requests received, subject to 417 errors
MAIN.client_req         11134619        27.27 Good client requests received
MAIN.cache_hit           5343061        13.08 Cache hits
MAIN.cache_hitpass            90         0.00 Cache hits for pass.
MAIN.cache_miss          5776885        14.15 Cache misses
```