### PR TITLE
Add extra locking to protect the pools list and refcounts

### DIFF
--- a/bin/varnishd/cache/cache_backend_tcp.c
+++ b/bin/varnishd/cache/cache_backend_tcp.c
@@ -69,6 +69,7 @@ struct tcp_pool {
 
 };
 
+static struct lock		pools_mtx;
 static VTAILQ_HEAD(, tcp_pool)	pools = VTAILQ_HEAD_INITIALIZER(pools);
 
 /*--------------------------------------------------------------------
@@ -125,6 +126,7 @@ VBT_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6)
 {
 	struct tcp_pool *tp;
 
+	Lck_Lock(&pools_mtx);
 	VTAILQ_FOREACH(tp, &pools, list) {
 		assert(tp->refcnt > 0);
 		if (ip4 == NULL) {
@@ -146,8 +148,10 @@ VBT_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6)
 				continue;
 		}
 		tp->refcnt++;
+		Lck_Unlock(&pools_mtx);
 		return (tp);
 	}
+	Lck_Unlock(&pools_mtx);
 
 	ALLOC_OBJ(tp, TCP_POOL_MAGIC);
 	AN(tp);
@@ -159,7 +163,11 @@ VBT_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6)
 	Lck_New(&tp->mtx, lck_backend_tcp);
 	VTAILQ_INIT(&tp->connlist);
 	VTAILQ_INIT(&tp->killlist);
+
+	Lck_Lock(&pools_mtx);
 	VTAILQ_INSERT_HEAD(&pools, tp, list);
+	Lck_Unlock(&pools_mtx);
+
 	return (tp);
 }
 
@@ -174,11 +182,17 @@ VBT_Rel(struct tcp_pool **tpp)
 	struct vbc *vbc, *vbc2;
 
 	TAKE_OBJ_NOTNULL(tp, tpp, TCP_POOL_MAGIC);
+
+	Lck_Lock(&pools_mtx);
 	assert(tp->refcnt > 0);
-	if (--tp->refcnt > 0)
+	if (--tp->refcnt > 0) {
+		Lck_Unlock(&pools_mtx);
 		return;
+	}
 	AZ(tp->n_used);
 	VTAILQ_REMOVE(&pools, tp, list);
+	Lck_Unlock(&pools_mtx);
+
 	free(tp->name);
 	free(tp->ip4);
 	free(tp->ip6);
@@ -399,4 +413,12 @@ VBT_Wait(struct worker *wrk, struct vbc *vbc)
 	assert(vbc->state == VBC_STATE_USED);
 	vbc->cond = NULL;
 	Lck_Unlock(&tp->mtx);
+}
+
+/*--------------------------------------------------------------------*/
+
+void
+VBT_Init(void)
+{
+	Lck_New(&pools_mtx, lck_backend);
 }

--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -238,6 +238,7 @@ child_main(void)
 	HTTP_Init();
 
 	VBO_Init();
+	VBT_Init();
 	VBP_Init();
 	VBE_InitCfg();
 	Pool_Init();

--- a/bin/varnishd/cache/cache_priv.h
+++ b/bin/varnishd/cache/cache_priv.h
@@ -41,6 +41,9 @@ void VCA_Shutdown(void);
 void VBE_InitCfg(void);
 void VBE_Poll(void);
 
+/* cache_backend_tcp.c */
+void VBT_Init(void);
+
 /* cache_backend_poll.c */
 void VBP_Init(void);
 


### PR DESCRIPTION
Probes currently running on a worker thread at the time they are
deleted will delay the release of the refcount they hold on the TCP
pool. Since this call will not be from the CLI thread we need locking
to protect these datastructures.