### PR TITLE
Fix/Improve H1 Expect & 100 Continue / Logging / Start H2 Expect handling

### DIFF
--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -87,7 +87,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	yet = req->htc->content_length;
 	if (yet != 0 && req->want100cont) {
 		req->want100cont = 0;
-		(void) req->transport->sresp(req, 100);
+		(void) req->transport->minimal_response(req, 100);
 	}
 	if (yet < 0)
 		yet = 0;

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -37,6 +37,7 @@
 #include "vtim.h"
 #include "hash/hash_slinger.h"
 #include "storage/storage.h"
+#include "cache_transport.h"
 
 /*----------------------------------------------------------------------
  * Pull the req.body in via/into a objcore
@@ -84,6 +85,10 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	AZ(req->req_bodybytes);
 	AN(req->htc);
 	yet = req->htc->content_length;
+	if (yet != 0 && req->want100cont) {
+		req->want100cont = 0;
+		req->transport->sresp(req, R_100);
+	}
 	if (yet < 0)
 		yet = 0;
 	do {

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -87,7 +87,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	yet = req->htc->content_length;
 	if (yet != 0 && req->want100cont) {
 		req->want100cont = 0;
-		req->transport->sresp(req, R_100);
+		(void) req->transport->sresp(req, R_100);
 	}
 	if (yet < 0)
 		yet = 0;

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -87,7 +87,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	yet = req->htc->content_length;
 	if (yet != 0 && req->want100cont) {
 		req->want100cont = 0;
-		(void) req->transport->sresp(req, R_100);
+		(void) req->transport->sresp(req, 100);
 	}
 	if (yet < 0)
 		yet = 0;

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -238,6 +238,8 @@ VRB_Ignore(struct req *req)
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 
+	if (req->doclose)
+		return (0);
 	if (req->req_body_status == REQ_BODY_WITH_LEN ||
 	    req->req_body_status == REQ_BODY_WITHOUT_LEN)
 		(void)VRB_Iterate(req, httpq_req_body_discard, NULL);

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -194,18 +194,12 @@ cnt_synth(struct worker *wrk, struct req *req)
 	http_PutResponse(h, "HTTP/1.1", req->err_code, req->err_reason);
 
 	/*
-	 * Even with an unanswered Expect: 100-continue, the client may or may
-	 * not send data, so we would need to make an attempt to drain-read the
-	 * body. But if the client has not started sending a body, we'd read the
-	 * next request.
-	 *
-	 * So Connection: close is our only way out and for this specific case
-	 * we do not allow VCL to veto it.
+	 * For late 100-continue, we suggest to VCL to close the conenction to
+	 * neither send a 100-continue nor drain-read the request. But VCL has
+	 * the option to veto by removing Connection: close
 	 */
 	if (req->want100cont) {
 		http_SetHeader(h, "Connection: close");
-		req->doclose = SC_RESP_CLOSE;
-		req->want100cont = 0;
 	}
 
 	synth_body = VSB_new_auto();

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -747,6 +747,13 @@ cnt_recv(struct worker *wrk, struct req *req)
 		VCL_recv_method(req->vcl, wrk, req, NULL, NULL);
 	}
 
