### PR TITLE
Sticky options for fallback director

### DIFF
--- a/bin/varnishtest/tests/d00027.vtc
+++ b/bin/varnishtest/tests/d00027.vtc
@@ -1,0 +1,72 @@
+varnishtest "Sticky fallback director"
+
+server s1 {
+	rxreq
+	expect req.url == "/qux"
+	txresp
+} -start
+
+server s2 {
+	rxreq
+	expect req.url == "/foo"
+	txresp
+} -start
+
+server s3 {
+	rxreq
+	expect req.url == "/bar"
+	txresp
+
+	rxreq
+	expect req.url == "/baz"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import directors;
+
+	sub vcl_init {
+		new vd = directors.fallback(sticky = true);
+		vd.add_backend(s1);
+		vd.add_backend(s2);
+		vd.add_backend(s3);
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = vd.backend();
+		return(pass);
+	}
+
+} -start
+
+varnish v1 -cliok "backend.set_health s1 sick"
+
+client c1 {
+	txreq -url /foo
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cliok "backend.set_health s2 sick"
+
+client c1 {
+	txreq -url /bar
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cliok "backend.set_health s1 healthy"
+
+client c1 {
+	txreq -url /baz
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cliok "backend.set_health s3 sick"
+
+client c1 {
+	txreq -url /qux
+	rxresp
+	expect resp.status == 200
+} -run

--- a/bin/varnishtest/tests/d00028.vtc
+++ b/bin/varnishtest/tests/d00028.vtc
@@ -1,0 +1,85 @@
+varnishtest "Sticky fallback director, removing backends"
+
+server s1 {
+	rxreq
+	expect req.url == "/foo"
+	txresp
+} -start
+
+server s2 {}
+
+server s3 {
+	rxreq
+	expect req.url == "/bar"
+	txresp
+
+	rxreq
+	expect req.url == "/baz"
+	txresp
+
+	rxreq
+	expect req.url == "/qux"
+	txresp
+} -start
+
+server s4 {}
+
+varnish v1 -vcl+backend {
+	import directors;
+
+	sub vcl_init {
+		new vd = directors.fallback(sticky = true);
+		vd.add_backend(s1);
+		vd.add_backend(s2);
+		vd.add_backend(s3);
+		vd.add_backend(s4);
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = vd.backend();
+		return(pass);
+	}
+
+	sub vcl_deliver {
+		if (req.url == "/bar") {
+			vd.remove_backend(s2);
+		} else if (req.url == "/baz") {
+			vd.remove_backend(s4);
+		} else if (req.url == "/qux") {
+			vd.remove_backend(s3);
+		}
+	}
+} -start
+
+varnish v1 -cliok "backend.set_health s1 sick"
+varnish v1 -cliok "backend.set_health s2 sick"
+
+client c1 {
+	txreq -url /bar
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cliok "backend.set_health s2 healthy"
+
+client c1 {
+	txreq -url /baz
+	rxresp
+	expect resp.status == 200
+
+	txreq -url /qux
+	rxresp
+	expect resp.status == 200
+
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+varnish v1 -cliok "backend.set_health s1 healthy"
+
+client c1 {
+	txreq -url /foo
+	rxresp
+	expect resp.status == 200
+} -run

--- a/lib/libvmod_directors/fall_back.c
+++ b/lib/libvmod_directors/fall_back.c
@@ -123,7 +123,7 @@ vmod_fallback_remove_backend(VRT_CTX,
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(fb, VMOD_DIRECTORS_FALLBACK_MAGIC);
-	vdir_remove_backend(fb->vd, be);
+	vdir_remove_backend(fb->vd, be, NULL);
 }
 
 VCL_BACKEND __match_proto__()

--- a/lib/libvmod_directors/fall_back.c
+++ b/lib/libvmod_directors/fall_back.c
@@ -123,7 +123,7 @@ vmod_fallback_remove_backend(VRT_CTX,
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(fb, VMOD_DIRECTORS_FALLBACK_MAGIC);
-	(void)vdir_remove_backend(fb->vd, be);
+	vdir_remove_backend(fb->vd, be);
 }
 
 VCL_BACKEND __match_proto__()

--- a/lib/libvmod_directors/hash.c
+++ b/lib/libvmod_directors/hash.c
@@ -91,7 +91,7 @@ vmod_hash_remove_backend(VRT_CTX,
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_HASH_MAGIC);
-	(void)vdir_remove_backend(rr->vd, be);
+	vdir_remove_backend(rr->vd, be);
 }
 
 VCL_BACKEND __match_proto__()

--- a/lib/libvmod_directors/hash.c
+++ b/lib/libvmod_directors/hash.c
@@ -91,7 +91,7 @@ vmod_hash_remove_backend(VRT_CTX,
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_HASH_MAGIC);
-	vdir_remove_backend(rr->vd, be);
+	vdir_remove_backend(rr->vd, be, NULL);
 }
 
 VCL_BACKEND __match_proto__()

--- a/lib/libvmod_directors/random.c
+++ b/lib/libvmod_directors/random.c
@@ -118,7 +118,7 @@ VCL_VOID vmod_random_remove_backend(VRT_CTX,
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_RANDOM_MAGIC);
-	(void)vdir_remove_backend(rr->vd, be);
+	vdir_remove_backend(rr->vd, be);
 }
 
 VCL_BACKEND __match_proto__()

--- a/lib/libvmod_directors/random.c
+++ b/lib/libvmod_directors/random.c
@@ -118,7 +118,7 @@ VCL_VOID vmod_random_remove_backend(VRT_CTX,
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_RANDOM_MAGIC);
-	vdir_remove_backend(rr->vd, be);
+	vdir_remove_backend(rr->vd, be, NULL);
 }
 
 VCL_BACKEND __match_proto__()

--- a/lib/libvmod_directors/round_robin.c
+++ b/lib/libvmod_directors/round_robin.c
@@ -127,7 +127,7 @@ vmod_round_robin_remove_backend(VRT_CTX,
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_ROUND_ROBIN_MAGIC);
-	vdir_remove_backend(rr->vd, be);
+	vdir_remove_backend(rr->vd, be, NULL);
 }
 
 VCL_BACKEND __match_proto__()

