### PR TITLE
Set default.backend in vcl_init{}

### DIFF
--- a/bin/varnishd/cache/cache_priv.h
+++ b/bin/varnishd/cache/cache_priv.h
@@ -108,7 +108,7 @@ void VSL_ChgId(struct vsl_log *vsl, const char *typ, const char *why,
 void VSL_End(struct vsl_log *vsl);
 
 /* cache_vcl.c */
-struct director *VCL_DefaultDirector(const struct vcl *);
+const struct director *VCL_DefaultDirector(const struct vcl *);
 void VCL_SetDefaultDirector(struct vcl *, const struct director *);
 const struct vrt_backend_probe *VCL_DefaultProbe(const struct vcl *);
 void VCL_Init(void);

--- a/bin/varnishd/cache/cache_priv.h
+++ b/bin/varnishd/cache/cache_priv.h
@@ -109,6 +109,7 @@ void VSL_End(struct vsl_log *vsl);
 
 /* cache_vcl.c */
 struct director *VCL_DefaultDirector(const struct vcl *);
+void VCL_SetDefaultDirector(struct vcl *, const struct director *);
 const struct vrt_backend_probe *VCL_DefaultProbe(const struct vcl *);
 void VCL_Init(void);
 void VCL_Panic(struct vsb *, const struct vcl *);

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -488,6 +488,17 @@ VCL_DefaultDirector(const struct vcl *vcl)
 	return (*vcl->conf->default_director);
 }
 
+void
+VCL_SetDefaultDirector(struct vcl *vcl, const struct director *be)
+{
+
+	ASSERT_CLI();
+	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
+	CHECK_OBJ_NOTNULL(be, DIRECTOR_MAGIC);
+
+	INCOMPL();
+}
+
 const char *
 VCL_Name(const struct vcl *vcl)
 {

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -551,8 +551,11 @@ VRT_vcl_select(VRT_CTX, VCL_VCL vcl)
 	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
 	VCL_Rel(&req->vcl);
 	vcl_get(&req->vcl, vcl);
+	req->director_hint = vcl->default_director;
 	/* XXX: better logging */
 	VSLb(ctx->req->vsl, SLT_Debug, "Now using %s VCL", vcl->loaded_name);
+	VSLb(ctx->req->vsl, SLT_Debug, "Default backend is %s.%s",
+	    vcl->label->loaded_name, vcl->default_director->vcl_name);
 }
 
 struct vclref *
@@ -929,6 +932,7 @@ vcl_cli_label(struct cli *cli, const char * const *av, void *priv)
 		AN(lbl);
 		bprintf(lbl->state, "%s", VCL_TEMP_LABEL);
 		lbl->temp = VCL_TEMP_WARM;
+		lbl->default_director = vcl->default_director;
 		REPLACE(lbl->loaded_name, av[2]);
 		AZ(errno=pthread_rwlock_init(&lbl->temp_rwl, NULL));
 		VTAILQ_INSERT_TAIL(&vcl_head, lbl, list);

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -35,6 +35,7 @@
 #include "hash/hash_slinger.h"
 
 #include "cache_director.h"
+#include "vcl.h"
 #include "vrt.h"
 #include "vrt_obj.h"
 
@@ -768,3 +769,23 @@ HTTP_VAR(req)
 HTTP_VAR(resp)
 HTTP_VAR(bereq)
 HTTP_VAR(beresp)
+
+/*--------------------------------------------------------------------*/
+
+void
+VRT_l_default_backend(VRT_CTX, const struct director *be)
+{
+
+	ASSERT_CLI();
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_ORNULL(be, DIRECTOR_MAGIC);
+	AN(ctx->msg);
+
+	if (be == NULL) {
+		VSB_printf(ctx->msg, "The default backend can't be NULL.");
+		VRT_handling(ctx, VCL_RET_FAIL);
+		return;
+	}
+
+	VCL_SetDefaultDirector(ctx->vcl, be);
+}

