### PR TITLE
Free the allocation for the HPACK dynamic table

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -185,6 +185,7 @@ h2_del_req(struct worker *wrk, struct h2_req *r2)
 	if (r)
 		return;
 	/* All streams gone, including stream #0, clean up */
+	VHT_Fini(h2->dectbl);
 	req = h2->srq;
 	AZ(req->ws->r);
 	Req_Cleanup(sp, wrk, req);

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -103,7 +103,6 @@ h2_new_sess(const struct worker *wrk, struct sess *sp, struct req *srq)
 		h2->local_settings = H2_proto_settings;
 		h2->remote_settings = H2_proto_settings;
 
-		/* XXX: Lacks a VHT_Fini counterpart. Will leak memory. */
 		AZ(VHT_Init(h2->dectbl,
 			h2->local_settings.header_table_size));
 


### PR DESCRIPTION
This adds a call to VHT_Fini just before we let go of the h2_sess in
h2_del_req.