### PR TITLE
Fix a race in the h/2 Upgrade code

### DIFF
--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -231,6 +231,7 @@ h2_ou_session(struct worker *wrk, struct h2_sess *h2,
 	req->req_step = R_STP_TRANSPORT;
 	req->task.func = h2_do_req;
 	req->task.priv = req;
+	r2->scheduled = 1;
 	req->err_code = 0;
 	http_SetH(req->http, HTTP_HDR_PROTO, "HTTP/2.0");
 

--- a/bin/varnishtest/tests/r02310.vtc
+++ b/bin/varnishtest/tests/r02310.vtc
@@ -1,0 +1,40 @@
+varnishtest "#2310: Panic on premature hangup after Upgrade: h2c"
+
+barrier b1 cond 2
+
+server s1 {
+	rxreq
+	barrier b1 sync
+	txresp
+} -start
+
+varnish v1 -vcl+backend {} -start
+
+varnish v1 -cliok "param.set feature +http2"
+
+client c1 {
+	send "GET / HTTP/1.1\r\n"
+	send "Host: foo\r\n"
+	send "Connection: Upgrade, HTTP2-Settings\r\n"
+	send "Upgrade: h2c\r\n"
+	send "HTTP2-Settings: AAMAAABkAARAAAAA\r\n"
+	send "\r\n"
+	rxresp
+	expect resp.status == 101
+	expect resp.http.upgrade == h2c
+	expect resp.http.connection == Upgrade
+	txpri
+	stream 0 {
+		rxsettings
+		txsettings
+		txsettings -ack
+		rxsettings
+		expect settings.ack == true
+	} -run
+
+} -run
+
+barrier b1 sync
+varnish v1 -expect client_req != 0
+varnish v1 -wait
+


### PR DESCRIPTION
Make sure we flag the request as scheduled when dispatched from the h/2
Upgrade code.

Without this, the h/2 code will happily clean it up once the client
hangs up even though it is still being processed in a different thread.

Fixes: #2310