+	if (req->want100cont) {
+		req->want100cont = 0;
+		req->transport->sresp(req, R_100);
+		if (req->doclose)
+			return (-1);
+	}
+
 	/* Attempts to cache req.body may fail */
 	if (req->req_body_status == REQ_BODY_FAIL) {
 		req->doclose = SC_RX_BODY;

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -766,8 +766,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 
 	if (req->want100cont && !req->late100cont) {
 		req->want100cont = 0;
-		req->transport->sresp(req, R_100);
-		if (req->doclose)
+		if (req->transport->sresp(req, R_100))
 			return (-1);
 	}
 

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -766,7 +766,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 
 	if (req->want100cont && !req->late100cont) {
 		req->want100cont = 0;
-		if (req->transport->sresp(req, R_100))
+		if (req->transport->sresp(req, 100))
 			return (-1);
 	}
 

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -766,7 +766,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 
 	if (req->want100cont && !req->late100cont) {
 		req->want100cont = 0;
-		if (req->transport->sresp(req, 100))
+		if (req->transport->minimal_response(req, 100))
 			return (-1);
 	}
 

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -36,12 +36,20 @@
 struct req;
 struct boc;
 
+enum vtr_sresp {
+	R_100,
+	R_400,
+	R_417,
+	R_LIM
+};
+
 typedef void vtr_deliver_f (struct req *, struct boc *, int sendbody);
 typedef void vtr_req_body_f (struct req *);
 typedef void vtr_sess_panic_f (struct vsb *, const struct sess *);
 typedef void vtr_req_panic_f (struct vsb *, const struct req *);
 typedef void vtr_req_fail_f (struct req *, enum sess_close);
 typedef void vtr_reembark_f (struct worker *, struct req *);
+typedef void vtr_sresp_f (struct req *, enum vtr_sresp);
 
 struct transport {
 	unsigned			magic;
@@ -60,6 +68,7 @@ struct transport {
 	vtr_sess_panic_f		*sess_panic;
 	vtr_req_panic_f			*req_panic;
 	vtr_reembark_f			*reembark;
+	vtr_sresp_f			*sresp;
 
 	VTAILQ_ENTRY(transport)		list;
 };

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -36,20 +36,13 @@
 struct req;
 struct boc;
 
-enum vtr_sresp {
-	R_100,
-	R_400,
-	R_417,
-	R_LIM
-};
-
 typedef void vtr_deliver_f (struct req *, struct boc *, int sendbody);
 typedef void vtr_req_body_f (struct req *);
 typedef void vtr_sess_panic_f (struct vsb *, const struct sess *);
 typedef void vtr_req_panic_f (struct vsb *, const struct req *);
 typedef void vtr_req_fail_f (struct req *, enum sess_close);
 typedef void vtr_reembark_f (struct worker *, struct req *);
-typedef int vtr_sresp_f (struct req *, enum vtr_sresp);
+typedef int vtr_sresp_f (struct req *, uint16_t status);
 
 struct transport {
 	unsigned			magic;

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -42,7 +42,7 @@ typedef void vtr_sess_panic_f (struct vsb *, const struct sess *);
 typedef void vtr_req_panic_f (struct vsb *, const struct req *);
 typedef void vtr_req_fail_f (struct req *, enum sess_close);
 typedef void vtr_reembark_f (struct worker *, struct req *);
-typedef int vtr_sresp_f (struct req *, uint16_t status);
+typedef int vtr_minimal_response_f (struct req *, uint16_t status);
 
 struct transport {
 	unsigned			magic;
@@ -61,7 +61,7 @@ struct transport {
 	vtr_sess_panic_f		*sess_panic;
 	vtr_req_panic_f			*req_panic;
 	vtr_reembark_f			*reembark;
-	vtr_sresp_f			*sresp;
+	vtr_minimal_response_f		*minimal_response;
 
 	VTAILQ_ENTRY(transport)		list;
 };

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -49,7 +49,7 @@ typedef void vtr_sess_panic_f (struct vsb *, const struct sess *);
 typedef void vtr_req_panic_f (struct vsb *, const struct req *);
 typedef void vtr_req_fail_f (struct req *, enum sess_close);
 typedef void vtr_reembark_f (struct worker *, struct req *);
-typedef void vtr_sresp_f (struct req *, enum vtr_sresp);
+typedef int vtr_sresp_f (struct req *, enum vtr_sresp);
 
 struct transport {
 	unsigned			magic;

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -327,9 +327,7 @@ http1_dissect(struct worker *wrk, struct req *req)
 			wrk->stats->client_req_417++;
 			return (-1);
 		}
-		http1_simple_response(req, R_100);
-		if (req->doclose)
-			return (-1);
+		req->want100cont = 1;
 		http_Unset(req->http, H_Expect);
 	}
 

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -202,6 +202,40 @@ http1_reembark(struct worker *wrk, struct req *req)
 	usleep(10000);
 }
 
+static struct http1_simple_response_msg {
+	const unsigned  s;
+	const char      *r, *resp;
+} http1_simple_response_msg[] = {
+#define SRESP(s, r) [R_##s] = { s, r, "HTTP/1.1 " #s " " r "\r\n\r\n" }
+	SRESP(100, "Continue"),
+	SRESP(400, "Bad Request"),
+	SRESP(417, "Expectation Failed")
+#undef SRESP
+};
+
+static void __match_proto__(vtr_sresp_f)
+http1_simple_response(struct req *req, enum vtr_sresp sr)
+{
+	const struct http1_simple_response_msg *m;
+	ssize_t l;
+
+	assert(sr < R_LIM);
+	m = &http1_simple_response_msg[sr];
+	AN(m->s);
+
+	VSLb(req->vsl, SLT_RespProtocol, "HTTP/1.1");
+	VSLb(req->vsl, SLT_RespStatus, "%03d", m->s);
+	VSLb(req->vsl, SLT_RespReason, "%s", m->r);
+
+	if (m->s >= 400)
+		req->err_code = m->s;
+	l = write(req->sp->fd, m->resp, strlen(m->resp));
+	if (l > 0)
+		req->acct.resp_hdrbytes += l;
+	if (! req->doclose && l != strlen(m->resp))
+		req->doclose = SC_REM_CLOSE;
+}
+
 struct transport HTTP1_transport = {
 	.name =			"HTTP/1",
 	.magic =		TRANSPORT_MAGIC,
@@ -213,19 +247,25 @@ struct transport HTTP1_transport = {
 	.sess_panic =		http1_sess_panic,
 	.req_panic =		http1_req_panic,
 	.reembark =		http1_reembark,
+	.sresp =		http1_simple_response,
 };
 
 /*----------------------------------------------------------------------
  */
 
+static inline void
+http1_abort(struct req *req, enum vtr_sresp sr)
+{
+	AN(req->doclose);
+	assert(sr >= R_400);
+	http1_simple_response(req, sr);
+	return;
+}
+
 static int
 http1_dissect(struct worker *wrk, struct req *req)
 {
-	const char *r_100 = "HTTP/1.1 100 Continue\r\n\r\n";
-	const char *r_400 = "HTTP/1.1 400 Bad Request\r\n\r\n";
-	const char *r_417 = "HTTP/1.1 417 Expectation Failed\r\n\r\n";
 	const char *p;
-	ssize_t r;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
@@ -256,10 +296,8 @@ http1_dissect(struct worker *wrk, struct req *req)
 		    (int)(req->htc->rxbuf_e - req->htc->rxbuf_b),
 		    req->htc->rxbuf_b);
 		wrk->stats->client_req_400++;
-		r = write(req->sp->fd, r_400, strlen(r_400));
-		if (r > 0)
-			req->acct.resp_hdrbytes += r;
 		req->doclose = SC_RX_JUNK;
+		http1_abort(req, R_400);
 		return (-1);
 	}
 
@@ -284,21 +322,14 @@ http1_dissect(struct worker *wrk, struct req *req)
 
 	if (http_GetHdr(req->http, H_Expect, &p)) {
 		if (strcasecmp(p, "100-continue")) {
-			wrk->stats->client_req_417++;
-			req->err_code = 417;
-			r = write(req->sp->fd, r_417, strlen(r_417));
-			if (r > 0)
-				req->acct.resp_hdrbytes += r;
 			req->doclose = SC_RX_JUNK;
+			http1_abort(req, R_417);
+			wrk->stats->client_req_417++;
 			return (-1);
 		}
-		r = write(req->sp->fd, r_100, strlen(r_100));
-		if (r > 0)
-			req->acct.resp_hdrbytes += r;
-		if (r != strlen(r_100)) {
-			req->doclose = SC_REM_CLOSE;
+		http1_simple_response(req, R_100);
+		if (req->doclose)
 			return (-1);
-		}
 		http_Unset(req->http, H_Expect);
 	}
 
@@ -310,9 +341,7 @@ http1_dissect(struct worker *wrk, struct req *req)
 
 	req->doclose = http_DoConnection(req->http);
 	if (req->doclose == SC_RX_BAD) {
-		r = write(req->sp->fd, r_400, strlen(r_400));
-		if (r > 0)
-			req->acct.resp_hdrbytes += r;
+		http1_abort(req, R_400);
 		return (-1);
 	}
 

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -327,7 +327,8 @@ http1_dissect(struct worker *wrk, struct req *req)
 			wrk->stats->client_req_417++;
 			return (-1);
 		}
-		req->want100cont = 1;
+		if (req->http->protover >= 11 && req->htc->pipeline_b == NULL)
+			req->want100cont = 1;
 		http_Unset(req->http, H_Expect);
 	}
 

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -202,8 +202,8 @@ http1_reembark(struct worker *wrk, struct req *req)
 	usleep(10000);
 }
 
