### PR TITLE
support ncurses with a split tinfo library

### DIFF
--- a/bin/varnishhist/Makefile.am
+++ b/bin/varnishhist/Makefile.am
@@ -18,4 +18,4 @@ varnishhist_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 	-lm \
 	@SAN_LDFLAGS@ \
-	@CURSES_LIB@ ${RT_LIBS} ${PTHREAD_LIBS}
+	@CURSES_LIBS@ ${RT_LIBS} ${PTHREAD_LIBS}

--- a/bin/varnishstat/Makefile.am
+++ b/bin/varnishstat/Makefile.am
@@ -19,4 +19,4 @@ varnishstat_CFLAGS = \
 varnishstat_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 	@SAN_LDFLAGS@ \
-	@CURSES_LIB@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}
+	@CURSES_LIBS@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}

--- a/bin/varnishtop/Makefile.am
+++ b/bin/varnishtop/Makefile.am
@@ -17,4 +17,4 @@ varnishtop_CFLAGS = \
 varnishtop_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 	@SAN_LDFLAGS@ \
-	@CURSES_LIB@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}
+	@CURSES_LIBS@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}

--- a/m4/ax_with_curses.m4
+++ b/m4/ax_with_curses.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#      http://www.gnu.org/software/autoconf-archive/ax_with_curses.html
+#      https://www.gnu.org/software/autoconf-archive/ax_with_curses.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -12,7 +12,9 @@
 #   present, along with the associated header file.  The NcursesW
 #   (wide-character) library is searched for first, followed by Ncurses,
 #   then the system-default plain Curses.  The first library found is the
-#   one returned.
+#   one returned. Finding libraries will first be attempted by using
+#   pkg-config, and should the pkg-config files not be available, will
+#   fallback to combinations of known flags itself.
 #
 #   The following options are understood: --with-ncursesw, --with-ncurses,
 #   --without-ncursesw, --without-ncurses.  The "--with" options force the
@@ -52,23 +54,29 @@
 #
 #   (These preprocessor symbols are discussed later in this document.)
 #
-#   The following output variable is defined by this macro; it is precious
-#   and may be overridden on the ./configure command line:
+#   The following output variables are defined by this macro; they are
+#   precious and may be overridden on the ./configure command line:
 #
-#     CURSES_LIB  - library to add to xxx_LDADD
+#     CURSES_LIBS  - library to add to xxx_LDADD
+#     CURSES_CFLAGS  - include paths to add to xxx_CPPFLAGS
 #
-#   The library listed in CURSES_LIB is NOT added to LIBS by default. You
-#   need to add CURSES_LIB to the appropriate xxx_LDADD line in your
-#   Makefile.am.  For example:
+#   In previous versions of this macro, the flags CURSES_LIB and
+#   CURSES_CPPFLAGS were defined. These have been renamed, in keeping with
+#   AX_WITH_CURSES's close bigger brother, PKG_CHECK_MODULES, which should
+#   eventually supersede the use of AX_WITH_CURSES. Neither the library
+#   listed in CURSES_LIBS, nor the flags in CURSES_CFLAGS are added to LIBS,
+#   respectively CPPFLAGS, by default. You need to add both to the
+#   appropriate xxx_LDADD/xxx_CPPFLAGS line in your Makefile.am. For
+#   example:
 #
-#     prog_LDADD = @CURSES_LIB@
+#     prog_LDADD = @CURSES_LIBS@
+#     prog_CPPFLAGS = @CURSES_CFLAGS@
 #
-#   If CURSES_LIB is set on the configure command line (such as by running
-#   "./configure CURSES_LIB=-lmycurses"), then the only header searched for
-#   is <curses.h>.  The user may use the CPPFLAGS precious variable to
-#   override the standard #include search path.  If the user needs to
-#   specify an alternative path for a library (such as for a non-standard
-#   NcurseW), the user should use the LDFLAGS variable.
+#   If CURSES_LIBS is set on the configure command line (such as by running
+#   "./configure CURSES_LIBS=-lmycurses"), then the only header searched for
+#   is <curses.h>. If the user needs to specify an alternative path for a
+#   library (such as for a non-standard NcurseW), the user should use the
+#   LDFLAGS variable.
 #
 #   The following shell variables may be defined by this macro:
 #
@@ -88,7 +96,7 @@
 #
 #     AX_WITH_CURSES
 #     if test "x$ax_cv_ncursesw" != xyes && test "x$ax_cv_ncurses" != xyes; then
-#         AX_MSG_ERROR([requires either NcursesW or Ncurses library])
+#         AC_MSG_ERROR([requires either NcursesW or Ncurses library])
 #     fi
 #
 #   If any Curses library will do (but one must be present and must support
@@ -167,7 +175,7 @@
 #   Public License for more details.
 #
 #   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #   As a special exception, the respective Autoconf Macro's copyright owner
 #   gives unlimited permission to copy, distribute and modify the configure
