### PR TITLE
Don't process a CONTINUATION frame on a closed stream

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -614,8 +614,7 @@ h2_rx_continuation(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 	h2_error h2e;
 
 	ASSERT_RXTHR(h2);
-	AN(r2);
-	if (r2->state != H2_S_OPEN)
+	if (r2 == NULL || r2->state != H2_S_OPEN)
 		return (H2CE_PROTOCOL_ERROR);	// XXX spec ?
 	req = r2->req;
 	h2e = h2h_decode_bytes(h2, r2->decode, h2->rxf_data, h2->rxf_len);

--- a/bin/varnishtest/tests/t02003.vtc
+++ b/bin/varnishtest/tests/t02003.vtc
@@ -410,6 +410,21 @@ client c1 {
 	} -run
 } -run
 
+
+# 2350: Don't accept a continuation frame after stream is closed
+client c1 {
+	stream 1 {
+		txreq
+		rxresp
+		txcont -hdr "foo" "bar"
+	} -run
+
+	stream 0 {
+		rxgoaway
+		expect goaway.err == PROTOCOL_ERROR
+	} -run
+} -run
+
 varnish v1 -vsl_catchup
 
 varnish v1 -expect MEMPOOL.req0.live == 0


### PR DESCRIPTION
Fixes the panic reported in #2350 