### PR TITLE
Introduce `$ABI [strict|lenient]` for VMOD descriptors

### DIFF
--- a/config.phk
+++ b/config.phk
@@ -107,25 +107,23 @@ fi
 
 VCSF=include/vcs_version.h
 VMAV=include/vmod_abi.h
+V=NOGIT
 
 if [ -d ./.git ] ; then
 	V=`git show -s --pretty=format:%h`
-	B=`git rev-parse --abbrev-ref HEAD`
-else
-	V="NOGIT"
-	B="NOGIT"
 fi
-(
-echo "/* $V */"
-echo "/*"
-echo " * NB:  This file is machine generated, DO NOT EDIT!"
-echo " *"
-echo " * make(1) updates this when necessary"
-echo " *"
-echo " */"
-echo "#define VCS_Version \"$V\""
-echo "#define VCS_Branch \"$B\""
-) > ${VCSF}_
+
+cat > ${VCSF}_ <<EOF
+/* $V */
+/*
+ * NB:  This file is machine generated, DO NOT EDIT!
+ *
+ * make(1) updates this when necessary
+ *
+ */
+#define VCS_Version "$V"
+EOF
+
 if [ ! -f ${VCSF} ] ; then
 	mv ${VCSF}_ ${VCSF}
 	rm -f ${VMAV}

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -1414,7 +1414,6 @@ if i != "/* " + v + " */":
 	fo = open(vcsfn, "w")
 	file_header(fo)
 	fo.write('#define VCS_Version "%s"\n' % v)
-	fo.write('#define VCS_Branch "%s"\n' % b)
 	fo.close()
 
 	for i in open(os.path.join(buildroot, "Makefile")):

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -155,7 +155,7 @@ vcc_ParseImport(struct vcc *tl)
 		vcc_ErrWhere(tl, mod);
 		return;
 	}
-	if (strcmp(VCS_Branch, "master") == 0 &&
+	if (vmd->vrt_major == 0 && vmd->vrt_minor == 0 &&
 	    strcmp(vmd->abi, VMOD_ABI_Version) != 0) {
 		VSB_printf(tl->sb, "Incompatible VMOD %.*s\n", PF(mod));
 		VSB_printf(tl->sb, "\tFile name: %s\n", fnp);
@@ -164,8 +164,8 @@ vcc_ParseImport(struct vcc *tl)
 		vcc_ErrWhere(tl, mod);
 		return;
 	}
-	if (vmd->vrt_major != VRT_MAJOR_VERSION ||
-	    vmd->vrt_minor > VRT_MINOR_VERSION) {
+	if (vmd->vrt_major != 0 && (vmd->vrt_major != VRT_MAJOR_VERSION ||
+	    vmd->vrt_minor > VRT_MINOR_VERSION)) {
 		VSB_printf(tl->sb, "Incompatible VMOD %.*s\n", PF(mod));
 		VSB_printf(tl->sb, "\tFile name: %s\n", fnp);
 		VSB_printf(tl->sb, "\tVMOD version %u.%u\n",

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -26,6 +26,7 @@
 # SUCH DAMAGE.
 
 $Module debug 3 Development, test and debug
+$ABI strict
 
 DESCRIPTION
 ===========

--- a/lib/libvmod_directors/vmod.vcc
+++ b/lib/libvmod_directors/vmod.vcc
@@ -33,6 +33,7 @@
 # SUCH DAMAGE.
 
 $Module directors 3 Varnish Directors Module
+$ABI strict
 
 DESCRIPTION
 ===========

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -26,6 +26,7 @@
 # SUCH DAMAGE.
 
 $Module std 3 Varnish Standard Module
+$ABI strict
 
 DESCRIPTION
 ===========


### PR DESCRIPTION
When versioning appeared in the VRT API, the goal was to allow loose
ABI compliance on loaded VMODs based on the major/minor revision against
which it was built. Strict checking was performed if Varnish was built
from the master branch in the VCC code, but omitted by the child.

This however has two flaws:

1) Release management might go wrong like it happened in 5.1.2 that got
   released from the master branch.

2) This doesn't solve the original problem that some VMODs might rely
   on supported symbols encompassed by the VRT major/minor while others
   may choose to integrate deeper with Varnish and lose guarantees.

This patch retires the `VCS_Branch` macro that is no longer needed and
provides a new `$ABI` stanza that defaults to strict when omitted. To
help discovery, in-tree modules advertise a strict match.

To indicate that a VMOD needs the exact Varnish build to be loaded,
the VMOD's metadata contains 0.0 for the VRT major/minor revision.

In addition, both the VCC and child now perform the full ABI compliance
check, picking the strict or lenient option depending on the VMOD's
metadata.