### PR TITLE
add WS_Assert_Allocated: assert that ws->s <= a memory region < ws->f

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -1070,6 +1070,7 @@ uintptr_t WS_Snapshot(struct ws *ws);
 int WS_Overflowed(const struct ws *ws);
 void *WS_Printf(struct ws *ws, const char *fmt, ...) __v_printflike(2, 3);
 int WS_Inside(const struct ws *, const void *, const void *);
+void WS_Assert_Allocated(const struct ws *ws, const void *ptr, ssize_t len);
 
 static inline char*
 WS_Front(const struct ws *ws)

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -73,6 +73,16 @@ WS_Inside(const struct ws *ws, const void *bb, const void *ee)
 	return (1);
 }
 
+void
+WS_Assert_Allocated(const struct ws *ws, const void *ptr, ssize_t len)
+{
+	const char *p = ptr;
+
+	WS_Assert(ws);
+	if (len < 0)
+		len = strlen(p) + 1;
+	assert(p >= ws->s && (p + len) < ws->f);
+}
 
 /*
  * NB: The id must be max 3 char and lower-case.
@@ -98,7 +108,6 @@ WS_Init(struct ws *ws, const char *id, void *space, unsigned len)
 	strcpy(ws->id, id);
 	WS_Assert(ws);
 }
-
 
 void
 WS_MarkOverflow(struct ws *ws)


### PR DESCRIPTION
Verify that the region (ptr, ptr + len) lies strictly in the part of a workspace previously allocated with one of WS_Alloc, WS_Printf and friends. If len < 0, then check with len = strlen(ptr) + 1 (includes a terminating null byte in the check).

My use case for this is checking PRIV_TASK data that should have been previously allocated in the task's workspace, especially to ensure that subsequent uses of WS_Alloc and friends don't write over it.

```
if (priv->priv == NULL) {
    priv->priv = WS_Alloc(ctx->ws, sizeof(widget));
    // [...]
}
else {
    WS_Assert_Allocated(ctx->ws, priv->priv, sizeof(widget);
   // [...]
}
```