### PR TITLE
Properly handle END_STREAM for HEADERS+CONTINUATION

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -525,9 +525,6 @@ h2_end_headers(struct worker *wrk, const struct h2_sess *h2,
 	}
 	VSLb_ts_req(req, "Req", req->t_req);
 
-	if (h2->rxf_flags & H2FF_HEADERS_END_STREAM)
-		req->req_body_status = REQ_BODY_NONE;
-
 	req->req_step = R_STP_TRANSPORT;
 	req->task.func = h2_do_req;
 	req->task.priv = req;
@@ -598,6 +595,10 @@ h2_rx_headers(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 		h2_del_req(wrk, r2);
 		return (h2e);
 	}
+
+	if (h2->rxf_flags & H2FF_HEADERS_END_STREAM)
+		req->req_body_status = REQ_BODY_NONE;
+
 	if (h2->rxf_flags & H2FF_HEADERS_END_HEADERS)
 		return (h2_end_headers(wrk, h2, req, r2));
 	return (0);

--- a/bin/varnishtest/tests/t02003.vtc
+++ b/bin/varnishtest/tests/t02003.vtc
@@ -410,6 +410,15 @@ client c1 {
 	} -run
 } -run
 
+client c1 {
+	stream 1 {
+		txreq -nohdrend
+		txcont -hdr "bar" "foo"
+		rxresp
+		expect resp.status == 200
+	} -run
+} -run
+
 varnish v1 -vsl_catchup
 
 varnish v1 -expect MEMPOOL.req0.live == 0


### PR DESCRIPTION
When deciding the request body status, Varnish will only consider the flags of the last frame in a sequence of HEADERS+CONTINUATION. The result of this is that we end up with an incorrect body status for the regular case when END_STREAM is set for the HEADERS frame and END_HEADERS is set in the last CONTINUATION frame. 

This PR moves the req body decision to h2_rx_headers (it's not a defined flag for CONTINUATION).

The test case will end up with a timeout without the fix, since Varnish made the incorrect decision of expecting a request body.