### PR TITLE
Add documentation about cache misses and uncacheable content to the User's Guide

### DIFF
--- a/doc/sphinx/users-guide/increasing-your-hitrate.rst
+++ b/doc/sphinx/users-guide/increasing-your-hitrate.rst
@@ -102,7 +102,7 @@ https://addons.mozilla.org/en-US/firefox/addon/3829/ or by googling
 
 
 The role of HTTP Headers
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 Along with each HTTP request and response comes a bunch of headers
 carrying metadata. Varnish will look at these headers to determine if
@@ -122,7 +122,7 @@ Let's take a look at the important headers you should be aware of:
 .. _users-guide-cookies:
 
 Cookies
--------
+~~~~~~~
 
 Varnish will, in the default configuration, not cache an object coming
 from the backend with a 'Set-Cookie' header present. Also, if the client
@@ -135,7 +135,7 @@ cookie is used by the client side javascript and is therefore of no
 interest to the server.
 
 Cookies from the client
-~~~~~~~~~~~~~~~~~~~~~~~
++++++++++++++++++++++++
 
 For a lot of web applications it makes sense to completely disregard the
 cookies unless you are accessing a special part of the web site. This
@@ -216,7 +216,7 @@ Varnish Cache Wiki.
 
 
 Cookies coming from the backend
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++++++++++++++++++++++++++++++++
 
 If your backend server sets a cookie using the 'Set-Cookie' header
 Varnish will not cache the page when using the default configuration.

--- a/doc/sphinx/users-guide/increasing-your-hitrate.rst
+++ b/doc/sphinx/users-guide/increasing-your-hitrate.rst
@@ -499,11 +499,11 @@ The issues to consider are:
 Passing client requests
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Depending on how you site works, you may be able to recognize a client
-request for a response that cannot be cached, for example if the URL
-matches certain patterns, or due to the contents of a request header.
-In that case, you can set the fetch to *pass* with ``return(pass)``
-from ``vcl_recv``::
+Depending on how your site works, you may be able to recognize a
+client request for a response that cannot be cached, for example if
+the URL matches certain patterns, or due to the contents of a request
+header.  In that case, you can set the fetch to *pass* with
+``return(pass)`` from ``vcl_recv``::
 
   sub vcl_recv {
     if (req.url ~ "^/this/is/personal/") {


### PR DESCRIPTION
This started out as documentation of the varieties of pass for the 5.1 release: pass from vcl_recv, hit-for-miss and hit-for-pass. Which I think we need now that we have two kinds of hit-for-something.

That in turn required some background about what happens for misses, especially request coalescing and the fact that fetches on cache misses cannot be conditional. So I went ahead and added a chapter just about misses, also documenting how you can help in VCL by setting grace and keep.

This has gone into "Achieving a high hitrate", because that seemed to me to be the place in the existing docs where the content seems to fit best. But it might be odd for that chapter to have a lot info about subjects that are not cache hits. If that's too odd, we can move the new content into a new document.

Also I noticed that the "Cookies" section had subsections that aren't about cookies: Cache-Control, Age, Authorization etc. So I changed the header levels, so that "Cookies" and those other sections are subsections of "The role of HTTP headers".

Still to do: go over the rest of the docs where there are references to hit-for-pass, and update them to mention both of the hit-for-somethings, or distinguish them properly.

Note that these updates are committing us to that terminology (we were still referring to hit-for-miss as hit-for-pass in the 5.0 docs), so now's the time to object if we don't want that.