### PR TITLE
RFC: carve objects from power-of-two chunks

### DIFF
--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -45,6 +45,27 @@
 /* Flags for allocating memory in sml_stv_alloc */
 #define LESS_MEM_ALLOCED_IS_OK	1
 
+// https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+static inline unsigned int
+rnddn_pow2(unsigned int v)
+{
+	v--;
+	v |= v >> 1;
+	v |= v >> 2;
+	v |= v >> 4;
+	v |= v >> 8;
+	v |= v >> 16;
+#if UINT_MAX > 1<<32
+	v |= v >> 32;
+#if UINT_MAX > 1<<64
+#error really more than 64bit integers?
+#endif
+#endif
+	v++;
+	v >>= 1;
+	return (v);
+}
+
 /*-------------------------------------------------------------------*/
 
 static struct storage *
@@ -66,6 +87,10 @@ sml_stv_alloc(const struct stevedore *stv, size_t size, int flags)
 		size = cache_param->fetch_maxchunksize;
 
 	assert(size <= UINT_MAX);	/* field limit in struct storage */
+
+	if (size > 4096) {
+		size = rnddn_pow2(size);
+	}
 
 	for (;;) {
 		/* try to allocate from it */

--- a/bin/varnishtest/tests/c00073.vtc
+++ b/bin/varnishtest/tests/c00073.vtc
@@ -22,7 +22,7 @@ client c1 {
 } -start
 
 barrier b1 sync
-varnish v1 -expect SMA.s0.g_bytes > 10000
+varnish v1 -expect SMA.s0.g_bytes > 8000
 
 barrier b2 sync
 


### PR DESCRIPTION
This is a simple idea I've been carrying around with me for a long time, and it popped up again while trying to understand weird jemalloc behavior:
While, from a performance perspective, minimizing the number of IO vectors we need to deliver some object is optimal, from a memory footprint perspective minimizing the memory allocator overhead should be optimal.
So shouldn't we offer an option to try to help the allocator by only ever requesting allocations in sizes of powers of two?
I do not mean to propose this patch as-is - instead we should make this configurable at least for the stevedore, maybe from vcl. But to do so, we'd probably need to hand the allocation flags down to the stevedore.
Comments?