### PR TITLE
statistics aggregation overhaul

### DIFF
--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -21,6 +21,7 @@ varnishd_SOURCES = \
 	cache/cache_cli.c \
 	cache/cache_deliver_proc.c \
 	cache/cache_director.c \
+	cache/cache_dstat.c \
 	cache/cache_esi_deliver.c \
 	cache/cache_esi_fetch.c \
 	cache/cache_esi_parse.c \
@@ -112,6 +113,7 @@ varnishd_SOURCES = \
 noinst_HEADERS = \
 	builtin_vcl.h \
 	cache/cache_ban.h \
+	cache/cache_dstat.h \
 	cache/cache_esi.h \
 	cache/cache_obj.h \
 	cache/cache_pool.h \

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -852,9 +852,10 @@ struct VSC_C_lck *Lck_CreateClass(const char *name);
 #include "tbl/locks.h"
 
 /* cache_mempool.c */
+#define MPL_F_SIZE_ISH		1
 void MPL_AssertSane(void *item);
 struct mempool * MPL_New(const char *name, volatile struct poolparam *pp,
-    volatile unsigned *cur_size);
+    const unsigned flags, volatile unsigned *cur_size);
 void MPL_Destroy(struct mempool **mpp);
 void *MPL_Get(struct mempool *mpl, unsigned *size);
 void MPL_Free(struct mempool *mpl, void *item);

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -447,7 +447,7 @@ vca_accept_task(struct worker *wrk, void *arg)
 				break;
 			}
 			wrk->stats->sess_fail++;
-			(void)Pool_TrySumstat(wrk);
+			WRK_Stats_Update(wrk, NOW);
 			continue;
 		}
 

--- a/bin/varnishd/cache/cache_ban_lurker.c
+++ b/bin/varnishd/cache/cache_ban_lurker.c
@@ -380,7 +380,7 @@ ban_lurker(struct worker *wrk, void *priv)
 		d += VTIM_real();
 		Lck_Lock(&ban_mtx);
 		if (gen == ban_generation) {
-			Pool_Sumstat(wrk);
+			WRK_Stats_Update(wrk, NOW);
 			(void)Lck_CondWait(&ban_lurker_cond, &ban_mtx, d);
 			ban_batch = 0;
 		}

--- a/bin/varnishd/cache/cache_busyobj.c
+++ b/bin/varnishd/cache/cache_busyobj.c
@@ -50,7 +50,7 @@ VBO_Init(void)
 {
 
 	vbopool = MPL_New("busyobj", &cache_param->vbo_pool,
-	    &cache_param->workspace_backend);
+	    0, &cache_param->workspace_backend);
 	AN(vbopool);
 }
 

--- a/bin/varnishd/cache/cache_dstat.c
+++ b/bin/varnishd/cache/cache_dstat.c
@@ -1,0 +1,152 @@
+/*-
+ * Copyright 2017 UPLEX - Nils Goroll Systemoptimierung
+ * All rights reserved.
+ *
+ * Author: Nils Goroll <slink@uplex.de>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * Statistics mailman
+ */
+
+#include "config.h"
+
+#include "cache.h"
+#include "cache_dstat.h"
+
+struct dstat_mbx {
+	unsigned		magic;
+#define DSTAT_MBX_MAGIC	0x7a12f88e
+	struct lock		mtx;
+	VSLIST_HEAD(,dstat)	list;
+};
+
+struct dstat_mbx mbx;
+
+struct mempool			*dstatpool;
+
+static pthread_t		thr_dstat_mailman;
+
+
+/*--------------------------------------------------------------------
+ * Summing of stats into global stats counters
+ */
+
+static inline void
+pool_sumstat(const struct dstat *s)
+{
+
+#define L0(n)
+#define L1(n) (VSC_C_main->n += s->n)
+#define VSC_FF(n,t,l,s,f,v,d,e)	L##l(n);
+#include "tbl/vsc_f_main.h"
+#undef L0
+#undef L1
+}
+
+/*--------------------------------------------------------------------
+ * MPL Get / Free isolation
+ */
+
+struct dstat *
+Dstat_Get(void) {
+	struct dstat *s;
+
+	s = MPL_Get(dstatpool, NULL);
+	AN(s);
+	INIT_OBJ(s, DSTAT_MAGIC);
+	return (s);
+}
+
+void
+Dstat_Free(struct dstat **s) {
+	AN(s);
+	AN(*s);
+	CHECK_OBJ_NOTNULL(*s, DSTAT_MAGIC);
+	MPL_Free(dstatpool, *s);
+	*s = NULL;
+}
+
+/*--------------------------------------------------------------------
+ * submit stats to be added
+ */
+
+void
+Dstat_Submit(struct dstat **s)
+{
+	AN(s);
+	CHECK_OBJ_NOTNULL(*s, DSTAT_MAGIC);
+	CHECK_OBJ(&mbx, DSTAT_MBX_MAGIC);
+	Lck_Lock(&mbx.mtx);
+	VSLIST_INSERT_HEAD(&mbx.list, *s, list);
+	Lck_Unlock(&mbx.mtx);
+	*s = NULL;
+}
+
+/*--------------------------------------------------------------------
+ * Work incoming stats
+ */
+
+static void *
+dstat_mailman(void *priv)
+{
+	struct dstat		*s, *t;
+	VSLIST_HEAD(,dstat)	work;
+
+	THR_SetName("dstat_mailman");
+	(void) priv;
+
+	while(1) {
+		(void)usleep(cache_param->thread_stats_latency * 1e6 / 2);
+
+		CHECK_OBJ(&mbx, DSTAT_MBX_MAGIC);
+
+		if (VSLIST_EMPTY(&mbx.list))
+			continue;
+
+		VSLIST_INIT(&work);
+		Lck_Lock(&mbx.mtx);
+		VSLIST_SWAP(&mbx.list, &work, dstat);
+		Lck_Unlock(&mbx.mtx);
+
+		VSLIST_FOREACH_SAFE(s, &work, list, t) {
+			CHECK_OBJ_NOTNULL(s, DSTAT_MAGIC);
+			pool_sumstat(s);
+			MPL_Free(dstatpool, s);
+		}
+	}
+	NEEDLESS(return NULL);
+}
+
+void
+Dstat_Init(void)
+{
+	unsigned dstat_sz = sizeof(struct dstat);
+
+	dstatpool = MPL_New("dstat", &cache_param->wthread_dstat_pool,
+	    MPL_F_SIZE_ISH, &dstat_sz);
+	AN(dstatpool);
+	INIT_OBJ(&mbx, DSTAT_MBX_MAGIC);
+	Lck_New(&mbx.mtx, lck_dstat_mbx);
+	VSLIST_INIT(&mbx.list);
+	AZ(pthread_create(&thr_dstat_mailman, NULL, dstat_mailman, NULL));
+}