--- a/lib/libvmod_directors/round_robin.c
+++ b/lib/libvmod_directors/round_robin.c
@@ -127,7 +127,7 @@ vmod_round_robin_remove_backend(VRT_CTX,
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_ROUND_ROBIN_MAGIC);
-	(void)vdir_remove_backend(rr->vd, be);
+	vdir_remove_backend(rr->vd, be);
 }
 
 VCL_BACKEND __match_proto__()

--- a/lib/libvmod_directors/vdir.c
+++ b/lib/libvmod_directors/vdir.c
@@ -133,14 +133,14 @@ vdir_add_backend(struct vdir *vd, VCL_BACKEND be, double weight)
 	return (u);
 }
 
-unsigned
+void
 vdir_remove_backend(struct vdir *vd, VCL_BACKEND be)
 {
 	unsigned u, n;
 
 	CHECK_OBJ_NOTNULL(vd, VDIR_MAGIC);
 	if (be == NULL)
-		return (vd->n_backend);
+		return;
 	CHECK_OBJ(be, DIRECTOR_MAGIC);
 	vdir_wrlock(vd);
 	for (u = 0; u < vd->n_backend; u++)
@@ -148,7 +148,7 @@ vdir_remove_backend(struct vdir *vd, VCL_BACKEND be)
 			break;
 	if (u == vd->n_backend) {
 		vdir_unlock(vd);
-		return (vd->n_backend);
+		return;
 	}
 	vd->total_weight -= vd->weight[u];
 	n = (vd->n_backend - u) - 1;
@@ -156,7 +156,6 @@ vdir_remove_backend(struct vdir *vd, VCL_BACKEND be)
 	memmove(&vd->weight[u], &vd->weight[u+1], n * sizeof(vd->weight[0]));
 	vd->n_backend--;
 	vdir_unlock(vd);
-	return (vd->n_backend);
 }
 
 unsigned

