### PR TITLE
Collect vtest failed tests logs more reliably

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,9 @@ distcleancheck_listfiles = \
 	find . -type f -exec sh -c 'test -f $(srcdir)/$$1 || echo $$1' \
 		sh '{}' ';'
 
+vtest-clean:
+	$(am__remove_distdir)
+
 # XXX: This is a hack to ensure we have a built source tree when
 # running make dist If we had used non-recursive make we could have
 # solved it better, but we don't, so use this at least for now.

--- a/tools/vtest.sh
+++ b/tools/vtest.sh
@@ -73,6 +73,7 @@ autogen () (
 makedistcheck () (
 	set -e
 	cd "${BUILDDIR}"
+	nice make vtest-clean
 	nice make distcheck
 )
 

--- a/tools/vtest.sh
+++ b/tools/vtest.sh
@@ -77,21 +77,26 @@ makedistcheck () (
 )
 
 failedtests () (
-	for t in `grep '^FAIL: tests/' ${1} | sort -u | sed 's/.* //'`
+	set -e
+
+	REPORTDIR=$(pwd)/_report
+
+	cd varnish-cache
+
+	VERSION=$(./configure --version | awk 'NR == 1 {print $NF}')
+	LOGDIR=varnish-$VERSION/_build/sub/bin/varnishtest/tests
+	VTCDIR=bin/varnishtest/tests
+
+	grep -l ':test-result: FAIL' $LOGDIR/*.trs |
+	while read trs
 	do
-		printf 'VTCGITREV %s ' "${t}"
-		(
-			cd varnish-cache/bin/varnishtest/
-			git log -n 1 ${t} | head -1
-		)
-		b=`basename ${t} .vtc`
-		for i in `find "${BUILDDIR}" -name ${b}.log -print`
-		do
-			if [ -f ${i} ] ; then
-				mv ${i} "_report/_${b}.log"
-				echo "MANIFEST _${b}.log" >> ${LOG}
-			fi
-		done
+		name=$(basename $trs .trs)
+		vtc=${name}.vtc
+		log=${name}.log
+		rev=$(git log -n 1 --pretty=format:%H ${VTCDIR}/${vtc})
+		cp ${LOGDIR}/${log} ${REPORTDIR}/_${log}
+		echo "VTCGITREV ${name} ${rev}"
+		echo "MANIFEST _${log}"
 	done
 )
 
@@ -175,7 +180,7 @@ do
 			echo "MAKEDISTCHECK BAD" >> ${LOG}
 			echo "MANIFEST _autogen" >> ${LOG}
 			echo "MANIFEST _makedistcheck" >> ${LOG}
-			failedtests _report/_makedistcheck >> ${LOG}
+			failedtests >> ${LOG}
 		else
 			echo "MAKEDISTCHECK GOOD" >> ${LOG}
 			waitnext=${WAITGOOD}


### PR DESCRIPTION
Instead of randomly looking for the log files, look for them where we
expect them to land. For instance, after a git pull, a distclean
operation may not remove the dist directory if Varnish's version
changed because it would reconfigure itself on the fly.

Instead of taking a relative file name as a parameter, with the obvious
problems it may create when changing directories, the list of failed
tests is searched in the function's standard input.