### PR TITLE
First series of "vcl 6.0;" changes

### DIFF
--- a/bin/varnishtest/tests/c00084.vtc
+++ b/bin/varnishtest/tests/c00084.vtc
@@ -1,0 +1,38 @@
+varnishtest "legal symbol names"
+
+varnish v1 -arg "-s my-store=malloc" -vcl {
+	import directors;
+
+	acl my-acl { "127.0.0.1"; }
+
+	probe my-pb { }
+	backend my-be {
+		.host = "${bad_backend}";
+		.probe = my-pb;
+	}
+
+	sub vcl_init {
+		new my-dir = directors.round_robin();
+		my-dir.add_backend(my-be);
+	}
+
+	sub vcl_recv {
+		call my-sub;
+	}
+
+	sub my-sub {
+		if (client.ip ~ my-acl) { }
+		set req.storage = storage.my-store;
+		set req.backend_hint = my-dir.backend();
+	}
+} -start
+
+varnish v1 -cli "vcl.label my-label vcl1"
+
+varnish v1 -vcl {
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_recv {
+		return (vcl(my-label));
+	}
+}

--- a/bin/varnishtest/tests/d00006.vtc
+++ b/bin/varnishtest/tests/d00006.vtc
@@ -22,11 +22,11 @@ server s4 {
 	txresp -body "4444"
 } -start
 
-varnish v1 -errvcl {Name of VCL object, 'rr1-xx', contains illegal character '-'} {
+varnish v1 -errvcl {Name of VCL object, 'rr1.xx', contains illegal character '.'} {
 	import directors;
 	backend b1 { .host = "127.0.0.1"; .port = "8080";}
 	sub vcl_init {
-		new rr1-xx = directors.round_robin();
+		new rr1.xx = directors.round_robin();
 	}
 }
 

--- a/bin/varnishtest/tests/v00020.vtc
+++ b/bin/varnishtest/tests/v00020.vtc
@@ -204,12 +204,12 @@ varnish v1 -errvcl {IP + IP not possible.} {
 	}
 }
 
