### PR TITLE
export missing VTIM symbols from libvarnishapi

### DIFF
--- a/lib/libvarnishapi/Makefile.am
+++ b/lib/libvarnishapi/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 
 lib_LTLIBRARIES = libvarnishapi.la
 
-libvarnishapi_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:6:0
+libvarnishapi_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:7:0
 
 libvarnishapi_la_SOURCES = \
 	vsm_api.h \

--- a/lib/libvarnishapi/Makefile.am
+++ b/lib/libvarnishapi/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 
 lib_LTLIBRARIES = libvarnishapi.la
 
-libvarnishapi_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:7:0
+libvarnishapi_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:6:0
 
 libvarnishapi_la_SOURCES = \
 	vsm_api.h \

--- a/lib/libvarnishapi/libvarnishapi.map
+++ b/lib/libvarnishapi/libvarnishapi.map
@@ -171,10 +171,6 @@ LIBVARNISHAPI_1.6 {
 	VSB_vprintf;
 	VSB_delete;
 	VSB_indent;
-} LIBVARNISHAPI_1.0;
-
-LIBVARNISHAPI_1.7 {
-  global:
 	VTIM_parse;
 	VTIM_timespec;
 	VTIM_timeval;

--- a/lib/libvarnishapi/libvarnishapi.map
+++ b/lib/libvarnishapi/libvarnishapi.map
@@ -172,3 +172,10 @@ LIBVARNISHAPI_1.6 {
 	VSB_delete;
 	VSB_indent;
 } LIBVARNISHAPI_1.0;
+
+LIBVARNISHAPI_1.7 {
+  global:
+	VTIM_parse;
+	VTIM_timespec;
+	VTIM_timeval;
+} LIBVARNISHAPI_1.0;


### PR DESCRIPTION
Exports the remaining VTIM symbols: ``VTIM_parse``, ``_timespec`` and ``_timeval``. Also bumps the LIBVARNISHAPI version to 1.7 (soname 1.0.7).

If the PR is accepted, I promise to merge it to master the right way this time. %^)