### PR TITLE
Fix passing parameters to `varnishd` through `varnishtest`

### DIFF
--- a/bin/varnishtest/tests/a00018.vtc
+++ b/bin/varnishtest/tests/a00018.vtc
@@ -1,0 +1,8 @@
+varnishtest "Test varnishtest -p flag"
+
+shell {
+    echo 'varnishtest params' > _.vtc
+    echo 'varnish v1 -cliexpect {Value is: \+workspace} "param.show debug"' >> _.vtc
+    echo 'varnish v1 -cliexpect {Value is: 123\.000} "param.show default_grace"' >> _.vtc
+    exec varnishtest -p debug=+workspace -p default_grace=123 _.vtc
+}

--- a/bin/varnishtest/vtc_main.c
+++ b/bin/varnishtest/vtc_main.c
@@ -627,7 +627,7 @@ main(int argc, char * const *argv)
 			break;
 		case 'p':
 			VSB_printf(params_vsb, " -p ");
-			VSB_quote(params_vsb, optarg, -1, VSB_QUOTE_NONL);
+			VSB_quote(params_vsb, optarg, -1, 0);
 			break;
 		case 'q':
 			if (vtc_verbosity > 0)


### PR DESCRIPTION
After upgrading to Varnish 5.1.1, our Varnish tests stopped working. It seems that a newline is being added after each `-p` parameter passed to `varnishtest`'

```
> ./bin/varnishtest/varnishtest -p foo=bar bin/varnishtest/tests/b00000.vtc
...
***  v1    0.0 CMD: cd ${pwd} && exec varnishd  -d -n /tmp/vtc.24484.3c2bd692/v1 -p foo=bar
 -l 2m,1m,- -p auto_restart=off -p syslog_cli_traffic=off -p sigsegv_handler=on -p thread_pool_min=10 -p debug=+vtc_mode -a '127.0.0.1:0' -M '127.0.0.1 43425' -P /tmp/vtc.24484.3c2bd692/v1/varnishd.pid
***  v1    0.0 CMD: cd /home/josh/workspace/varnish-cache && exec varnishd  -d -n /tmp/vtc.24484.3c2bd692/v1 -p foo=bar
 -l 2m,1m,- -p auto_restart=off -p syslog_cli_traffic=off -p sigsegv_handler=on -p thread_pool_min=10 -p debug=+vtc_mode -a '127.0.0.1:0' -M '127.0.0.1 43425' -P /tmp/vtc.24484.3c2bd692/v1/varnishd.pid
...
```

I'm not entirely sure if my proposed fix is the best solution, but it seems to work.