### PR TITLE
fix argument processing -C regression

### DIFF
--- a/bin/varnishtest/tests/a00009.vtc
+++ b/bin/varnishtest/tests/a00009.vtc
@@ -1,6 +1,9 @@
 varnishtest "Code coverage of mgt_main, (VCL compiler and RSTdump etc)"
 
 shell "varnishd -b 127.0.0.1:80 -C 2> ${tmpdir}/_.c"
+# -C to ignore other arguments
+shell {varnishd -b 127.0.0.1:80 -a foo -h foo -l foo -M foo -P foo \
+       -S foo -s foo -T foo -W foo -C 2> ${tmpdir}/_.c}
 shell "varnishd -x dumprstparam > ${tmpdir}/_.param"
 shell "varnishd -x dumprstvsl > ${tmpdir}/_.vsl"
 shell "varnishd -x dumprstcli > ${tmpdir}/_.cli"


### PR DESCRIPTION
following up on #2141 

and as a side effect, also fix the -M error

```
slink@haggis:~/Devel/varnish-git/varnish-cache (2141-followups)$ /tmp/sbin/varnishd -b 127.0.0.1:80 -a foo -h foo -l foo -M foo -P foo \
>        -S foo -s foo -T foo -W foo -C 2>&1 | head -1
/* ---===### include/vdef.h ###===--- */
```

```
slink@haggis:~/Devel/varnish-git/varnish-cache (2141-followups)$ /tmp/sbin/varnishd -a 127.0.0.1:8888 -b 127.0.0.1:8080 -S /sfd
Error: Cannot open -S file (/sfd): No such file or directory
slink@haggis:~/Devel/varnish-git/varnish-cache (2141-followups)$ /tmp/sbin/varnishd -a 127.0.0.1:8888 -b 127.0.0.1:8080 -T 8.9.10.11:80
Debug: Platform: Linux,3.16.0-4-amd64,x86_64,-jnone,-smalloc,-smalloc,-hcritbit
Error: -T 8.9.10.11:80 could not be listened on.
slink@haggis:~/Devel/varnish-git/varnish-cache (2141-followups)$ /tmp/sbin/varnishd -a 127.0.0.1:8888 -b 127.0.0.1:8080 -M bazz.bar.boom:80
Debug: Platform: Linux,3.16.0-4-amd64,x86_64,-jnone,-smalloc,-smalloc,-hcritbit
Error: Could not resolve -M argument to address
	Name or service not known
```