-varnish v1 -errvcl {Name of function, 'foo-bar', contains illegal character '-'} {
+varnish v1 -errvcl {Name of function, 'foo.bar', contains illegal character '.'} {
 	backend b { .host = "127.0.0.1"; }
-	sub foo-bar {
+	sub foo.bar {
 	}
 	sub vcl_recv {
-		call foo-bar;
+		call foo.bar;
 	}
 }
 
@@ -238,9 +238,9 @@ varnish v1 -errvcl {'beresp.status': Not available in method 'vcl_recv'.} {
 	}
 }
 
-varnish v1 -errvcl {Name of ACL, 'foo-bar', contains illegal character '-'} {
+varnish v1 -errvcl {Name of ACL, 'foo.bar', contains illegal character '.'} {
 	backend b { .host = "127.0.0.1"; }
-	acl foo-bar {
+	acl foo.bar {
 	}
 	sub vcl_recv {
 		if (client.ip ~ foo.bar) {

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -820,6 +820,7 @@ stv_variables = (
 
 vcltypes = {
 	'STRING_LIST':	"void*",
+	'SUB':			"void*",
 }
 
 fi = open(join(srcroot, "include/vrt.h"))

--- a/lib/libvcc/vcc_acl.c
+++ b/lib/libvcc/vcc_acl.c
@@ -484,7 +484,7 @@ vcc_ParseAcl(struct vcc *tl)
 	vcc_NextToken(tl);
 	VTAILQ_INIT(&tl->acl);
 
-	vcc_ExpectCid(tl, "ACL");
+	vcc_ExpectVid(tl, "ACL");
 	ERRCHK(tl);
 	an = tl->t;
 	vcc_NextToken(tl);

--- a/lib/libvcc/vcc_acl.c
+++ b/lib/libvcc/vcc_acl.c
@@ -485,7 +485,7 @@ vcc_ParseAcl(struct vcc *tl)
 
 	acln = TlDupTok(tl, an);
 
-	(void)VCC_HandleSymbol(tl, an, ACL, "&vrt_acl_named");
+	(void)VCC_HandleSymbol(tl, an, ACL, ACL_SYMBOL_PREFIX);
 	ERRCHK(tl);
 
 	SkipToken(tl, '{');

--- a/lib/libvcc/vcc_acl.c
+++ b/lib/libvcc/vcc_acl.c
@@ -485,7 +485,7 @@ vcc_ParseAcl(struct vcc *tl)
 
 	acln = TlDupTok(tl, an);
 
-	(void)VCC_HandleSymbol(tl, an, ACL, "&vrt_acl_named_%s", acln);
+	(void)VCC_HandleSymbol(tl, an, ACL, "&vrt_acl_named");
 	ERRCHK(tl);
 
 	SkipToken(tl, '{');

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -46,7 +46,7 @@ parse_call(struct vcc *tl)
 	vcc_NextToken(tl);
 	ExpectErr(tl, ID);
 	vcc_AddCall(tl, tl->t);
-	vcc_AddRef(tl, tl->t, SYM_SUB);
+	(void)vcc_AddRef(tl, tl->t, SYM_SUB);
 	Fb(tl, 1, "VGC_function_%.*s(ctx);\n", PF(tl->t));
 	vcc_NextToken(tl);
 }

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -258,8 +258,7 @@ vcc_ParseProbe(struct vcc *tl)
 	t_probe = tl->t;
 	vcc_NextToken(tl);
 
-	(void)VCC_HandleSymbol(tl, t_probe, PROBE, "&vgc_probe_%.*s",
-	    PF(t_probe));
+	(void)VCC_HandleSymbol(tl, t_probe, PROBE, "&vgc_probe");
 	ERRCHK(tl);
 
 	vcc_ParseProbeSpec(tl, t_probe, &p);
@@ -481,7 +480,7 @@ vcc_ParseBackend(struct vcc *tl)
 	bprintf(vgcname, "vgc_backend_%.*s", PF(t_be));
 	Fh(tl, 0, "\nstatic struct director *%s;\n", vgcname);
 
-	sym = VCC_HandleSymbol(tl, t_be, BACKEND, "%s", vgcname);
+	sym = VCC_HandleSymbol(tl, t_be, BACKEND, "vgc_backend");
 	ERRCHK(tl);
 
 	vcc_ParseHostDef(tl, t_be, vgcname);

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -263,7 +263,7 @@ vcc_ParseProbe(struct vcc *tl)
 
 	vcc_ParseProbeSpec(tl, t_probe, &p);
 	if (vcc_IdIs(t_probe, "default")) {
-		vcc_AddRef(tl, t_probe, SYM_PROBE);
+		(void)vcc_AddRef(tl, t_probe, SYM_PROBE);
 		tl->default_probe = p;
 	}
 }
@@ -395,7 +395,7 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 				return;
 			}
 			Fb(tl, 0, "\t.probe = &vgc_probe_%.*s,\n", PF(tl->t));
-			vcc_AddRef(tl, tl->t, SYM_PROBE);
+			(void)vcc_AddRef(tl, tl->t, SYM_PROBE);
 			vcc_NextToken(tl);
 			SkipToken(tl, ';');
 		} else if (vcc_IdIs(t_field, "probe")) {

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -255,7 +255,7 @@ vcc_ParseProbe(struct vcc *tl)
 
 	vcc_NextToken(tl);			/* ID: probe */
 
-	vcc_ExpectCid(tl, "backend probe");	/* ID: name */
+	vcc_ExpectVid(tl, "backend probe");	/* ID: name */
 	ERRCHK(tl);
 	t_probe = tl->t;
 	vcc_NextToken(tl);
@@ -466,7 +466,7 @@ vcc_ParseBackend(struct vcc *tl)
 	t_first = tl->t;
 	vcc_NextToken(tl);		/* ID: backend */
 
-	vcc_ExpectCid(tl, "backend");	/* ID: name */
+	vcc_ExpectVid(tl, "backend");	/* ID: name */
 	ERRCHK(tl);
 
 	/* XXX: lift this limit once VSM ident becomes dynamic */

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -411,7 +411,7 @@ EmitStruct(const struct vcc *tl)
 	Fc(tl, 0, "\t.event_vcl = VGC_Event,\n");
 	Fc(tl, 0, "\t.default_director = &%s,\n", tl->default_director);
 	if (tl->default_probe != NULL)
-		Fc(tl, 0, "\t.default_probe = &%s,\n", tl->default_probe);
+		Fc(tl, 0, "\t.default_probe = %s,\n", tl->default_probe);
 	Fc(tl, 0, "\t.ref = VGC_ref,\n");
 	Fc(tl, 0, "\t.nref = VGC_NREFS,\n");
 	Fc(tl, 0, "\t.nsrc = VGC_NSRCS,\n");

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -568,9 +568,9 @@ vcc_CompileSource(struct vcc *tl, struct source *sp)
 		sym->fmt = v->fmt;
 		sym->eval = vcc_Eval_Var;
 		sym->r_methods = v->r_methods;
-		sym->rname = v->rname;
 		sym->w_methods = v->w_methods;
 		sym->lname = v->lname;
+		REPLACE(sym->rname, v->rname);
 	}
 
 	Fh(tl, 0, "/* ---===### VCC generated .h code ###===---*/\n");

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -619,7 +619,7 @@ vcc_CompileSource(struct vcc *tl, struct source *sp)
 	}
 
 	/* Configure the default director */
-	vcc_AddRef(tl, tl->t_default_director, SYM_BACKEND);
+	(void)vcc_AddRef(tl, tl->t_default_director, SYM_BACKEND);
 
 	/* Check for orphans */
 	if (vcc_CheckReferences(tl))

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -280,7 +280,7 @@ void vcc_Eval_Func(struct vcc *tl, const char *spec,
     const char *extra, const struct symbol *sym);
 enum symkind VCC_HandleKind(vcc_type_t fmt);
 struct symbol *VCC_HandleSymbol(struct vcc *, const struct token *,
-    vcc_type_t fmt, const char *str, ...);
+    vcc_type_t fmt, const char *pfx);
 
 /* vcc_obj.c */
 extern const struct var vcc_vars[];

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -337,8 +337,10 @@ void vcc_ParseImport(struct vcc *tl);
 void vcc_ParseNew(struct vcc *tl);
 
 /* vcc_xref.c */
-int vcc_AddDef(struct vcc *tl, const struct token *t, enum symkind type);
-void vcc_AddRef(struct vcc *tl, const struct token *t, enum symkind type);
+struct symbol *vcc_AddDef(struct vcc *tl, const struct token *t,
+    enum symkind type);
+struct symbol *vcc_AddRef(struct vcc *tl, const struct token *t,
+    enum symkind type);
 int vcc_CheckReferences(struct vcc *tl);
 void VCC_XrefTable(struct vcc *);
 

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -137,7 +137,7 @@ struct symbol {
 	const char			*extra;
 
 	/* SYM_VAR */
-	const char			*rname;
+	char				*rname;
 	unsigned			r_methods;
 	const char			*lname;
 	unsigned			w_methods;
@@ -279,6 +279,7 @@ sym_expr_t vcc_Eval_SymFunc;
 void vcc_Eval_Func(struct vcc *tl, const char *spec,
     const char *extra, const struct symbol *sym);
 enum symkind VCC_HandleKind(vcc_type_t fmt);
+void VCC_GlobalSymbol(struct symbol *, vcc_type_t fmt, const char *pfx);
 struct symbol *VCC_HandleSymbol(struct vcc *, const struct token *,
     vcc_type_t fmt, const char *pfx);
 

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -361,4 +361,4 @@ int vcc_CheckUses(struct vcc *tl);
 #define SkipToken(a, b) \
     do { vcc__Expect(a, b, __LINE__); ERRCHK(a); vcc_NextToken(a); } while (0)
 
-#define ACL_SYMBOL_PREFIX "&vrt_acl_named"
+#define ACL_SYMBOL_PREFIX "vrt_acl_named"

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -360,3 +360,5 @@ int vcc_CheckUses(struct vcc *tl);
     do { vcc__Expect(a, b, __LINE__); ERRCHK(a);} while (0)
 #define SkipToken(a, b) \
     do { vcc__Expect(a, b, __LINE__); ERRCHK(a); vcc_NextToken(a); } while (0)
+
+#define ACL_SYMBOL_PREFIX "&vrt_acl_named"

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -318,7 +318,7 @@ void vcc_ErrWhere2(struct vcc *, const struct token *, const struct token *);
 
 void vcc__Expect(struct vcc *tl, unsigned tok, unsigned line);
 int vcc_IdIs(const struct token *t, const char *p);
-void vcc_ExpectCid(struct vcc *tl, const char *what);
+void vcc_ExpectVid(struct vcc *tl, const char *what);
 void vcc_Lexer(struct vcc *tl, struct source *sp);
 void vcc_NextToken(struct vcc *tl);
 void vcc__ErrInternal(struct vcc *tl, const char *func,

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -300,6 +300,7 @@ void Resolve_Sockaddr(struct vcc *tl, const char *host, const char *defport,
 void vcc_stevedore(struct vcc *vcc, const char *stv_name);
 
 /* vcc_symb.c */
+void VCC_PrintCName(struct vsb *vsb, const char *b, const char *e);
 struct symbol *VCC_Symbol(struct vcc *, struct symbol *,
     const char *, const char *, enum symkind, int);
 #define VCC_SymbolTok(vcc, sym, tok, kind, create) \

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -471,7 +471,7 @@ vcc_Eval_Handle(struct vcc *tl, struct expr **e, const struct symbol *sym,
 		*e = vcc_mk_expr(STRING, "\"%s\"", sym->name);
 		(void)vcc_AddRef(tl, tl->t, sym->kind);
 	} else {
-		vcc_ExpectCid(tl, "handle");
+		vcc_ExpectVid(tl, "handle");
 		(void)vcc_AddRef(tl, tl->t, sym->kind);
 		*e = vcc_mk_expr(sym->fmt, "%s", sym->rname);
 		(*e)->constant = EXPR_VAR;	/* XXX ? */
@@ -1203,7 +1203,7 @@ vcc_expr_cmp(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 	    (tl->t->tok == '~' || tl->t->tok == T_NOMATCH)) {
 		not = tl->t->tok == '~' ? "" : "!";
 		vcc_NextToken(tl);
-		vcc_ExpectCid(tl, "ACL");
+		vcc_ExpectVid(tl, "ACL");
 		sym = vcc_AddRef(tl, tl->t, SYM_ACL);
 		VCC_GlobalSymbol(sym, ACL, ACL_SYMBOL_PREFIX);
 		bprintf(buf, "%sVRT_acl_match(ctx, %s, \v1)", not, sym->rname);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -469,10 +469,10 @@ vcc_Eval_Handle(struct vcc *tl, struct expr **e, const struct symbol *sym,
 
 	if (sym->fmt != STRING && (fmt == STRING || fmt == STRING_LIST)) {
 		*e = vcc_mk_expr(STRING, "\"%s\"", sym->name);
-		vcc_AddRef(tl, tl->t, sym->kind);
+		(void)vcc_AddRef(tl, tl->t, sym->kind);
 	} else {
 		vcc_ExpectCid(tl, "handle");
-		vcc_AddRef(tl, tl->t, sym->kind);
+		(void)vcc_AddRef(tl, tl->t, sym->kind);
 		*e = vcc_mk_expr(sym->fmt, "%s", sym->rname);
 		(*e)->constant = EXPR_VAR;	/* XXX ? */
 	}
@@ -1203,7 +1203,7 @@ vcc_expr_cmp(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		not = tl->t->tok == '~' ? "" : "!";
 		vcc_NextToken(tl);
 		vcc_ExpectCid(tl, "ACL");
-		vcc_AddRef(tl, tl->t, SYM_ACL);
+		(void)vcc_AddRef(tl, tl->t, SYM_ACL);
 		bprintf(buf, "%smatch_acl_named_%.*s(ctx, \v1)",
 		    not, PF(tl->t));
 		vcc_NextToken(tl);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1204,9 +1204,9 @@ vcc_expr_cmp(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		not = tl->t->tok == '~' ? "" : "!";
 		vcc_NextToken(tl);
 		vcc_ExpectCid(tl, "ACL");
-		(void)vcc_AddRef(tl, tl->t, SYM_ACL);
-		bprintf(buf, "%smatch_acl_named_%.*s(ctx, \v1)",
-		    not, PF(tl->t));
+		sym = vcc_AddRef(tl, tl->t, SYM_ACL);
+		VCC_GlobalSymbol(sym, ACL, ACL_SYMBOL_PREFIX);
+		bprintf(buf, "%sVRT_acl_match(ctx, %s, \v1)", not, sym->rname);
 		vcc_NextToken(tl);
 		*e = vcc_expr_edit(BOOL, buf, *e, NULL);
 		return;

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1150,6 +1150,7 @@ vcc_expr_cmp(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 	const char *re;
 	const char *not;
 	struct token *tk;
+	struct symbol *sym;
 	enum symkind kind;
 
 	*e = NULL;

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -213,7 +213,7 @@ vcc_ParseFunction(struct vcc *tl)
 	int m, i;
 
 	vcc_NextToken(tl);
-	vcc_ExpectCid(tl, "function");
+	vcc_ExpectVid(tl, "function");
 	ERRCHK(tl);
 
 	m = IsMethod(tl->t);

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -240,17 +240,17 @@ vcc_ParseFunction(struct vcc *tl)
 	} else {
 		tl->fb = tl->fc;
 		sym = vcc_AddDef(tl, tl->t, SYM_SUB);
+		VCC_GlobalSymbol(sym, SUB, "VGC_function");
 		if (sym->ndef > 1) {
 			VSB_printf(tl->sb,
-			    "Function '%.*s' redefined\n", PF(tl->t));
+			    "Function '%s' redefined\n", sym->name);
 			vcc_ErrWhere(tl, tl->t);
 			return;
 		}
 		tl->curproc = vcc_AddProc(tl, tl->t);
-		Fh(tl, 0, "void VGC_function_%.*s(VRT_CTX);\n", PF(tl->t));
+		Fh(tl, 0, "void %s(VRT_CTX);\n", sym->rname);
 		Fc(tl, 1, "\nvoid __match_proto__(vcl_func_t)\n");
-		Fc(tl, 1, "VGC_function_%.*s(VRT_CTX)\n",
-		    PF(tl->t));
+		Fc(tl, 1, "%s(VRT_CTX)\n", sym->rname);
 	}
 	vcc_NextToken(tl);
 	tl->indent += INDENT;

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -209,6 +209,7 @@ vcc_Compound(struct vcc *tl)
 static void
 vcc_ParseFunction(struct vcc *tl)
 {
+	struct symbol *sym;
 	int m, i;
 
 	vcc_NextToken(tl);
@@ -229,7 +230,7 @@ vcc_ParseFunction(struct vcc *tl)
 		tl->fb = tl->fm[m];
 		if (tl->mprocs[m] == NULL) {
 			(void)vcc_AddDef(tl, tl->t, SYM_SUB);
-			vcc_AddRef(tl, tl->t, SYM_SUB);
+			(void)vcc_AddRef(tl, tl->t, SYM_SUB);
 			tl->mprocs[m] = vcc_AddProc(tl, tl->t);
 		}
 		tl->curproc = tl->mprocs[m];
@@ -238,8 +239,8 @@ vcc_ParseFunction(struct vcc *tl)
 		Fb(tl, 0, " */\n");
 	} else {
 		tl->fb = tl->fc;
-		i = vcc_AddDef(tl, tl->t, SYM_SUB);
-		if (i > 1) {
+		sym = vcc_AddDef(tl, tl->t, SYM_SUB);
+		if (sym->ndef > 1) {
 			VSB_printf(tl->sb,
 			    "Function '%.*s' redefined\n", PF(tl->t));
 			vcc_ErrWhere(tl, tl->t);

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -45,6 +45,7 @@ VCC_HandleKind(vcc_type_t fmt)
 	if (fmt == BACKEND)	return(SYM_BACKEND);
 	if (fmt == PROBE)	return(SYM_PROBE);
 	if (fmt == STEVEDORE)	return(SYM_STEVEDORE);
+	if (fmt == SUB)		return(SYM_SUB);
 	if (fmt == INSTANCE)	return(SYM_INSTANCE);
 	return(SYM_NONE);
 }

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -36,6 +36,8 @@
 
 #include "vcc_compile.h"
 
+#include "vct.h"
+
 /*--------------------------------------------------------------------*/
 
 enum symkind
@@ -61,6 +63,24 @@ VCC_SymKind(struct vcc *tl, const struct symbol *s)
 		VSB_printf(tl->sb, "Symbol Kind 0x%x\n", s->kind);
 		return("INTERNALERROR");
 	}
+}
+
+void
+VCC_PrintCName(struct vsb *vsb, const char *b, const char *e)
+{
+
+	AN(vsb);
+	AN(b);
+
+	if (e == NULL)
+		e = strchr(b, '\0');
+	assert(b < e);
+
+	for (; b < e; b++)
+		if (vct_isalnum(*b))
+			VSB_putc(vsb, *b);
+		else
+			VSB_printf(vsb, "_%02x_", *b);
 }
 
 static struct symbol *
@@ -189,7 +209,8 @@ VCC_GlobalSymbol(struct symbol *sym, vcc_type_t fmt, const char *pfx)
 
 	vsb = VSB_new_auto();
 	AN(vsb);
-	VSB_printf(vsb, "%s_%s", pfx, sym->name);
+	VSB_printf(vsb, "%s_", pfx);
+	VCC_PrintCName(vsb, sym->name, NULL);
 	AZ(VSB_finish(vsb));
 	REPLACE(sym->rname, VSB_data(vsb));
 	AN(sym->rname);

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -178,8 +178,8 @@ VCC_WalkSymbols(struct vcc *tl, symwalk_f *func, enum symkind kind)
 	vcc_walksymbols(tl, tl->symbols, func, kind);
 }
 
-static void
-vcc_global(struct vcc *tl, struct symbol *sym, vcc_type_t fmt, const char *pfx)
+void
+VCC_GlobalSymbol(struct symbol *sym, vcc_type_t fmt, const char *pfx)
 {
 	struct vsb *vsb;
 
@@ -190,10 +190,7 @@ vcc_global(struct vcc *tl, struct symbol *sym, vcc_type_t fmt, const char *pfx)
 	AN(vsb);
 	VSB_printf(vsb, "%s_%s", pfx, sym->name);
 	AZ(VSB_finish(vsb));
-	if (tl != NULL)
-		sym->rname = TlDup(tl, VSB_data(vsb));
-	else
-		sym->rname = strdup(VSB_data(vsb));
+	REPLACE(sym->rname, VSB_data(vsb));
 	AN(sym->rname);
 	VSB_destroy(&vsb);
 
@@ -247,7 +244,7 @@ VCC_HandleSymbol(struct vcc *tl, const struct token *tk, vcc_type_t fmt,
 		sym = VCC_SymbolTok(tl, NULL, tk, kind, 1);
 	AN(sym);
 	AZ(sym->ndef);
-	vcc_global(tl, sym, fmt, pfx);
+	VCC_GlobalSymbol(sym, fmt, pfx);
 	sym->ndef = 1;
 	if (sym->def_b == NULL)
 		sym->def_b = tk;

--- a/lib/libvcc/vcc_token.c
+++ b/lib/libvcc/vcc_token.c
@@ -291,26 +291,25 @@ vcc_IdIs(const struct token *t, const char *p)
 }
 
 /*--------------------------------------------------------------------
- * Check that we have a C-identifier
+ * Check that we have a Varnish identifier
  */
 
 void
-vcc_ExpectCid(struct vcc *tl, const char *what)
+vcc_ExpectVid(struct vcc *tl, const char *what)
 {
-	const char *q;
+	const char *bad;
 
 	ExpectErr(tl, ID);
 	ERRCHK(tl);
-	/* XXX: too soon to use vct_invalid_name() */
-	for (q = tl->t->b; q < tl->t->e; q++) {
-		if (!vct_isalnum(*q) && *q != '_') {
-			VSB_printf(tl->sb, "Name of %s, ", what);
-			vcc_ErrToken(tl, tl->t);
-			VSB_printf(tl->sb,
-			    ", contains illegal character '%c'\n", *q);
-			vcc_ErrWhere(tl, tl->t);
-			return;
-		}
+
+	bad = VCT_invalid_name(tl->t->b, tl->t->e);
+	if (bad != NULL) {
+		VSB_printf(tl->sb, "Name of %s, ", what);
+		vcc_ErrToken(tl, tl->t);
+		VSB_printf(tl->sb,
+		    ", contains illegal character '%c'\n", *bad);
+		vcc_ErrWhere(tl, tl->t);
+		return;
 	}
 }
 

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -140,6 +140,11 @@ const struct type STRING_LIST[1] = {{
 	.tostring =		"VRT_CollectString(ctx,\n\v1,\nvrt_magic_string_end)",
 }};
 
+const struct type SUB[1] = {{
+	.magic =		TYPE_MAGIC,
+	.name =			"SUB",
+}};
+
 const struct type TIME[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"TIME",

--- a/lib/libvcc/vcc_var.c
+++ b/lib/libvcc/vcc_var.c
@@ -44,9 +44,8 @@ vcc_Var_Wildcard(struct vcc *tl, struct symbol *parent,
 	struct symbol *sym;
 	struct var *v;
 	const struct var *vh;
-	unsigned u;
-	const char *p;
 	struct vsb *vsb;
+	unsigned len;
 
 	vh = parent->wildcard_priv;
 	assert(vh->fmt == HEADER);
@@ -68,17 +67,14 @@ vcc_Var_Wildcard(struct vcc *tl, struct symbol *parent,
 	vsb = VSB_new_auto();
 	AN(vsb);
 	VSB_printf(vsb, "&VGC_%s_", vh->rname);
-	for (p = b, u = 1; p < e; p++, u++)
-		if (vct_isalnum(*p))
-			VSB_putc(vsb, *p);
-		else
-			VSB_printf(vsb, "_%02x_", *p);
+	VCC_PrintCName(vsb, b, e);
 	AZ(VSB_finish(vsb));
 
 	/* Create the static identifier */
+	len = (unsigned)(e - b);
 	Fh(tl, 0, "static const struct gethdr_s %s =\n", VSB_data(vsb) + 1);
 	Fh(tl, 0, "    { %s, \"\\%03o%.*s:\"};\n",
-	    vh->rname, u, (int)(e - b), b);
+	    vh->rname, len + 1, len, b);
 
 	/* Create the symbol r/l values */
 	v->rname = TlDup(tl, VSB_data(vsb));

--- a/lib/libvcc/vcc_var.c
+++ b/lib/libvcc/vcc_var.c
@@ -29,6 +29,9 @@
 
 #include "config.h"
 
+#include <stdlib.h>
+#include <string.h>
+
 #include "vcc_compile.h"
 #include "vct.h"
 
@@ -90,9 +93,9 @@ vcc_Var_Wildcard(struct vcc *tl, struct symbol *parent,
 	sym->fmt = v->fmt;
 	sym->eval = vcc_Eval_Var;
 	sym->r_methods = v->r_methods;
-	sym->rname = v->rname;
 	sym->w_methods = v->w_methods;
 	sym->lname = v->lname;
+	REPLACE(sym->rname, v->rname);
 }
 
 /*--------------------------------------------------------------------*/

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -282,7 +282,7 @@ vcc_ParseNew(struct vcc *tl)
 	ExpectErr(tl, ID);
 	vcc_ExpectCid(tl, "VCL object");
 	ERRCHK(tl);
-	sy1 = VCC_HandleSymbol(tl, tl->t, INSTANCE, "XXX");
+	sy1 = VCC_HandleSymbol(tl, tl->t, INSTANCE, "vo");
 	ERRCHK(tl);
 
 	/* We allow implicit use of VMOD objects:  Pretend it's ref'ed */
@@ -309,10 +309,10 @@ vcc_ParseNew(struct vcc *tl)
 	s_obj = p;
 	p += strlen(p) + 1;
 
-	Fh(tl, 0, "static %s *vo_%s;\n\n", p, sy1->name);
+	Fh(tl, 0, "static %s *%s;\n\n", p, sy1->rname);
 	p += strlen(p) + 1;
 
-	bprintf(buf1, ", &vo_%s, \"%s\"", sy1->name, sy1->name);
+	bprintf(buf1, ", &%s, \"%s\"", sy1->rname, sy1->name);
 	vcc_Eval_Func(tl, p, buf1, sy2);
 	ExpectErr(tl, ';');
 
@@ -322,14 +322,14 @@ vcc_ParseNew(struct vcc *tl)
 
 	ifp = New_IniFin(tl);
 	p += strlen(p) + 1;
-	VSB_printf(ifp->fin, "\t\t%s(&vo_%s);", p, sy1->name);
+	VSB_printf(ifp->fin, "\t\t%s(&%s);", p, sy1->rname);
 
 	while (p[0] != '\0' || p[1] != '\0' || p[2] != '\0')
 		p++;
 	p += 3;
 
 	/* Instantiate symbols for the methods */
-	bprintf(buf1, ", vo_%s", sy1->name);
+	bprintf(buf1, ", %s", sy1->rname);
 	while (*p != '\0') {
 		p += strlen(s_obj);
 		bprintf(buf2, "%s%s", sy1->name, p);

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -280,7 +280,7 @@ vcc_ParseNew(struct vcc *tl)
 
 	vcc_NextToken(tl);
 	ExpectErr(tl, ID);
-	vcc_ExpectCid(tl, "VCL object");
+	vcc_ExpectVid(tl, "VCL object");
 	ERRCHK(tl);
 	sy1 = VCC_HandleSymbol(tl, tl->t, INSTANCE, "vo");
 	ERRCHK(tl);

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -73,7 +73,7 @@ struct proc {
  * Keep track of definitions and references
  */
 
-void
+struct symbol *
 vcc_AddRef(struct vcc *tl, const struct token *t, enum symkind kind)
 {
 	struct symbol *sym;
@@ -83,9 +83,10 @@ vcc_AddRef(struct vcc *tl, const struct token *t, enum symkind kind)
 		sym->ref_b = t;
 	AN(sym);
 	sym->nref++;
+	return (sym);
 }
 
-int
+struct symbol *
 vcc_AddDef(struct vcc *tl, const struct token *t, enum symkind kind)
 {
 	struct symbol *sym;
@@ -95,7 +96,7 @@ vcc_AddDef(struct vcc *tl, const struct token *t, enum symkind kind)
 		sym->def_b = t;
 	AN(sym);
 	sym->ndef++;
-	return (sym->ndef);
+	return (sym);
 }
 
 /*--------------------------------------------------------------------*/


### PR DESCRIPTION
This is a partial implementation of what was reported here: https://github.com/varnishcache/varnish-cache/issues/2325#issuecomment-301457374

The changes to the VCL syntax are summed up in this test case:

https://github.com/Dridi/varnish-cache/blob/vsym/bin/varnishtest/tests/c00084.vtc

Basically, all kinds of VCL symbols can contain dashes (`-`) and VCL labels moved to a name space. This isn't done yet for VMODs, it is not possible to declare a function with this character yet. The other missing bit is symbol uniqueness for everything that is not in a name space.

I'm not continuing this effort yet, I will take advantage of the probable delay until it's reviewed and hopefully merged to work on some other assignment. However I will of course reply to comments as soon as I see them.