### PR TITLE
New rollover director

### DIFF
--- a/bin/varnishtest/tests/d00027.vtc
+++ b/bin/varnishtest/tests/d00027.vtc
@@ -1,0 +1,68 @@
+varnishtest "rollover director"
+
+server s1 {
+	rxreq
+	expect req.url == "/qux"
+	txresp
+} -start
+
+server s2 {
+	rxreq
+	expect req.url == "/foo"
+	txresp
+} -start
+
+server s3 {
+	rxreq
+	expect req.url == "/bar"
+	txresp
+
+	rxreq
+	expect req.url == "/baz"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import directors;
+
+	sub vcl_init {
+		new vd = directors.rollover();
+		vd.add_backend(s1);
+		vd.add_backend(s2);
+		vd.add_backend(s3);
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = vd.backend();
+		return(pass);
+	}
+
+} -start
+
+varnish v1 -cliok "backend.set_health s1 sick"
+
+client c1 {
+	txreq -url /foo
+	rxresp
+} -run
+
+varnish v1 -cliok "backend.set_health s2 sick"
+
+client c1 {
+	txreq -url /bar
+	rxresp
+} -run
+
+varnish v1 -cliok "backend.set_health s1 healthy"
+
+client c1 {
+	txreq -url /baz
+	rxresp
+} -run
+
+varnish v1 -cliok "backend.set_health s3 sick"
+
+client c1 {
+	txreq -url /qux
+	rxresp
+} -run

--- a/lib/libvmod_directors/Makefile.am
+++ b/lib/libvmod_directors/Makefile.am
@@ -24,6 +24,7 @@ libvmod_directors_la_SOURCES = \
 	fall_back.c \
 	hash.c \
 	random.c \
+	roll_over.c \
 	round_robin.c \
 	vmod_shard.c \
 	shard_cfg.c \

