### PR TITLE
Introduce a ZERO_OBJ macro similar to bzero

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,7 @@ AC_CHECK_HEADERS([pthread_np.h], [], [], [#include <pthread.h>])
 AC_CHECK_HEADERS([priv.h])
 
 # Checks for library functions.
+AC_CHECK_FUNCS([explicit_bzero])
 AC_CHECK_FUNCS([nanosleep])
 AC_CHECK_FUNCS([setppriv])
 AC_CHECK_FUNCS([fallocate])

--- a/include/miniobj.h
+++ b/include/miniobj.h
@@ -5,6 +5,12 @@
  *
  */
 
+#if HAVE_EXPLICIT_BZERO
+#  define ZERO_OBJ(to, sz)	explicit_bzero(to, sz)
+#else
+#  define ZERO_OBJ(to, sz)	(void)memset(to, 0, sz)
+#endif
+
 #define INIT_OBJ(to, type_magic)					\
 	do {								\
 		(void)memset(to, 0, sizeof *to);			\
@@ -20,7 +26,7 @@
 
 #define FREE_OBJ(to)							\
 	do {								\
-		(to)->magic = (0);					\
+		ZERO_OBJ(&(to)->magic, sizeof (to)->magic);		\
 		free(to);						\
 		to = NULL;						\
 	} while (0)


### PR DESCRIPTION
`explicit_bzero(3)` is coming to glibc and I was thinking that it might be the occasion to hint compilers that we really want the erasure of magic numbers. Instead of having different interfaces for zeroing I hid the details behind a `ZERO_OBJ` macro.

I haven't actually tested this on a system that has the function, but I believe FreeBSD does. I can only confirm the fallback works so far.