### PR TITLE
Master cooling problem

### DIFF
--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -387,14 +387,14 @@ mgt_vcl_setstate(struct cli *cli, struct vclprog *vp, const char *vs)
 	}
 	if (vs == VCL_STATE_AUTO) {
 		now = VTIM_mono();
-		vs = vp->warm ? VCL_STATE_WARM : VCL_STATE_COLD;
+		vs = (vp->warm ? VCL_STATE_WARM : VCL_STATE_COLD);
 		if (vp->go_cold > 0 && vp->state == VCL_STATE_AUTO &&
 		    vp->go_cold + mgt_param.vcl_cooldown < now)
 			vs = VCL_STATE_COLD;
 	}
 
 	assert(vs != VCL_STATE_AUTO);
-	warm = vs == VCL_STATE_WARM ? 1 : 0;
+	warm = (vs == VCL_STATE_WARM ? 1 : 0);
 
 	if (vp->warm == warm)
 		return (0);

--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -399,16 +399,15 @@ mgt_vcl_setstate(struct cli *cli, struct vclprog *vp, const char *vs)
 	if (vp->warm == warm)
 		return (0);
 
-	vp->warm = warm;
-
-	if (vp->warm == 0)
-		vp->go_cold = 0;
-
-	if (!MCH_Running())
+	if (!MCH_Running()) {
+		vp->warm = warm;
+		if (vp->warm == 0)
+			vp->go_cold = 0;
 		return (0);
+	}
 
 	i = mgt_cli_askchild(&status, &p, "vcl.state %s %d%s\n",
-	    vp->name, vp->warm, vp->state);
+	    vp->name, warm, vp->state);
 	if (i && cli != NULL) {
 		VCLI_SetResult(cli, status);
 		VCLI_Out(cli, "%s", p);
@@ -416,8 +415,15 @@ mgt_vcl_setstate(struct cli *cli, struct vclprog *vp, const char *vs)
 		MGT_Complain(C_ERR,
 		    "Please file ticket: VCL poker problem: "
 		    "'vcl.state %s %d%s' -> %03d '%s'",
-		    vp->name, vp->warm, vp->state, i, p);
+		    vp->name, warm, vp->state, i, p);
+	} else {
+		/* Success, update mgt's VCL state to reflect child's
+		   state */
+		vp->warm = warm;
+		if (vp->warm == 0)
+			vp->go_cold = 0;
 	}
+
 	free(p);
 	return (i);
 }

--- a/bin/varnishtest/tests/v00044.vtc
+++ b/bin/varnishtest/tests/v00044.vtc
@@ -90,4 +90,5 @@ varnish v1 -clierr 300 "vcl.state vcl1 warm"
 
 # A warm-up failure can also fail a child start
 varnish v1 -cliok stop
+varnish v1 -cliok "vcl.state vcl1 warm"
 varnish v1 -clierr 300 start


### PR DESCRIPTION
Fix a problem that could lead to asserts like:

```
Error: Child (16091) not responding to CLI, killed it.
400 33      
CLI communication error (hdr eof)
Error: Child (16091) died signal=6
Error: Child (16091) Last panic at: Wed, 22 Mar 2017 12:35:13 GMT
"Assert error in ccf_config_use(), cache/cache_vcl.c line 851:
  Condition(vcl->temp == VCL_TEMP_WARM) not true.
thread = (cache-main)
version = varnish-plus-4.1.5r2-beta1 revision 4653e4f
ident = Linux,3.16.0-4-amd64,x86_64,-jnone,-smalloc,-smalloc,-hcritbit,epoll
now = 301627.711396 (mono), 1490186113.598806 (real)
Backtrace:
  0x460aa0: pan_backtrace+0x20
  0x460861: pan_ic+0x3c1
  0x4609b0: ccf_panic
  0x47c1e0: ccf_config_use+0x1c0
  0x7f0f2f39e0c4: libvarnish.so(+0xb0c4) [0x7f0f2f39e0c4]
  0x7f0f2f39dcfb: libvarnish.so(+0xacfb) [0x7f0f2f39dcfb]
  0x7f0f2f39c807: libvarnish.so(+0x9807) [0x7f0f2f39c807]
  0x7f0f2f3a64b1: libvarnish.so(+0x134b1) [0x7f0f2f3a64b1]
  0x7f0f2f3a63c4: libvarnish.so(VLU_Fd+0x104) [0x7f0f2f3a63c4]
  0x7f0f2f39d640: libvarnish.so(VCLS_Poll+0x300) [0x7f0f2f39d640]
addr = (nil),
shared maps {
  7f0f274f4000-7f0f2c5f4000 rw-s 00000000 fe:02 659957                     /opt/varnish/var/varnish/friday/_.vsm
},
```