### PR TITLE
Document default timeout for varnishtest

### DIFF
--- a/doc/sphinx/reference/varnishtest.rst
+++ b/doc/sphinx/reference/varnishtest.rst
@@ -52,7 +52,7 @@ The following options are available:
 
 -q               Quiet mode: report only failures
 
--t duration      Time tests out after this long
+-t duration      Time tests out after this long (default: 60s)
 
 -v               Verbose mode: always report test log
 


### PR DESCRIPTION
To avoid surprises on the user side, document the default timeout for `varnishtest`.

Found while testing a VCL that used `delay 300`.