### PR TITLE
Log hits-for-pass and -miss with HitPass and HitMiss tags

### DIFF
--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -443,6 +443,8 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 				oc = NULL;
 			} else if (oc->flags & OC_F_PASS) {
 				wrk->stats->cache_hitmiss++;
+				VSLb(req->vsl, SLT_HitMiss, "%u",
+				     ObjGetXID(wrk, oc));
 				oc = NULL;
 				*bocp = hsh_insert_busyobj(wrk, oh);
 			} else {
@@ -466,6 +468,7 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 
 	if (exp_oc != NULL && exp_oc->flags & OC_F_PASS) {
 		wrk->stats->cache_hitmiss++;
+		VSLb(req->vsl, SLT_HitMiss, "%u", ObjGetXID(wrk, exp_oc));
 		exp_oc = NULL;
 		busy_found = 0;
 	}

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -438,6 +438,8 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 			assert(oc->objhead == oh);
 			if (oc->flags & OC_F_HFP) {
 				wrk->stats->cache_hitpass++;
+				VSLb(req->vsl, SLT_HitPass, "%u",
+				     ObjGetXID(wrk, oc));
 				oc = NULL;
 			} else if (oc->flags & OC_F_PASS) {
 				wrk->stats->cache_hitmiss++;

--- a/bin/varnishtest/tests/c00011.vtc
+++ b/bin/varnishtest/tests/c00011.vtc
@@ -1,4 +1,4 @@
-varnishtest "Test hit for pass (pass from fetch)"
+varnishtest "Test hit for miss (beresp.uncacheable = true)"
 
 server s1 {
 	rxreq
@@ -20,6 +20,10 @@ varnish v1 -vcl+backend {
 		set resp.http.o_grace = obj.grace;
 		set resp.http.o_keep = obj.keep;
 	}
+} -start
+
+logexpect l1 -v v1 -g vxid {
+	expect 1003 *	HitMiss "^1002$"
 } -start
 
 client c1 {
@@ -49,3 +53,5 @@ client c1 {
 }
 
 client c1 -run
+
+logexpect l1 -wait

--- a/bin/varnishtest/tests/c00081.vtc
+++ b/bin/varnishtest/tests/c00081.vtc
@@ -29,6 +29,10 @@ varnish v1 -vcl+backend {
 
 } -start
 
+logexpect l1 -v v1 -g vxid {
+	expect 1003 *	HitPass "^1002$"
+} -start
+
 client c1 {
 	txreq
 	rxresp
@@ -44,6 +48,8 @@ client c1 {
 	rxresp
 	expect resp.http.miss == True
 } -run
+
+logexpect l1 -wait
 
 varnish v1 -expect MAIN.cache_hitpass == 1
 varnish v1 -expect MAIN.cache_miss == 2

--- a/bin/varnishtest/tests/r01858.vtc
+++ b/bin/varnishtest/tests/r01858.vtc
@@ -22,6 +22,11 @@ varnish v1 -vcl+backend {
 	}
 } -start
 
+# Tests logging hit-for-miss on an expired object
+logexpect l1 -v v1 -g vxid {
+	expect 1003 *	HitMiss "^1002$"
+} -start
+
 client c1 {
 	txreq
 	rxresp
@@ -36,3 +41,4 @@ client c1 {
 	expect resp.body == "bar"
 } -run
 
+logexpect l1 -wait

--- a/include/tbl/vsl_tags.h
+++ b/include/tbl/vsl_tags.h
@@ -541,6 +541,11 @@ SLTM(H2TxBody, 0, "Transmitted HTTP2 frame body",
 	"Binary data"
 )
 
+SLTM(HitMiss, 0, "Hit for miss object in cache.",
+	"Hit-for-miss object looked up in cache. Shows the VXID of the"
+	" hit-for-miss object.\n\n"
+)
+
 #undef NODEF_NOTICE
 #undef SLTM
 


### PR DESCRIPTION
The HitPass tag was already there, but evidently was not used in 5.0. The HitMiss tag is added.