### PR TITLE
Introduce varnishd -f [name[,label]=]file (discussion, not to be merged)

### DIFF
--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -182,8 +182,8 @@ char *mgt_VccCompile(struct cli *, struct vclprog *, const char *vclname,
     const char *vclsrc, const char *vclsrcfile, int C_flag);
 
 void mgt_vcl_init(void);
-void mgt_vcl_startup(struct cli *, const char *vclsrc, const char *origin,
-    const char *vclname, int Cflag);
+int mgt_vcl_startup(struct cli *, const char *vclsrc, const char *vclname,
+    const char *vcllabel, const char *origin, int Cflag);
 int mgt_push_vcls_and_start(struct cli *, unsigned *status, char **p);
 void mgt_vcl_export_labels(struct vcc *);
 int mgt_has_vcl(void);

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -440,7 +440,8 @@ mgt_f_arg(struct f_arg *fa)
 	if (p != NULL) {
 		q = memchr(fa->farg, ',', p - fa->farg);
 		if (q != NULL) {
-			fa->label = strndup(q, p - q);
+			/* Off by one to avoid the comma */
+			fa->label = strndup(q + 1, p - q - 1);
 			AN(fa->label);
 		}
 		else

--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -370,11 +370,15 @@ mgt_new_vcl(struct cli *cli, const char *vclname, const char *vclsrc,
 
 /*--------------------------------------------------------------------*/
 
+static void __match_proto__(cli_func_t)
+mcf_vcl_label(struct cli *cli, const char * const *av, void *priv);
+
 int
 mgt_vcl_startup(struct cli *cli, const char *vclsrc, const char *vclname,
     const char *vcllabel, const char *origin, int C_flag)
 {
 	char buf[20];
+	const char *av[5];
 	static int n = 0;
 
 	AN(vclsrc);
@@ -387,8 +391,15 @@ mgt_vcl_startup(struct cli *cli, const char *vclsrc, const char *vclname,
 		return (-1);
 	mgt_new_vcl(cli, vclname, vclsrc, origin, NULL, C_flag);
 	active_vcl = mcf_vcl_byname(vclname);
-	if (active_vcl != NULL && vcllabel != NULL)
-		INCOMPL();
+	if (active_vcl != NULL && vcllabel != NULL) {
+		/* XXX: not sure what goes in av */
+		av[0] = NULL;
+		av[1] = NULL;
+		av[2] = vcllabel;
+		av[3] = vclname;
+		av[4] = NULL;
+		mcf_vcl_label(cli, av, NULL);
+	}
 	return (0);
 }
 

--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -370,9 +370,9 @@ mgt_new_vcl(struct cli *cli, const char *vclname, const char *vclsrc,
 
 /*--------------------------------------------------------------------*/
 
-void
+int
 mgt_vcl_startup(struct cli *cli, const char *vclsrc, const char *vclname,
-    const char *origin, int C_flag)
+    const char *vcllabel, const char *origin, int C_flag)
 {
 	char buf[20];
 	static int n = 0;
@@ -383,8 +383,13 @@ mgt_vcl_startup(struct cli *cli, const char *vclsrc, const char *vclname,
 		bprintf(buf, "boot%d", n++);
 		vclname = buf;
 	}
+	if (mcf_vcl_byname(vclname) != NULL)
+		return (-1);
 	mgt_new_vcl(cli, vclname, vclsrc, origin, NULL, C_flag);
 	active_vcl = mcf_vcl_byname(vclname);
+	if (active_vcl != NULL && vcllabel != NULL)
+		INCOMPL();
+	return (0);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishtest/tests/a00009.vtc
+++ b/bin/varnishtest/tests/a00009.vtc
@@ -116,3 +116,21 @@ delay 1
 shell -match "stopped" {varnishadm -n ${tmpdir}/v0 status}
 
 process p3 -stop -wait
+
+# Test an -f option with a VCL name
+
+process p4 {
+	exec varnishd -n ${tmpdir}/v0 -F -a :0 -l2m,3m -f ok1=${tmpdir}/ok1
+} -log -start
+
+delay 1
+shell -match "active.*ok1" {varnishadm -n ${tmpdir}/v0 vcl.list}
+
+process p4 -stop -wait
+
+# Test multiple -f options with a VCL name collision
+
+shell -err -expect "Error: Cannot load two VCLs with the same name." {
+	exec varnishd -n ${tmpdir}/v0 -F -a :0 -l2m,3m -f boot=${tmpdir}/ok1 \
+	    -f ${tmpdir}/ok2
+}

--- a/bin/varnishtest/tests/a00009.vtc
+++ b/bin/varnishtest/tests/a00009.vtc
@@ -134,3 +134,25 @@ shell -err -expect "Error: Cannot load two VCLs with the same name." {
 	exec varnishd -n ${tmpdir}/v0 -F -a :0 -l2m,3m -f boot=${tmpdir}/ok1 \
 	    -f ${tmpdir}/ok2
 }
+
+# Test an -f option with a VCL name and label
+
+process p5 {
+	exec varnishd -n ${tmpdir}/v0 -F -a :0 -l2m,3m -f ok1,lbl=${tmpdir}/ok1
+} -log -start
+
+delay 1
+shell -match "ok1 .1 label." {varnishadm -n ${tmpdir}/v0 vcl.list}
+shell -match "lbl -> ok1"    {varnishadm -n ${tmpdir}/v0 vcl.list}
+
+process p5 -stop -wait
+
+# Test an -f option with an invalid VCL name or label
+
+shell -err -expect "Illegal character in VCL name ('!')" {
+	exec varnishd -n ${tmpdir}/v0 -F -a :0 -l2m,3m -f !!!,lbl=${tmpdir}/ok1
+}
+
+shell -err -expect "Illegal character in VCL name ('!')" {
+	exec varnishd -n ${tmpdir}/v0 -F -a :0 -l2m,3m -f ok1,!!!=${tmpdir}/ok1
+}


### PR DESCRIPTION
This is a response to d306f91 that I reviewed today:

> The plan is to also allow both specification of an (optional) label and
which VCL is to be the active one, but I want to think about if we should
shoehorn that into -f or use a different option letter.

I've done little thinking on this and think that using a different flag would make things too complicated because we'd need to correlate `boot${N}` names to labels. Instead I'd like to suggest using a syntax somewhat similar to storage options, allowing to set both the name and the label.

I chose to put the label before the equal sign because shoehorning it there was easier to quickly do. But having it after the file name (like `-a`, `-s`, `-j` etc) could also help decide which one is to be active. With this PR, it's still the last `-f`.

In the absence of a name, it falls back to the `boot${N}` automatic name. It also makes things less convoluted regarding VCL dependencies. Supposing a `-L` option to declare labels, one would need to jump between flags but links would also look more explicit:

```
# prod references the labels www and static (eg. independent sub-domains)

# this PR syntax
varnishd -f www1,www=www.vcl -f static1,static=static.vcl -f prod=prod.vcl

# the -L example
varnishd -f www1=www.vcl -f static1=static.vcl -L www=www1 -L static=static1 -f prod=prod.vcl

# you may later relink www to www2, ww3 and so on...
```

Other parameters have comma-separated arguments at the end which would be fine too, but to start the discussion I took the easy route.

Pros: you can start Varnish with any VCL (including the active one) referencing labels. Name collisions are rejected, and the error message could be improved (once again, quick'n'dirty).

Cons: users can no longer freely use VCL file names containing an equal sign or a comma. I can live with that :)

The reason why I baked this quickly was to hijack the discussion on the `-C` option too (ping @nigoroll). Now that we can have multiple `-f` flag, I think that `-C` concatenates every single C file in the output. I haven't checked but that's how it looks.

Instead I would like to suggest adding an optarg to `-C`: a glob expression matching VCL names. I don't think that dumping them all by default would help, as myself a user wanting to inspect generated code I would likely want to see the C code for one VCL at a time (and it would now work even when labels are involved).

As a side note,  ~~current master leaks `struct f_arg.farg`, and~~ I found a bit of a conflict (see 917773a).