--- a/lib/libvmod_directors/roll_over.c
+++ b/lib/libvmod_directors/roll_over.c
@@ -1,0 +1,168 @@
+/*-
+ * Copyright (c) 2013-2015 Varnish Software AS
+ * All rights reserved.
+ *
+ * Author: Poul-Henning Kamp <phk@FreeBSD.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+
+#include "cache/cache.h"
+#include "cache/cache_director.h"
+
+#include "vrt.h"
+#include "vcc_if.h"
+
+#include "vdir.h"
+
+struct vmod_directors_rollover {
+	unsigned				magic;
+#define VMOD_DIRECTORS_ROLL_OVER_MAGIC	0xd992217a
+	struct vdir				*vd;
+	unsigned				cur;
+};
+
+static unsigned __match_proto__(vdi_healthy)
+vmod_ro_healthy(const struct director *dir, const struct busyobj *bo,
+    double *changed)
+{
+	struct vmod_directors_rollover *ro;
+
+	CAST_OBJ_NOTNULL(ro, dir->priv, VMOD_DIRECTORS_ROLL_OVER_MAGIC);
+	return (vdir_any_healthy(ro->vd, bo, changed));
+}
+
+static const struct director * __match_proto__(vdi_resolve_f)
+vmod_ro_resolve(const struct director *dir, struct worker *wrk,
+    struct busyobj *bo)
+{
+	struct vmod_directors_rollover *ro;
+	unsigned u;
+	VCL_BACKEND be = NULL;
+
+	CHECK_OBJ_NOTNULL(dir, DIRECTOR_MAGIC);
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
+	CAST_OBJ_NOTNULL(ro, dir->priv, VMOD_DIRECTORS_ROLL_OVER_MAGIC);
+	vdir_rdlock(ro->vd);
+	assert(ro->cur < ro->vd->n_backend);
+	for (u = 0; u < ro->vd->n_backend; u++) {
+		be = ro->vd->backend[ro->cur];
+		CHECK_OBJ_NOTNULL(be, DIRECTOR_MAGIC);
+		if (be->healthy(be, bo, NULL))
+			break;
+		ro->cur++;
+		if (ro->cur >= ro->vd->n_backend)
+			ro->cur -= ro->vd->n_backend;
+	}
+	vdir_unlock(ro->vd);
+	if (u == ro->vd->n_backend)
+		be = NULL;
+	return (be);
+}
+
+VCL_VOID __match_proto__()
+vmod_rollover__init(VRT_CTX,
+    struct vmod_directors_rollover **rop, const char *vcl_name)
+{
+	struct vmod_directors_rollover *ro;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(rop);
+	AZ(*rop);
+	ALLOC_OBJ(ro, VMOD_DIRECTORS_ROLL_OVER_MAGIC);
+	AN(ro);
+	*rop = ro;
+	vdir_new(&ro->vd, "rollover", vcl_name, vmod_ro_healthy,
+	    vmod_ro_resolve, ro);
+}
+
+VCL_VOID __match_proto__()
+vmod_rollover__fini(struct vmod_directors_rollover **rop)
+{
+	struct vmod_directors_rollover *ro;
+
+	ro = *rop;
+	*rop = NULL;
+	CHECK_OBJ_NOTNULL(ro, VMOD_DIRECTORS_ROLL_OVER_MAGIC);
+	vdir_delete(&ro->vd);
+	FREE_OBJ(ro);
+}
+
+VCL_VOID __match_proto__()
+vmod_rollover_add_backend(VRT_CTX,
+    struct vmod_directors_rollover *ro, VCL_BACKEND be)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ro, VMOD_DIRECTORS_ROLL_OVER_MAGIC);
+	(void)vdir_add_backend(ro->vd, be, 0.0);
+}
+
+/* this one is vdir_remove_backend but set ro->cur if needed */
+VCL_VOID __match_proto__()
+vmod_rollover_remove_backend(VRT_CTX,
+    struct vmod_directors_rollover *ro, VCL_BACKEND be)
+{
+	unsigned u, n;
+	struct vdir *vd;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ro, VMOD_DIRECTORS_ROLL_OVER_MAGIC);
+
+	vd = ro->vd;
+	if (be == NULL)
+		return;
+	CHECK_OBJ(be, DIRECTOR_MAGIC);
+	vdir_wrlock(vd);
+	for (u = 0; u < vd->n_backend; u++)
+		if (vd->backend[u] == be)
+			break;
+	if (u == vd->n_backend) {
+		vdir_unlock(vd);
+		return;
+	}
+	vd->total_weight -= vd->weight[u];
+	n = (vd->n_backend - u) - 1;
+	memmove(&vd->backend[u], &vd->backend[u+1], n * sizeof(vd->backend[0]));
+	memmove(&vd->weight[u], &vd->weight[u+1], n * sizeof(vd->weight[0]));
+	vd->n_backend--;
+	if (u < ro->cur)
+		ro->cur--;
+	vdir_unlock(vd);
+	return;
+
+}
+
+VCL_BACKEND __match_proto__()
+vmod_rollover_backend(VRT_CTX,
+    struct vmod_directors_rollover *ro)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ro, VMOD_DIRECTORS_ROLL_OVER_MAGIC);
+	return (ro->vd->dir);
+}

--- a/lib/libvmod_directors/vmod.vcc
+++ b/lib/libvmod_directors/vmod.vcc
@@ -134,6 +134,47 @@ Example
 	set req.backend_hint = vdir.backend();
 
 
+$Object rollover()
+
+Description
+	Create a rollover director.
+
+	A rollover director will behave as a "sticky" fallback director: it'll
+	return the first healthy backend and will keep using it. If it gets sick
+	it'll progress through the list to find a new healthy backend.
+
+	Once it has gone through the whole list, it'll start over.
+
+Example
+	new vdir = directors.rollover();
+
+$Method VOID .add_backend(BACKEND)
+
+Description
+	Add a backend to the director.
+
+	Note that the order in which this is done matters for the rollover
+	director.
+
+Example
+	vdir.add_backend(backend1);
+	vdir.add_backend(backend2);
+
+$Method VOID .remove_backend(BACKEND)
+
+Description
+	Remove a backend from the director.
+Example
+	vdir.remove_backend(backend1);
+	vdir.remove_backend(backend2);
+
+$Method BACKEND .backend()
+
+Description
+	Pick a backend from the director.
+Example
+	set req.backend_hint = vdir.backend();
+
 $Object random()
 
 Description


### PR DESCRIPTION
I'd like to introduce a new type to director to vmod-director: the rollover one.

This is basically the fallback director, except it doesn't revert back if a backend with a higher priority goes healthy again. This has be requested by some clients as it can help with consistency when backends are not totally in sync.