--- a/bin/varnishd/cache/cache_dstat.h
+++ b/bin/varnishd/cache/cache_dstat.h
@@ -1,9 +1,8 @@
 /*-
- * Copyright (c) 2006 Verdens Gang AS
- * Copyright (c) 2006-2011 Varnish Software AS
+ * Copyright 2017 UPLEX - Nils Goroll Systemoptimierung
  * All rights reserved.
  *
- * Author: Poul-Henning Kamp <phk@phk.freebsd.dk>
+ * Author: Nils Goroll <slink@uplex.de>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,40 +25,9 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * Private include file for the pool aware code.
+ * Statistics mailman
  */
 
-VTAILQ_HEAD(taskhead, pool_task);
-
-struct poolsock;
-
-struct pool {
-	unsigned			magic;
-#define POOL_MAGIC			0x606658fa
-	VTAILQ_ENTRY(pool)		list;
-	VTAILQ_HEAD(,poolsock)		poolsocks;
-
-	int				die;
-	pthread_cond_t			herder_cond;
-	pthread_t			herder_thr;
-
-	struct lock			mtx;
-	unsigned			nidle;
-	struct taskhead			idle_queue;
-	struct taskhead			queues[TASK_QUEUE_END];
-	unsigned			nthr;
-	unsigned			dry;
-	unsigned			lqueue;
-	uintmax_t			ndropped;
-	uintmax_t			nqueued;
-
-	struct mempool			*mpl_req;
-	struct mempool			*mpl_sess;
-	struct waiter			*waiter;
-};
-
-void *pool_herder(void*);
-task_func_t pool_stat_summ;
-extern struct lock			pool_mtx;
-void VCA_NewPool(struct pool *);
-void VCA_DestroyPool(struct pool *);
+struct dstat *Dstat_Get(void);
+void Dstat_Free(struct dstat **);
+void Dstat_Submit(struct dstat **);

--- a/bin/varnishd/cache/cache_expire.c
+++ b/bin/varnishd/cache/cache_expire.c
@@ -331,7 +331,7 @@ exp_thread(struct worker *wrk, void *priv)
 				oc->exp_flags &= OC_EF_REFD;
 		} else if (tnext > t) {
 			VSL_Flush(&ep->vsl, 0);
-			Pool_Sumstat(wrk);
+			WRK_Stats_Update(wrk, NOW);
 			(void)Lck_CondWait(&ep->condvar, &ep->mtx, tnext);
 		}
 		Lck_Unlock(&ep->mtx);

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -639,7 +639,8 @@ double keep)
 		}
 	} while (more);
 	WS_Release(wrk->aws, 0);
