### PR TITLE
Make sure Age is always less than max-age

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -93,7 +93,7 @@ cnt_deliver(struct worker *wrk, struct req *req)
 	 * age. Truncate to zero in that case).
 	 */
 	http_PrintfHeader(req->resp, "Age: %.0f",
-	    fmax(0., req->t_prev - req->objcore->t_origin));
+	    floor(fmax(0., req->t_prev - req->objcore->t_origin)));
 
 	http_SetHeader(req->resp, "Via: 1.1 varnish (Varnish/5.0)");
 

--- a/bin/varnishtest/tests/s00006.vtc
+++ b/bin/varnishtest/tests/s00006.vtc
@@ -1,0 +1,30 @@
+varnishtest "Check that Age is always less than max-age while not stale"
+
+server s1 {
+	rxreq
+	expect req.url == "/"
+	txresp -hdr "Cache-control: max-age=2"
+} -start
+
+varnish v1 -vcl+backend { } -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Age == 0
+
+	delay 0.8
+
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Age == 0
+
+	delay 1.0
+
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Age == 1
+} -run


### PR DESCRIPTION
By rounding Age down, we make sure Age < max-age while the object
is fresh. Otherwise, we can prematurely get Age == max-age and Varnish
will calculate that as a 0s TTL and create a pass scenario.

More info can be found in this dev list email:

https://www.varnish-cache.org/lists/pipermail/varnish-dev/2016-December/009079.html