### PR TITLE
A `write_body` VTC command

### DIFF
--- a/bin/varnishtest/tests/a00015.vtc
+++ b/bin/varnishtest/tests/a00015.vtc
@@ -1,9 +1,14 @@
 varnishtest "Write a body to a file"
 
 server s1 {
+	# First, HTTP checks
 	rxreq
 	expect req.http.Content-Type == "text/plain"
+
+	# Then, payload checks
 	write_body req.txt
+	shell {grep -q request req.txt}
+
 	txresp -hdr "Content-Type: text/plain" -body response
 } -start
 
@@ -11,10 +16,12 @@ varnish v1 -vcl+backend {} -start
 
 client c1 {
 	txreq -req POST -hdr "Content-Type: text/plain" -body request
+
+	# First, HTTP checks
 	rxresp
 	expect resp.http.Content-Type == "text/plain"
-	write_body resp.txt
-} -run
 
-shell {grep -q request req.txt}
-shell {grep -q response resp.txt}
+	# Then, payload checks
+	write_body resp.txt
+	shell {grep -q response resp.txt}
+} -run

--- a/bin/varnishtest/tests/a00015.vtc
+++ b/bin/varnishtest/tests/a00015.vtc
@@ -1,0 +1,20 @@
+varnishtest "Write a body to a file"
+
+server s1 {
+	rxreq
+	expect req.http.Content-Type == "text/plain"
+	write_body req.txt
+	txresp -hdr "Content-Type: text/plain" -body response
+} -start
+
+varnish v1 -vcl+backend {} -start
+
+client c1 {
+	txreq -req POST -hdr "Content-Type: text/plain" -body request
+	rxresp
+	expect resp.http.Content-Type == "text/plain"
+	write_body resp.txt
+} -run
+
+shell {grep -q request req.txt}
+shell {grep -q response resp.txt}

