### PR TITLE
If pipe'ing, unset any existing Connection headers

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -676,7 +676,7 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	HTTP_Setup(bo->bereq, bo->ws, bo->vsl, SLT_BereqMethod);
 	http_FilterReq(bo->bereq, req->http, 0);	// XXX: 0 ?
 	http_PrintfHeader(bo->bereq, "X-Varnish: %u", VXID(req->vsl->wid));
-	http_SetHeader(bo->bereq, "Connection: close");
+	http_ForceHeader(bo->bereq, H_Connection, "close");
 
 	if (req->want100cont) {
 		http_SetHeader(bo->bereq, "Expect: 100-continue");

--- a/bin/varnishtest/tests/b00001.vtc
+++ b/bin/varnishtest/tests/b00001.vtc
@@ -2,17 +2,30 @@ varnishtest "Check that a pipe transaction works"
 
 server s1 -repeat 1 {
 	rxreq
-	txresp -body "012345\n"
+	expect req.http.connection == "close"
+	txresp
+	rxreq
+	expect req.http.connection == "keep-alive"
+	txresp
 } -start
 
 varnish v1 -vcl+backend {
 	sub vcl_recv {
 		return(pipe);
 	}
+
+	sub vcl_pipe {
+		if (req.url == "/2") {
+			set bereq.http.connection = req.http.connection;
+		}
+	}
 } -start
 
 client c1 {
-	txreq -url "/"
+	txreq -url /1 -hdr "Connection: keep-alive"
+	rxresp
+	expect resp.status == 200
+	txreq -url /2 -hdr "Connection: keep-alive"
 	rxresp
 	expect resp.status == 200
 } -run


### PR DESCRIPTION
Otherwise the backend might see multiple Connection entries.
Fixes #2337.