--- a/bin/varnishtest/tests/v00040.vtc
+++ b/bin/varnishtest/tests/v00040.vtc
@@ -12,7 +12,7 @@ client c1 {
 	rxresp
 } -run
 
-varnish v1 -errvcl {VCL "vcl2" Failed initialization} {
+varnish v1 -errvcl {VCL "vcl2" failed initialization} {
 	sub vcl_init {
 		return (fail);
 	}

--- a/bin/varnishtest/tests/v00051.vtc
+++ b/bin/varnishtest/tests/v00051.vtc
@@ -1,0 +1,55 @@
+varnishtest "default_backend coverage"
+
+# A dummy VCL to start the child
+
+varnish v1 -arg "-b ${bad_ip}:8090" -start
+
+# Illegal uses of default_backend
+
+varnish v1 -errvcl {VCL "vcl1" failed with no default backend} {}
+
+varnish v1 -errvcl "The default backend can't be NULL." {
+	import debug;
+
+	sub vcl_init {
+		set default_backend = debug.no_backend();
+	}
+}
+
+# Set a director as the default backend
+
+varnish v1 -vcl {
+	import directors;
+
+	backend b1 { .host = "${bad_ip}"; .port = "8090"; }
+	backend b2 { .host = "${bad_ip}"; .port = "8090"; }
+
+	sub vcl_init {
+		new rr = directors.round_robin();
+		rr.add_backend(b1);
+		rr.add_backend(b2);
+		set default_backend = rr.backend();
+	}
+}
+
+# Useful with dynamic backends too
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import debug;
+
+	sub vcl_init {
+		new s1 = debug.dyn("${s1_addr}", "${s1_port}");
+		set default_backend = s1.backend();
+	}
+}
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run

--- a/bin/varnishtest/tests/v00052.vtc
+++ b/bin/varnishtest/tests/v00052.vtc
@@ -1,0 +1,64 @@
+varnishtest "A top-level VCL program with no backend"
+
+server s1 {
+	rxreq
+	expect req.http.host == varnish.org
+	txresp
+} -start
+
+server s2 {
+	rxreq
+	expect req.http.host == varnish-cache.org
+	txresp -status 204 -nolen
+} -start
+
+varnish v1 -vcl {
+	backend s1 { .host = "${s1_addr}"; .port="${s1_port}"; }
+}
+
+varnish v1 -vcl {
+	backend s2 { .host = "${s2_addr}"; .port="${s2_port}"; }
+}
+
+varnish v1 -cli "vcl.label l_vo vcl1"
+varnish v1 -cli "vcl.label l_vc vcl2"
+
+varnish v1 -vcl {
+	import directors;
+
+	sub vcl_init {
+		new dummy = directors.fallback();
+		set default_backend = dummy.backend();
+	}
+
+	# stolen from vcl-separate.rst
+	sub vcl_recv {
+		if (req.http.host ~ "varnish.org$") {
+			return (vcl(l_vo));
+		}
+		if (req.http.host ~ "varnish-cache.org$") {
+			return (vcl(l_vc));
+		}
+		return (synth(302, "http://varnish-cache.org"));
+	}
+
+	sub vcl_synth {
+		if (resp.status == 301 || resp.status == 302) {
+			set resp.http.location = resp.reason;
+			set resp.reason = "Moved";
+			return (deliver);
+		}
+	}
+}
+
+varnish v1 -start
+
+client c1 {
+	txreq -hdr "Host: varnish.org"
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "Host: varnish-cache.org"
+	rxresp
+	expect resp.status == 204
+} -run

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -43,16 +43,11 @@
  *	Varnish 5.0 release "better safe than sorry" bump
  * 4.0:
  *	VCL_BYTES changed to long long
+ *	VRT_CacheReqBody changed signature
  * 3.2:
  *	vrt_backend grew .proxy_header field
  *	vrt_ctx grew .sp field.
- *
- * older version:
- * Bump VRT_MINOR_VERSION due to:
- * - VCL_ACL type added
- * Bump VRT_MAJOR_VERSION due to:
- * - VRT_CacheReqBody changed signature
- *
+ *      vrt_acl type added
  */
 
 #define VRT_MAJOR_VERSION	5U

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -39,6 +39,8 @@
  * binary/load-time compatible, increment MAJOR version
  *
  *
+ * 5.1 (unreleased):
+ *      default_backend VCL variable (VRT_l_default_backend)
  * 5.0:
  *	Varnish 5.0 release "better safe than sorry" bump
  * 4.0:
@@ -52,7 +54,7 @@
 
 #define VRT_MAJOR_VERSION	5U
 
-#define VRT_MINOR_VERSION	0U
+#define VRT_MINOR_VERSION	1U
 
 
 /***********************************************************************/

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -158,6 +158,14 @@ returns = (
 # 'both' means all methods tagged "B" or "C"
 
 sp_variables = [
+	('default_backend',
+		'BACKEND',
+		(),
+		('init',), """
+		The default backend. It can be set in vcl_init{}. This
+		is useful if your default backend is a director.
+		"""
+	),
 	('remote.ip',
 		'IP',
 		('both',),

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -164,6 +164,10 @@ sp_variables = [
 		('init',), """
 		The default backend. It can be set in vcl_init{}. This
 		is useful if your default backend is a director.
+		If the default backend is not manually set, it falls
+		back to the VCL's default backend. When a top-level VCL
+		selects a label, the label's default backend is also
+		selected.
 		"""
 	),
 	('remote.ip',

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -415,7 +415,8 @@ EmitStruct(const struct vcc *tl)
 	Fc(tl, 0, "\nconst struct VCL_conf VCL_conf = {\n");
 	Fc(tl, 0, "\t.magic = VCL_CONF_MAGIC,\n");
 	Fc(tl, 0, "\t.event_vcl = VGC_Event,\n");
-	Fc(tl, 0, "\t.default_director = &%s,\n", tl->default_director);
+	if (tl->default_director != NULL)
+		Fc(tl, 0, "\t.default_director = &%s,\n", tl->default_director);
 	if (tl->default_probe != NULL)
 		Fc(tl, 0, "\t.default_probe = &%s,\n", tl->default_probe);
 	Fc(tl, 0, "\t.ref = VGC_ref,\n");
@@ -615,17 +616,17 @@ vcc_CompileSource(struct vcc *tl, struct source *sp)
 	if (tl->err)
 		return (NULL);
 
-	/* Check if we have any backends at all */
-	if (tl->default_director == NULL) {
-		VSB_printf(tl->sb,
-		    "No backends or directors found in VCL program, "
-		    "at least one is necessary.\n");
-		tl->err = 1;
-		return (NULL);
-	}
-
-	/* Configure the default director */
-	vcc_AddRef(tl, tl->t_default_director, SYM_BACKEND);
+	/* NB: Check whether we have any backends at all and reference the
+	 * default one. It may effectively be unused and slip through the
+	 * reference checks if it's overridden in vcl_init{} and not actually
+	 * used anywhere. We can solve this in the realm of static analysis
+	 * or decide it's a good-enough trade off.
+	 *
+	 * It is OK not to have backends as long as a director is set at load
+	 * time.
+	 */
+	if (tl->default_director != NULL)
+		vcc_AddRef(tl, tl->t_default_director, SYM_BACKEND);
 
 	/* Check for orphans */
 	if (vcc_CheckReferences(tl))


### PR DESCRIPTION
This patch set introduces a new optional `default.backend` variable that can be set to a backend or a director in `vcl_init`. It also allows compilation of VCLs without backends, but such VCLs won't load if they don't have a `default.backend` when they leave `vcl_init`.

The last patch fixes an alleged bug in label selection by relying on the `default.backend`.

It is not documented yet, except if you consider the two test cases proper documentation. I'd like a review first.