### PR TITLE
Make varnishd -f honor the vcl_path

### DIFF
--- a/bin/varnishtest/tests/r02342.vtc
+++ b/bin/varnishtest/tests/r02342.vtc
@@ -1,0 +1,20 @@
+varnishtest "honor vcl_path with varnishd -f"
+
+shell {
+	cat >unlikely_file_name.vcl <<-EOF
+	vcl 4.0;
+
+	backend be {
+		.host = "${bad_backend}";
+	}
+	EOF
+}
+
+shell -err -expect "Cannot read -f file 'unlikely_file_name.vcl'" {
+	varnishd -F -a :0 -n ${tmpdir}/tmp -f unlikely_file_name.vcl
+}
+
+varnish v1 -arg "-p vcl_path=${tmpdir} -f unlikely_file_name.vcl" -start
+
+# Even when loaded from a relative path, show an absolute one
+varnish v1 -cliexpect "VCL.SHOW .+ ${tmpdir}/unlikely_file_name.vcl" "vcl.show -v boot"

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,7 +8,9 @@ Varnish Cache Trunk (ongoing)
 
 * VSM_Name() returns the -i argument name, rather than the -n name.
 
-* VUT.name is goine, use VSM_Name(VUT.vsm)
+* VUT.name is gone, use VSM_Name(VUT.vsm)
+
+* varnishd honors vcl_path (#2342)
 
 ================================
 Varnish Cache 5.1.2 (2017-04-07)

--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -70,6 +70,13 @@ Basic options
   script (-I option) and the child process will be started if there
   is an active VCL at the end of the initialization.
 
+  When used with a relative file name, config is searched in the
+  ``vcl_path``. It is possible to set this path prior to using ``-f``
+  options with a ``-p`` option. During startup, `varnishd` doesn't
+  complain about unsafe VCL paths: unlike the `varnish-cli(7)` that
+  could later be accessed remotely, starting `varnishd` requires
+  local privileges.
+
 -n name
 
   Specify the name for this instance.  This name is used to construct


### PR DESCRIPTION
Tested manually, I will provide test coverage if this is acknowledged as a bug. For a description of the problem, see this comment:

https://github.com/varnishcache/pkg-varnish-cache/pull/70#issuecomment-307152655

I believe all versions of Varnish with a `vcl_dir` or `vcl_path` are affected.