### PR TITLE
Make sure first_byte_timeout is applied on reused backend connection

### DIFF
--- a/bin/varnishd/cache/cache_backend.h
+++ b/bin/varnishd/cache/cache_backend.h
@@ -127,7 +127,7 @@ void VBT_Recycle(const struct worker *, struct tcp_pool *, struct vbc **);
 void VBT_Close(struct tcp_pool *tp, struct vbc **vbc);
 struct vbc *VBT_Get(struct tcp_pool *, double tmo, const struct backend *,
     struct worker *);
-void VBT_Wait(struct worker *, struct vbc *);
+int VBT_Wait(struct worker *, struct vbc *, double tmo);
 
 /* cache_vcl.c */
 int VCL_AddBackend(struct vcl *, struct backend *);


### PR DESCRIPTION
This avoids getting stuck with a stalled backend connection until
reaching backend_idle_timeout.

We now wait for the waiter to release the fd for a limited amount of
time (first_byte_timeout). In case we reach the timeout, the backend
connection is killed to make sure we are not going to reuse it.

Fixes #1772.