-	Pool_PurgeStat(nobj);
+	wrk->stats->n_purges++;
+	wrk->stats->n_obj_purged += nobj;
 }
 
 /*---------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -227,6 +227,8 @@ child_main(void)
 
 	Lck_New(&vxid_lock, lck_vxid);
 
+	Dstat_Init();
+
 	CLI_Init();
 	PAN_Init();
 	VFP_Init();

--- a/bin/varnishd/cache/cache_mempool.c
+++ b/bin/varnishd/cache/cache_mempool.c
@@ -281,7 +281,6 @@ MPL_Get(struct mempool *mpl, unsigned *size)
 	struct memitem *mi;
 
 	CHECK_OBJ_NOTNULL(mpl, MEMPOOL_MAGIC);
-	AN(size);
 
 	Lck_Lock(&mpl->mtx);
 
@@ -311,7 +310,9 @@ MPL_Get(struct mempool *mpl, unsigned *size)
 
 	if (mi == NULL)
 		mi = mpl_alloc(mpl);
-	*size = mi->size - sizeof *mi;
+
+	if (size)
+		*size = mi->size - sizeof *mi;
 
 	CHECK_OBJ_NOTNULL(mi, MEMITEM_MAGIC);
 	/* Throw away sizeof info for FlexeLint: */

--- a/bin/varnishd/cache/cache_priv.h
+++ b/bin/varnishd/cache/cache_priv.h
@@ -65,6 +65,9 @@ void CLI_Init(void);
 void CLI_Run(void);
 void CLI_AddFuncs(struct cli_proto *p);
 
+/* cache_dstat.c */
+void Dstat_Init(void);
+
 /* cache_expire.c */
 void EXP_Init(void);
 

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -596,10 +596,10 @@ SES_NewPool(struct pool *pp, unsigned pool_no)
 	CHECK_OBJ_NOTNULL(pp, POOL_MAGIC);
 	bprintf(nb, "req%u", pool_no);
 	pp->mpl_req = MPL_New(nb, &cache_param->req_pool,
-	    &cache_param->workspace_client);
+	    0, &cache_param->workspace_client);
 	bprintf(nb, "sess%u", pool_no);
 	pp->mpl_sess = MPL_New(nb, &cache_param->sess_pool,
-	    &cache_param->workspace_session);
+	    0, &cache_param->workspace_session);
 
 	pp->waiter = Waiter_New();
 }