--- a/bin/varnishtest/tests/a02002.vtc
+++ b/bin/varnishtest/tests/a02002.vtc
@@ -1,7 +1,7 @@
 varnishtest "Trigger a compression error via bad index"
 
 server s1 {
-	non-fatal
+	non_fatal
 	stream 1 {
 		rxreq
 		expect req.http.foo == <undef>

--- a/bin/varnishtest/tests/a02020.vtc
+++ b/bin/varnishtest/tests/a02020.vtc
@@ -32,7 +32,7 @@ client c1 -connect ${s1_sock} {
 	stream 3 { txreq		} -run
 	stream 0 { txsettings -hdrtbl 0 } -run
 
-	non-fatal
+	non_fatal
 	stream 3 {
 		rxresp
 		expect resp.http.foo == <undef>

--- a/bin/varnishtest/tests/a02024.vtc
+++ b/bin/varnishtest/tests/a02024.vtc
@@ -3,9 +3,14 @@ varnishtest "Write a body to a file"
 server s1 {
 	fatal
 	stream 1 {
+		# First, HTTP checks
 		rxreq
 		expect req.http.Content-Type == "text/plain"
+
+		# Then, payload checks
 		write_body req.txt
+		shell {grep -q request req.txt}
+
 		txresp -hdr Content-Type text/plain -body response
 	} -run
 
@@ -15,13 +20,15 @@ client c1 -connect ${s1_sock} {
 	fatal
 	stream 1 {
 		txreq -req POST -hdr Content-Type text/plain -body request
+
+		# First, HTTP checks
 		rxresp
 		expect resp.http.Content-Type == "text/plain"
+
+		# Then, payload checks
 		write_body resp.txt
+		shell {grep -q response resp.txt}
 	} -run
 } -run
 
 server s1 -wait
-
-shell {grep -q request req.txt}
-shell {grep -q response resp.txt}

--- a/bin/varnishtest/tests/a02024.vtc
+++ b/bin/varnishtest/tests/a02024.vtc
@@ -1,0 +1,27 @@
+varnishtest "Write a body to a file"
+
+server s1 {
+	fatal
+	stream 1 {
+		rxreq
+		expect req.http.Content-Type == "text/plain"
+		write_body req.txt
+		txresp -hdr Content-Type text/plain -body response
+	} -run
+
+} -start
+
+client c1 -connect ${s1_sock} {
+	fatal
+	stream 1 {
+		txreq -req POST -hdr Content-Type text/plain -body request
+		rxresp
+		expect resp.http.Content-Type == "text/plain"
+		write_body resp.txt
+	} -run
+} -run
+
+server s1 -wait
+
+shell {grep -q request req.txt}
+shell {grep -q response resp.txt}

--- a/bin/varnishtest/tests/b00020.vtc
+++ b/bin/varnishtest/tests/b00020.vtc
@@ -28,7 +28,7 @@ varnish v1 -expect n_object == 0
 varnish v1 -expect n_objectcore == 0
 
 server s1 -wait {
-	non-fatal
+	non_fatal
 	rxreq
 	send "HTTP/1.0 200 OK\r\nConnection: close\r\n\r\n"
 	delay 0.5

--- a/bin/varnishtest/tests/c00046.vtc
+++ b/bin/varnishtest/tests/c00046.vtc
@@ -33,7 +33,7 @@ varnish v1 -expect SMA.s2.g_space > 1000000
 
 server s1 -wait {
 	rxreq
-	non-fatal
+	non_fatal
 	txresp -hdr "Connection: close" -bodylen 1000001
 } -start
 
@@ -55,7 +55,7 @@ varnish v1 -expect SMA.s2.g_space > 1000000
 
 server s1 -wait {
 	rxreq
-	# non-fatal
+	# non_fatal
 	txresp -hdr "Connection: close" -bodylen 1000002
 } -start
 

--- a/bin/varnishtest/tests/r00387.vtc
+++ b/bin/varnishtest/tests/r00387.vtc
@@ -2,7 +2,7 @@ varnishtest "Regression test for #387: too long chunk header"
 
 server s1 {
 	rxreq
-	non-fatal
+	non_fatal
 	send "HTTP/1.1 200 OK\r\n"
 	send "Transfer-encoding: chunked\r\n"
 	send "\r\n"

--- a/bin/varnishtest/tests/r00942.vtc
+++ b/bin/varnishtest/tests/r00942.vtc
@@ -19,7 +19,7 @@ server s1 {
 		sendhex "00000000"
 	send "\r\n"
 	chunked "FOOBAR"
-	non-fatal
+	non_fatal
 	chunkedlen 0
 } -start
 
@@ -62,7 +62,7 @@ server s1 -wait {
 		sendhex "00000000"
 	send "\r\n"
 	chunked "FOOBAR"
-	non-fatal
+	non_fatal
 	chunkedlen 0
 } -start
 

--- a/bin/varnishtest/tests/r01036.vtc
+++ b/bin/varnishtest/tests/r01036.vtc
@@ -3,7 +3,7 @@ varnishtest "Test case for #1036"
 server s1 {
 	rxreq
 	# Send a bodylen of 1,5M, which will exceed cache space of 1M
-	non-fatal
+	non_fatal
 	txresp -bodylen 1572864
 } -start
 

--- a/bin/varnishtest/tests/r01037.vtc
+++ b/bin/varnishtest/tests/r01037.vtc
@@ -3,7 +3,7 @@ varnishtest "Test case for #1037"
 server s1 {
 	rxreq
 	# Send a bodylen of 1,5M, which will exceed cache space of 1M
-	non-fatal
+	non_fatal
 	txresp -nolen -hdr "Transfer-encoding: chunked"
 	chunked {<HTML>}
 	chunkedlen 500000

--- a/bin/varnishtest/tests/r01086.vtc
+++ b/bin/varnishtest/tests/r01086.vtc
@@ -23,7 +23,7 @@ server s1 {
 	delay .2
 
 	chunked "FOOBAR"
-	non-fatal
+	non_fatal
 	chunkedlen 0
 } -start
 
@@ -70,7 +70,7 @@ server s1 -wait {
 	delay .2
 
 	chunked "FOOBAR"
-	non-fatal
+	non_fatal
 	chunkedlen 0
 
 } -start

--- a/bin/varnishtest/tests/r01391.vtc
+++ b/bin/varnishtest/tests/r01391.vtc
@@ -3,7 +3,7 @@ varnishtest "client abandoning hit-for-pass"
 barrier b1 cond 2
 
 server s1 {
-	non-fatal
+	non_fatal
 	rxreq
 	txresp -nolen -hdr "Transfer-Encoding: chunked" -hdr "Set-Cookie: foo=bar"
 	chunked "foo"

--- a/bin/varnishtest/tests/r01562.vtc
+++ b/bin/varnishtest/tests/r01562.vtc
@@ -1,13 +1,13 @@
 varnishtest "retrying a short client body read should not panic varnish"
 
 server s1 {
-	non-fatal
+	non_fatal
 	rxreq
 	txresp -status 200 -hdr "Foo: BAR" -body "1234"
 } -start
 
 server s2 {
-	non-fatal
+	non_fatal
 	rxreq
 	txresp -status 200 -hdr "Foo: Foo" -body "56"
 } -start

--- a/bin/varnishtest/tests/r01608.vtc
+++ b/bin/varnishtest/tests/r01608.vtc
@@ -7,7 +7,7 @@ varnish v1 -arg "-p http_req_size=1024" -vcl+backend {
 } -start
 
 client c1 {
-	non-fatal
+	non_fatal
 	send "GET /"
 	send_n 2048 "A"
 	send " HTTP/1.1\r\n\r\n"

--- a/bin/varnishtest/tests/r01624.vtc
+++ b/bin/varnishtest/tests/r01624.vtc
@@ -25,7 +25,7 @@ varnish v1 -vcl+backend {} -start
 
 client c1 {
 	txreq
-	non-fatal
+	non_fatal
 	timeout 3
 	rxresp
 } -run

--- a/bin/varnishtest/tests/r01729.vtc
+++ b/bin/varnishtest/tests/r01729.vtc
@@ -1,7 +1,7 @@
 varnishtest "C-L/T-E:chunked conflict"
 
 server s1 {
-	non-fatal
+	non_fatal
 	rxreq
 	expect req.bodylen == 20
 
@@ -21,7 +21,7 @@ varnish v1 -vcl+backend { } -start
 
 client c1 {
 
-	non-fatal
+	non_fatal
 	send "PUT /1 HTTP/1.1\r\n"
 	send "Content-Length: 31\r\n"
 	send "Transfer-Encoding: chunked\r\n"

--- a/bin/varnishtest/tests/r01810.vtc
+++ b/bin/varnishtest/tests/r01810.vtc
@@ -1,7 +1,7 @@
 varnishtest "POST HTTP/1.0 response"
 
 server s1 {
-	non-fatal
+	non_fatal
 	rxreq
 	txresp -proto HTTP/1.1 -nolen -hdr "Connection: close"
 	send "Hello World\n"

--- a/bin/varnishtest/tests/r02035.vtc
+++ b/bin/varnishtest/tests/r02035.vtc
@@ -3,7 +3,7 @@ varnishtest "Streaming range early finish"
 barrier b1 cond 2
 
 server s1 {
-	non-fatal
+	non_fatal
 	rxreq
 	txresp -nolen -hdr "Content-Length: 11"
 	# Delay to get around Nagle. Without the delay the body bytes

--- a/bin/varnishtest/vtc.c
+++ b/bin/varnishtest/vtc.c
@@ -665,20 +665,20 @@ cmd_feature(CMD_ARGS)
  */
 
 static const struct cmds cmds[] = {
-#define CMD(n) { #n, cmd_##n }
-	CMD(server),
-	CMD(client),
-	CMD(varnish),
-	CMD(delay),
-	CMD(varnishtest),
-	CMD(shell),
-	CMD(err_shell),
-	CMD(barrier),
-	CMD(feature),
-	CMD(logexpect),
-	CMD(process),
+#define CMD(n) { #n, cmd_##n },
+	CMD(server)
+	CMD(client)
+	CMD(varnish)
+	CMD(delay)
+	CMD(varnishtest)
+	CMD(shell)
+	CMD(err_shell)
+	CMD(barrier)
+	CMD(feature)
+	CMD(logexpect)
+	CMD(process)
 #undef CMD
-	{ NULL,		NULL }
+	{ NULL, NULL }
 };
 
 int

--- a/bin/varnishtest/vtc.c
+++ b/bin/varnishtest/vtc.c
@@ -441,8 +441,12 @@ cmd_varnishtest(CMD_ARGS)
  *
  * The vtc will fail if the return code of the shell is not 0.
  */
+/* SECTION: client-server.spec.shell shell
+ *
+ * Same as for the top-level shell.
+ */
 
-static void
+void
 cmd_shell(CMD_ARGS)
 {
 	(void)priv;
@@ -471,8 +475,12 @@ cmd_shell(CMD_ARGS)
  * err_shell expect the shell command to fail AND stdout to match the string,
  * failing the test case otherwise.
  */
+/* SECTION: client-server.spec.shell err_shell
+ *
+ * Same as for the top-level err_shell.
+ */
 
-static void
+void
 cmd_err_shell(CMD_ARGS)
 {
 	(void)priv;

--- a/bin/varnishtest/vtc.h
+++ b/bin/varnishtest/vtc.h
@@ -66,6 +66,8 @@ CMD(varnish);
 CMD(barrier);
 CMD(logexpect);
 CMD(process);
+CMD(err_shell);
+CMD(shell);
 #undef CMD
 
 extern volatile sig_atomic_t vtc_error; /* Error, bail out */

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -743,7 +743,7 @@ cmd_http_rxresphdrs(CMD_ARGS)
 #define OVERHEAD 64L
 
 static void
-cmd_http_gunzip_body(CMD_ARGS)
+cmd_http_gunzip(CMD_ARGS)
 {
 	int i;
 	z_stream vz;
@@ -1632,7 +1632,7 @@ cmd_http_loop(CMD_ARGS)
 
 /* SECTION: client-server.spec.fatal
  *
- * fatal|non-fatal
+ * fatal|non_fatal
  *         Control whether a failure of this entity should stop the test.
  */
 
@@ -1645,12 +1645,14 @@ cmd_http_fatal(CMD_ARGS)
 	AZ(av[1]);
 	if (!strcmp(av[0], "fatal"))
 		hp->fatal = 0;
-	else if (!strcmp(av[0], "non-fatal"))
+	else if (!strcmp(av[0], "non_fatal"))
 		hp->fatal = -1;
 	else {
 		vtc_log(vl, 0, "XXX: fatal %s", cmd->name);
 	}
 }
+
+#define cmd_http_non_fatal cmd_http_fatal
 
 /* SECTION: client-server.spec.delay
  *
@@ -1779,43 +1781,61 @@ cmd_http_stream(CMD_ARGS)
  */
 
 static const struct cmds http_cmds[] = {
-	{ "timeout",		cmd_http_timeout },
-	{ "txreq",		cmd_http_txreq },
+#define CMD(n) { #n, cmd_##n }
+#define CMD_HTTP(n) { #n, cmd_http_##n }
+	/* session */
+	CMD_HTTP(accept),
+	CMD_HTTP(close),
+	CMD_HTTP(expect_close),
+	CMD_HTTP(recv),
+	CMD_HTTP(send),
+	CMD_HTTP(send_n),
+	CMD_HTTP(send_urgent),
+	CMD_HTTP(sendhex),
+	CMD_HTTP(timeout),
 
-	{ "rxreq",		cmd_http_rxreq },
-	{ "rxreqhdrs",		cmd_http_rxreqhdrs },
-	{ "rxreqbody",		cmd_http_rxreqbody },
-	{ "rxchunk",		cmd_http_rxchunk },
+	/* spec */
+	CMD_HTTP(fatal),
+	CMD_HTTP(loop),
+	CMD_HTTP(non_fatal),
 
-	{ "txresp",		cmd_http_txresp },
-	{ "rxresp",		cmd_http_rxresp },
-	{ "rxresphdrs",		cmd_http_rxresphdrs },
-	{ "rxrespbody",		cmd_http_rxrespbody },
-	{ "gunzip",		cmd_http_gunzip_body },
-	{ "expect",		cmd_http_expect },
-	{ "expect_pattern",	cmd_http_expect_pattern },
-	{ "recv",		cmd_http_recv },
-	{ "send",		cmd_http_send },
-	{ "send_n",		cmd_http_send_n },
-	{ "send_urgent",	cmd_http_send_urgent },
-	{ "sendhex",		cmd_http_sendhex },
-	{ "chunked",		cmd_http_chunked },
-	{ "chunkedlen",		cmd_http_chunkedlen },
-	{ "delay",		cmd_delay },
-	{ "barrier",		cmd_barrier },
-	{ "expect_close",	cmd_http_expect_close },
-	{ "close",		cmd_http_close },
-	{ "accept",		cmd_http_accept },
-	{ "loop",		cmd_http_loop },
-	{ "fatal",		cmd_http_fatal },
-	{ "non-fatal",		cmd_http_fatal },
+	/* body */
+	CMD_HTTP(gunzip),
 
-	{ "rxpri",		cmd_http_rxpri },
-	{ "txpri",		cmd_http_txpri },
-	{ "stream",		cmd_http_stream },
-	{ "settings",		cmd_http_settings },
-	{ "upgrade",		cmd_http_upgrade },
-	{ NULL,			NULL }
+	/* HTTP/1.x */
+	CMD_HTTP(chunked),
+	CMD_HTTP(chunkedlen),
+	CMD_HTTP(rxchunk),
+
+	/* HTTP/2 */
+	CMD_HTTP(stream),
+	CMD_HTTP(settings),
+
+	/* client */
+	CMD_HTTP(rxresp),
+	CMD_HTTP(rxrespbody),
+	CMD_HTTP(rxresphdrs),
+	CMD_HTTP(txpri),
+	CMD_HTTP(txreq),
+
+	/* server */
+	CMD_HTTP(rxpri),
+	CMD_HTTP(rxreq),
+	CMD_HTTP(rxreqbody),
+	CMD_HTTP(rxreqhdrs),
+	CMD_HTTP(txresp),
+	CMD_HTTP(upgrade),
+
+	/* checks */
+	CMD_HTTP(expect),
+	CMD_HTTP(expect_pattern),
+
+	/* general purpose */
+	CMD(barrier),
+	CMD(delay),
+#undef CMD_HTTP
+#undef CMD
+	{ NULL, NULL }
 };
 
 int

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -1807,61 +1807,61 @@ cmd_http_write_body(CMD_ARGS)
  */
 
 static const struct cmds http_cmds[] = {
-#define CMD(n) { #n, cmd_##n }
-#define CMD_HTTP(n) { #n, cmd_http_##n }
+#define CMD(n) { #n, cmd_##n },
+#define CMD_HTTP(n) { #n, cmd_http_##n },
 	/* session */
-	CMD_HTTP(accept),
-	CMD_HTTP(close),
-	CMD_HTTP(expect_close),
-	CMD_HTTP(recv),
-	CMD_HTTP(send),
-	CMD_HTTP(send_n),
-	CMD_HTTP(send_urgent),
-	CMD_HTTP(sendhex),
-	CMD_HTTP(timeout),
+	CMD_HTTP(accept)
+	CMD_HTTP(close)
+	CMD_HTTP(expect_close)
+	CMD_HTTP(recv)
+	CMD_HTTP(send)
+	CMD_HTTP(send_n)
+	CMD_HTTP(send_urgent)
+	CMD_HTTP(sendhex)
+	CMD_HTTP(timeout)
 
 	/* spec */
-	CMD_HTTP(fatal),
-	CMD_HTTP(loop),
-	CMD_HTTP(non_fatal),
+	CMD_HTTP(fatal)
+	CMD_HTTP(loop)
+	CMD_HTTP(non_fatal)
 
 	/* body */
-	CMD_HTTP(gunzip),
-	CMD_HTTP(write_body),
+	CMD_HTTP(gunzip)
+	CMD_HTTP(write_body)
 
 	/* HTTP/1.x */
-	CMD_HTTP(chunked),
-	CMD_HTTP(chunkedlen),
-	CMD_HTTP(rxchunk),
+	CMD_HTTP(chunked)
+	CMD_HTTP(chunkedlen)
+	CMD_HTTP(rxchunk)
 
 	/* HTTP/2 */
-	CMD_HTTP(stream),
-	CMD_HTTP(settings),
+	CMD_HTTP(stream)
+	CMD_HTTP(settings)
 
 	/* client */
-	CMD_HTTP(rxresp),
-	CMD_HTTP(rxrespbody),
-	CMD_HTTP(rxresphdrs),
-	CMD_HTTP(txpri),
-	CMD_HTTP(txreq),
+	CMD_HTTP(rxresp)
+	CMD_HTTP(rxrespbody)
+	CMD_HTTP(rxresphdrs)
+	CMD_HTTP(txpri)
+	CMD_HTTP(txreq)
 
 	/* server */
-	CMD_HTTP(rxpri),
-	CMD_HTTP(rxreq),
-	CMD_HTTP(rxreqbody),
-	CMD_HTTP(rxreqhdrs),
-	CMD_HTTP(txresp),
-	CMD_HTTP(upgrade),
+	CMD_HTTP(rxpri)
+	CMD_HTTP(rxreq)
+	CMD_HTTP(rxreqbody)
+	CMD_HTTP(rxreqhdrs)
+	CMD_HTTP(txresp)
+	CMD_HTTP(upgrade)
 
 	/* checks */
-	CMD_HTTP(expect),
-	CMD_HTTP(expect_pattern),
+	CMD_HTTP(expect)
+	CMD_HTTP(expect_pattern)
 
 	/* general purpose */
-	CMD(barrier),
-	CMD(delay),
-	CMD(err_shell),
-	CMD(shell),
+	CMD(barrier)
+	CMD(delay)
+	CMD(err_shell)
+	CMD(shell)
 #undef CMD_HTTP
 #undef CMD
 	{ NULL, NULL }

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -1860,6 +1860,8 @@ static const struct cmds http_cmds[] = {
 	/* general purpose */
 	CMD(barrier),
 	CMD(delay),
+	CMD(err_shell),
+	CMD(shell),
 #undef CMD_HTTP
 #undef CMD
 	{ NULL, NULL }

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -1812,7 +1812,6 @@ static const struct cmds http_cmds[] = {
 	/* session */
 	CMD_HTTP(accept)
 	CMD_HTTP(close)
-	CMD_HTTP(expect_close)
 	CMD_HTTP(recv)
 	CMD_HTTP(send)
 	CMD_HTTP(send_n)
@@ -1853,8 +1852,9 @@ static const struct cmds http_cmds[] = {
 	CMD_HTTP(txresp)
 	CMD_HTTP(upgrade)
 
-	/* checks */
+	/* expect */
 	CMD_HTTP(expect)
+	CMD_HTTP(expect_close)
 	CMD_HTTP(expect_pattern)
 
 	/* general purpose */

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -43,6 +43,7 @@
 #include "vtc_http.h"
 
 #include "vct.h"
+#include "vfil.h"
 #include "vgz.h"
 #include "vnum.h"
 #include "vre.h"
@@ -1776,6 +1777,31 @@ cmd_http_stream(CMD_ARGS)
 	cmd_stream(av, hp, cmd, vl);
 }
 
+/* SECTION: client-server.spec.write_body
+ *
+ * write_body STRING
+ *	Write the body of a request or a response to a file. By using the
+ *	shell or err_shell commands, higher-level checks on the body can
+ *	be performed (eg. XML, JSON, ...) provided that such checks can be
+ *	delegated to an external program.
+ */
+static void
+cmd_http_write_body(CMD_ARGS)
+{
+	struct http *hp;
+
+	(void)cmd;
+	(void)vl;
+	CAST_OBJ_NOTNULL(hp, priv, HTTP_MAGIC);
+	AN(av[0]);
+	AN(av[1]);
+	AZ(av[2]);
+	AZ(strcmp(av[0], "write_body"));
+	if (VFIL_writefile(NULL, av[1], hp->body, hp->bodyl) != 0)
+		vtc_log(hp->vl, 0, "failed to write body: %s (%d)",
+		    strerror(errno), errno);
+}
+
 /**********************************************************************
  * Execute HTTP specifications
  */
@@ -1801,6 +1827,7 @@ static const struct cmds http_cmds[] = {
 
 	/* body */
 	CMD_HTTP(gunzip),
+	CMD_HTTP(write_body),
 
 	/* HTTP/1.x */
 	CMD_HTTP(chunked),

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -1376,6 +1376,12 @@ cmd_sendhex(CMD_ARGS)
  *	\-pad, or one that is generated for you, of length INT is -padlen
  *	case.
  */
+
+#define cmd_txreq	cmd_tx11obj
+#define cmd_txresp	cmd_tx11obj
+#define cmd_txpush	cmd_tx11obj
+#define cmd_txcont	cmd_tx11obj
+
 static void
 cmd_tx11obj(CMD_ARGS)
 {
@@ -2233,8 +2239,12 @@ cmd_rxdata(CMD_ARGS)
  * by a server, and rxresp by a client.
  *
  */
+
+#define cmd_rxreq	cmd_rxmsg
+#define cmd_rxresp	cmd_rxmsg
+
 static void
-cmd_rxreqsp(CMD_ARGS)
+cmd_rxmsg(CMD_ARGS)
 {
 	struct stream *s;
 	struct frame *f;
@@ -2388,10 +2398,8 @@ cmd_rxframe(CMD_ARGS)
 	rxstuff(s);
 }
 
-
-
 static void
-cmd_http_expect(CMD_ARGS)
+cmd_expect(CMD_ARGS)
 {
 	struct http *hp;
 	struct stream *s;
@@ -2465,35 +2473,42 @@ cmd_http_expect(CMD_ARGS)
  * client or a server.
  */
 static const struct cmds stream_cmds[] = {
-	{ "expect",		cmd_http_expect },
-	{ "sendhex",		cmd_sendhex },
-	{ "rxframe",		cmd_rxframe },
-	{ "txdata",		cmd_txdata },
-	{ "rxdata",		cmd_rxdata },
-	{ "rxhdrs",		cmd_rxhdrs },
-	{ "txreq",		cmd_tx11obj },
-	{ "rxreq",		cmd_rxreqsp },
-	{ "txresp",		cmd_tx11obj },
-	{ "rxresp",		cmd_rxreqsp },
-	{ "txprio",		cmd_txprio },
-	{ "rxprio",		cmd_rxprio },
-	{ "txrst",		cmd_txrst },
-	{ "rxrst",		cmd_rxrst },
-	{ "txsettings",		cmd_txsettings },
-	{ "rxsettings",		cmd_rxsettings },
-	{ "txpush",		cmd_tx11obj },
-	{ "rxpush",		cmd_rxpush },
-	{ "txping",		cmd_txping },
-	{ "rxping",		cmd_rxping },
-	{ "txgoaway",		cmd_txgoaway },
-	{ "rxgoaway",		cmd_rxgoaway },
-	{ "txwinup",		cmd_txwinup },
-	{ "rxwinup",		cmd_rxwinup },
-	{ "txcont",		cmd_tx11obj },
-	{ "rxcont",		cmd_rxcont },
-	{ "delay",		cmd_delay },
-	{ "barrier",		cmd_barrier },
+#define CMD(n) { #n, cmd_##n },
+#define CMD_STREAM(n) { #n, cmd_##n },
+	/* spec */
+	CMD_STREAM(expect)
+	CMD_STREAM(rxcont)
+	CMD_STREAM(rxdata)
+	CMD_STREAM(rxframe)
+	CMD_STREAM(rxgoaway)
+	CMD_STREAM(rxhdrs)
+	CMD_STREAM(rxping)
+	CMD_STREAM(rxprio)
+	CMD_STREAM(rxpush)
+	CMD_STREAM(rxreq)
+	CMD_STREAM(rxresp)
+	CMD_STREAM(rxrst)
+	CMD_STREAM(rxsettings)
+	CMD_STREAM(rxwinup)
+	CMD_STREAM(sendhex)
+	CMD_STREAM(txcont)
+	CMD_STREAM(txdata)
+	CMD_STREAM(txgoaway)
+	CMD_STREAM(txping)
+	CMD_STREAM(txprio)
+	CMD_STREAM(txpush)
+	CMD_STREAM(txreq)
+	CMD_STREAM(txresp)
+	CMD_STREAM(txrst)
+	CMD_STREAM(txsettings)
+	CMD_STREAM(txwinup)
+
+	/* general purpose */
+	CMD(barrier)
+	CMD(delay)
 	{ NULL,			NULL }
+#undef CMD_STREAM
+#undef CMD
 };
 
 static void *

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -2530,6 +2530,8 @@ static const struct cmds stream_cmds[] = {
 	/* general purpose */
 	CMD(barrier)
 	CMD(delay)
+	CMD(err_shell)
+	CMD(shell)
 	{ NULL,			NULL }
 #undef CMD_STREAM
 #undef CMD

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -45,6 +45,7 @@
 #include "vtc_http.h"
 
 #include "vct.h"
+#include "vfil.h"
 #include "vgz.h"
 #include "vnum.h"
 #include "vre.h"
@@ -2467,6 +2468,28 @@ cmd_expect(CMD_ARGS)
 	AZ(pthread_mutex_unlock(&s->hp->mtx));
 }
 
+/* SECTION: stream.spec.write_body
+ *
+ * write_body STRING
+ *	Same as the ``write_body`` command for HTTP/1.
+ */
+static void
+cmd_write_body(CMD_ARGS)
+{
+	struct stream *s;
+
+	(void)cmd;
+	(void)vl;
+	CAST_OBJ_NOTNULL(s, priv, STREAM_MAGIC);
+	AN(av[0]);
+	AN(av[1]);
+	AZ(av[2]);
+	AZ(strcmp(av[0], "write_body"));
+	if (VFIL_writefile(NULL, av[1], s->body, s->bodylen) != 0)
+		vtc_log(s->hp->vl, 0, "failed to write body: %s (%d)",
+		    strerror(errno), errno);
+}
+
 /* SECTION: stream.spec Specification
  *
  * The specification of a stream follows the exact same rules as one for a
@@ -2502,6 +2525,7 @@ static const struct cmds stream_cmds[] = {
 	CMD_STREAM(txrst)
 	CMD_STREAM(txsettings)
 	CMD_STREAM(txwinup)
+	CMD_STREAM(write_body)
 
 	/* general purpose */
 	CMD(barrier)

--- a/include/vfil.h
+++ b/include/vfil.h
@@ -33,6 +33,7 @@ struct vfil_path;
 /* from libvarnish/vfil.c */
 int seed_random(void);
 char *VFIL_readfile(const char *pfx, const char *fn, ssize_t *sz);
+int VFIL_writefile(const char *pfx, const char *fn, const char *buf, size_t sz);
 int VFIL_nonblocking(int fd);
 int VFIL_fsinfo(int fd, unsigned *pbs, uintmax_t *size, uintmax_t *space);
 int VFIL_allocate(int fd, off_t size, int insist);

--- a/lib/libvarnish/vfil.c
+++ b/lib/libvarnish/vfil.c
@@ -85,21 +85,30 @@ vfil_readfd(int fd, ssize_t *sz)
 	return (f);
 }
 
+static int
+vfil_openfile(const char *pfx, const char *fn, int flags, int mode)
+{
+	char fnb[PATH_MAX + 1];
+
+	if (fn[0] != '/' && pfx != NULL) {
+		/* XXX: graceful length check */
+		bprintf(fnb, "/%s/%s", pfx, fn);
+		fn = fnb;
+	}
+
+	if (flags & O_CREAT)
+		return (open(fn, flags, mode));
+	else
+		return (open(fn, flags));
+}
+
 char *
 VFIL_readfile(const char *pfx, const char *fn, ssize_t *sz)
 {
 	int fd, err;
 	char *r;
-	char fnb[PATH_MAX + 1];
 
-	if (fn[0] == '/')
-		fd = open(fn, O_RDONLY);
-	else if (pfx != NULL) {
-		bprintf(fnb, "/%s/%s", pfx, fn);
-		    /* XXX: graceful length check */
-		fd = open(fnb, O_RDONLY);
-	} else
-		fd = open(fn, O_RDONLY);
+	fd = vfil_openfile(pfx, fn, O_RDONLY, 0);
 	if (fd < 0)
 		return (NULL);
 	r = vfil_readfd(fd, sz);


### PR DESCRIPTION
Following my campaign for empowering out-of-tree uses of `varnishtest`, an escape hatch to delegate body (XML, JSON, etc) checks to external programs.

This is also slightly breaking the VTC syntax as part of a general cleanup, `non-fatal` was renamed to `non_fatal`.

It includes opinionated changes to `libvarnish.a`, hopefully not controversial.