### PR TITLE
Set the go-cold timer on newly loaded warm auto VCLs

### DIFF
--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -475,8 +475,13 @@ mgt_new_vcl(struct cli *cli, const char *vclname, const char *vclsrc,
 		mgt_vcl_del(vp);
 		VCLI_Out(cli, "%s", p);
 		VCLI_SetResult(cli, status);
+		free(p);
+		return;
 	}
 	free(p);
+
+	if (vp->warm && !strcmp(vp->state, "auto"))
+		vp->go_cold = VTIM_mono();
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishtest/tests/r02270.vtc
+++ b/bin/varnishtest/tests/r02270.vtc
@@ -1,0 +1,19 @@
+varnishtest "Test that never used VCLs go cold automatically"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-p vcl_cooldown=1" -vcl+backend {
+} -start
+
+varnish v1 -expect VBE.vcl1.s1.happy >= 0
+
+varnish v1 -cliok {vcl.inline vcl2 "vcl 4.0; backend s1 {.host = \"${s1_addr}\"; .port = \"${s1_port}\"; }"}
+
+varnish v1 -expect VBE.vcl2.s1.happy >= 0
+
+delay 5
+
+varnish v1 -expect !VBE.vcl2.s1.happy


### PR DESCRIPTION
Newly loaded VCLs didn't get their go cold timer set even when they
were set to auto, causing them to never go cold automatically.

Fixes: #2270