### PR TITLE
Include `libvmod_debug.so` in the Varnish package

### DIFF
--- a/lib/libvmod_debug/Makefile.am
+++ b/lib/libvmod_debug/Makefile.am
@@ -10,8 +10,7 @@ vmoddir = $(pkglibdir)/vmods
 vmod_srcdir = $(top_srcdir)/lib/libvmod_debug
 vmodtool = $(top_srcdir)/lib/libvcc/vmodtool.py
 vmodtoolargs =
-
-noinst_LTLIBRARIES = libvmod_debug.la
+vmod_LTLIBRARIES = libvmod_debug.la
 
 libvmod_debug_la_CFLAGS = \
 	@SAN_CFLAGS@


### PR DESCRIPTION
Currently, `libvmod_debug.so` isn't included in the resulting `varnish` package. Although it does somewhat make sense to exclude `libvmod_debug.so`, it makes it difficult for users to write tricky `varnishtest` test cases. Specifically, I am trying to write a regression test for #2275, but I am able to add `import debug` fails. I was thinking that I could solve this by installing the `varnish-dbg` package, but no such package exists. Given that VMODs aren't loaded automatically but rather are only loaded explicitly within VCL, I think that it's reasonable to bundle `/usr/lib/varnish/vmods/libvmod_debug.so` with the rest of the Varnish package.