### PR TITLE
Added std.file_exists("/foo") to check if "/foo" exists.

### DIFF
--- a/bin/varnishtest/tests/m00029.vtc
+++ b/bin/varnishtest/tests/m00029.vtc
@@ -1,0 +1,83 @@
+varnishtest "Test file_exists for std VMOD"
+
+shell {
+	touch "${tmpdir}/m00029_file_empty"
+	touch "${tmpdir}/m00029_file_noperm"; chmod 000 "${tmpdir}/m00029_file_noperm"
+	printf "Content" > "${tmpdir}/m00029_file_content"
+}
+
+server s1 {
+	rxreq
+	expect req.http.exists == "true"
+	txresp
+	rxreq
+	expect req.http.exists == "true"
+	txresp
+	rxreq
+	expect req.http.exists == "true"
+	txresp
+	rxreq
+	expect req.http.exists == "false"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_recv {
+		set req.http.exists = std.file_exists("${tmpdir}/m00029_file_" + req.http.filename);
+	}
+} -start
+
+client c1 {
+	txreq -hdr "filename: empty"
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "filename: noperm"
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "filename: content"
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "filename: nowhere"
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_recv {
+		if (req.url == "/healthcheck") {
+			if (std.file_exists("${tmpdir}/exclude_me_from_loadbalancer")) {
+				return (synth(503, "Varnish is in maintenance"));
+			}
+			else {
+				return (synth(200, "Varnish is healthy"));
+			}
+		}
+	}
+}
+
+varnish v1 -cli "vcl.list"
+varnish v1 -cli "vcl.use vcl2"
+varnish v1 -cli "vcl.discard vcl1"
+
+client c1 {
+	txreq -url "/healthcheck"
+	rxresp
+	expect resp.status == 200
+} -run
+
+shell {
+	touch "${tmpdir}/exclude_me_from_loadbalancer"
+}
+
+client c1 {
+	txreq -url "/healthcheck"
+	rxresp
+	expect resp.status == 503
+} -run

--- a/bin/varnishtest/tests/m00029.vtc
+++ b/bin/varnishtest/tests/m00029.vtc
@@ -1,83 +1,22 @@
 varnishtest "Test file_exists for std VMOD"
 
-shell {
-	touch "${tmpdir}/m00029_file_empty"
-	touch "${tmpdir}/m00029_file_noperm"; chmod 000 "${tmpdir}/m00029_file_noperm"
-	printf "Content" > "${tmpdir}/m00029_file_content"
-}
-
 server s1 {
 	rxreq
-	expect req.http.exists == "true"
-	txresp
-	rxreq
-	expect req.http.exists == "true"
-	txresp
-	rxreq
-	expect req.http.exists == "true"
-	txresp
-	rxreq
-	expect req.http.exists == "false"
 	txresp
 } -start
 
 varnish v1 -vcl+backend {
 	import std;
 
-	sub vcl_recv {
-		set req.http.exists = std.file_exists("${tmpdir}/m00029_file_" + req.http.filename);
+	sub vcl_deliver {
+		set resp.http.existsA = std.file_exists("/non/existent");
+		set resp.http.existsB = std.file_exists("${tmpdir}/v1/_.vsm");
 	}
 } -start
 
 client c1 {
-	txreq -hdr "filename: empty"
+	txreq
 	rxresp
-	expect resp.status == 200
-
-	txreq -hdr "filename: noperm"
-	rxresp
-	expect resp.status == 200
-
-	txreq -hdr "filename: content"
-	rxresp
-	expect resp.status == 200
-
-	txreq -hdr "filename: nowhere"
-	rxresp
-	expect resp.status == 200
-} -run
-
-varnish v1 -vcl+backend {
-	import std;
-
-	sub vcl_recv {
-		if (req.url == "/healthcheck") {
-			if (std.file_exists("${tmpdir}/exclude_me_from_loadbalancer")) {
-				return (synth(503, "Varnish is in maintenance"));
-			}
-			else {
-				return (synth(200, "Varnish is healthy"));
-			}
-		}
-	}
-}
-
-varnish v1 -cli "vcl.list"
-varnish v1 -cli "vcl.use vcl2"
-varnish v1 -cli "vcl.discard vcl1"
-
-client c1 {
-	txreq -url "/healthcheck"
-	rxresp
-	expect resp.status == 200
-} -run
-
-shell {
-	touch "${tmpdir}/exclude_me_from_loadbalancer"
-}
-
-client c1 {
-	txreq -url "/healthcheck"
-	rxresp
-	expect resp.status == 503
+	expect resp.http.existsA == "false"
+	expect resp.http.existsB == "true"
 } -run

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -112,9 +112,9 @@ $Function BOOL file_exists(STRING path)
 Description
 	Return TRUE if path exists, else FALSE.
 Example
-	if (std.file_exists("/etc/return_503")) {
-		return (synth(503, "Varnish is in maintenance"));
-        }
+	| if (std.file_exists("/etc/return_503")) {
+	| 	return (synth(503, "Varnish is in maintenance"));
+	| }
 
 $Function VOID collect(HEADER hdr)
 

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -107,6 +107,15 @@ Description
 Example
 	set beresp.http.served-by = std.fileread("/etc/hostname");
 
+$Function BOOL file_exists(STRING path)
+
+Description
+	Return TRUE if path exists, else FALSE.
+Example
+	if (std.file_exists("/etc/return_503")) {
+		return (synth(503, "Varnish is in maintenance"));
+        }
+
 $Function VOID collect(HEADER hdr)
 
 Description

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -33,6 +33,9 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <syslog.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "cache/cache.h"
 
@@ -171,6 +174,15 @@ vmod_syslog(VRT_CTX, VCL_INT fac, const char *fmt, ...)
 	if (t.e != NULL)
 		syslog((int)fac, "%s", t.b);
 	WS_Release(ctx->ws, 0);
+}
+
+VCL_BOOL __match_proto__(td_std_file_exists)
+vmod_file_exists(VRT_CTX, VCL_STRING file_name)
+{
+	struct stat st;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	return (stat(file_name, &st) == 0);
 }
 
 VCL_VOID __match_proto__(td_std_collect)


### PR DESCRIPTION
I'm suggesting to add a new function to test the presence of a file.

For Varnish3, it has already be done via a VMOD (see https://github.com/thomsonreuters/libvmod-utils) but since, Varnish4 has introduced more and more functions (e.g. `fileread`), so I guess the best place for `file_exists()` should be in vmod_std instead of a separate VMOD.
Also, I used `stat(2)` and not the other variants e.g. `lstat(2)`, but I guess that's OK.

For us, the main purpose of this function is the ability to check if a local file exists, and reply 200 or 503 accordingly. Then, a loadbalancer in front of Varnish can send an healthcheck to Varnish and can exclude or include it accordingly to the presence of the file.

If you're OK in principle, let me know if anything can be improved into this PR to get accepted.

Thanks