### PR TITLE
Remove duplicated word to improve reading pleasure

### DIFF
--- a/doc/sphinx/users-guide/run_security.rst
+++ b/doc/sphinx/users-guide/run_security.rst
@@ -162,7 +162,7 @@ Furthermore you may want to look at and lock down:
 
 :ref:`ref_param_vmod_path`
         The directory (or colon separated list of directories) where
-        Varnish will will look for modules. This could potentially be
+        Varnish will look for modules. This could potentially be
         used to load rogue modules into Varnish.
 
 The CLI interface


### PR DESCRIPTION
As a reader of the docs
I mentally stumbled over a duplicated word
In order to... no wait, wrong format.

In hope of improving the codebase and the world as a whole, I hereby offer this change free of charge and with the usual "AS IS"-disclaimer to improve the flow of reading the documentation. 