--- a/lib/libvmod_directors/vdir.c
+++ b/lib/libvmod_directors/vdir.c
@@ -134,7 +134,7 @@ vdir_add_backend(struct vdir *vd, VCL_BACKEND be, double weight)
 }
 
 void
-vdir_remove_backend(struct vdir *vd, VCL_BACKEND be)
+vdir_remove_backend(struct vdir *vd, VCL_BACKEND be, unsigned *cur)
 {
 	unsigned u, n;
 
@@ -155,6 +155,15 @@ vdir_remove_backend(struct vdir *vd, VCL_BACKEND be)
 	memmove(&vd->backend[u], &vd->backend[u+1], n * sizeof(vd->backend[0]));
 	memmove(&vd->weight[u], &vd->weight[u+1], n * sizeof(vd->weight[0]));
 	vd->n_backend--;
+
+	if (cur) {
+		assert(*cur >= 0);
+		assert(*cur <= vd->n_backend);
+		if (u < *cur)
+			(*cur)--;
+		else if (*cur == vd->n_backend)
+			*cur = 0;
+	}
 	vdir_unlock(vd);
 }
 

--- a/lib/libvmod_directors/vdir.h
+++ b/lib/libvmod_directors/vdir.h
@@ -48,7 +48,7 @@ void vdir_rdlock(struct vdir *vd);
 void vdir_wrlock(struct vdir *vd);
 void vdir_unlock(struct vdir *vd);
 unsigned vdir_add_backend(struct vdir *, VCL_BACKEND be, double weight);
-unsigned vdir_remove_backend(struct vdir *, VCL_BACKEND be);
+void vdir_remove_backend(struct vdir *, VCL_BACKEND be);
 unsigned vdir_any_healthy(struct vdir *, const struct busyobj *,
     double *changed);
 VCL_BACKEND vdir_pick_be(struct vdir *, double w, const struct busyobj *);

--- a/lib/libvmod_directors/vdir.h
+++ b/lib/libvmod_directors/vdir.h
@@ -48,7 +48,7 @@ void vdir_rdlock(struct vdir *vd);
 void vdir_wrlock(struct vdir *vd);
 void vdir_unlock(struct vdir *vd);
 unsigned vdir_add_backend(struct vdir *, VCL_BACKEND be, double weight);
-void vdir_remove_backend(struct vdir *, VCL_BACKEND be);
+void vdir_remove_backend(struct vdir *, VCL_BACKEND be, unsigned *cur);
 unsigned vdir_any_healthy(struct vdir *, const struct busyobj *,
     double *changed);
 VCL_BACKEND vdir_pick_be(struct vdir *, double w, const struct busyobj *);

--- a/lib/libvmod_directors/vmod.vcc
+++ b/lib/libvmod_directors/vmod.vcc
@@ -95,13 +95,17 @@ Example
 	set req.backend_hint = vdir.backend();
 
 
-$Object fallback()
+$Object fallback(BOOL sticky = 0)
 
 Description
 	Create a fallback director.
 
 	A fallback director will try each of the added backends in turn,
 	and return the first one that is healthy.
+
+	If ``sticky`` is set to true, the director will keep using the healthy
+	backend, even if a higher-priority backend becomes available. Once the
+	whole backend list is exhausted, it'll start over at the beginning.
 
 Example
 	new vdir = directors.fallback();


### PR DESCRIPTION
Add a "sticky" argument to the fallback director. If set, the director doesn't go back to a higher priority backend coming back to health.

I also took the opportunity to rename variables in a more consistent way in the last commit.