### PR TITLE
Don't reset memory out of `struct http` at http_Teardown

### DIFF
--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -186,7 +186,6 @@ http_Teardown(struct http *hp)
 	AN(hp->shd);
 	memset(&hp->nhd, 0, sizeof *hp - offsetof(struct http, nhd));
 	memset(hp->hd, 0, sizeof *hp->hd * hp->shd);
-	memset(hp->hdf, 0, sizeof *hp->hdf * hp->shd);
 }
 
 /*--------------------------------------------------------------------*/


### PR DESCRIPTION
Usual code to create a `struct http` looks lie:
```
nhttp = (uint16_t)cache_param->http_max_hdr;
hl = HTTP_estimate(nhttp);

req->http = HTTP_create(p, nhttp);
p += hl;
p = (void*)PRNDUP(p);
assert(p < e);

req->http0 = HTTP_create(p, nhttp);
p += hl;
p = (void*)PRNDUP(p);
assert(p < e);
```

Well, when someone do `http_Teardown(req->http)` it will reset memory inside `req->http0` because `req->http->hdf` is a pointer to last `struct http` in allocated/reserved memory.