### PR TITLE
Add the vtc feature ignore_unknown_macro.

### DIFF
--- a/bin/varnishtest/tests/a00018.vtc
+++ b/bin/varnishtest/tests/a00018.vtc
@@ -1,0 +1,35 @@
+varnishtest "feature ignore_unknown_macro"
+
+feature ignore_unknown_macro
+
+server s1 {
+	rxreq
+	expect req.http.Foo == "${foo}"
+	txresp -hdr "Bar: ${bar}"
+} -start
+
+varnish v1 -vcl {
+	backend default {
+		.host = "${s1_addr}";
+		.port = "${s1_port}";
+	}
+
+	sub vcl_deliver {
+	    if (resp.http.Bar == "${bar}") {
+	       set resp.http.Baz = "${baz}";
+	    }
+	}
+} -start
+
+client c1 {
+       txreq -hdr "Foo: ${foo}"
+       rxresp
+       expect resp.status == 200
+       expect resp.http.Bar == "${bar}"
+       expect resp.http.Baz == "${baz}"
+} -run
+
+shell {
+      touch ${tmpdir}/tst
+      rm ${tmpdir}/tst
+}

--- a/bin/varnishtest/vtc.c
+++ b/bin/varnishtest/vtc.c
@@ -58,6 +58,7 @@ volatile sig_atomic_t	vtc_error;	/* Error encountered */
 int			vtc_stop;	/* Stops current test without error */
 pthread_t		vtc_thread;
 static struct vtclog	*vltop;
+static int		ign_unknown_macro = 0;
 
 /**********************************************************************
  * Macro facility
@@ -236,13 +237,18 @@ macro_expand(struct vtclog *vl, const char *text)
 		p += 2;
 		m = macro_get(p, q);
 		if (m == NULL) {
-			VSB_destroy(&vsb);
-			vtc_fatal(vl, "Macro ${%.*s} not found", (int)(q - p),
-			    p);
-			NEEDLESS(return (NULL));
+			if (!ign_unknown_macro) {
+				VSB_destroy(&vsb);
+				vtc_fatal(vl, "Macro ${%.*s} not found",
+					  (int)(q - p), p);
+				NEEDLESS(return (NULL));
+			}
+			VSB_printf(vsb, "${%.*s}", (int)(q - p), p);
 		}
-		VSB_printf(vsb, "%s", m);
-		free(m);
+		else {
+			VSB_printf(vsb, "%s", m);
+			free(m);
+		}
 		text = q + 1;
 	}
 	AZ(VSB_finish(vsb));
@@ -662,8 +668,9 @@ cmd_delay(CMD_ARGS)
 
 /* SECTION: feature feature
  *
- * Test that the required feature(s) for a test are available, and skip the test
- * otherwise. feature takes any number of arguments from this list:
+ * Test that the required feature(s) for a test are available, and skip
+ * the test otherwise; or change the interpretation of the test, as
+ * documented below. feature takes any number of arguments from this list:
  *
  * SO_RCVTIMEO_WORKS
  *        The SO_RCVTIMEO socket option is working
@@ -685,6 +692,13 @@ cmd_delay(CMD_ARGS)
  *        The varnish group is present
  * cmd <command-line>
  *        A command line that should execute with a zero exit status
+ * ignore_unknown_macro
+ *        Do not fail the test if a string of the form ${...} is not
+ *        recognized as a macro.
+ *
+ * Be careful with the last feature, because it may cause a test with a
+ * misspelled macro to fail silently. You should only need if you must
+ * run a test with strings of the form "${...}".
  */
 
 static void
@@ -746,7 +760,8 @@ cmd_feature(CMD_ARGS)
 				vtc_stop = 2;
 			}
 #endif
-		} else if (!strcmp(*av, "cmd")) {
+		}
+		else if (!strcmp(*av, "cmd")) {
 			av++;
 			if (*av == NULL)
 				vtc_fatal(vl, "Missing the command-line");
@@ -755,6 +770,10 @@ cmd_feature(CMD_ARGS)
 				good = 1;
 			else
 				vtc_stop = 2;
+		}
+		else if (!strcmp(*av, "ignore_unknown_macro")) {
+			ign_unknown_macro = 1;
+			good = 1;
 		}
 		if (good)
 			continue;


### PR DESCRIPTION
When this feature is switched on, strings of the form ``"${foo}"`` may be used in a vtc test; the test does not fail with the "Macro not found" error.

I needed it for a VMOD that binds pcre2, which has a new substitution function where the substitution strings may use syntax like ``${1}``.

``vtc(7)`` points out that this feature should be used very carefully, if ever, since misspelled macros will be silently ignored.