### PR TITLE
Add a setenv command to varnishtest

### DIFF
--- a/bin/varnishtest/tests/m00028.vtc
+++ b/bin/varnishtest/tests/m00028.vtc
@@ -1,0 +1,73 @@
+varnishtest "Test setenv"
+
+setenv FOO "BAR BAZ"
+
+varnish v1 -vcl {
+	import std from "${topbuild}/lib/libvmod_std/.libs/";
+
+	backend dummy { .host = "${bad_ip}"; .port = "9080"; }
+
+	sub vcl_recv {
+		return(synth(200));
+	}
+
+	sub vcl_synth {
+		set resp.http.X-FOO = std.getenv("FOO");
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.X-FOO == "BAR BAZ"
+} -run
+
+varnish v1 -stop
+
+setenv -ifunset FOO QUUX
+
+varnish v2 -vcl {
+	import std from "${topbuild}/lib/libvmod_std/.libs/";
+
+	backend dummy { .host = "${bad_ip}"; .port = "9080"; }
+
+	sub vcl_recv {
+		return(synth(200));
+	}
+
+	sub vcl_synth {
+		set resp.http.X-FOO = std.getenv("FOO");
+	}
+} -start
+
+client c2 -connect ${v2_sock} {
+	txreq
+	rxresp
+	expect resp.http.X-FOO == "BAR BAZ"
+} -run
+
+varnish v2 -stop
+
+setenv FOO QUUX
+
+varnish v3 -vcl {
+	import std from "${topbuild}/lib/libvmod_std/.libs/";
+
+	backend dummy { .host = "${bad_ip}"; .port = "9080"; }
+
+	sub vcl_recv {
+		return(synth(200));
+	}
+
+	sub vcl_synth {
+		set resp.http.X-FOO = std.getenv("FOO");
+	}
+} -start
+
+client c3 -connect ${v3_sock} {
+	txreq
+	rxresp
+	expect resp.http.X-FOO == "QUUX"
+} -run
+
+varnish v2 -stop

--- a/bin/varnishtest/vtc.c
+++ b/bin/varnishtest/vtc.c
@@ -594,6 +594,47 @@ cmd_err_shell(CMD_ARGS)
 	cmd_shell_engine(vl, -1, av[2], av[1], NULL);
 }
 
+/* SECTION: setenv setenv
+ *
+ * Set or change an environment variable::
+ *
+ *         setenv FOO "bar baz"
+ *
+ * The above will set the environment variable $FOO to the value
+ * provided. There is also an ``-ifunset`` argument which will only
+ * set the value if the the environment variable does not already
+ * exist::
+ *
+ *        setenv -ifunset FOO quux
+ */
+static void
+cmd_setenv(CMD_ARGS)
+{
+	int r;
+	int force;
+
+	(void)priv;
+	(void)cmd;
+
+	if (av == NULL)
+		return;
+	AN(av[1]);
+	AN(av[2]);
+
+	force = 1;
+	if (strcmp("-ifunset", av[1]) == 0) {
+		force = 0;
+		av++;
+		AN(av[2]);
+	}
+	if (av[3] != NULL)
+		vtc_log(vl, 0, "CMD setenv: Unexpected argument '%s'", av[3]);
+	r = setenv(av[1], av[2], force);
+	if (r != 0)
+		vtc_log(vl, 0, "CMD setenv %s=\"%s\" failed: %s",
+		    av[1], av[2], strerror(errno));
+}
+
 /* SECTION: delay delay
  *
  * Sleep for the number of seconds specified in the argument. The number
@@ -744,6 +785,7 @@ static const struct cmds cmds[] = {
 	CMD(feature)
 	CMD(logexpect)
 	CMD(process)
+	CMD(setenv)
 #undef CMD
 	{ NULL, NULL }
 };


### PR DESCRIPTION
This lets you set environment variables in a test case. Useful for test cases for VMODs using libraries that are configured via environment variables.

Usage is

    setenv "FOO" "bar"

which will set FOO=bar if FOO does not already exist.

There is also an optional '-force' argument, which will overwrite an
existing variable if already set:

    setenv -force "FOO" "baz"

The force argument corresponds to passing a non-zero third argument to
setenv(3).