### PR TITLE
Introduce a parameter value for extrachance retries

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -182,7 +182,7 @@ static int __match_proto__(vdi_gethdrs_f)
 vbe_dir_gethdrs(const struct director *d, struct worker *wrk,
     struct busyobj *bo)
 {
-	int i, extrachance = 1;
+	int i, extrachance = cache_param->gethdr_extrachance;
 	struct backend *bp;
 	struct vbc *vbc;
 
@@ -237,7 +237,7 @@ vbe_dir_gethdrs(const struct director *d, struct worker *wrk,
 		    bo->req->req_body_status != REQ_BODY_CACHED)
 			break;
 		VSC_C_main->backend_retry++;
-	} while (extrachance);
+	} while (extrachance-- > 0);
 	return (-1);
 }
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -494,6 +494,21 @@ PARAM(
 )
 
 PARAM(
+	/* name */	gethdr_extrachance,
+	/* typ */	uint,
+	/* min */	"0",
+	/* max */	"100",
+	/* default */	"1",
+	/* units */	NULL,
+	/* flags */	EXPERIMENTAL,
+	/* s-text */
+	"Maximum number of retries in vbe_dir_gethdrs. "
+	"Setting this to zero disables the feature.",
+	/* l-text */	"",
+	/* func */	NULL
+)
+
+PARAM(
 	/* name */	gzip_buffer,
 	/* typ */	bytes_u,
 	/* min */	"2k",


### PR DESCRIPTION
There seem to be conditions in the extrachance logic under which Varnish
could retry a backend request indefinitely. This commit introduces a new
parameter, gethdr_extrachance, allowing to set an upper bound for the
amount of retries in vbe_dir_gethdrs.

The default value for the newly introduced parameter is 1, setting it to
0 disables the feature entirely.

The issue we've observed in production is described here: https://phabricator.wikimedia.org/T150247

Potentially related bugs: https://github.com/varnishcache/varnish-cache/issues/2126 https://github.com/varnishcache/varnish-cache/issues/1806 https://github.com/varnishcache/varnish-cache/issues/1772