-static int __match_proto__(vtr_sresp_f)
-http1_simple_response(struct req *req, uint16_t status)
+static int __match_proto__(vtr_minimal_response_f)
+http1_minimal_response(struct req *req, uint16_t status)
 {
 	size_t wl, l, spc = 80;
 	char buf[spc];
@@ -246,7 +246,7 @@ struct transport HTTP1_transport = {
 	.sess_panic =		http1_sess_panic,
 	.req_panic =		http1_req_panic,
 	.reembark =		http1_reembark,
-	.sresp =		http1_simple_response,
+	.minimal_response =	http1_minimal_response,
 };
 
 /*----------------------------------------------------------------------
@@ -257,7 +257,7 @@ http1_abort(struct req *req, unsigned status)
 {
 	AN(req->doclose);
 	assert(status >= 400);
-	(void) http1_simple_response(req, status);
+	(void) http1_minimal_response(req, status);
 	return;
 }
 

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -228,8 +228,10 @@ http1_minimal_response(struct req *req, uint16_t status)
 
 	if (wl > 0)
 		req->acct.resp_hdrbytes += wl;
-	if (! req->doclose && wl != l) {
-		req->doclose = SC_REM_CLOSE;
+	if (wl != l) {
+		VTCP_Assert(1);
+		if (! req->doclose)
+			req->doclose = SC_REM_CLOSE;
 		return (-1);
 	}
 	return (0);

--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -125,7 +125,7 @@ vtr_sess_panic_f h2_sess_panic;
 /* http2/cache_http2_deliver.c */
 #ifdef TRANSPORT_MAGIC
 vtr_deliver_f h2_deliver;
-vtr_sresp_f h2_simple_response;
+vtr_minimal_response_f h2_minimal_response;
 #endif /* TRANSPORT_MAGIC */
 
 /* http2/cache_http2_hpack.c */

--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -125,6 +125,7 @@ vtr_sess_panic_f h2_sess_panic;
 /* http2/cache_http2_deliver.c */
 #ifdef TRANSPORT_MAGIC
 vtr_deliver_f h2_deliver;
+vtr_sresp_f h2_simple_response;
 #endif /* TRANSPORT_MAGIC */
 
 /* http2/cache_http2_hpack.c */

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -93,7 +93,7 @@ h2_bytes(struct req *req, enum vdp_action act, void **priv,
 }
 
 static inline size_t
-h2_status(char *p, uint16_t status) {
+h2_status(uint8_t *p, uint16_t status) {
 	size_t l = 1;
 
 	switch (status) {

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -117,8 +117,8 @@ h2_status(char *p, uint16_t status) {
 	return (l);
 }
 
-int __match_proto__(vtr_sresp_f)
-h2_simple_response(struct req *req, uint16_t status)
+int __match_proto__(vtr_minimal_response_f)
+h2_minimal_response(struct req *req, uint16_t status)
 {
 	struct h2_req *r2;
 	const size_t spc = 6;

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -105,7 +105,7 @@ static struct h2_simple_response_msg {
 #undef SRESP
 };
 
-void __match_proto__(vtr_sresp_f)
+int __match_proto__(vtr_sresp_f)
 h2_simple_response(struct req *req, enum vtr_sresp sr)
 {
 	const struct h2_simple_response_msg *m;
@@ -126,9 +126,11 @@ h2_simple_response(struct req *req, enum vtr_sresp sr)
 	if (m->s >= 400)
 		req->err_code = m->s;
 
+	/* XXX return code checking once H2_Send returns anything but 0 */
 	H2_Send(req->wrk, r2, 1,
 	    H2_FRAME_HEADERS, H2FF_HEADERS_END_HEADERS,
 	    m->l, m->p);
+	return (0);
 }
 
 void __match_proto__(vtr_deliver_f)

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -92,6 +92,45 @@ h2_bytes(struct req *req, enum vdp_action act, void **priv,
 	return (0);
 }
 
+static struct h2_simple_response_msg {
+	const char	*p;
+	size_t		l;
+	unsigned	s;
+	const char	*r;
+} h2_simple_response_msg[] = {
+	[R_400] = { "\x92", 1, 400, "Bad Request"},
+#define SRESP(s, r) [R_##s] = { "\x18\x03" #s, 5, s, r}
+	SRESP(100, "Continue"),
+	SRESP(417, "Expectation Failed")
+#undef SRESP
+};
+
+void __match_proto__(vtr_sresp_f)
+h2_simple_response(struct req *req, enum vtr_sresp sr)
+{
+	const struct h2_simple_response_msg *m;
+	struct h2_req *r2;
+
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	CAST_OBJ_NOTNULL(r2, req->transport_priv, H2_REQ_MAGIC);
+
+	assert(sr < R_LIM);
+	m = &h2_simple_response_msg[sr];
+	AN(m->p);
+	AN(m->l);
+
+	VSLb(req->vsl, SLT_RespProtocol, "HTTP/2.0");
+	VSLb(req->vsl, SLT_RespStatus, "%03d", m->s);
+	VSLb(req->vsl, SLT_RespReason, "%s", m->r);
+
+	if (m->s >= 400)
+		req->err_code = m->s;
+
+	H2_Send(req->wrk, r2, 1,
+	    H2_FRAME_HEADERS, H2FF_HEADERS_END_HEADERS,
+	    m->l, m->p);
+}
+
 void __match_proto__(vtr_deliver_f)
 h2_deliver(struct req *req, struct boc *boc, int sendbody)
 {

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -92,44 +92,59 @@ h2_bytes(struct req *req, enum vdp_action act, void **priv,
 	return (0);
 }
 
-static struct h2_simple_response_msg {
-	const char	*p;
-	size_t		l;
-	unsigned	s;
-	const char	*r;
-} h2_simple_response_msg[] = {
-	[R_400] = { "\x92", 1, 400, "Bad Request"},
-#define SRESP(s, r) [R_##s] = { "\x18\x03" #s, 5, s, r}
-	SRESP(100, "Continue"),
-	SRESP(417, "Expectation Failed")
-#undef SRESP
-};
+static inline size_t
+h2_status(char *p, uint16_t status) {
+	size_t l = 1;
+
+	switch (status) {
+	case 200: *p = 0x80 |  8; break;
+	case 204: *p = 0x80 |  9; break;
+	case 206: *p = 0x80 | 10; break;
+	case 304: *p = 0x80 | 11; break;
+	case 400: *p = 0x80 | 12; break;
+	case 404: *p = 0x80 | 13; break;
+	case 500: *p = 0x80 | 14; break;
+	default:
+		*p++ = 0x18;
+		*p++ = 0x03;
+		l = 2;
+
+		l += snprintf((char*)p, 4, "%03d", status);
+		assert(l == 5);
+		break;
+	}
+
+	return (l);
+}
 
 int __match_proto__(vtr_sresp_f)
-h2_simple_response(struct req *req, enum vtr_sresp sr)
+h2_simple_response(struct req *req, uint16_t status)
 {
-	const struct h2_simple_response_msg *m;
 	struct h2_req *r2;
+	const size_t spc = 6;
+	size_t l;
+	uint8_t buf[spc];
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	CAST_OBJ_NOTNULL(r2, req->transport_priv, H2_REQ_MAGIC);
 
-	assert(sr < R_LIM);
-	m = &h2_simple_response_msg[sr];
-	AN(m->p);
-	AN(m->l);
+	assert(status >= 100);
+	assert(status < 1000);
+
+	l = h2_status(buf, status);
+	assert(l < spc);
 
 	VSLb(req->vsl, SLT_RespProtocol, "HTTP/2.0");
-	VSLb(req->vsl, SLT_RespStatus, "%03d", m->s);
-	VSLb(req->vsl, SLT_RespReason, "%s", m->r);
+	VSLb(req->vsl, SLT_RespStatus, "%03d", status);
+	VSLb(req->vsl, SLT_RespReason, "%s", http_Status2Reason(status, NULL));
 
-	if (m->s >= 400)
-		req->err_code = m->s;
+	if (status >= 400)
+		req->err_code = status;
 
 	/* XXX return code checking once H2_Send returns anything but 0 */
 	H2_Send(req->wrk, r2, 1,
 	    H2_FRAME_HEADERS, H2FF_HEADERS_END_HEADERS,
-	    m->l, m->p);
+	    l, buf);
 	return (0);
 }
 
@@ -159,22 +174,7 @@ h2_deliver(struct req *req, struct boc *boc, int sendbody)
 	(void)WS_Reserve(req->ws, 0);
 	p = (void*)req->ws->f;
 
-	switch (req->resp->status) {
-	case 200: *p++ = 0x80 |  8; break;
-	case 204: *p++ = 0x80 |  9; break;
-	case 206: *p++ = 0x80 | 10; break;
-	case 304: *p++ = 0x80 | 11; break;
-	case 400: *p++ = 0x80 | 12; break;
-	case 404: *p++ = 0x80 | 13; break;
-	case 500: *p++ = 0x80 | 14; break;
-	default:
-		*p++ = 0x18;
-		*p++ = 0x03;
-
-		assert(snprintf((char*)p, 4, "%03d", req->resp->status) == 3);
-		p += 3;
-		break;
-	}
+	p += h2_status(p, req->resp->status);
 
 	hp = req->resp;
 	for (u = HTTP_HDR_FIRST; u < hp->nhd; u++) {

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -831,5 +831,5 @@ struct transport H2_transport = {
 	.new_session =		h2_new_session,
 	.sess_panic =		h2_sess_panic,
 	.deliver =		h2_deliver,
-	.sresp =		h2_simple_response,
+	.minimal_response =	h2_minimal_response,
 };

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -831,4 +831,5 @@ struct transport H2_transport = {
 	.new_session =		h2_new_session,
 	.sess_panic =		h2_sess_panic,
 	.deliver =		h2_deliver,
+	.sresp =		h2_simple_response,
 };

--- a/bin/varnishtest/tests/c00018.vtc
+++ b/bin/varnishtest/tests/c00018.vtc
@@ -1,6 +1,8 @@
-varnishtest "Check Expect headers"
+varnishtest "Check Expect headers / 100 Continue"
 
 server s1 {
+	rxreq
+	txresp
 	rxreq
 	txresp
 } -start
@@ -8,11 +10,18 @@ server s1 {
 varnish v1 -vcl+backend { } -start
 
 client c1 {
-	txreq -url "/" -req POST -hdr "Expect: 100-continue " -body "foo"
+	txreq -url "/" -req POST -hdr "Expect: 100-continue " \
+		-hdr "Content-Length: 20"
 	rxresp
 	expect resp.status == 100
+	send "01234567890123456789"
 	rxresp
 	expect resp.status == 200
+
+	txreq -url "/" -req POST -hdr "Expect: 100-continue " -body "foo"
+	rxresp
+	expect resp.status == 200
+
 	txreq -url "/" -req POST -hdr "Expect: 101-continue" -body "foo"
 	rxresp
 	expect resp.status == 417

--- a/bin/varnishtest/tests/c00018.vtc
+++ b/bin/varnishtest/tests/c00018.vtc
@@ -5,11 +5,140 @@ server s1 {
 	txresp
 	rxreq
 	txresp
+	rxreq
+	txresp
+	rxreq
+	txresp
 } -start
 
-varnish v1 -vcl+backend { } -start
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_recv {
+	    if (req.url == "/") {
+		return (pass);
+	    }
+
+	    std.late_100_continue(true);
+
+	    if (req.url ~ "^/err") {
+		return (synth(405));
+	    }
+
+	    if (req.url == "/latecache") {
+		std.cache_req_body(1KB);
+	    }
+	    return (pass);
+
+	}
+	sub vcl_synth {
+	    if (req.url == "/errcl") {
+		set resp.http.Connection = "close";
+	    }
+	}
+
+} -start
+
+logexpect l1 -v v1 -g raw {
+	# base case: bad Expect
+	expect * 1001	RespStatus      417
+
+	# base case: Immediate 100-continue
+	expect * 1003	ReqUnset        {^Expect: 100-continue$}
+	expect 0 1003	ReqStart        {^.}
+	expect 0 1003	ReqMethod       {^POST$}
+	expect 0 1003	ReqURL          {^/$}
+	expect 0 1003	ReqProtocol     {^HTTP/1.1$}
+	expect 0 1003	ReqHeader       {^Content-Length: 20$}
+	expect 0 1003	ReqHeader       {^X-Forwarded-For:}
+	expect 0 1003	VCL_call        {^RECV$}
+	expect 0 1003	VCL_return      {^pass$}
+	expect 0 1003	RespProtocol    {^HTTP/1.1$}
+	expect 0 1003	RespStatus      {^100$}
+	expect 0 1003	RespReason      {^Continue$}
+	expect 0 1003	VCL_call        {^HASH$}
+
+	# no 100 if client has already sent body (and it fits)
+	expect * 1005	ReqUnset        {^Expect: 100-continue$}
+	expect 0 1005	ReqStart        {^.}
+	expect 0 1005	ReqMethod       {^POST$}
+	expect 0 1005	ReqURL          {^/$}
+	expect 0 1005	ReqProtocol     {^HTTP/1.1$}
+	expect 0 1005	ReqHeader       {^Content-Length: 3$}
+	expect 0 1005	ReqHeader       {^X-Forwarded-For:}
+	expect 0 1005	VCL_call        {^RECV$}
+	expect 0 1005	VCL_return      {^pass$}
+	expect 0 1005	VCL_call        {^HASH$}
+
+	# late no cache
+	expect * 1007	ReqUnset        {^Expect: 100-continue$}
+	expect 0 1007	ReqStart        {^.}
+	expect 0 1007	ReqMethod       {^POST$}
+	expect 0 1007	ReqURL          {^/late$}
+	expect 0 1007	ReqProtocol     {^HTTP/1.1$}
+	expect 0 1007	ReqHeader       {^Content-Length: 20$}
+	expect 0 1007	ReqHeader       {^X-Forwarded-For:}
+	expect 0 1007	VCL_call        {^RECV$}
+	expect 0 1007	VCL_return      {^pass$}
+	expect 0 1007	VCL_call        {^HASH$}
+	expect 0 1007	VCL_return      {^lookup$}
+	expect 0 1007	VCL_call        {^PASS$}
+	expect 0 1007	VCL_return      {^fetch$}
+	expect 0 1007	Link            {^bereq 1008 pass$}
+	expect 0 1007	Storage         {^malloc Transient$}
+	expect 0 1007	RespProtocol    {^HTTP/1.1$}
+	expect 0 1007	RespStatus      {^100$}
+	expect 0 1007	RespReason      {^Continue$}
+	expect 0 1007	Timestamp       {^ReqBody:}
+	expect 0 1007	Timestamp       {^Fetch:}
+
+	# late cache
+	expect * 1009	ReqUnset        {^Expect: 100-continue$}
+	expect 0 1009	ReqStart        {^.}
+	expect 0 1009	ReqMethod       {^POST$}
+	expect 0 1009	ReqURL          {^/latecache$}
+	expect 0 1009	ReqProtocol     {^HTTP/1.1$}
+	expect 0 1009	ReqHeader       {^Content-Length: 20$}
+	expect 0 1009	ReqHeader       {^X-Forwarded-For:}
+	expect 0 1009	VCL_call        {^RECV$}
+	expect 0 1009	Storage         {^malloc Transient$}
+	expect 0 1009	RespProtocol    {^HTTP/1.1$}
+	expect 0 1009	RespStatus      {^100$}
+	expect 0 1009	RespReason      {^Continue$}
+	expect 0 1009	Timestamp       {^ReqBody:}
+	expect 0 1009	VCL_return      {^pass$}
+	expect 0 1009	VCL_call        {^HASH$}
+
+	# err
+	expect * 1011	ReqUnset        {^Expect: 100-continue$}
+	expect 0 1011	ReqStart        {^.}
+	expect 0 1011	ReqMethod       {^POST$}
+	expect 0 1011	ReqURL          {^/err$}
+	expect 0 1011	ReqProtocol     {^HTTP/1.1$}
+	expect 0 1011	ReqHeader       {^Content-Length: 20$}
+	expect 0 1011	ReqHeader       {^X-Forwarded-For:}
+	expect 0 1011	VCL_call        {^RECV$}
+	expect 0 1011	VCL_return      {^synth$}
+	expect 0 1011	VCL_call        {^HASH$}
+	expect 0 1011	VCL_return      {^lookup$}
+	expect 0 1011	Timestamp       {^Process:}
+	expect 0 1011	RespHeader      {^Date:}
+	expect 0 1011	RespHeader      {^Server: Varnish$}
+	expect 0 1011	RespHeader      {^X-Varnish: 1011$}
+	expect 0 1011	RespProtocol    {^HTTP/1.1$}
+	expect 0 1011	RespStatus      {^405$}
+
+} -start
 
 client c1 {
+	# base case: bad Expect
+	txreq -url "/" -req POST -hdr "Expect: 101-continue" -body "foo"
+	rxresp
+	expect resp.status == 417
+} -run
+
+client c1 {
+	# base case: Immediate 100-continue
 	txreq -url "/" -req POST -hdr "Expect: 100-continue " \
 		-hdr "Content-Length: 20"
 	rxresp
@@ -18,11 +147,35 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 
+	# no 100 if client has already sent body (and it fits)
 	txreq -url "/" -req POST -hdr "Expect: 100-continue " -body "foo"
 	rxresp
 	expect resp.status == 200
 
-	txreq -url "/" -req POST -hdr "Expect: 101-continue" -body "foo"
+	# late no cache
+	txreq -url "/late" -req POST -hdr "Expect: 100-continue " \
+		-hdr "Content-Length: 20"
 	rxresp
-	expect resp.status == 417
+	expect resp.status == 100
+	send "01234567890123456789"
+	rxresp
+	expect resp.status == 200
+
+	# late cache
+	txreq -url "/latecache" -req POST -hdr "Expect: 100-continue " \
+		-hdr "Content-Length: 20"
+	rxresp
+	expect resp.status == 100
+	send "01234567890123456789"
+	rxresp
+	expect resp.status == 200
+
+	# err
+	txreq -url "/err" -req POST -hdr "Expect: 100-continue " \
+		-hdr "Content-Length: 20"
+	rxresp
+	expect resp.status == 405
+	expect_close
 } -run
+
+logexpect l1 -wait

--- a/bin/varnishtest/tests/c00018.vtc
+++ b/bin/varnishtest/tests/c00018.vtc
@@ -9,6 +9,8 @@ server s1 {
 	txresp
 	rxreq
 	txresp
+	rxreq
+	txresp
 } -start
 
 varnish v1 -vcl+backend {
@@ -183,6 +185,19 @@ client c1 {
 } -run
 
 client c1 {
+	# Immediate 100-continue with Client Connection: close
+	txreq -url "/" -req POST -hdr "Expect: 100-continue " \
+		-hdr "Content-Length: 20" \
+		-hdr "Connection: close"
+	rxresp
+	expect resp.status == 100
+	send "01234567890123456789"
+	rxresp
+	expect resp.status == 200
+	expect_close
+} -run
+
+client c1 {
 	# vcl vetoing the Connection: close in synth
 	txreq -url "/synthnocl" -req POST -hdr "Expect: 100-continue " \
 		-hdr "Content-Length: 20"
@@ -191,6 +206,14 @@ client c1 {
 	send "01234567890123456789"
 	rxresp
 	expect resp.status == 200
+
+	# vcl vetoing the Connection: close in synth but client close
+	txreq -url "/synthnocl" -req POST -hdr "Expect: 100-continue " \
+		-hdr "Content-Length: 20" \
+		-hdr "Connection: close"
+	rxresp
+	expect resp.status == 200
+	expect_close
 } -run
 
 logexpect l1 -wait

--- a/bin/varnishtest/tests/c00018.vtc
+++ b/bin/varnishtest/tests/c00018.vtc
@@ -25,6 +25,10 @@ varnish v1 -vcl+backend {
 		return (synth(405));
 	    }
 
+	    if (req.url ~ "^/synthnocl") {
+		return (synth(200));
+	    }
+
 	    if (req.url == "/latecache") {
 		std.cache_req_body(1KB);
 	    }
@@ -32,8 +36,8 @@ varnish v1 -vcl+backend {
 
 	}
 	sub vcl_synth {
-	    if (req.url == "/errcl") {
-		set resp.http.Connection = "close";
+	    if (req.url == "/synthnocl") {
+		unset resp.http.Connection;
 	    }
 	}
 
@@ -176,6 +180,17 @@ client c1 {
 	rxresp
 	expect resp.status == 405
 	expect_close
+} -run
+
+client c1 {
+	# vcl vetoing the Connection: close in synth
+	txreq -url "/synthnocl" -req POST -hdr "Expect: 100-continue " \
+		-hdr "Content-Length: 20"
+	rxresp
+	expect resp.status == 100
+	send "01234567890123456789"
+	rxresp
+	expect resp.status == 200
 } -run
 
 logexpect l1 -wait

--- a/include/tbl/http_response.h
+++ b/include/tbl/http_response.h
@@ -30,6 +30,7 @@
 
 /*lint -save -e525 -e539 */
 
+HTTP_RESP(100, "Continue")
 HTTP_RESP(101, "Switching Protocols")
 HTTP_RESP(200, "OK")
 HTTP_RESP(201, "Created")

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -36,6 +36,7 @@ REQ_FLAG(hash_always_miss,	1, 1, "")
 REQ_FLAG(is_hit,		0, 0, "")
 REQ_FLAG(waitinglist,		0, 0, "")
 REQ_FLAG(want100cont,		0, 0, "")
+REQ_FLAG(late100cont,		0, 0, "")
 #undef REQ_FLAG
 
 /*lint -restore */

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -35,6 +35,7 @@ REQ_FLAG(hash_ignore_busy,	1, 1, "")
 REQ_FLAG(hash_always_miss,	1, 1, "")
 REQ_FLAG(is_hit,		0, 0, "")
 REQ_FLAG(waitinglist,		0, 0, "")
+REQ_FLAG(want100cont,		0, 0, "")
 #undef REQ_FLAG
 
 /*lint -restore */

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -283,6 +283,31 @@ Description
 Example
 	| set req.http.My-Env = getenv("MY_ENV");
 
+$Function VOID late_100_continue(BOOL late)
+
+Description
+	Controls when varnish reacts to an `Expect: 100-continue` client
+	request header.
+
+	Varnish always generates a `100 Continue` response if
+	requested by the by the client trough the `Expect:
+	100-continue` header when waiting for request body data.
+
+	But, by default, the `100 Continue` response is already
+	generated immediately after `vcl_recv` returns to reduce
+	latencies under the assumption that the request body will be
+	read eventually.
+
+	Calling `std.late_100_continue(true)` in `vcl_recv` will cause
+	the `100 Continue` response to only be sent when needed. This
+	may cause additional latencies for processing request bodies,
+	but is the correct behavior by strict interpretation of
+	RFC7231.
+
+	This function has no effect outside `vcl_recv` and after
+	calling `std.cache_req_body()` or any other function consuming
+	the request body.
+
 SEE ALSO
 ========
 

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -41,6 +41,7 @@
 #include "vtcp.h"
 #include "vsa.h"
 #include "vtim.h"
+#include "vcl.h"
 
 #include "cache/cache_director.h"
 
@@ -254,4 +255,25 @@ vmod_getenv(VRT_CTX, VCL_STRING name)
 	if (name == NULL || *name == '\0')
 		return (NULL);
 	return (getenv(name));
+}
+
+VCL_VOID __match_proto__(td_std_late_100_continue)
+vmod_late_100_continue(VRT_CTX, VCL_BOOL late)
+{
+	struct req *req;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	if (ctx->method != VCL_MET_RECV) {
+		VSLb(ctx->vsl, SLT_VCL_Error,
+		    "std.late_100_continue() only valid in vcl_recv{}");
+		return;
+	}
+
+	req = ctx->req;
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+
+	if (! req->want100cont)
+		return;
+
+	req->late100cont = !!late;
 }


### PR DESCRIPTION
supersedes #2196 

on @bsdphk 's comments:

> We always optimize Varnish based on the assumption that traffic is legit, so early/immediate 100-C will continue to be the default.

done, but I have fixed the default behavior:
* No 100-C if we already read some of a body
* No 100-C for < HTTP/1.1

> Adding a std.late_100_continue{} which postpones the decision until we have VRB-activity to guide us before doing socket-ops to backend seems feasible.

Done.

> Not sending 100-C, be it vcl_synth{} or because we contact backend, exposes us to the "did they or didn't they send the body anyway" race. We need a transport->method() (->dont_send_100c() ?) which for H1 causes "Connection:close" on the response to the client.

I have only implemented this for the synth case and kept the 100-C for the fetch case for now. I _think_ that for fetch with late 100, we should actually add back the Expect header and let the backand decide. The alternative would be to read the backend response headers before starting VRB handling.

The Expect header now gets added back for pipe with late 100.

> Preferably it should be possible to remove that "Connection: close" again from VCL, if it is known that the client will be patient (enough) about the 100-C.

(edited, see additional comment below):I don't think this is related to the client, but rather to VCL policy: For a synth response, do we want to just send our response and be done, or do we want to drain-read the client body? I've now made the former the default and the latter possible.

>    For H2, the stream is not reused and the transport->method() is a functional no-op as seen from VCL, even though activity happens at H2 frame-level.

I've kept the H2 code as-is for now. DATA support is missing anyway and I'd like to avoid wasting more time in case the H1 part needs more attention.