--- a/bin/varnishd/common/com_params.h
+++ b/bin/varnishd/common/com_params.h
@@ -95,6 +95,7 @@ struct params {
 	unsigned		wthread_stats_rate;
 	ssize_t			wthread_stacksize;
 	unsigned		wthread_queue_limit;
+	struct poolparam	wthread_dstat_pool;
 
 	struct vre_limits	vre_limits;
 

--- a/bin/varnishd/hash/hash_critbit.c
+++ b/bin/varnishd/hash/hash_critbit.c
@@ -324,7 +324,7 @@ hcb_cleaner(struct worker *wrk, void *priv)
 		VSTAILQ_CONCAT(&dead_y, &cool_y);
 		VTAILQ_CONCAT(&dead_h, &cool_h, hoh_list);
 		Lck_Unlock(&hcb_mtx);
-		Pool_Sumstat(wrk);
+		WRK_Stats_Update(wrk, NOW);
 		VTIM_sleep(cache_param->critbit_cooloff);
 	}
 	NEEDLESS(return NULL);

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -383,6 +383,7 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 	req->transport = &HTTP1_transport;
 
 	while (1) {
+		WRK_Stats_Update(wrk, PERIODIC);
 		st = http1_getstate(sp);
 		if (st == H1NEWREQ) {
 			CHECK_OBJ_NOTNULL(req->transport, TRANSPORT_MAGIC);

--- a/bin/varnishd/mgt/mgt_param_tbl.c
+++ b/bin/varnishd/mgt/mgt_param_tbl.c
@@ -150,6 +150,12 @@ struct parspec mgt_parspec[] = {
 		0,
 		"255b",
 		"bytes" },
+	{ "pool_dstat", tweak_poolparam, &mgt_param.wthread_dstat_pool,
+		NULL, NULL,
+		"Parameters for worker statistics memory pool.\n"
+		MEMPOOL_TEXT,
+		0,
+		"10,100,10", ""},	// max_age ~ wthread_timeout
 
 	{ NULL, NULL, NULL }
 };

--- a/bin/varnishd/mgt/mgt_pool.c
+++ b/bin/varnishd/mgt/mgt_pool.c
@@ -186,17 +186,6 @@ struct parspec WRK_parspec[] = {
 		"destroyed and later recreated.",
 		EXPERIMENTAL,
 		"0.2", "seconds" },
-	{ "thread_stats_rate",
-		tweak_uint, &mgt_param.wthread_stats_rate,
-		"0", NULL,
-		"Worker threads accumulate statistics, and dump these into "
-		"the global stats counters if the lock is free when they "
-		"finish a job (request/fetch etc.)\n"
-		"This parameters defines the maximum number of jobs "
-		"a worker thread may handle, before it is forced to dump "
-		"its accumulated stats into the global counters.",
-		EXPERIMENTAL,
-		"10", "requests" },
 	{ "thread_queue_limit", tweak_uint, &mgt_param.wthread_queue_limit,
 		"0", NULL,
 		"Permitted request queue length per thread-pool.\n"

--- a/bin/varnishd/storage/storage_persistent_silo.c
+++ b/bin/varnishd/storage/storage_persistent_silo.c
@@ -175,7 +175,7 @@ smp_load_seg(struct worker *wrk, const struct smp_sc *sc,
 		(void)HSH_DerefObjCore(wrk, &oc, HSH_RUSH_POLICY);
 		wrk->stats->n_vampireobject++;
 	}
-	Pool_Sumstat(wrk);
+	WRK_Stats_Update(wrk, NOW);
 	sg->flags |= SMP_SEG_LOADED;
 }
 

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -930,7 +930,7 @@ varnish_expect(const struct varnish *v, char * const *av)
 	sp.v = v;
 	ref = 0;
 	good = 0;
-	for (i = 0; i < 10; i++, (void)usleep(100000)) {
+	for (i = 0; i < 20; i++, (void)usleep(100000)) {
 		if (VSM_Abandoned(v->vd)) {
 			VSM_Close(v->vd);
 			good = VSM_Open(v->vd);

--- a/include/tbl/locks.h
+++ b/include/tbl/locks.h
@@ -47,7 +47,7 @@ LOCK(vcl)
 LOCK(vxid)
 LOCK(waiter)
 LOCK(wq)
-LOCK(wstat)
+LOCK(dstat_mbx)
 #undef LOCK
 
 /*lint -restore */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1336,27 +1336,24 @@ PARAM(
 	/* l-text */	"",
 	/* func */	NULL
 )
+#endif
 
-/* actual location mgt_pool.c */
 PARAM(
-	/* name */	thread_stats_rate,
-	/* typ */	uint,
-	/* min */	"0",
+	/* name */	thread_stats_latency,
+	/* typ */	timeout,
+	/* min */	"0.010",
 	/* max */	NULL,
-	/* default */	"10",
-	/* units */	"requests",
+	/* default */	"1.000",
+	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
 	/* s-text */
-	"Worker threads accumulate statistics, and dump these into the "
-	"global stats counters if the lock is free when they finish a job "
-	"(request/fetch etc).\n"
-	"This parameters defines the maximum number of jobs a worker "
-	"thread may handle, before it is forced to dump its accumulated "
-	"stats into the global counters.",
+	"Maximum latency goal for worker thread statistics to appear in "
+	"the global stats counters.\n"
+	"Increasing this latency goal will reduce overhead and contention "
+	"on the lck_dstat_mbx lock.",
 	/* l-text */	"",
 	/* func */	NULL
 )
-#endif
 
 #if defined(XYZZY)
   #error "Temporary macro XYZZY already defined"

--- a/include/tbl/vsc_f_main.h
+++ b/include/tbl/vsc_f_main.h
@@ -612,12 +612,12 @@ VSC_FF(bans_persisted_fragmentation, uint64_t, 0, 'g', 'B', diag,
 
 /*--------------------------------------------------------------------*/
 
-VSC_FF(n_purges,			uint64_t, 0, 'g', 'i', info,
+VSC_FF(n_purges,			uint64_t, 1, 'g', 'i', info,
     "Number of purge operations executed",
 	""
 )
 
-VSC_FF(n_obj_purged,		uint64_t, 0, 'g', 'i', info,
+VSC_FF(n_obj_purged,		uint64_t, 1, 'g', 'i', info,
     "Number of purged objects",
 	""
 )


### PR DESCRIPTION
not to be merged before 5.1.2, but I'd appreciate earlier reviews
the first two commits are only to get support for fixed size mempools
the actual patch is the third commit, copied description:

    Previously, statistics aggregation was a three-level process:
    
    1) workers collected per-thread statistics
    
    2) When wthread_stats_rate was reached or a worker went idle,
       statistics were aggregated on the pool level
    
    3) Only when a worker was idle were the pool level statistics added to
       the global aggregation
    
    This could lead to long delays between the time some statistic was
    generated and it being reported, in particular under full load. Global
    statistics were never updated as long as all worker threads were busy
    at all times.
    
    We now simplify this into a two-level process: As before, workers keep
    their own statistics, but when it is time to aggregate, we send them
    off to a separate thread, which periodically adds all received stats
    to the global counters.
    
    The parameter thread_stats_rate is replaced by thread_stats_latency,
    which specifies a latency goal for statistics aggregation. The default
    of 1s is motivated by the default varnishstat update interval.