@@ -182,11 +190,66 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 13
+#serial 18
+
+# internal function to factorize common code that is used by both ncurses
+# and ncursesw
+AC_DEFUN([_FIND_CURSES_FLAGS], [
+    AC_MSG_CHECKING([for $1 via pkg-config])
+
+    AX_REQUIRE_DEFINED([PKG_CHECK_EXISTS])
+    _PKG_CONFIG([_ax_cv_$1_libs], [libs], [$1])
+    _PKG_CONFIG([_ax_cv_$1_cppflags], [cflags], [$1])
+
+    AS_IF([test "x$pkg_failed" = "xyes" || test "x$pkg_failed" = "xuntried"],[
+        AC_MSG_RESULT([no])
+        # No suitable .pc file found, have to find flags via fallback
+        AC_CACHE_CHECK([for $1 via fallback], [ax_cv_$1], [
+            AS_ECHO()
+            pkg_cv__ax_cv_$1_libs="-l$1"
+            pkg_cv__ax_cv_$1_cppflags="-D_GNU_SOURCE $CURSES_CFLAGS"
+            LIBS="$ax_saved_LIBS $pkg_cv__ax_cv_$1_libs"
+            CPPFLAGS="$ax_saved_CPPFLAGS $pkg_cv__ax_cv_$1_cppflags"
+
+            AC_MSG_CHECKING([for initscr() with $pkg_cv__ax_cv_$1_libs])
+            AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
+                [
+                    AC_MSG_RESULT([yes])
+                    AC_MSG_CHECKING([for nodelay() with $pkg_cv__ax_cv_$1_libs])
+                    AC_LINK_IFELSE([AC_LANG_CALL([], [nodelay])],[
+                        ax_cv_$1=yes
+                        ],[
+                        AC_MSG_RESULT([no])
+                        m4_if(
+                            [$1],[ncursesw],[pkg_cv__ax_cv_$1_libs="$pkg_cv__ax_cv_$1_libs -ltinfow"],
+                            [$1],[ncurses],[pkg_cv__ax_cv_$1_libs="$pkg_cv__ax_cv_$1_libs -ltinfo"]
+                        )
+                        LIBS="$ax_saved_LIBS $pkg_cv__ax_cv_$1_libs"
+
+                        AC_MSG_CHECKING([for nodelay() with $pkg_cv__ax_cv_$1_libs])
+                        AC_LINK_IFELSE([AC_LANG_CALL([], [nodelay])],[
+                            ax_cv_$1=yes
+                            ],[
+                            ax_cv_$1=no
+                        ])
+                    ])
+                ],[
+                    ax_cv_$1=no
+            ])
+        ])
+        ],[
+        AC_MSG_RESULT([yes])
+        # Found .pc file, using its information
+        LIBS="$ax_saved_LIBS $pkg_cv__ax_cv_$1_libs"
+        CPPFLAGS="$ax_saved_CPPFLAGS $pkg_cv__ax_cv_$1_cppflags"
+        ax_cv_$1=yes
+    ])
+])
 
 AU_ALIAS([MP_WITH_CURSES], [AX_WITH_CURSES])
 AC_DEFUN([AX_WITH_CURSES], [
-    AC_ARG_VAR([CURSES_LIB], [linker library for Curses, e.g. -lcurses])
+    AC_ARG_VAR([CURSES_LIBS], [linker library for Curses, e.g. -lcurses])
+    AC_ARG_VAR([CURSES_CFLAGS], [preprocessor flags for Curses, e.g. -I/usr/include/ncursesw])
     AC_ARG_WITH([ncurses], [AS_HELP_STRING([--with-ncurses],
         [force the use of Ncurses or NcursesW])],
         [], [with_ncurses=check])
@@ -195,20 +258,17 @@ AC_DEFUN([AX_WITH_CURSES], [
         [], [with_ncursesw=check])
 
     ax_saved_LIBS=$LIBS
+    ax_saved_CPPFLAGS=$CPPFLAGS
+
     AS_IF([test "x$with_ncurses" = xyes || test "x$with_ncursesw" = xyes],
         [ax_with_plaincurses=no], [ax_with_plaincurses=check])
 
     ax_cv_curses_which=no
 
     # Test for NcursesW
+    AS_IF([test "x$CURSES_LIBS" = x && test "x$with_ncursesw" != xno], [
+        _FIND_CURSES_FLAGS([ncursesw])
 
-    AS_IF([test "x$CURSES_LIB" = x && test "x$with_ncursesw" != xno], [
-        LIBS="$ax_saved_LIBS -lncursesw"
-
-        AC_CACHE_CHECK([for NcursesW wide-character library], [ax_cv_ncursesw], [
-            AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
-                [ax_cv_ncursesw=yes], [ax_cv_ncursesw=no])
-        ])
         AS_IF([test "x$ax_cv_ncursesw" = xno && test "x$with_ncursesw" = xyes], [
             AC_MSG_ERROR([--with-ncursesw specified but could not find NcursesW library])
         ])
@@ -216,7 +276,8 @@ AC_DEFUN([AX_WITH_CURSES], [
         AS_IF([test "x$ax_cv_ncursesw" = xyes], [
             ax_cv_curses=yes
             ax_cv_curses_which=ncursesw
-            CURSES_LIB="-lncursesw"
+            CURSES_LIBS="$pkg_cv__ax_cv_ncursesw_libs"
+            CURSES_CFLAGS="$pkg_cv__ax_cv_ncursesw_cppflags"
             AC_DEFINE([HAVE_NCURSESW], [1], [Define to 1 if the NcursesW library is present])
             AC_DEFINE([HAVE_CURSES],   [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
 
@@ -318,16 +379,13 @@ AC_DEFUN([AX_WITH_CURSES], [
             ])
         ])
     ])
+    unset pkg_cv__ax_cv_ncursesw_libs
+    unset pkg_cv__ax_cv_ncursesw_cppflags
 
     # Test for Ncurses
+    AS_IF([test "x$CURSES_LIBS" = x && test "x$with_ncurses" != xno && test "x$ax_cv_curses_which" = xno], [
+        _FIND_CURSES_FLAGS([ncurses])
 
-    AS_IF([test "x$CURSES_LIB" = x && test "x$with_ncurses" != xno && test "x$ax_cv_curses_which" = xno], [
-        LIBS="$ax_saved_LIBS -lncurses"
-
-        AC_CACHE_CHECK([for Ncurses library], [ax_cv_ncurses], [
-            AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
-                [ax_cv_ncurses=yes], [ax_cv_ncurses=no])
-        ])
         AS_IF([test "x$ax_cv_ncurses" = xno && test "x$with_ncurses" = xyes], [
             AC_MSG_ERROR([--with-ncurses specified but could not find Ncurses library])
         ])
@@ -335,7 +393,8 @@ AC_DEFUN([AX_WITH_CURSES], [
         AS_IF([test "x$ax_cv_ncurses" = xyes], [
             ax_cv_curses=yes
             ax_cv_curses_which=ncurses
-            CURSES_LIB="-lncurses"
+            CURSES_LIBS="$pkg_cv__ax_cv_ncurses_libs"
+            CURSES_CFLAGS="$pkg_cv__ax_cv_ncurses_cppflags"
             AC_DEFINE([HAVE_NCURSES], [1], [Define to 1 if the Ncurses library is present])
             AC_DEFINE([HAVE_CURSES],  [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
 
@@ -390,12 +449,13 @@ AC_DEFUN([AX_WITH_CURSES], [
             ])
         ])
     ])
+    unset pkg_cv__ax_cv_ncurses_libs
+    unset pkg_cv__ax_cv_ncurses_cppflags
 
-    # Test for plain Curses (or if CURSES_LIB was set by user)
-
+    # Test for plain Curses (or if CURSES_LIBS was set by user)
     AS_IF([test "x$with_plaincurses" != xno && test "x$ax_cv_curses_which" = xno], [
-        AS_IF([test "x$CURSES_LIB" != x], [
-            LIBS="$ax_saved_LIBS $CURSES_LIB"
+        AS_IF([test "x$CURSES_LIBS" != x], [
+            LIBS="$ax_saved_LIBS $CURSES_LIBS"
         ], [
             LIBS="$ax_saved_LIBS -lcurses"
         ])
@@ -408,8 +468,8 @@ AC_DEFUN([AX_WITH_CURSES], [
         AS_IF([test "x$ax_cv_plaincurses" = xyes], [
             ax_cv_curses=yes
             ax_cv_curses_which=plaincurses
-            AS_IF([test "x$CURSES_LIB" = x], [
-                CURSES_LIB="-lcurses"
+            AS_IF([test "x$CURSES_LIBS" = x], [
+                CURSES_LIBS="-lcurses"
             ])
             AC_DEFINE([HAVE_CURSES], [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
 
@@ -515,4 +575,8 @@ AC_DEFUN([AX_WITH_CURSES], [
     AS_IF([test "x$ax_cv_curses_obsolete" != xyes], [ax_cv_curses_obsolete=no])
 
     LIBS=$ax_saved_LIBS
+    CPPFLAGS=$ax_saved_CPPFLAGS
+
+    unset ax_saved_LIBS
+    unset ax_saved_CPPFLAGS
 ])dnl


### PR DESCRIPTION
Some Linux distributions like Gentoo can install ncurses with a separate libtinfo. This pull request adds support for that scenario by simply updating m4/ax_with_curses.m4 to the latest version from https://www.gnu.org/software/autoconf-archive/ax_with_curses.html and replacing the deprecated variable CURSES_LIB with CURSES_LIBS in the affected Makefile.am files.

In order to delete the related Makefile.in files, you might have to do a "git clean -x".

later edit: Travis fails with "error: possibly undefined macro: PKG_CHECK_EXISTS". Is pkg-config installed in the test environment?