### PR TITLE
cannot link to varnishapi, symbols missing

### DIFF
--- a/lib/libvarnishapi/libvarnishapi.map
+++ b/lib/libvarnishapi/libvarnishapi.map
@@ -40,8 +40,8 @@ LIBVARNISHAPI_1.0 {
 	VSM_Head;
 	VSM_Find_Chunk;
 	VSM_Close;
-	VSM_iter0;
-	VSM_intern;
+	VSM__iter0;
+	VSM__intern;
 
 	VSC_Setup;
 	VSC_Arg;


### PR DESCRIPTION
fixes https://github.com/varnishcache/varnish-cache/issues/2313