### PR TITLE
Updated instructions for building on SmartOS

### DIFF
--- a/doc/sphinx/installation/install.rst
+++ b/doc/sphinx/installation/install.rst
@@ -119,12 +119,16 @@ Optionally, to rebuild the svg files:
 Build dependencies on a SmartOS Zone
 ------------------------------------
 
-As of SmartOS pkgsrc 2015Q4, install the following packages::
+As of SmartOS pkgsrc 2017Q1, install the following packages::
 
 	pkgin in autoconf automake libedit libtool ncurses \
 		 pcre py27-sphinx python27 gmake gcc49 pkg-config
+		 
+For the `configure` step (below) use::
 
-Optionally, to rebuild the svg files:
+	sh configure --prefix=/opt/local --mandir=/opt/local/man
+
+Optionally, to rebuild the svg files::
 
         pkgin in graphviz
 


### PR DESCRIPTION
Varnish needs a couple of configure flags to make everything go well on SmartOS.

I also have an SMF (a manifest for SmartOS's boot system) at https://gist.github.com/RantyDave/1d67e4fa571e675c3eced6896c6872ee but considered it impolite to reference off-repo in the patch itself. Feel free to do whatever, but it would certainly help new installs if they could get it from somewhere...

Cheers,
Dave