### PR TITLE
Support Unix domain sockets as -a listen addresses and backend addresses

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -37,6 +37,8 @@
 #include <stdlib.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 
 #include "cache_varnishd.h"
 

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -329,7 +329,7 @@ vca_mk_tcp(struct wrk_accept *wa, struct sess *sp)
 	char rport[VTCP_PORTBUFSIZE];
 
 	SES_Reserve_remote_addr(sp, &sa);
-	AN(VSA_Build(sa, &wa->acceptaddr, wa->acceptaddrlen, NULL));
+	AN(VSA_Build(sa, &wa->acceptaddr, wa->acceptaddrlen));
 	sp->sattr[SA_CLIENT_ADDR] = sp->sattr[SA_REMOTE_ADDR];
 
 	VTCP_name(sa, raddr, sizeof raddr, rport, sizeof rport);
@@ -339,7 +339,7 @@ vca_mk_tcp(struct wrk_accept *wa, struct sess *sp)
 	sl = sizeof ss;
 	AZ(getsockname(sp->fd, (void*)&ss, &sl));
 	SES_Reserve_local_addr(sp, &sa);
-	AN(VSA_Build(sa, &ss, sl, NULL));
+	AN(VSA_Build(sa, &ss, sl));
 	sp->sattr[SA_SERVER_ADDR] = sp->sattr[SA_LOCAL_ADDR];
 
 	VSL(SLT_Begin, sp->vxid, "sess 0 %s", wa->acceptlsock->transport->name);

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -362,7 +362,7 @@ vca_mk_uds(struct wrk_accept *wa, struct sess *sp)
 
 	suds = VSA_Get_Sockaddr(wa->acceptlsock->addr, &sl);
 	SES_Reserve_remote_addr(sp, &sa);
-	AN(VSA_Build(sa, &wa->acceptaddr, wa->acceptaddrlen, suds));
+	AN(VSA_Build_UDS(sa, suds));
 	sp->sattr[SA_CLIENT_ADDR] = sp->sattr[SA_REMOTE_ADDR];
 	sp->sattr[SA_LOCAL_ADDR] = sp->sattr[SA_REMOTE_ADDR];
 	sp->sattr[SA_SERVER_ADDR] = sp->sattr[SA_REMOTE_ADDR];

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -86,25 +86,26 @@ static struct tcp_opt {
 	socklen_t	sz;
 	void		*ptr;
 	int		need;
+	int		iponly;
 } tcp_opts[] = {
-#define TCPO(lvl, nam, sz) { lvl, nam, #nam, sizeof(sz), 0, 0},
+#define TCPO(lvl, nam, sz, ip) { lvl, nam, #nam, sizeof(sz), 0, 0, ip},
 
-	TCPO(SOL_SOCKET, SO_LINGER, struct linger)
-	TCPO(SOL_SOCKET, SO_KEEPALIVE, int)
-	TCPO(IPPROTO_TCP, TCP_NODELAY, int)
+	TCPO(SOL_SOCKET, SO_LINGER, struct linger, 0)
+	TCPO(SOL_SOCKET, SO_KEEPALIVE, int, 0)
+	TCPO(IPPROTO_TCP, TCP_NODELAY, int, 1)
 
 #ifdef SO_SNDTIMEO_WORKS
-	TCPO(SOL_SOCKET, SO_SNDTIMEO, struct timeval)
+	TCPO(SOL_SOCKET, SO_SNDTIMEO, struct timeval, 0)
 #endif
 
 #ifdef SO_RCVTIMEO_WORKS
-	TCPO(SOL_SOCKET, SO_RCVTIMEO, struct timeval)
+	TCPO(SOL_SOCKET, SO_RCVTIMEO, struct timeval, 0)
 #endif
 
 #ifdef HAVE_TCP_KEEP
-	TCPO(IPPROTO_TCP, TCP_KEEPIDLE, int)
-	TCPO(IPPROTO_TCP, TCP_KEEPCNT, int)
-	TCPO(IPPROTO_TCP, TCP_KEEPINTVL, int)
+	TCPO(IPPROTO_TCP, TCP_KEEPIDLE, int, 1)
+	TCPO(IPPROTO_TCP, TCP_KEEPCNT, int, 1)
+	TCPO(IPPROTO_TCP, TCP_KEEPINTVL, int, 1)
 #endif
 
 #undef TCPO
@@ -218,15 +219,20 @@ vca_tcp_opt_init(void)
 }
 
 static void
-vca_tcp_opt_test(int sock)
+vca_tcp_opt_test(struct listen_sock *ls)
 {
-	int i, n;
+	int i, n, family, sock;
 	struct tcp_opt *to;
 	socklen_t l;
 	void *ptr;
 
+	sock = ls->sock;
+	family = VSA_Get_Proto(ls->addr);
+
 	for (n = 0; n < n_tcp_opts; n++) {
 		to = &tcp_opts[n];
+		if (to->iponly && family == PF_UNIX)
+			continue;
 		to->need = 1;
 		ptr = calloc(1, to->sz);
 		AN(ptr);
@@ -241,13 +247,18 @@ vca_tcp_opt_test(int sock)
 }
 
 static void
-vca_tcp_opt_set(int sock, int force)
+vca_tcp_opt_set(struct listen_sock *ls, int force)
 {
-	int n;
+	int n, family, sock;
 	struct tcp_opt *to;
+
+	sock = ls->sock;
+	family = VSA_Get_Proto(ls->addr);
 
 	for (n = 0; n < n_tcp_opts; n++) {
 		to = &tcp_opts[n];
+		if (to->iponly && family == PF_UNIX)
+			continue;
 		if (to->need || force) {
 			VTCP_Assert(setsockopt(sock,
 			    to->level, to->optname, to->ptr, to->sz));
@@ -304,19 +315,69 @@ vca_pace_good(void)
  * Called from assigned worker thread
  */
 
+static void
+vca_mk_tcp(struct wrk_accept *wa, struct sess *sp)
+{
+	struct suckaddr *sa;
+	struct sockaddr_storage ss;
+	socklen_t sl;
+	char laddr[VTCP_ADDRBUFSIZE];
+	char lport[VTCP_PORTBUFSIZE];
+	char raddr[VTCP_ADDRBUFSIZE];
+	char rport[VTCP_PORTBUFSIZE];
+
+	SES_Reserve_remote_addr(sp, &sa);
+	AN(VSA_Build(sa, &wa->acceptaddr, wa->acceptaddrlen, NULL));
+	sp->sattr[SA_CLIENT_ADDR] = sp->sattr[SA_REMOTE_ADDR];
+
+	VTCP_name(sa, raddr, sizeof raddr, rport, sizeof rport);
+	SES_Set_String_Attr(sp, SA_CLIENT_IP, raddr);
+	SES_Set_String_Attr(sp, SA_CLIENT_PORT, rport);
+
+	sl = sizeof ss;
+	AZ(getsockname(sp->fd, (void*)&ss, &sl));
+	SES_Reserve_local_addr(sp, &sa);
+	AN(VSA_Build(sa, &ss, sl, NULL));
+	sp->sattr[SA_SERVER_ADDR] = sp->sattr[SA_LOCAL_ADDR];
+
+	VSL(SLT_Begin, sp->vxid, "sess 0 %s", wa->acceptlsock->transport->name);
+	VTCP_name(sa, laddr, sizeof laddr, lport, sizeof lport);
+
+	VSL(SLT_SessOpen, sp->vxid, "%s %s %s %s %s %.6f %d",
+	    raddr, rport,
+	    wa->acceptlsock->name != NULL ?
+	    wa->acceptlsock->name : wa->acceptlsock->endpoint,
+	    laddr, lport,
+	    sp->t_open, sp->fd);
+}
+
+static void
+vca_mk_uds(struct wrk_accept *wa, struct sess *sp)
+{
+	struct suckaddr *sa;
+	const struct sockaddr_un *suds;
+	socklen_t sl;
+
+	suds = VSA_Get_Sockaddr(wa->acceptlsock->addr, &sl);
+	SES_Reserve_remote_addr(sp, &sa);
+	AN(VSA_Build(sa, &wa->acceptaddr, wa->acceptaddrlen, suds));
+	sp->sattr[SA_CLIENT_ADDR] = sp->sattr[SA_REMOTE_ADDR];
+	sp->sattr[SA_LOCAL_ADDR] = sp->sattr[SA_REMOTE_ADDR];
+	sp->sattr[SA_SERVER_ADDR] = sp->sattr[SA_REMOTE_ADDR];
+
+	VSL(SLT_Begin, sp->vxid, "sess 0 %s", wa->acceptlsock->transport->name);
+	VSL(SLT_SessOpen, sp->vxid, "- - %s - - %.6f %d",
+	    wa->acceptlsock->name != NULL ?
+	    wa->acceptlsock->name : wa->acceptlsock->endpoint,
+	    sp->t_open, sp->fd);
+}
+
 static void v_matchproto_(task_func_t)
 vca_make_session(struct worker *wrk, void *arg)
 {
 	struct sess *sp;
 	struct req *req;
 	struct wrk_accept *wa;
-	struct sockaddr_storage ss;
-	struct suckaddr *sa;
-	socklen_t sl;
-	char laddr[VTCP_ADDRBUFSIZE];
-	char lport[VTCP_PORTBUFSIZE];
-	char raddr[VTCP_ADDRBUFSIZE];
-	char rport[VTCP_PORTBUFSIZE];
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CAST_OBJ_NOTNULL(wa, arg, WRK_ACCEPT_MAGIC);
@@ -355,27 +416,11 @@ vca_make_session(struct worker *wrk, void *arg)
 	wa->acceptsock = -1;
 
 	assert(wa->acceptaddrlen <= vsa_suckaddr_len);
-	SES_Reserve_remote_addr(sp, &sa);
-	AN(VSA_Build(sa, &wa->acceptaddr, wa->acceptaddrlen));
-	sp->sattr[SA_CLIENT_ADDR] = sp->sattr[SA_REMOTE_ADDR];
 
-	VTCP_name(sa, raddr, sizeof raddr, rport, sizeof rport);
-	SES_Set_String_Attr(sp, SA_CLIENT_IP, raddr);
-	SES_Set_String_Attr(sp, SA_CLIENT_PORT, rport);
-
-	sl = sizeof ss;
-	AZ(getsockname(sp->fd, (void*)&ss, &sl));
-	SES_Reserve_local_addr(sp, &sa);
-	AN(VSA_Build(sa, &ss, sl));
-	sp->sattr[SA_SERVER_ADDR] = sp->sattr[SA_LOCAL_ADDR];
-
-	VTCP_name(sa, laddr, sizeof laddr, lport, sizeof lport);
-
-	VSL(SLT_Begin, sp->vxid, "sess 0 %s",
-	    wa->acceptlsock->transport->name);
-	VSL(SLT_SessOpen, sp->vxid, "%s %s %s %s %s %.6f %d",
-	    raddr, rport, wa->acceptlsock->name, laddr, lport,
-	    sp->t_open, sp->fd);
+	if (VSA_Get_Proto(wa->acceptlsock->addr) == PF_UNIX)
+		vca_mk_uds(wa, sp);
+	else
+		vca_mk_tcp(wa, sp);
 
 	WS_Release(wrk->aws, 0);
 
@@ -383,10 +428,10 @@ vca_make_session(struct worker *wrk, void *arg)
 	wrk->stats->sess_conn++;
 
 	if (need_test) {
-		vca_tcp_opt_test(sp->fd);
+		vca_tcp_opt_test(wa->acceptlsock);
 		need_test = 0;
 	}
-	vca_tcp_opt_set(sp->fd, 0);
+	vca_tcp_opt_set(wa->acceptlsock, 0);
 
 	req = Req_New(wrk, sp);
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
@@ -562,7 +607,7 @@ vca_acct(void *arg)
 				    ls->sock, i, strerror(errno));
 		}
 		AZ(listen(ls->sock, cache_param->listen_depth));
-		vca_tcp_opt_set(ls->sock, 1);
+		vca_tcp_opt_set(ls, 1);
 		if (cache_param->accept_filter) {
 			int i;
 			i = VTCP_filter_http(ls->sock);
@@ -585,7 +630,7 @@ vca_acct(void *arg)
 				if (ls->sock == -2)
 					continue;	// VCA_Shutdown
 				assert (ls->sock > 0);
-				vca_tcp_opt_set(ls->sock, 1);
+				vca_tcp_opt_set(ls, 1);
 			}
 			AZ(pthread_mutex_unlock(&shut_mtx));
 		}

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -390,6 +390,10 @@ vbe_destroy(const struct director *d)
 #undef DA
 #undef DN
 
+	free(be->uds_addr);
+	free(be->uds_suckaddr);
+	be->uds_addr = NULL;
+	be->uds_suckaddr = NULL;
 	Lck_Delete(&be->mtx);
 	FREE_OBJ(be);
 }
@@ -425,13 +429,18 @@ static int v_matchproto_(vss_resolved_f)
 uds_callback(void *priv, const struct suckaddr *sa)
 {
 	struct backend *b;
+	const void *uds_addr;
 	unsigned sl;
 
 	CAST_OBJ_NOTNULL(b, priv, BACKEND_MAGIC);
-	b->uds_suckaddr = VSA_Clone(sa);
-	AN(b->uds_suckaddr);
-	b->uds_addr = VSA_Get_Sockaddr(b->uds_suckaddr, &sl);
+	AN(sa);
+	uds_addr = VSA_Get_Sockaddr(sa, &sl);
+	AN(uds_addr);
+	b->uds_addr = malloc(sl);
 	AN(b->uds_addr);
+	memcpy(b->uds_addr, uds_addr, sl);
+	b->uds_suckaddr = VSA_Malloc(b->uds_addr, 0, b->uds_addr);
+	AN(b->uds_suckaddr);
 	return(0);
 }
 

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -429,18 +429,12 @@ static int v_matchproto_(vss_resolved_f)
 uds_callback(void *priv, const struct suckaddr *sa)
 {
 	struct backend *b;
-	const void *uds_addr;
-	unsigned sl;
 
 	CAST_OBJ_NOTNULL(b, priv, BACKEND_MAGIC);
 	AN(sa);
-	uds_addr = VSA_Get_Sockaddr(sa, &sl);
-	AN(uds_addr);
-	b->uds_addr = malloc(sl);
-	AN(b->uds_addr);
-	memcpy(b->uds_addr, uds_addr, sl);
-	b->uds_suckaddr = VSA_Malloc(b->uds_addr, 0, b->uds_addr);
+	b->uds_suckaddr = VSA_Malloc_UDS(sa, &b->uds_addr);
 	AN(b->uds_suckaddr);
+	AN(b->uds_addr);
 	return(0);
 }
 

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -137,10 +137,16 @@ vbe_dir_getfd(struct worker *wrk, struct backend *bp, struct busyobj *bo,
 	if (bp->proxy_header != 0)
 		VPX_Send_Proxy(vtp->fd, bp->proxy_header, bo->sp);
 
-	VTCP_myname(vtp->fd, abuf1, sizeof abuf1, pbuf1, sizeof pbuf1);
-	VTCP_hisname(vtp->fd, abuf2, sizeof abuf2, pbuf2, sizeof pbuf2);
-	VSLb(bo->vsl, SLT_BackendOpen, "%d %s %s %s %s %s",
-	    vtp->fd, bp->director->display_name, abuf2, pbuf2, abuf1, pbuf1);
+	if (VSA_Get_Proto(vtp->addr) == PF_UNIX)
+		VSLb(bo->vsl, SLT_BackendOpen, "%d %s %s - - -", vtp->fd,
+		     bp->director->display_name, VSA_Path(vtp->addr));
+	else {
+		VTCP_myname(vtp->fd, abuf1, sizeof abuf1, pbuf1, sizeof pbuf1);
+		VTCP_hisname(vtp->fd, abuf2, sizeof abuf2, pbuf2, sizeof pbuf2);
+		VSLb(bo->vsl, SLT_BackendOpen, "%d %s %s %s %s %s",
+		     vtp->fd, bp->director-> display_name, abuf2, pbuf2,
+		     abuf1, pbuf1);
+	}
 
 	INIT_OBJ(bo->htc, HTTP_CONN_MAGIC);
 	bo->htc->priv = vtp;

--- a/bin/varnishd/cache/cache_backend.h
+++ b/bin/varnishd/cache/cache_backend.h
@@ -59,7 +59,7 @@ struct backend {
 	VRT_BACKEND_FIELDS()
 
 	struct suckaddr		*uds_suckaddr;
-	const void		*uds_addr;
+	void			*uds_addr;
 
 	struct vbp_target	*probe;
 

--- a/bin/varnishd/cache/cache_backend.h
+++ b/bin/varnishd/cache/cache_backend.h
@@ -41,6 +41,7 @@ struct vbp_target;
 struct vrt_ctx;
 struct vrt_backend_probe;
 struct tcp_pool;
+struct suckaddr;
 
 /*--------------------------------------------------------------------
  * An instance of a backend from a VCL program.
@@ -56,6 +57,9 @@ struct backend {
 	struct lock		mtx;
 
 	VRT_BACKEND_FIELDS()
+
+	struct suckaddr		*uds_suckaddr;
+	const void		*uds_addr;
 
 	struct vbp_target	*probe;
 

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -95,6 +95,8 @@ static const unsigned char vbp_proxy_local[] = {
 	0x55, 0x49, 0x54, 0x0a, 0x20, 0x00, 0x00, 0x00,
 };
 
+static const char vbp_proxy_unknown[] = "PROXY UNKNOWN\r\n";
+
 /*--------------------------------------------------------------------*/
 
 static void
@@ -256,6 +258,9 @@ vbp_write_proxy_v1(struct vbp_target *vt, int *sock)
 		VSB_printf(&vsb, " TCP6 ");
 	else if (ss.ss_family == AF_INET)
 		VSB_printf(&vsb, " TCP4 ");
+	else if (ss.ss_family == AF_UNIX)
+		return(vbp_write(vt, sock, vbp_proxy_unknown,
+				 sizeof(vbp_proxy_unknown)));
 	else
 		WRONG("Unknown family");
 	VSB_printf(&vsb, "%s %s %s %s\r\n", addr, addr, port, port);
@@ -288,6 +293,8 @@ vbp_poke(struct vbp_target *vt)
 		vt->good_ipv4 |= 1;
 	else if (i == AF_INET6)
 		vt->good_ipv6 |= 1;
+	else if (i == AF_UNIX)
+		vt->good_unix |= 1;
 	else
 		WRONG("Wrong probe protocol family");
 

--- a/bin/varnishd/cache/cache_tcp_pool.c
+++ b/bin/varnishd/cache/cache_tcp_pool.c
@@ -134,8 +134,6 @@ VTP_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6,
 	const struct suckaddr *uds, const void *id)
 {
 	struct tcp_pool *tp;
-	const void *uds_addr;
-	socklen_t sl;
 
 	assert(uds != NULL || ip4 != NULL || ip6 != NULL);
 	Lck_Lock(&tcp_pools_mtx);
@@ -156,13 +154,9 @@ VTP_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6,
 	ALLOC_OBJ(tp, TCP_POOL_MAGIC);
 	AN(tp);
 	if (uds != NULL) {
-		uds_addr = VSA_Get_Sockaddr(uds, &sl);
-		AN(uds_addr);
-		tp->uds_sockaddr = malloc(sl);
-		AN(tp->uds_sockaddr);
-		memcpy(tp->uds_sockaddr, uds_addr, sl);
-		tp->uds = VSA_Malloc(tp->uds_sockaddr, 0, tp->uds_sockaddr);
+		tp->uds = VSA_Malloc_UDS(uds, &tp->uds_sockaddr);
 		AN(tp->uds);
+		AN(tp->uds_sockaddr);
 	}
 	else {
 		if (ip4 != NULL)

--- a/bin/varnishd/cache/cache_tcp_pool.c
+++ b/bin/varnishd/cache/cache_tcp_pool.c
@@ -51,6 +51,8 @@ struct tcp_pool {
 	const void		*id;
 	struct suckaddr		*ip4;
 	struct suckaddr		*ip6;
+	struct suckaddr		*uds;
+	const void		*uds_sockaddr;
 
 	VTAILQ_ENTRY(tcp_pool)	list;
 	int			refcnt;
@@ -113,39 +115,37 @@ tcp_handle(struct waited *w, enum wait_event ev, double now)
 }
 
 /*--------------------------------------------------------------------
- * Reference a TCP pool given by {ip4, ip6} pair.  Create if it
- * doesn't exist already.
+ * Reference a TCP pool given by a {ip4, ip6} pair or by a UDS.  Create if
+ * it doesn't exist already.
  */
 
+static int
+vtp_differ(const struct suckaddr *a, const struct suckaddr *b)
+{
+	if (a == NULL && b == NULL)
+		return (0);
+	if (a == NULL || b == NULL)
+		return (1);
+	return (VSA_Compare(a, b));
+}
+
 struct tcp_pool *
-VTP_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6, const void *id)
+VTP_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6,
+	const struct suckaddr *uds, const void *id)
 {
 	struct tcp_pool *tp;
+	socklen_t sl;
 
-	assert(ip4 != NULL || ip6 != NULL);
+	assert(uds != NULL || ip4 != NULL || ip6 != NULL);
 	Lck_Lock(&tcp_pools_mtx);
 	VTAILQ_FOREACH(tp, &tcp_pools, list) {
 		assert(tp->refcnt > 0);
 		if (tp->id != id)
 			continue;
-		if (ip4 == NULL) {
-			if (tp->ip4 != NULL)
-				continue;
-		} else {
-			if (tp->ip4 == NULL)
-				continue;
-			if (VSA_Compare(ip4, tp->ip4))
-				continue;
-		}
-		if (ip6 == NULL) {
-			if (tp->ip6 != NULL)
-				continue;
-		} else {
-			if (tp->ip6 == NULL)
-				continue;
-			if (VSA_Compare(ip6, tp->ip6))
-				continue;
-		}
+		if (vtp_differ(uds, tp->uds) ||
+		    vtp_differ(ip4, tp->ip4) ||
+		    vtp_differ(ip6, tp->ip6))
+			continue;
 		tp->refcnt++;
 		Lck_Unlock(&tcp_pools_mtx);
 		return (tp);
@@ -154,10 +154,16 @@ VTP_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6, const void *id)
 
 	ALLOC_OBJ(tp, TCP_POOL_MAGIC);
 	AN(tp);
-	if (ip4 != NULL)
-		tp->ip4 = VSA_Clone(ip4);
-	if (ip6 != NULL)
-		tp->ip6 = VSA_Clone(ip6);
+	if (uds != NULL) {
+		tp->uds = VSA_Clone(uds);
+		tp->uds_sockaddr = VSA_Get_Sockaddr(uds, &sl);
+	}
+	else {
+		if (ip4 != NULL)
+			tp->ip4 = VSA_Clone(ip4);
+		if (ip6 != NULL)
+			tp->ip6 = VSA_Clone(ip6);
+	}
 	tp->refcnt = 1;
 	tp->id = id;
 	Lck_New(&tp->mtx, lck_tcp_pool);
@@ -210,6 +216,8 @@ VTP_Rel(struct tcp_pool **tpp)
 
 	free(tp->ip4);
 	free(tp->ip6);
+	free((void *) tp->uds_sockaddr);
+	free(tp->uds);
 	Lck_Lock(&tp->mtx);
 	VTAILQ_FOREACH_SAFE(vtp, &tp->connlist, list, vtp2) {
 		VTAILQ_REMOVE(&tp->connlist, vtp, list);
@@ -247,6 +255,11 @@ VTP_Open(const struct tcp_pool *tp, double tmo, const struct suckaddr **sa)
 	CHECK_OBJ_NOTNULL(tp, TCP_POOL_MAGIC);
 
 	msec = (int)floor(tmo * 1000.0);
+	if (tp->uds != NULL) {
+		*sa = tp->uds;
+		s = VTCP_connect(tp->uds, msec);
+		return (s);
+	}
 	if (cache_param->prefer_ipv6) {
 		*sa = tp->ip6;
 		s = VTCP_connect(tp->ip6, msec);

--- a/bin/varnishd/cache/cache_tcp_pool.h
+++ b/bin/varnishd/cache/cache_tcp_pool.h
@@ -54,7 +54,7 @@ struct vtp {
  */
 
 struct tcp_pool *VTP_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6,
-    const void *id);
+    const struct suckaddr *uds, const void *id);
 	/*
 	 * Get a reference to a TCP pool.  Either ip4 or ip6 arg must be
 	 * non-NULL. If recycling is to be used, the id pointer distinguishes

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -450,16 +450,15 @@ VRT_IP_string(VRT_CTX, VCL_IP ip)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (ip == NULL)
 		return (NULL);
+	if (VSA_Get_Proto(ip) == PF_UNIX)
+		return NULL;
 	len = WS_Reserve(ctx->ws, 0);
 	if (len == 0) {
 		WS_Release(ctx->ws, 0);
 		return (NULL);
 	}
 	p = ctx->ws->f;
-	if (VSA_Get_Proto(ip) != PF_UNIX)
-		VTCP_name(ip, p, len, NULL, 0);
-	else
-		strcpy(p, VSA_Path(ip));
+	VTCP_name(ip, p, len, NULL, 0);
 	WS_Release(ctx->ws, strlen(p) + 1);
 	return (p);
 }

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -456,7 +456,10 @@ VRT_IP_string(VRT_CTX, VCL_IP ip)
 		return (NULL);
 	}
 	p = ctx->ws->f;
-	VTCP_name(ip, p, len, NULL, 0);
+	if (VSA_Get_Proto(ip) != PF_UNIX)
+		VTCP_name(ip, p, len, NULL, 0);
+	else
+		strcpy(p, VSA_Path(ip));
 	WS_Release(ctx->ws, strlen(p) + 1);
 	return (p);
 }

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -83,6 +83,8 @@ VRT_acl_match(VRT_CTX, VCL_ACL acl, VCL_IP ip)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(acl, VRT_ACL_MAGIC);
+	if (ip == NULL)
+		return (acl->match(ctx, NULL));
 	assert(VSA_Sane(ip));
 	return (acl->match(ctx, ip));
 }

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -340,6 +340,21 @@ VRT_r_beresp_backend_ip(VRT_CTX)
 
 /*--------------------------------------------------------------------*/
 
+const char*
+VRT_r_beresp_backend_path(VRT_CTX)
+{
+	VCL_IP ip;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+	ip = VDI_GetIP(ctx->bo->wrk, ctx->bo);
+	if (VSA_Get_Proto(ip) == PF_UNIX)
+		return VSA_Path(ip);
+	return (NULL);
+}
+
+/*--------------------------------------------------------------------*/
+
 VCL_STEVEDORE
 VRT_r_req_storage(VRT_CTX)
 {

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -670,6 +670,18 @@ GIP(server)
 /*--------------------------------------------------------------------*/
 
 const char*
+VRT_r_local_path(VRT_CTX)
+{
+	struct suckaddr *sa;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AZ(SES_Get_local_addr(ctx->sp, &sa));
+	return(VSA_Path(sa));
+}
+
+/*--------------------------------------------------------------------*/
+
+const char*
 VRT_r_server_identity(VRT_CTX)
 {
 

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -37,6 +37,7 @@
 
 #include "cache_director.h"
 #include "vrt_obj.h"
+#include "vsa.h"
 
 static char vrt_hostname[255] = "";
 
@@ -322,10 +323,14 @@ VRT_r_beresp_backend_name(VRT_CTX)
 VCL_IP
 VRT_r_beresp_backend_ip(VRT_CTX)
 {
+	VCL_IP ip;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
-	return (VDI_GetIP(ctx->bo->wrk, ctx->bo));
+	ip = VDI_GetIP(ctx->bo->wrk, ctx->bo);
+	if (VSA_Get_Proto(ip) == PF_UNIX)
+		return NULL;
+	return (ip);
 }
 
 /*--------------------------------------------------------------------*/
@@ -646,6 +651,8 @@ VRT_r_req_##field(VRT_CTX)						\
 		CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);		\
 		CHECK_OBJ_NOTNULL(ctx->sp, SESS_MAGIC);		\
 		AZ(SES_Get_##fld##_addr(ctx->sp, &sa));		\
+		if (VSA_Get_Proto(sa) == PF_UNIX)		\
+			return (NULL);				\
 		return (sa);					\
 	}
 

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -249,12 +249,17 @@ VRT_r_beresp_uncacheable(VRT_CTX)
 const char *
 VRT_r_client_identity(VRT_CTX)
 {
+	const char *id;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
 	if (ctx->req->client_identity != NULL)
 		return (ctx->req->client_identity);
-	return (SES_Get_String_Attr(ctx->req->sp, SA_CLIENT_IP));
+	id = SES_Get_String_Attr(ctx->req->sp, SA_CLIENT_IP);
+	if (id != NULL)
+		return id;
+	VRT_fail(ctx, "client.identity not set and there is no client IP");
+	return (NULL);
 }
 
 void

--- a/bin/varnishd/common/heritage.h
+++ b/bin/varnishd/common/heritage.h
@@ -35,6 +35,7 @@ struct suckaddr;
 struct listen_sock;
 struct transport;
 struct VCLS;
+struct uds_perms;
 
 struct listen_sock {
 	unsigned			magic;
@@ -46,6 +47,7 @@ struct listen_sock {
 	const char			*name;
 	struct suckaddr			*addr;
 	const struct transport		*transport;
+	const struct uds_perms		*perms;
 };
 
 VTAILQ_HEAD(listen_sock_head, listen_sock);

--- a/bin/varnishd/mgt/mgt_acceptor.c
+++ b/bin/varnishd/mgt/mgt_acceptor.c
@@ -146,7 +146,7 @@ mac_callback(void *priv, const struct suckaddr *sa)
 			    la->endpoint, strerror(fail));
 		return(0);
 	}
-	if (VSA_Port(ls->addr) == 0) {
+	if (VSA_Port(ls->addr) == 0 && VSA_Get_Proto(ls->addr) != PF_UNIX) {
 		/*
 		 * If the argv port number is zero, we adopt whatever
 		 * port number this VTCP_bind() found us, as if
@@ -204,7 +204,11 @@ MAC_Arg(const char *spec)
 	AN(xp);
 	la->transport = xp;
 
-	error = VSS_resolver(av[1], "80", mac_callback, la, &err);
+	if (la->endpoint[0] != '/')
+		error = VSS_resolver(av[1], "80", mac_callback, la, &err);
+	else
+		error = VSS_unix(av[1], mac_callback, la, &err);
+
 	if (VTAILQ_EMPTY(&la->socks) || error)
 		ARGV_ERR("Got no socket(s) for %s\n", av[1]);
 	VAV_Free(av);

--- a/bin/varnishd/mgt/mgt_acceptor.c
+++ b/bin/varnishd/mgt/mgt_acceptor.c
@@ -221,6 +221,10 @@ MAC_Arg(const char *spec)
 	}
 	la->name = name;
 
+	if (la->endpoint[0] != '/' && strchr(la->endpoint, '/') != NULL)
+		ARGV_ERR("Unix domain socket addresses must be absolute paths in -a "
+			 "(%s)\n", la->endpoint);
+
 	for (int i = 2; av[i] != NULL; i++) {
 		char *eq, *val;
 		int len;

--- a/bin/varnishd/mgt/mgt_acceptor.c
+++ b/bin/varnishd/mgt/mgt_acceptor.c
@@ -223,7 +223,7 @@ MAC_Arg(const char *spec)
 
 	for (int i = 2; av[i] != NULL; i++) {
 		char *eq, *val;
-		size_t len;
+		int len;
 
 		if ((eq = strchr(av[i], '=')) == NULL) {
 			if (xp != NULL)

--- a/bin/varnishd/mgt/mgt_acceptor.c
+++ b/bin/varnishd/mgt/mgt_acceptor.c
@@ -302,11 +302,11 @@ MAC_Arg(const char *spec)
 		if (pwd != NULL)
 			perms->uid = pwd->pw_uid;
 		else
-			perms->uid = -1;
+			perms->uid = (uid_t) -1;
 		if (grp != NULL)
 			perms->gid = grp->gr_gid;
 		else
-			perms->gid = -1;
+			perms->gid = (gid_t) -1;
 		perms->mode = mode;
 		la->perms = perms;
 	}

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -581,7 +581,12 @@ main(int argc, char * const *argv)
 			AN(vsb);
 			VSB_printf(vsb, "vcl 4.0;\n");
 			VSB_printf(vsb, "backend default {\n");
-			VSB_printf(vsb, "    .host = \"%s\";\n", optarg);
+			if (optarg[0] != '/')
+				VSB_printf(vsb, "    .host = \"%s\";\n",
+					   optarg);
+			else
+				VSB_printf(vsb, "    .path = \"%s\";\n",
+					   optarg);
 			VSB_printf(vsb, "}\n");
 			AZ(VSB_finish(vsb));
 			fa->src = strdup(VSB_data(vsb));

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -118,7 +118,7 @@ vpx_proto1(const struct worker *wrk, struct req *req)
 		return (-1);
 	}
 	SES_Reserve_client_addr(req->sp, &sa);
-	AN(VSA_Build(sa, res->ai_addr, res->ai_addrlen, NULL));
+	AN(VSA_Build(sa, res->ai_addr, res->ai_addrlen));
 	SES_Set_String_Attr(req->sp, SA_CLIENT_IP, fld[1]);
 	SES_Set_String_Attr(req->sp, SA_CLIENT_PORT, fld[3]);
 	freeaddrinfo(res);
@@ -139,7 +139,7 @@ vpx_proto1(const struct worker *wrk, struct req *req)
 		return (-1);
 	}
 	SES_Reserve_server_addr(req->sp, &sa);
-	AN(VSA_Build(sa, res->ai_addr, res->ai_addrlen, NULL));
+	AN(VSA_Build(sa, res->ai_addr, res->ai_addrlen));
 	freeaddrinfo(res);
 
 	VSL(SLT_Proxy, req->sp->vxid, "1 %s %s %s %s",
@@ -245,14 +245,14 @@ vpx_proto2(const struct worker *wrk, struct req *req)
 		memcpy(&sin4.sin_addr, p + 20, 4);
 		memcpy(&sin4.sin_port, p + 26, 2);
 		SES_Reserve_server_addr(req->sp, &sa);
-		AN(VSA_Build(sa, &sin4, sizeof sin4, NULL));
+		AN(VSA_Build(sa, &sin4, sizeof sin4));
 		VTCP_name(sa, ha, sizeof ha, pa, sizeof pa);
 
 		/* src/client */
 		memcpy(&sin4.sin_addr, p + 16, 4);
 		memcpy(&sin4.sin_port, p + 24, 2);
 		SES_Reserve_client_addr(req->sp, &sa);
-		AN(VSA_Build(sa, &sin4, sizeof sin4, NULL));
+		AN(VSA_Build(sa, &sin4, sizeof sin4));
 		break;
 	case AF_INET6:
 		memset(&sin6, 0, sizeof sin6);
@@ -262,14 +262,14 @@ vpx_proto2(const struct worker *wrk, struct req *req)
 		memcpy(&sin6.sin6_addr, p + 32, 16);
 		memcpy(&sin6.sin6_port, p + 50, 2);
 		SES_Reserve_server_addr(req->sp, &sa);
-		AN(VSA_Build(sa, &sin6, sizeof sin6, NULL));
+		AN(VSA_Build(sa, &sin6, sizeof sin6));
 		VTCP_name(sa, ha, sizeof ha, pa, sizeof pa);
 
 		/* src/client */
 		memcpy(&sin6.sin6_addr, p + 16, 16);
 		memcpy(&sin6.sin6_port, p + 48, 2);
 		SES_Reserve_client_addr(req->sp, &sa);
-		AN(VSA_Build(sa, &sin6, sizeof sin6, NULL));
+		AN(VSA_Build(sa, &sin6, sizeof sin6));
 		break;
 	default:
 		WRONG("Wrong pfam");

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -415,8 +415,10 @@ static void
 vpx_enc_path(struct vsb *vsb, const struct suckaddr *s)
 {
 	char b[108] = { 0 };
+	const char *p = VSA_Path(s);
 
-	strcpy(b, VSA_Path(s));
+	AN(p);
+	strcpy(b, p);
 	VSB_bcat(vsb, b, sizeof(b));
 	VSB_bcat(vsb, b, sizeof(b));
 }

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -118,7 +118,7 @@ vpx_proto1(const struct worker *wrk, struct req *req)
 		return (-1);
 	}
 	SES_Reserve_client_addr(req->sp, &sa);
-	AN(VSA_Build(sa, res->ai_addr, res->ai_addrlen));
+	AN(VSA_Build(sa, res->ai_addr, res->ai_addrlen, NULL));
 	SES_Set_String_Attr(req->sp, SA_CLIENT_IP, fld[1]);
 	SES_Set_String_Attr(req->sp, SA_CLIENT_PORT, fld[3]);
 	freeaddrinfo(res);
@@ -139,7 +139,7 @@ vpx_proto1(const struct worker *wrk, struct req *req)
 		return (-1);
 	}
 	SES_Reserve_server_addr(req->sp, &sa);
-	AN(VSA_Build(sa, res->ai_addr, res->ai_addrlen));
+	AN(VSA_Build(sa, res->ai_addr, res->ai_addrlen, NULL));
 	freeaddrinfo(res);
 
 	VSL(SLT_Proxy, req->sp->vxid, "1 %s %s %s %s",
@@ -245,14 +245,14 @@ vpx_proto2(const struct worker *wrk, struct req *req)
 		memcpy(&sin4.sin_addr, p + 20, 4);
 		memcpy(&sin4.sin_port, p + 26, 2);
 		SES_Reserve_server_addr(req->sp, &sa);
-		AN(VSA_Build(sa, &sin4, sizeof sin4));
+		AN(VSA_Build(sa, &sin4, sizeof sin4, NULL));
 		VTCP_name(sa, ha, sizeof ha, pa, sizeof pa);
 
 		/* src/client */
 		memcpy(&sin4.sin_addr, p + 16, 4);
 		memcpy(&sin4.sin_port, p + 24, 2);
 		SES_Reserve_client_addr(req->sp, &sa);
-		AN(VSA_Build(sa, &sin4, sizeof sin4));
+		AN(VSA_Build(sa, &sin4, sizeof sin4, NULL));
 		break;
 	case AF_INET6:
 		memset(&sin6, 0, sizeof sin6);
@@ -262,14 +262,14 @@ vpx_proto2(const struct worker *wrk, struct req *req)
 		memcpy(&sin6.sin6_addr, p + 32, 16);
 		memcpy(&sin6.sin6_port, p + 50, 2);
 		SES_Reserve_server_addr(req->sp, &sa);
-		AN(VSA_Build(sa, &sin6, sizeof sin6));
+		AN(VSA_Build(sa, &sin6, sizeof sin6, NULL));
 		VTCP_name(sa, ha, sizeof ha, pa, sizeof pa);
 
 		/* src/client */
 		memcpy(&sin6.sin6_addr, p + 16, 16);
 		memcpy(&sin6.sin6_port, p + 48, 2);
 		SES_Reserve_client_addr(req->sp, &sa);
-		AN(VSA_Build(sa, &sin6, sizeof sin6));
+		AN(VSA_Build(sa, &sin6, sizeof sin6, NULL));
 		break;
 	default:
 		WRONG("Wrong pfam");

--- a/bin/varnishtest/tests/a00019.vtc
+++ b/bin/varnishtest/tests/a00019.vtc
@@ -1,0 +1,41 @@
+varnishtest "vtc remote.ip and remote.port"
+
+server s1 {
+	rxreq
+	expect remote.ip == "${localhost}"
+	expect remote.port > 0
+	txresp
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect remote.ip == <undef>
+	expect remote.port == <undef>
+	txresp
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {
+
+	sub vcl_recv {
+		if (req.url == "/s1") {
+			set req.backend_hint = s1;
+		}
+		else {
+			set req.backend_hint = s2;
+		}
+	}
+} -start
+
+client c1 {
+	txreq -url "/s1"
+	rxresp
+	expect remote.ip == "${v1_addr}"
+	expect remote.port == "${v1_port}"
+} -run
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq -url "/s2"
+	rxresp
+	expect remote.ip == <undef>
+	expect remote.port == <undef>
+} -run

--- a/bin/varnishtest/tests/a00019.vtc
+++ b/bin/varnishtest/tests/a00019.vtc
@@ -8,38 +8,32 @@ server s1 {
 	txresp
 } -start
 
-server s2 -listen "${tmpdir}/s2.sock" {
-	rxreq
-	expect remote.ip == <undef>
-	expect remote.port == <undef>
-	expect remote.path == "${tmpdir}/s2.sock"
-	txresp
-} -start
-
-varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {
-
-	sub vcl_recv {
-		if (req.url == "/s1") {
-			set req.backend_hint = s1;
-		}
-		else {
-			set req.backend_hint = s2;
-		}
-	}
-} -start
+varnish v1 -vcl+backend {} -start
 
 client c1 {
-	txreq -url "/s1"
+	txreq
 	rxresp
 	expect remote.ip == "${v1_addr}"
 	expect remote.port == "${v1_port}"
 	expect remote.path == <undef>
 } -run
 
-client c1 -connect "${tmpdir}/v1.sock" {
-	txreq -url "/s2"
+varnish v1 -stop
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect remote.ip == <undef>
+	expect remote.port == <undef>
+	expect remote.path == "${tmpdir}/s1.sock"
+	txresp
+} -start
+
+varnish v2 -arg "-a ${tmpdir}/v2.sock" -vcl+backend {} -start
+
+client c1 -connect "${tmpdir}/v2.sock" {
+	txreq
 	rxresp
 	expect remote.ip == <undef>
 	expect remote.port == <undef>
-	expect remote.path == "${tmpdir}/v1.sock"
+	expect remote.path == "${tmpdir}/v2.sock"
 } -run

--- a/bin/varnishtest/tests/a00019.vtc
+++ b/bin/varnishtest/tests/a00019.vtc
@@ -1,9 +1,10 @@
-varnishtest "vtc remote.ip and remote.port"
+varnishtest "vtc remote.ip, remote.port and remote.path"
 
 server s1 {
 	rxreq
 	expect remote.ip == "${localhost}"
 	expect remote.port > 0
+	expect remote.path == <undef>
 	txresp
 } -start
 
@@ -11,6 +12,7 @@ server s2 -listen "${tmpdir}/s2.sock" {
 	rxreq
 	expect remote.ip == <undef>
 	expect remote.port == <undef>
+	expect remote.path == "${tmpdir}/s2.sock"
 	txresp
 } -start
 
@@ -31,6 +33,7 @@ client c1 {
 	rxresp
 	expect remote.ip == "${v1_addr}"
 	expect remote.port == "${v1_port}"
+	expect remote.path == <undef>
 } -run
 
 client c1 -connect "${tmpdir}/v1.sock" {
@@ -38,4 +41,5 @@ client c1 -connect "${tmpdir}/v1.sock" {
 	rxresp
 	expect remote.ip == <undef>
 	expect remote.port == <undef>
+	expect remote.path == "${tmpdir}/v1.sock"
 } -run

--- a/bin/varnishtest/tests/b00053.vtc
+++ b/bin/varnishtest/tests/b00053.vtc
@@ -1,0 +1,34 @@
+varnishtest "Does anything get through Unix domain sockets at all ?"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -body "012345\n"
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.do_stream = false;
+	}
+} -start
+
+varnish v1 -cliok "param.set debug +workspace"
+varnish v1 -cliok "param.set debug +witness"
+
+varnish v1 -expect n_object == 0
+varnish v1 -expect sess_conn == 0
+varnish v1 -expect client_req == 0
+varnish v1 -expect cache_miss == 0
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -expect n_object == 1
+varnish v1 -expect sess_conn == 1
+varnish v1 -expect client_req == 1
+varnish v1 -expect cache_miss == 1
+varnish v1 -expect s_sess == 1
+varnish v1 -expect s_resp_bodybytes == 7
+varnish v1 -expect s_resp_hdrbytes == 178

--- a/bin/varnishtest/tests/b00054.vtc
+++ b/bin/varnishtest/tests/b00054.vtc
@@ -1,0 +1,18 @@
+varnishtest "Check poll acceptor on a UDS listen address"
+
+server s1 {
+	rxreq
+	txresp -hdr "Connection: close" -body "012345\n"
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock -Wpoll" -vcl+backend {} -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+	delay .1
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+} -run

--- a/bin/varnishtest/tests/b00055.vtc
+++ b/bin/varnishtest/tests/b00055.vtc
@@ -1,0 +1,30 @@
+varnishtest "Check pipelining over a UDS listen address"
+
+server s1 {
+	rxreq
+	expect req.url == "/foo"
+	txresp -body "foo"
+	rxreq
+	expect req.url == "/bar"
+	txresp -body "foobar"
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {} -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	send "GET /foo HTTP/1.1\n\nGET /bar HTTP/1.1\n\nGET /bar HTTP/1.1\n\n"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 3
+	expect resp.http.x-varnish == "1001"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 6
+	expect resp.http.x-varnish == "1003"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 6
+	expect resp.http.x-varnish == "1005 1004"
+} -run
+
+varnish v1 -expect sess_readahead == 2

--- a/bin/varnishtest/tests/b00056.vtc
+++ b/bin/varnishtest/tests/b00056.vtc
@@ -1,0 +1,36 @@
+varnishtest "Check read-head / partial pipelining over a UDS listen address"
+
+server s1 {
+	rxreq
+	expect req.url == "/foo"
+	txresp -body "foo"
+	rxreq
+	expect req.url == "/bar"
+	txresp -body "foobar"
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {}
+
+# NB: The accept_filter param may not exist.
+varnish v1 -cli "param.set accept_filter false"
+varnish v1 -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	send "GET /foo HTTP/1.1\r\n\r\nGET "
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 3
+	expect resp.http.x-varnish == "1001"
+	send "/bar HTTP/1.1\n\nGET /bar "
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 6
+	expect resp.http.x-varnish == "1003"
+	send "HTTP/1.1\n\n"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 6
+	expect resp.http.x-varnish == "1005 1004"
+} -run
+
+varnish v1 -expect sess_readahead == 2

--- a/bin/varnishtest/tests/b00057.vtc
+++ b/bin/varnishtest/tests/b00057.vtc
@@ -1,0 +1,22 @@
+varnishtest "Test orderly connection closure of a UDS listen socket"
+
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -nolen -hdr "Transfer-encoding: chunked"
+	delay .2
+	chunkedlen 30000
+	delay .2
+	chunkedlen 100000
+	delay .2
+	chunkedlen 0
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend { } -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq -hdr "Connection: close"
+	delay 3
+	rxresp
+	expect resp.bodylen == 130000
+} -run

--- a/bin/varnishtest/tests/b00058.vtc
+++ b/bin/varnishtest/tests/b00058.vtc
@@ -1,0 +1,20 @@
+varnishtest "Test X-Forward-For headers with a UDS listen address"
+
+server s1 {
+	rxreq
+	expect req.http.X-Forwarded-For == <undef>
+	txresp
+	rxreq
+	expect req.http.X-Forwarded-For == "1.2.3.4"
+	txresp
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {
+} -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq -url /1
+	rxresp
+	txreq -url /2 -hdr "X-forwarded-for: 1.2.3.4"
+	rxresp
+} -run

--- a/bin/varnishtest/tests/b00059.vtc
+++ b/bin/varnishtest/tests/b00059.vtc
@@ -1,0 +1,52 @@
+varnishtest "Run a lot of transactions through Unix domain sockets"
+
+server s0 -listen "${tmpdir}/s1.sock" {
+	loop 10 {
+		rxreq
+		txresp -body "foo1"
+	}
+	rxreq
+	txresp -hdr "Connection: close" -body "foo1"
+	expect_close
+} -dispatch
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock -Wpoll" -vcl+backend {
+	sub vcl_recv {
+		return (pass);
+	}
+	sub vcl_backend_fetch {
+		set bereq.backend = s0;
+	}
+
+} -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	loop 20 {
+		txreq -url /c1
+		rxresp
+		expect resp.bodylen == 4
+		expect resp.status == 200
+	}
+} -start
+
+client c2 -connect "${tmpdir}/v1.sock" {
+	loop 20 {
+		txreq -url /c2
+		rxresp
+		expect resp.bodylen == 4
+		expect resp.status == 200
+	}
+} -start
+
+client c3 -connect "${tmpdir}/v1.sock" {
+	loop 20 {
+		txreq -url /c3
+		rxresp
+		expect resp.bodylen == 4
+		expect resp.status == 200
+	}
+} -start
+
+client c1 -wait
+client c2 -wait
+client c3 -wait

--- a/bin/varnishtest/tests/b00060.vtc
+++ b/bin/varnishtest/tests/b00060.vtc
@@ -1,0 +1,15 @@
+varnishtest "-b arg with a Unix domain socket"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -hdr "s1: got it"
+} -start
+
+varnish v1 -arg "-b ${s1_addr}" -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.s1 == "got it"
+} -run

--- a/bin/varnishtest/tests/c00003.vtc
+++ b/bin/varnishtest/tests/c00003.vtc
@@ -18,6 +18,11 @@ shell -err -expect "Too many protocol sub-args" {
 	varnishd -a 127.0.0.1:80000,HTTP,FOO -d
 }
 
+# -a relative path for a UDS address not permitted
+shell -err -expect "Unix domain socket addresses must be absolute paths" {
+	varnishd -a foo/bar.sock -d
+}
+
 # -a args for UDS permissions not permitted with IP addresses
 shell -err -expect "Invalid sub-arg user=u for IP addresses" {
 	varnishd -a 127.0.0.1:80000,user=u -d

--- a/bin/varnishtest/tests/c00003.vtc
+++ b/bin/varnishtest/tests/c00003.vtc
@@ -6,12 +6,101 @@ shell -err -match "have same address|already in use" {
 	varnishd -d -a 127.0.0.1:38484 -a 127.0.0.1:38484 -b localhost:80
 }
 
+shell -err -match "have same address|already in use" {
+	varnishd -d -a ${tmpdir}/vtc.sock -a ${tmpdir}/vtc.sock -b localhost:80
+}
+
 # -a bad protocol specs
-shell -err -expect "Too many sub-arguments" {
+shell -err -expect "Too many protocol sub-args" {
 	varnishd -a 127.0.0.1:80000,PROXY,FOO -d
 }
-shell -err -expect "Too many sub-arguments" {
+shell -err -expect "Too many protocol sub-args" {
 	varnishd -a 127.0.0.1:80000,HTTP,FOO -d
+}
+
+# -a args for UDS permissions not permitted with IP addresses
+shell -err -expect "Invalid sub-arg user=u for IP addresses" {
+	varnishd -a 127.0.0.1:80000,user=u -d
+}
+
+shell -err -expect "Invalid sub-arg group=g for IP addresses" {
+	varnishd -a 127.0.0.1:80000,group=g -d
+}
+
+shell -err -expect "Invalid sub-arg mode=660 for IP addresses" {
+	varnishd -a 127.0.0.1:80000,mode=660 -d
+}
+
+# Illegal mode sub-args
+shell -err -expect "Too many mode sub-args" {
+	varnishd -a ${tmpdir}/vtc.sock,mode=660,mode=600 -d
+}
+
+shell -err -expect "Empty mode sub-arg" {
+	varnishd -a ${tmpdir}/vtc.sock,mode= -d
+}
+
+shell -err -expect "Invalid mode sub-arg 666devilish" {
+	varnishd -a ${tmpdir}/vtc.sock,mode=666devilish -d
+}
+
+shell -err -expect "Invalid mode sub-arg devilish" {
+	varnishd -a ${tmpdir}/vtc.sock,mode=devilish -d
+}
+
+shell -err -expect "Invalid mode sub-arg 999" {
+	varnishd -a ${tmpdir}/vtc.sock,mode=999 -d
+}
+
+shell -err -expect "Cannot parse mode sub-arg 7" {
+	varnishd -a ${tmpdir}/vtc.sock,mode=77777777777777777777777777777777 -d
+}
+
+shell -err -expect "Cannot parse mode sub-arg -7" {
+	varnishd -a ${tmpdir}/vtc.sock,mode=-77777777777777777777777777777777 -d
+}
+
+shell -err -expect "Mode sub-arg 1666 out of range" {
+	varnishd -a ${tmpdir}/vtc.sock,mode=1666 -d
+}
+
+shell -err -expect "Mode sub-arg 0 out of range" {
+	varnishd -a ${tmpdir}/vtc.sock,mode=0 -d
+}
+
+shell -err -expect "Mode sub-arg -1 out of range" {
+	varnishd -a ${tmpdir}/vtc.sock,mode=-1 -d
+}
+
+##
+## user and group sub-args tested in c00084.vtc, where the user and group
+## features are enabled.
+##
+
+# Invalid sub-arg
+shell -err -expect "Invalid sub-arg foo=bar" {
+	varnishd -a ${tmpdir}/vtc.sock,foo=bar -d
+}
+
+# A sub-arg without '=' is interpreted as a protocol name.
+shell -err -expect "Unknown protocol" {
+	varnishd -a ${tmpdir}/vtc.sock,foobar -d
+}
+
+shell -err -expect "Invalid sub-arg userfoo=u" {
+	varnishd -a ${tmpdir}/vtc.sock,userfoo=u -d
+}
+
+shell -err -expect "Invalid sub-arg groupfoo=g" {
+	varnishd -a ${tmpdir}/vtc.sock,groupfoo=g -d
+}
+
+shell -err -expect "Invalid sub-arg modefoo=666" {
+	varnishd -a ${tmpdir}/vtc.sock,modefoo=666 -d
+}
+
+shell -err -expect "Invalid sub-arg =foo" {
+	varnishd -a ${tmpdir}/vtc.sock,=foo -d
 }
 
 # This requires non-local binds to be disabled.  If you see this fail

--- a/bin/varnishtest/tests/c00086.vtc
+++ b/bin/varnishtest/tests/c00086.vtc
@@ -1,0 +1,44 @@
+varnishtest "Dropping polling of a backend that listens at UDS"
+
+server s1 -listen "${tmpdir}/s1.sock" -repeat 40 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	probe default {
+		.window = 8;
+		.initial = 7;
+		.threshold = 8;
+		.interval = 0.1s;
+	}
+	backend s1 {
+		.path = "${s1_addr}";
+	}
+} -start
+
+delay 1
+
+varnish v1 -vcl+backend { } -cliok "vcl.use vcl2" -cliok "vcl.discard vcl1"
+
+delay 1
+
+varnish v1 -cliok "vcl.list"
+varnish v1 -cliok "backend.list -p"
+
+server s1 -break {
+	rxreq
+	expect req.url == /foo
+	txresp -bodylen 4
+} -start
+
+delay 1
+
+client c1 {
+	txreq -url /foo
+	rxresp
+	txreq -url /foo
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 4
+} -run

--- a/bin/varnishtest/tests/c00087.vtc
+++ b/bin/varnishtest/tests/c00087.vtc
@@ -1,0 +1,33 @@
+varnishtest "Backend close retry with a UDS"
+
+server s1 -listen "${tmpdir}/s1.sock" -repeat 1 {
+	rxreq
+	txresp -bodylen 5
+
+	rxreq
+	accept
+
+	rxreq
+	txresp -bodylen 6
+
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return(pass);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 5
+
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 6
+} -run
+
+varnish v1 -expect backend_retry == 1

--- a/bin/varnishtest/tests/c00088.vtc
+++ b/bin/varnishtest/tests/c00088.vtc
@@ -1,0 +1,65 @@
+varnishtest "Forcing health of backends listening at UDS"
+
+server s1 -listen "${tmpdir}/s1.sock" -repeat 3 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	backend s1 {
+		.path = "${s1_addr}";
+		.probe = {
+			.window = 8;
+			.initial = 7;
+			.threshold = 8;
+			.interval = 10s;
+		}
+	}
+
+	sub vcl_recv {
+		return(pass);
+	}
+
+} -start
+
+delay 1
+
+varnish v1 -cliok "vcl.list"
+varnish v1 -cliok "backend.list -p"
+varnish v1 -cliok "backend.set_health s1 auto"
+varnish v1 -cliok "backend.list -p"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cliok "backend.list"
+varnish v1 -cliok "backend.set_health s1 sick"
+varnish v1 -cliok "backend.list"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+varnish v1 -cliok "backend.list"
+varnish v1 -cliok "backend.set_health s1 healthy"
+varnish v1 -cliok "backend.list"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -clierr 106 "backend.set_health s1 foo"
+varnish v1 -clierr 106 "backend.set_health s2 foo"
+varnish v1 -clierr 106 "backend.set_health s2 auto"
+varnish v1 -cliok "vcl.list"
+varnish v1 -cliok "backend.list *"
+varnish v1 -cliok "backend.list *.foo"
+varnish v1 -cliok "backend.list vcl1.*"
+

--- a/bin/varnishtest/tests/c00089.vtc
+++ b/bin/varnishtest/tests/c00089.vtc
@@ -1,0 +1,50 @@
+varnishtest	"vcl_backend_response{} retry with a UDS backend"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -hdr "foo: 1"
+	accept
+	rxreq
+	txresp -hdr "foo: 2"
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv { return (pass); }
+	sub vcl_backend_response {
+		set beresp.http.bar = bereq.retries;
+		if (beresp.http.foo != bereq.http.stop) {
+			return (retry);
+		}
+	}
+} -start
+
+varnish v1 -cliok "param.set debug +syncvsl"
+
+client c1 {
+	txreq -hdr "stop: 2"
+	rxresp
+	expect resp.http.foo == 2
+} -run
+
+delay .1
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -hdr "foo: 1"
+	accept
+	rxreq
+	txresp -hdr "foo: 2"
+	accept
+	rxreq
+	txresp -hdr "foo: 3"
+} -start
+
+varnish v1 -cliok "param.set max_retries 2"
+
+client c1 {
+	txreq -hdr "stop: 3"
+	rxresp
+	expect resp.http.foo == 3
+} -run
+
+# XXX: Add a test which exceeds max_retries and gets 503 back

--- a/bin/varnishtest/tests/c00090.vtc
+++ b/bin/varnishtest/tests/c00090.vtc
@@ -1,0 +1,32 @@
+varnishtest "Check aborted backend body with a backend listening at UDS"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -nolen -hdr "Transfer-encoding: chunked"
+	chunked {<HTML>}
+	barrier b1 sync
+	chunked {<HTML>}
+	barrier b2 sync
+} -start
+
+varnish v1 -cliok "param.set debug +syncvsl" -vcl+backend {
+
+} -start
+
+
+client c1 {
+	txreq
+	rxresphdrs
+	expect resp.status == 200
+	rxchunk
+	barrier b1 sync
+	rxchunk
+	barrier b2 sync
+	expect_close
+} -run
+
+
+

--- a/bin/varnishtest/tests/c00091.vtc
+++ b/bin/varnishtest/tests/c00091.vtc
@@ -1,0 +1,39 @@
+varnishtest "Test resp.is_streaming with a UDS backend"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -nolen -hdr "Content-Length: 10"
+	delay 1
+	send "1234567890"
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.url == "/synth") {
+			return(synth(200, "OK"));
+		}
+	}
+	sub vcl_synth {
+		set resp.http.streaming = resp.is_streaming;
+	}
+	sub vcl_deliver {
+		set resp.http.streaming = resp.is_streaming;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.streaming == "true"
+
+	delay 0.1
+
+	txreq
+	rxresp
+	expect resp.http.streaming == "false"
+
+	txreq -url /synth
+	rxresp
+	expect resp.http.streaming == "false"
+} -run
+

--- a/bin/varnishtest/tests/c00092.vtc
+++ b/bin/varnishtest/tests/c00092.vtc
@@ -1,0 +1,68 @@
+varnishtest "Unix domain sockets don't work with ACLs"
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl {
+	backend b { .host = "${bad_ip}"; }
+
+	acl acl1 {
+		"${localhost}";
+	}
+
+	sub vcl_recv {
+		return(synth(200));
+	}
+
+	sub vcl_synth {
+		set resp.http.client = client.ip ~ acl1;
+		set resp.http.server = server.ip ~ acl1;
+		set resp.http.local = local.ip ~ acl1;
+		set resp.http.remote = remote.ip ~ acl1;
+	}
+} -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq -url "foo"
+	rxresp
+	expect resp.http.client == "false"
+	expect resp.http.server == "false"
+	expect resp.http.local == "false"
+	expect resp.http.remote == "false"
+} -run
+
+logexpect l1 -v v1 -d 1 -g vxid -q "VCL_acl" {
+	expect 0 * Begin req
+	expect * = VCL_acl "^NO_FAM acl1$"
+	expect * = VCL_acl "^NO_FAM acl1$"
+	expect * = VCL_acl "^NO_FAM acl1$"
+	expect * = VCL_acl "^NO_FAM acl1$"
+	expect * = End
+} -run
+
+varnish v1 -errvcl {Expected CSTR got 'acl1'} {
+	backend b { .host = "${bad_ip}"; }
+
+	acl acl1 {
+		"${localhost}";
+	}
+
+	sub vcl_recv {
+		if (local.path ~ acl1) {
+			return(pass);
+		}
+	}
+}
+
+varnish v1 -errvcl {.../mask is not numeric.} {
+	backend b { .host = "${bad_ip}"; }
+
+	acl acl1 {
+		"${tmpdir}/v1.sock";
+	}
+}
+
+varnish v1 -errvcl {DNS lookup():} {
+	backend b { .host = "${bad_ip}"; }
+
+	acl acl1 {
+		"/8";
+	}
+}

--- a/bin/varnishtest/tests/c00093.vtc
+++ b/bin/varnishtest/tests/c00093.vtc
@@ -1,0 +1,53 @@
+varnishtest "-a sub-args user, group and mode"
+
+feature user_vcache
+feature group_varnish
+feature root
+
+shell -err -expect "Too many user sub-args" {
+	varnishd -a ${tmpdir}/vtc.sock,user=vcache,user=vcache -d
+}
+
+shell -err -expect "Too many group sub-args" {
+	varnishd -a ${tmpdir}/vtc.sock,group=varnish,group=varnish -d
+}
+
+# Assuming that empty user and group names always fail getpwnam and getgrnam
+shell -err -expect "Unknown user " {
+	varnishd -a ${tmpdir}/vtc.sock,user= -d
+}
+
+shell -err -expect "Unknown group " {
+	varnishd -a ${tmpdir}/vtc.sock,group= -d
+}
+
+server s1 {} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock,user=vcache,group=varnish,mode=660" \
+	-vcl+backend {}
+
+shell -match "rw-rw----.+vcache.+varnish" { ls -l ${tmpdir}/v1.sock }
+
+varnish v2 -arg "-a ${tmpdir}/v2.sock,user=vcache,mode=600" -vcl+backend {}
+
+shell -match "rw-------.+vcache" { ls -l ${tmpdir}/v2.sock }
+
+varnish v3 -arg "-a ${tmpdir}/v3.sock,group=varnish,mode=660" -vcl+backend {}
+
+shell -match "rw---- .+root.+varnish" { ls -l ${tmpdir}/v3.sock }
+
+varnish v4 -arg "-a ${tmpdir}/v4.sock,mode=666" -vcl+backend {}
+
+shell -match "rw-rw-rw-.+root" { ls -l ${tmpdir}/v4.sock }
+
+varnish v5 -arg "-a ${tmpdir}/v5.sock,user=vcache,group=varnish" -vcl+backend {}
+
+shell -match "vcache.+varnish" { ls -l ${tmpdir}/v5.sock }
+
+varnish v6 -arg "-a ${tmpdir}/v6.sock,user=vcache" -vcl+backend {}
+
+shell -match "vcache" { ls -l ${tmpdir}/v6.sock }
+
+varnish v7 -arg "-a ${tmpdir}/v7.sock,group=varnish" -vcl+backend {}
+
+shell -match "root.+varnish" { ls -l ${tmpdir}/v7.sock }

--- a/bin/varnishtest/tests/c00094.vtc
+++ b/bin/varnishtest/tests/c00094.vtc
@@ -1,0 +1,50 @@
+varnishtest "Test Backend Polling with a backend listening at a UDS"
+
+barrier b1 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	# Probes
+	loop 8 {
+		rxreq
+		expect req.url == "/"
+		txresp -hdr "Bar: foo" -body "foobar"
+		accept
+	}
+
+	loop 3 {
+		rxreq
+		expect req.url == "/"
+		txresp -status 404 -hdr "Bar: foo" -body "foobar"
+		accept
+	}
+	loop 2 {
+		rxreq
+		expect req.url == "/"
+		txresp -proto "FROBOZ" -status 200 -hdr "Bar: foo" -body "foobar"
+		accept
+	}
+	loop 2 {
+		rxreq
+		expect req.url == "/"
+		send "HTTP/1.1 200 \r\n"
+		accept
+	}
+
+	barrier b1 sync
+} -start
+
+varnish v1 -vcl {
+
+	backend foo {
+		.path = "${s1_addr}";
+		.probe = {
+			.timeout = 1 s;
+			.interval = 0.1 s;
+		}
+	}
+
+} -start
+
+barrier b1 sync
+
+varnish v1 -cliexpect "^CLI RX|  -+H{10}-{5}H{2}-{0,5} Happy" "backend.list -p"

--- a/bin/varnishtest/tests/d00029.vtc
+++ b/bin/varnishtest/tests/d00029.vtc
@@ -1,0 +1,86 @@
+varnishtest "Test round robin director with UDS backends"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -body "1"
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	txresp -body "22"
+} -start
+
+server s3 -listen "${tmpdir}/s3.sock" {
+	rxreq
+	txresp -body "333"
+} -start
+
+server s4 -listen "${tmpdir}/s4.sock" {
+	rxreq
+	txresp -body "4444"
+} -start
+
+varnish v1 -vcl+backend {
+	import directors;
+
+	sub vcl_init {
+		new rr = directors.round_robin();
+		rr.add_backend(s1);
+		rr.add_backend(s2);
+		rr.add_backend(s3);
+		rr.add_backend(s4);
+	}
+
+	sub vcl_recv {
+		if (req.method == "DELETE") {
+			rr.remove_backend(s1);
+			rr.remove_backend(s2);
+			rr.remove_backend(s3);
+			return(synth(204));
+		}
+	}
+
+	sub vcl_backend_fetch {
+		set bereq.backend = rr.backend();
+	}
+} -start
+
+client c1 {
+	timeout 3
+	txreq -url "/foo1"
+	rxresp
+	expect resp.bodylen == 1
+	txreq -url "/foo2"
+	rxresp
+	expect resp.bodylen == 2
+	txreq -url "/foo3"
+	rxresp
+	expect resp.bodylen == 3
+	txreq -url "/foo4"
+	rxresp
+	expect resp.bodylen == 4
+} -run
+
+server s1 -start
+server s2 -start
+
+client c2 {
+	timeout 3
+	txreq -url "/foo11"
+	rxresp
+	expect resp.bodylen == 1
+	txreq -url "/foo22"
+	rxresp
+	expect resp.bodylen == 2
+} -run
+
+server s4 -start
+
+client c3 {
+	txreq -req "DELETE"
+	rxresp
+	expect resp.status == 204
+	txreq -url "/foo31"
+	rxresp
+	expect resp.bodylen == 4
+} -run

--- a/bin/varnishtest/tests/d00030.vtc
+++ b/bin/varnishtest/tests/d00030.vtc
@@ -1,0 +1,70 @@
+varnishtest "Test dynamic backends listening at Unix domain sockets"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_addr}");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = s1.backend();
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -errvcl {path must be an absolute path} {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("");
+	}
+}
+
+varnish v1 -errvcl {path must be an absolute path} {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("s1.sock");
+	}
+}
+
+shell { rm -f ${tmpdir}/foo }
+
+varnish v1 -errvcl {Cannot stat path} {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${tmpdir}/foo");
+	}
+}
+
+varnish v1 -errvcl {is not a socket} {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${tmpdir}");
+	}
+}

--- a/bin/varnishtest/tests/d00031.vtc
+++ b/bin/varnishtest/tests/d00031.vtc
@@ -1,0 +1,47 @@
+varnishtest "Test dynamic UDS backends hot swap"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	txresp
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/bar"
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_addr}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+		set req.backend_hint = s1.backend();
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+
+	txreq -req "SWAP" -hdr "X-Path: ${s2_addr}"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+} -run

--- a/bin/varnishtest/tests/d00032.vtc
+++ b/bin/varnishtest/tests/d00032.vtc
@@ -1,0 +1,58 @@
+varnishtest "Test dynamic UDS backends hot swap while being used"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/bar"
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_addr}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+		set req.backend_hint = s1.backend();
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+} -start
+
+client c2 {
+	barrier b1 sync
+	txreq -req "SWAP" -hdr "X-Path: ${s2_addr}"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+} -run
+
+client c1 -wait

--- a/bin/varnishtest/tests/d00033.vtc
+++ b/bin/varnishtest/tests/d00033.vtc
@@ -1,0 +1,59 @@
+varnishtest "Test dynamic UDS backends hot swap during a pipe"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/bar"
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_addr}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+		set req.backend_hint = s1.backend();
+		return (pipe);
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+} -start
+
+client c2 {
+	barrier b1 sync
+	txreq -req "SWAP" -hdr "X-Path: ${s2_addr}"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+} -run
+
+client c1 -wait

--- a/bin/varnishtest/tests/d00034.vtc
+++ b/bin/varnishtest/tests/d00034.vtc
@@ -1,0 +1,61 @@
+varnishtest "Test dynamic UDS backend hot swap after it was picked by a bereq"
+
+barrier b1 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import std;
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_addr}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+	}
+
+	sub vcl_backend_fetch {
+		set bereq.backend = s1.backend();
+		# hot swap should happen while we sleep
+		debug.sleep(2s);
+		if (std.healthy(bereq.backend)) {
+			return(abandon);
+		} else {
+			set bereq.backend = s1.backend();
+		}
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq
+	barrier b1 sync
+	rxresp
+	expect resp.status == 200
+}
+
+client c2 {
+	barrier b1 sync
+	delay 0.1
+	txreq -req "SWAP" -hdr "X-Path: ${s2_addr}"
+	rxresp
+	expect resp.status == 200
+}
+
+client c1 -start
+client c2 -run
+client c1 -wait

--- a/bin/varnishtest/tests/d00035.vtc
+++ b/bin/varnishtest/tests/d00035.vtc
@@ -1,0 +1,76 @@
+varnishtest "Test a dynamic UDS backend discard during a request"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -arg "-p thread_pools=1" -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_addr}");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = s1.backend();
+	}
+} -start
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/bar"
+	txresp
+} -start
+
+barrier b1 sync
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s2 = debug.dyn_uds("${s2_addr}");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = s2.backend();
+	}
+}
+
+varnish v1 -cli "vcl.discard vcl1"
+barrier b2 sync
+
+client c1 -wait
+delay 2
+
+varnish v1 -expect MAIN.n_backend == 4
+
+varnish v1 -expect n_vcl_avail == 1
+varnish v1 -expect n_vcl_discard == 1
+
+client c1 {
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cli "vcl.list"
+varnish v1 -expect n_vcl_avail == 1

--- a/bin/varnishtest/tests/d00036.vtc
+++ b/bin/varnishtest/tests/d00036.vtc
@@ -1,0 +1,60 @@
+varnishtest "Test a dynamic UDS backend hot swap after it was hinted to a req"
+
+barrier b1 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import std;
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_addr}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+		set req.backend_hint = s1.backend();
+		# hot swap should happen while we sleep
+		debug.sleep(2s);
+		if (std.healthy(req.backend_hint)) {
+			return(synth(800));
+		} else {
+			set req.backend_hint = s1.backend();
+		}
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq
+	barrier b1 sync
+	rxresp
+	expect resp.status == 200
+}
+
+client c2 {
+	barrier b1 sync
+	delay 0.1
+	txreq -req "SWAP" -hdr "X-Path: ${s2_addr}"
+	rxresp
+	expect resp.status == 200
+}
+
+client c1 -start
+client c2 -run
+client c1 -wait
+
+varnish v1 -cli backend.list

--- a/bin/varnishtest/tests/j00004.vtc
+++ b/bin/varnishtest/tests/j00004.vtc
@@ -1,0 +1,42 @@
+varnishtest "Listen at a Unix domain socket while in jail"
+
+feature user_varnish
+feature group_varnish
+feature root
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" \
+	-jail "-junix,user=varnish,ccgroup=varnish" \
+	-vcl+backend {
+} -start
+
+# Socket is created as management owner before the child goes to jail
+shell -match "root" { ls -l ${tmpdir}/v1.sock }
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v2 -arg "-a ${tmpdir}/v2.sock,user=varnish,group=varnish,mode=666" \
+	-jail "-junix,user=varnish,ccgroup=varnish" \
+	-vcl+backend {
+} -start
+
+shell -match "rw-rw-rw-.+varnish.+varnish" { ls -l ${tmpdir}/v2.sock }
+
+client c1 -connect "${tmpdir}/v2.sock" {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run

--- a/bin/varnishtest/tests/m00046.vtc
+++ b/bin/varnishtest/tests/m00046.vtc
@@ -1,4 +1,4 @@
-varnishtest "std.ip() and std.port() don't work for UDS addresses"
+varnishtest "std.ip(), .port() and .set_ip_tos() don't work for UDS addresses"
 
 # Note that the fallback in std.ip() may be NULL now, since *.ip is
 # NULL for UDS.
@@ -39,3 +39,24 @@ varnish v1 -errvcl {Cannot convert to an IP address:} {
 		set resp.http.s1port = std.port("${s1_addr}");
 	}
 }
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_recv {
+	    # Invokes VCL failure for a UDS
+	    std.set_ip_tos(0);
+	}
+}
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+logexpect l1 -v v1 -d 1 -g vxid -q "VCL_Error" {
+	expect 0 * Begin req
+	expect * = VCL_Error "std.set_ip_tos.. cannot be applied to a Unix domain socket"
+	expect * = End
+} -run

--- a/bin/varnishtest/tests/m00046.vtc
+++ b/bin/varnishtest/tests/m00046.vtc
@@ -1,0 +1,41 @@
+varnishtest "std.ip() and std.port() don't work for UDS addresses"
+
+# Note that the fallback in std.ip() may be NULL now, since *.ip is
+# NULL for UDS.
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {
+	import std;
+
+	sub vcl_deliver {
+		set resp.http.foobar = std.ip("/foo/bar", client.ip);
+		set resp.http.s1 = std.ip("${s1_addr}", server.ip);
+	}
+} -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq
+	rxresp
+	expect resp.http.foobar == ""
+	expect resp.http.s1 == ""
+} -run
+
+varnish v1 -errvcl {Cannot convert to an IP address:} {
+	import std;
+
+	sub vcl_recv {
+		set resp.http.fooport = std.port("/foo/bar");
+	}
+}
+
+varnish v1 -errvcl {Cannot convert to an IP address:} {
+	import std;
+
+	sub vcl_recv {
+		set resp.http.s1port = std.port("${s1_addr}");
+	}
+}

--- a/bin/varnishtest/tests/t02013.vtc
+++ b/bin/varnishtest/tests/t02013.vtc
@@ -1,0 +1,58 @@
+varnishtest	"Direct H2 start over Unix domain sockets"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.http.host == foo.bar
+	txresp \
+		-hdr "H234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789I: foo" \
+		-hdr "Foo: H234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789I" \
+		-bodylen 10
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {
+	sub vcl_recv {
+		return (pipe);
+	}
+} -start
+
+varnish v1 -cliok "param.set debug +syncvsl"
+
+varnish v1 -cliok "param.set feature -http2"
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txpri
+	expect_close
+} -run
+
+varnish v1 -cliok "param.set feature +http2"
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	stream 1 {
+		txprio -weight 10 -stream 0
+	} -run
+	stream 3 {
+		txprio -weight 10 -stream 0
+	} -run
+	stream 5 {
+		txprio -weight 10 -stream 2
+	} -run
+	stream 7 {
+		txreq -dep 3 -hdr :authority foo.bar -pad cotton
+		rxresp
+		expect resp.status == 200
+		delay 1
+		txrst -err 0x1111
+	} -start
+	stream 0 {
+		txping -data "_-__-_-_"
+		rxping
+		expect ping.ack == "true"
+		expect ping.data == "_-__-_-_"
+	} -run
+	stream 7 -wait
+} -run
+
+varnish v1 -expect MEMPOOL.req0.live == 0
+varnish v1 -expect MEMPOOL.req1.live == 0
+varnish v1 -expect MEMPOOL.sess0.live == 0
+varnish v1 -expect MEMPOOL.sess1.live == 0

--- a/bin/varnishtest/tests/u00008.vtc
+++ b/bin/varnishtest/tests/u00008.vtc
@@ -37,4 +37,3 @@ process p1 -need-bytes 5000 -screen_dump
 process p1 -winsz 25 132
 
 process p1 -need-bytes 7000 -screen_dump -write {q} -wait
-

--- a/bin/varnishtest/tests/u00013.vtc
+++ b/bin/varnishtest/tests/u00013.vtc
@@ -1,0 +1,36 @@
+varnishtest "varnishncsa outputs when UDS addresses are in use"
+
+# The %h formatter gets its value from ReqStart or BackendStart,
+# which now may be a UDS address.
+
+# For UDS backends without a .hosthdr setting, the Host header is
+# set to "localhost", which may appear in %r output.
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {} -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq
+	rxresp
+} -run
+
+# Socket path
+shell -expect "${s1_addr}" {
+      varnishncsa -n ${v1_name} -d -b -F "%h"
+}
+
+shell -expect "${tmpdir}/v1.sock" {
+      varnishncsa -n ${v1_name} -d -c -F "%h"
+}
+
+shell -expect "http://localhost/" {
+      varnishncsa -n ${v1_name} -d -b -F "%r"
+}
+
+shell -expect "http://localhost/" {
+      varnishncsa -n ${v1_name} -d -c -F "%r"
+}

--- a/bin/varnishtest/tests/v00038.vtc
+++ b/bin/varnishtest/tests/v00038.vtc
@@ -87,7 +87,7 @@ varnish v1 -errvcl "Unknown field:" {
 	}
 }
 
-varnish v1 -errvcl "Mandatory field 'host' missing." {
+varnish v1 -errvcl "Expected .host or .path." {
 	backend b1 {
 		.port = "NONE";
 	}
@@ -108,4 +108,31 @@ varnish v1 -errvcl "Only one default director possible." {
 varnish v1 -errvcl "Unused backend b1, defined:" {
 	backend b1 { .host = "127.0.0.1"; }
 	backend default { .host = "127.0.0.1"; }
+}
+
+varnish v1 -errvcl "Address redefinition at:" {
+	backend b1 {
+		.host = "127.0.0.1";
+		.path = "/path/to/uds";
+	}
+}
+
+varnish v1 -errvcl "Must be an absolute path:" {
+	backend b1 {
+		.path = "server.sock";
+	}
+}
+
+shell { rm -f ${tmpdir}/foo }
+
+varnish v1 -errvcl "Cannot stat:" {
+	backend b1 {
+		.path = "${tmpdir}/foo";
+	}
+}
+
+varnish v1 -errvcl "Not a socket:" {
+	backend b1 {
+		.path = "${tmpdir}";
+	}
 }

--- a/bin/varnishtest/tests/v00053.vtc
+++ b/bin/varnishtest/tests/v00053.vtc
@@ -1,0 +1,41 @@
+varnishtest "Check backend connection limit with UDS backends"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -vcl {
+
+	backend default {
+		.path = "${s1_addr}";
+		.max_connections = 1;
+	}
+	sub vcl_recv {
+		return(pass);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -start
+
+
+client c2 {
+	barrier b1 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+barrier b2 sync
+client c1 -wait
+
+varnish v1 -expect backend_busy == 1

--- a/bin/varnishtest/tests/v00054.vtc
+++ b/bin/varnishtest/tests/v00054.vtc
@@ -1,0 +1,70 @@
+varnishtest "Check req.backend.healthy with UDS backends"
+
+barrier b1 cond 2
+barrier b2 cond 2
+barrier b3 cond 2
+barrier b4 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	barrier b1 sync
+	expect req.url == "/"
+	txresp -body "slash"
+	accept
+	rxreq
+	barrier b2 sync
+	barrier b3 sync
+	expect req.url == "/"
+	txresp -body "slash"
+	accept
+	barrier b4 sync
+} -start
+
+varnish v1 -vcl {
+
+	import std;
+
+	probe foo {
+		.url = "/";
+		.timeout = 1s;
+		.interval = 1s;
+		.window = 3;
+		.threshold = 2;
+		.initial = 0;
+	}
+
+	backend default {
+		.path = "${s1_addr}";
+		.max_connections = 1;
+		.probe = foo;
+	}
+
+	sub vcl_recv {
+		if (std.healthy(default)) {
+			return(synth(200,"Backend healthy"));
+		} else {
+			return(synth(500,"Backend sick"));
+		}
+	}
+} -start
+
+varnish v1 -cliok "backend.list -p"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 500
+
+	barrier b1 sync
+
+	barrier b2 sync
+	txreq
+	rxresp
+	expect resp.status == 500
+
+	barrier b3 sync
+	barrier b4 sync
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run

--- a/bin/varnishtest/tests/v00055.vtc
+++ b/bin/varnishtest/tests/v00055.vtc
@@ -1,0 +1,41 @@
+varnishtest "Test backend .hosthdr with UDS backends"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	expect req.http.host == "snafu"
+	txresp -body "foo1"
+
+	rxreq
+	expect req.url == "/bar"
+	expect req.http.host == "localhost"
+	txresp -body "foo1"
+} -start
+
+varnish v1 -vcl+backend { } -start
+
+client c1 {
+	txreq -url "/foo" -hdr "Host: snafu"
+	rxresp
+	txreq -url "/bar"
+	rxresp
+} -run
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/barf"
+	expect req.http.host == "FOObar"
+	txresp -body "foo1"
+} -start
+
+varnish v1 -vcl {
+	backend b1 {
+		.path = "${s2_addr}";
+		.host_header = "FOObar";
+	}
+}
+
+client c1 {
+	txreq -url "/barf"
+	rxresp
+} -run

--- a/bin/varnishtest/tests/v00055.vtc
+++ b/bin/varnishtest/tests/v00055.vtc
@@ -45,7 +45,7 @@ client c1 -connect "${tmpdir}/v1.sock" {
 # To compare a string with IP, VCC attempts to resolve the string as
 # an address. We make no attempt to convert a path to a UDS suckaddr.
 
-varnish v1 -errvcl {could not be resolved} {
+varnish v1 -errvcl {Cannot convert to an IP address} {
 
 	sub vcl_backend_response {
 	    set beresp.http.compare = beresp.backend.ip == "${s1_addr}";

--- a/bin/varnishtest/tests/v00055.vtc
+++ b/bin/varnishtest/tests/v00055.vtc
@@ -1,41 +1,54 @@
-varnishtest "Test backend .hosthdr with UDS backends"
+varnishtest "VCL *.ip variables when the address is a UDS"
 
 server s1 -listen "${tmpdir}/s1.sock" {
 	rxreq
-	expect req.url == "/foo"
-	expect req.http.host == "snafu"
-	txresp -body "foo1"
-
-	rxreq
-	expect req.url == "/bar"
-	expect req.http.host == "localhost"
-	txresp -body "foo1"
+	txresp
 } -start
 
-varnish v1 -vcl+backend { } -start
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl+backend {
 
-client c1 {
-	txreq -url "/foo" -hdr "Host: snafu"
-	rxresp
-	txreq -url "/bar"
-	rxresp
-} -run
-
-server s2 -listen "${tmpdir}/s2.sock" {
-	rxreq
-	expect req.url == "/barf"
-	expect req.http.host == "FOObar"
-	txresp -body "foo1"
-} -start
-
-varnish v1 -vcl {
-	backend b1 {
-		.path = "${s2_addr}";
-		.host_header = "FOObar";
+	sub vcl_backend_response {
+	    set beresp.http.b-client = client.ip;
+	    set beresp.http.b-server = server.ip;
+	    set beresp.http.b-local = local.ip;
+	    set beresp.http.b-remote = remote.ip;
+	    set beresp.http.b-backend = beresp.backend.ip;
+	    set beresp.http.b-compare = beresp.backend.ip == beresp.backend.ip;
 	}
-}
 
-client c1 {
-	txreq -url "/barf"
+	sub vcl_deliver {
+	    set resp.http.c-client = client.ip;
+	    set resp.http.c-server = server.ip;
+	    set resp.http.c-local = local.ip;
+	    set resp.http.c-remote = remote.ip;
+	    set resp.http.c-compare = client.ip == client.ip;
+	}
+}-start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq
 	rxresp
+	expect resp.status == 200
+	expect resp.http.c-client == ""
+	expect resp.http.c-server == ""
+	expect resp.http.c-local == ""
+	expect resp.http.c-remote == ""
+	expect resp.http.c-compare == "false"
+	expect resp.http.b-client == ""
+	expect resp.http.b-server == ""
+	expect resp.http.b-local == ""
+	expect resp.http.b-remote == ""
+	expect resp.http.b-backend == ""
+	expect resp.http.b-compare == "false"
 } -run
+
+# To compare a string with IP, VCC attempts to resolve the string as
+# an address. We make no attempt to convert a path to a UDS suckaddr.
+
+varnish v1 -errvcl {could not be resolved} {
+
+	sub vcl_backend_response {
+	    set beresp.http.compare = beresp.backend.ip == "${s1_addr}";
+	}
+
+}

--- a/bin/varnishtest/tests/v00056.vtc
+++ b/bin/varnishtest/tests/v00056.vtc
@@ -1,0 +1,34 @@
+varnishtest "read client.identity causes VCL fail if unset & client addr is UDS"
+
+varnish v1 -arg "-a ${tmpdir}/v1.sock" -vcl {
+	backend b { .host = "${bad_ip}"; }
+
+	sub vcl_recv {
+		if (req.url == "/nobody") {
+			set client.identity = "Samuel B. Nobody";
+		}
+		set req.http.id = client.identity;
+		return(synth(200));
+	}
+
+	sub vcl_synth {
+		set resp.http.id = req.http.id;
+	}
+} -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
+	txreq -url "/nobody"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.id == "Samuel B. Nobody"
+	txreq
+	rxresp
+	expect resp.status == 503
+	expect resp.http.id == ""
+} -run
+
+logexpect l1 -v v1 -d 1 -g vxid -q "VCL_Error" {
+	expect 0 * Begin req
+	expect * = VCL_Error "client.identity not set and there is no client IP"
+	expect * = End
+} -run

--- a/bin/varnishtest/tests/v00057.vtc
+++ b/bin/varnishtest/tests/v00057.vtc
@@ -1,0 +1,47 @@
+varnishtest "local.path"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+
+	sub vcl_backend_response {
+		set beresp.http.b-path = local.path;
+	}
+
+	sub vcl_deliver {
+		set resp.http.c-path = local.path;
+	}
+
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.b-path == ""
+	expect resp.http.c-path == ""
+} -run
+
+server s1 -wait
+server s1 -start
+
+varnish v2 -arg "-a ${tmpdir}/v2.sock" -vcl+backend {
+
+	sub vcl_backend_response {
+		set beresp.http.b-path = local.path;
+	}
+
+	sub vcl_deliver {
+		set resp.http.c-path = local.path;
+	}
+
+} -start
+
+client c1 -connect "${tmpdir}/v2.sock" {
+	txreq
+	rxresp
+	expect resp.http.b-path == "${tmpdir}/v2.sock"
+	expect resp.http.c-path == "${tmpdir}/v2.sock"
+} -run

--- a/bin/varnishtest/tests/v00058.vtc
+++ b/bin/varnishtest/tests/v00058.vtc
@@ -1,0 +1,37 @@
+varnishtest "beresp.backend.path"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp
+} -start
+
+server s2 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+
+	sub vcl_backend_fetch {
+		if (bereq.url == "/uds") {
+			set bereq.backend = s1;
+		}
+		else {
+			set bereq.backend = s2;
+		}
+	}
+
+	sub vcl_backend_response {
+		set beresp.http.path = beresp.backend.path;
+	}
+
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.path == ""
+	txreq -url "/uds"
+	rxresp
+	expect resp.http.path == "${tmpdir}/s1.sock"
+} -run

--- a/bin/varnishtest/tests/v00059.vtc
+++ b/bin/varnishtest/tests/v00059.vtc
@@ -1,0 +1,41 @@
+varnishtest "Test backend .hosthdr with UDS backends"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	expect req.http.host == "snafu"
+	txresp -body "foo1"
+
+	rxreq
+	expect req.url == "/bar"
+	expect req.http.host == "localhost"
+	txresp -body "foo1"
+} -start
+
+varnish v1 -vcl+backend { } -start
+
+client c1 {
+	txreq -url "/foo" -hdr "Host: snafu"
+	rxresp
+	txreq -url "/bar"
+	rxresp
+} -run
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/barf"
+	expect req.http.host == "FOObar"
+	txresp -body "foo1"
+} -start
+
+varnish v1 -vcl {
+	backend b1 {
+		.path = "${s2_addr}";
+		.host_header = "FOObar";
+	}
+}
+
+client c1 {
+	txreq -url "/barf"
+	rxresp
+} -run

--- a/bin/varnishtest/vtc.h
+++ b/bin/varnishtest/vtc.h
@@ -65,6 +65,12 @@ struct cmds {
 	cmd_f		*cmd;
 };
 
+enum sock_e {
+	IP,
+	UDS_CONNECT,
+	UDS_LISTEN
+};
+
 void parse_string(const char *spec, const struct cmds *cmd, void *priv,
     struct vtclog *vl);
 int fail_out(void);
@@ -93,7 +99,8 @@ extern int feature_dns;
 
 void init_server(void);
 
-int http_process(struct vtclog *vl, const char *spec, int sock, int *sfd);
+int http_process(struct vtclog *vl, const char *spec, int sock, int *sfd,
+		 enum sock_e stype);
 
 char * synth_body(const char *len, int rnd);
 

--- a/bin/varnishtest/vtc_client.c
+++ b/bin/varnishtest/vtc_client.c
@@ -142,8 +142,12 @@ client_thread(void *priv)
 		/* VTCP_blocking does its own checks, trust it */
 		(void)VTCP_blocking(fd);
 		VTCP_myname(fd, mabuf, sizeof mabuf, mpbuf, sizeof mpbuf);
-		vtc_log(vl, 3, "connected fd %d from %s %s to %s",
-		    fd, mabuf, mpbuf, VSB_data(vsb));
+		if (strcmp(mpbuf, "<none>") != 0)
+			vtc_log(vl, 3, "connected fd %d from %s %s to %s",
+				fd, mabuf, mpbuf, VSB_data(vsb));
+		else
+			vtc_log(vl, 3, "connected fd %d to %s",
+				fd, VSB_data(vsb));
 		if (c->proxy_spec != NULL)
 			client_proxy(vl, fd, c->proxy_version, c->proxy_spec);
 		fd = http_process(vl, c->spec, fd, NULL);

--- a/bin/varnishtest/vtc_client.c
+++ b/bin/varnishtest/vtc_client.c
@@ -142,7 +142,7 @@ client_thread(void *priv)
 		/* VTCP_blocking does its own checks, trust it */
 		(void)VTCP_blocking(fd);
 		VTCP_myname(fd, mabuf, sizeof mabuf, mpbuf, sizeof mpbuf);
-		if (strcmp(mpbuf, "<none>") != 0)
+		if (strcmp(mpbuf, "-") != 0)
 			vtc_log(vl, 3, "connected fd %d from %s %s to %s",
 				fd, mabuf, mpbuf, VSB_data(vsb));
 		else
@@ -150,7 +150,7 @@ client_thread(void *priv)
 				fd, VSB_data(vsb));
 		if (c->proxy_spec != NULL)
 			client_proxy(vl, fd, c->proxy_version, c->proxy_spec);
-		if (strcmp(mpbuf, "<none>") != 0)
+		if (strcmp(mpbuf, "-") != 0)
 			fd = http_process(vl, c->spec, fd, NULL, IP);
 		else
 			fd = http_process(vl, c->spec, fd, NULL, UDS_CONNECT);

--- a/bin/varnishtest/vtc_client.c
+++ b/bin/varnishtest/vtc_client.c
@@ -150,7 +150,10 @@ client_thread(void *priv)
 				fd, VSB_data(vsb));
 		if (c->proxy_spec != NULL)
 			client_proxy(vl, fd, c->proxy_version, c->proxy_spec);
-		fd = http_process(vl, c->spec, fd, NULL);
+		if (strcmp(mpbuf, "<none>") != 0)
+			fd = http_process(vl, c->spec, fd, NULL, IP);
+		else
+			fd = http_process(vl, c->spec, fd, NULL, UDS_CONNECT);
 		vtc_log(vl, 3, "closing fd %d", fd);
 		VTCP_close(&fd);
 	}

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -1840,7 +1840,8 @@ const struct cmds http_cmds[] = {
 };
 
 int
-http_process(struct vtclog *vl, const char *spec, int sock, int *sfd)
+http_process(struct vtclog *vl, const char *spec, int sock, int *sfd,
+	     enum sock_e stype)
 {
 	struct http *hp;
 	int retval;
@@ -1870,8 +1871,19 @@ http_process(struct vtclog *vl, const char *spec, int sock, int *sfd)
 	hp->gziplevel = 0;
 	hp->gzipresidual = -1;
 
-	VTCP_hisname(sock,
-	    hp->rem_ip, VTCP_ADDRBUFSIZE, hp->rem_port, VTCP_PORTBUFSIZE);
+	switch(stype) {
+	case IP:
+		VTCP_hisname(sock, hp->rem_ip, VTCP_ADDRBUFSIZE, hp->rem_port,
+			     VTCP_PORTBUFSIZE);
+		break;
+	case UDS_CONNECT:
+	case UDS_LISTEN:
+		hp->rem_ip = NULL;
+		hp->rem_port = NULL;
+		break;
+	default:
+		WRONG("socket type enum");
+	}
 	parse_string(spec, http_cmds, hp, vl);
 	if (hp->h2)
 		stop_h2(hp);

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -277,6 +277,7 @@ http_count_header(char * const *hh, const char *hdr)
  *
  *         - remote.ip
  *         - remote.port
+ *         - remote.path
  *         - req.method
  *         - req.url
  *         - req.proto
@@ -300,6 +301,8 @@ cmd_var_resolve(struct http *hp, char *spec)
 		return(hp->rem_ip);
 	if (!strcmp(spec, "remote.port"))
 		return(hp->rem_port);
+	if (!strcmp(spec, "remote.path"))
+		return(hp->rem_path);
 	if (!strcmp(spec, "req.method"))
 		return(hp->req[0]);
 	if (!strcmp(spec, "req.url"))
@@ -1875,9 +1878,19 @@ http_process(struct vtclog *vl, const char *spec, int sock, int *sfd,
 	case IP:
 		VTCP_hisname(sock, hp->rem_ip, VTCP_ADDRBUFSIZE, hp->rem_port,
 			     VTCP_PORTBUFSIZE);
+		hp->rem_path = NULL;
 		break;
 	case UDS_CONNECT:
 	case UDS_LISTEN:
+		hp->rem_path = malloc(VTCP_ADDRBUFSIZE);
+		if (stype == UDS_CONNECT)
+			VTCP_hisname(sock, hp->rem_path, VTCP_ADDRBUFSIZE,
+				     hp->rem_port, VTCP_PORTBUFSIZE);
+		else
+			VTCP_myname(sock, hp->rem_path, VTCP_ADDRBUFSIZE,
+				    hp->rem_port, VTCP_PORTBUFSIZE);
+		free(hp->rem_ip);
+		free(hp->rem_port);
 		hp->rem_ip = NULL;
 		hp->rem_port = NULL;
 		break;

--- a/bin/varnishtest/vtc_http.h
+++ b/bin/varnishtest/vtc_http.h
@@ -14,6 +14,7 @@ struct http {
 	char			*rxbuf;
 	char			*rem_ip;
 	char			*rem_port;
+	char			*rem_path;
 	int			prxbuf;
 	char			*body;
 	unsigned		bodyl;

--- a/include/tbl/backend_poll.h
+++ b/include/tbl/backend_poll.h
@@ -31,6 +31,7 @@
 
 BITMAP(good_ipv4, '4', "Good IPv4", 0)
 BITMAP(good_ipv6, '6', "Good IPv6", 0)
+BITMAP(good_unix, 'U', "Good UNIX", 0)
 BITMAP( err_xmit, 'x', "Error Xmit", 0)
 BITMAP(good_xmit, 'X', "Good Xmit", 0)
 BITMAP( err_recv, 'r', "Error Recv", 0)

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -243,6 +243,7 @@ extern const void * const vrt_magic_string_unset;
 	rigid char			*vcl_name;		\
 	rigid char			*ipv4_addr;		\
 	rigid char			*ipv6_addr;		\
+	rigid char			*path;			\
 	rigid char			*port;			\
 	rigid char			*hosthdr;		\
 	double				connect_timeout;	\
@@ -256,6 +257,7 @@ extern const void * const vrt_magic_string_unset;
 		DA(vcl_name);			\
 		DA(ipv4_addr);			\
 		DA(ipv6_addr);			\
+		DA(path);			\
 		DA(port);			\
 		DA(hosthdr);			\
 		DN(connect_timeout);		\

--- a/include/vsa.h
+++ b/include/vsa.h
@@ -58,10 +58,9 @@ struct suckaddr *VSA_Malloc_UDS(const struct suckaddr *uds, void **uds_sockaddr)
 
 /*
  * 'd' SHALL point to vsa_suckaddr_len aligned bytes of storage,
- * 's' is a sockaddr of some kind, 'sal' is its length.
+ * 's' is a PF_INET* sockaddr, 'sal' is its length.
  */
-struct suckaddr *VSA_Build(void *d, const void *s, unsigned sal,
-			   const void *suds);
+struct suckaddr *VSA_Build(void *d, const void *s, unsigned sal);
 
 /*
  * 'd' SHALL point to vsa_suckaddr_len aligned bytes of storage,

--- a/include/vsa.h
+++ b/include/vsa.h
@@ -63,6 +63,15 @@ struct suckaddr *VSA_Malloc_UDS(const struct suckaddr *uds, void **uds_sockaddr)
 struct suckaddr *VSA_Build(void *d, const void *s, unsigned sal,
 			   const void *suds);
 
+/*
+ * 'd' SHALL point to vsa_suckaddr_len aligned bytes of storage,
+ * 's' is a sockaddr_un whose storage is "owned" by the caller, who is
+ * responsible for freeing it.
+ * Store the suckaddr in d that points to the sockaddr_un storage, and
+ * return a pointer to the suckaddr.
+ */
+struct suckaddr *VSA_Build_UDS(void *d, const void *s);
+
 const char * VSA_Path(const struct suckaddr *sua);
 
 #endif

--- a/include/vsa.h
+++ b/include/vsa.h
@@ -43,9 +43,9 @@ const void *VSA_Get_Sockaddr(const struct suckaddr *, socklen_t *sl);
 int VSA_Get_Proto(const struct suckaddr *);
 
 /*
- * 's' is a sockaddr of some kind, 'sal' is its length
+ * 's' is a PF_INET* sockaddr, 'sal' is its length
  */
-struct suckaddr *VSA_Malloc(const void *s, unsigned  sal, const void *suds);
+struct suckaddr *VSA_Malloc(const void *s, unsigned  sal);
 
 /*
  * 'uds' is a PF_UNIX suckaddr. '*uds_sockaddr' will point to storage for

--- a/include/vsa.h
+++ b/include/vsa.h
@@ -48,6 +48,15 @@ int VSA_Get_Proto(const struct suckaddr *);
 struct suckaddr *VSA_Malloc(const void *s, unsigned  sal, const void *suds);
 
 /*
+ * 'uds' is a PF_UNIX suckaddr. '*uds_sockaddr' will point to storage for
+ * the sockaddr_un that will be "owned" by the caller -- the caller is
+ * responsible for freeing it.
+ * Allocate the sockaddr_un in *uds_sockaddr, and return a dup of uds that
+ * points to the newly allocated sockaddr_un.
+ */
+struct suckaddr *VSA_Malloc_UDS(const struct suckaddr *uds, void **uds_sockaddr);
+
+/*
  * 'd' SHALL point to vsa_suckaddr_len aligned bytes of storage,
  * 's' is a sockaddr of some kind, 'sal' is its length.
  */

--- a/include/vsa.h
+++ b/include/vsa.h
@@ -45,12 +45,15 @@ int VSA_Get_Proto(const struct suckaddr *);
 /*
  * 's' is a sockaddr of some kind, 'sal' is its length
  */
-struct suckaddr *VSA_Malloc(const void *s, unsigned  sal);
+struct suckaddr *VSA_Malloc(const void *s, unsigned  sal, const void *suds);
 
 /*
  * 'd' SHALL point to vsa_suckaddr_len aligned bytes of storage,
  * 's' is a sockaddr of some kind, 'sal' is its length.
  */
-struct suckaddr *VSA_Build(void *d, const void *s, unsigned sal);
+struct suckaddr *VSA_Build(void *d, const void *s, unsigned sal,
+			   const void *suds);
+
+const char * VSA_Path(const struct suckaddr *sua);
 
 #endif

--- a/include/vss.h
+++ b/include/vss.h
@@ -32,3 +32,5 @@ struct suckaddr;
 typedef int vss_resolved_f(void *priv, const struct suckaddr *);
 int VSS_resolver(const char *addr, const char *def_port, vss_resolved_f *func,
    void *priv, const char **err);
+int VSS_unix(const char *path, vss_resolved_f *func, void *priv,
+	     const char **err);

--- a/include/vtcp.h
+++ b/include/vtcp.h
@@ -31,8 +31,11 @@
 struct suckaddr;
 
 /* from libvarnish/tcp.c */
-/* NI_MAXHOST and NI_MAXSERV are ridiculously long for numeric format */
-#define VTCP_ADDRBUFSIZE		64
+/*
+ * NI_MAXHOST and NI_MAXSERV are ridiculously long for numeric format
+ * VTCP_ADDRBUFSIZE is more than enough to hold a UDS path.
+ */
+#define VTCP_ADDRBUFSIZE		128
 #define VTCP_PORTBUFSIZE		16
 
 int VTCP_Check(int a);

--- a/lib/libvarnish/vsa.c
+++ b/lib/libvarnish/vsa.c
@@ -281,6 +281,35 @@ VSA_Build(void *d, const void *s, unsigned sal, const void *suds)
 	return (NULL);
 }
 
+/*
+ * 'uds' is a PF_UNIX suckaddr. '*uds_sockaddr' will point to storage for
+ * the sockaddr_un that will be "owned" by the caller -- the caller is
+ * responsible for freeing it.
+ * Allocate the sockaddr_un in *uds_sockaddr, and return a dup of uds that
+ * points to the newly allocated sockaddr_un.
+ */
+struct suckaddr *
+VSA_Malloc_UDS(const struct suckaddr *uds, void **uds_sockaddr)
+{
+	struct suckaddr *sua;
+
+	CHECK_OBJ_NOTNULL(uds, SUCKADDR_MAGIC);
+	assert(uds->sa_family == PF_UNIX);
+	AN(uds_sockaddr);
+
+	*uds_sockaddr = malloc(sizeof *uds->sa.sau);
+	if (*uds_sockaddr == NULL)
+		return (NULL);
+	memcpy(*uds_sockaddr, uds->sa.sau, sizeof *uds->sa.sau);
+
+	ALLOC_OBJ(sua, SUCKADDR_MAGIC);
+	if (sua == NULL)
+		return (NULL);
+	sua->sa_family = PF_UNIX;
+	sua->sa.sau = *uds_sockaddr;
+	return (sua);
+}
+
 const void *
 VSA_Get_Sockaddr(const struct suckaddr *sua, socklen_t *sl)
 {

--- a/lib/libvarnish/vsa.c
+++ b/lib/libvarnish/vsa.c
@@ -331,10 +331,11 @@ VSA_Compare(const struct suckaddr *sua1, const struct suckaddr *sua2)
 
 	CHECK_OBJ_NOTNULL(sua1, SUCKADDR_MAGIC);
 	CHECK_OBJ_NOTNULL(sua2, SUCKADDR_MAGIC);
-	if (sua1->sa_family == PF_UNIX)
-		return (sua2->sa_family == PF_UNIX
-			&& memcmp(sua1->sa.sau, sua2->sa.sau,
-				  sizeof(struct sockaddr_un)));
+	if (sua1->sa_family == PF_UNIX) {
+		if (sua2->sa_family != PF_UNIX)
+			return 1;
+		return (strcmp(sua1->sa.sau->sun_path, sua2->sa.sau->sun_path));
+	}
 	return (memcmp(sua1, sua2, vsa_suckaddr_len));
 }
 

--- a/lib/libvarnish/vsa.c
+++ b/lib/libvarnish/vsa.c
@@ -210,17 +210,18 @@ VRT_VSA_GetPtr(const struct suckaddr *sua, const unsigned char ** dst)
 }
 
 /*
- * Malloc a suckaddr from a sockaddr of some kind.
+ * Malloc a suckaddr from a PF_INET* sockaddr.
  */
 
 struct suckaddr *
-VSA_Malloc(const void *s, unsigned  sal, const void *suds)
+VSA_Malloc(const void *s, unsigned  sal)
 {
 	struct suckaddr *sua = NULL;
 	const struct sockaddr *sa = s;
 	unsigned l = 0;
 
 	AN(s);
+	assert(sa->sa_family != PF_UNIX);
 	switch (sa->sa_family) {
 	case PF_INET:
 		if (sal == sizeof sua->sa.sa4)
@@ -233,15 +234,12 @@ VSA_Malloc(const void *s, unsigned  sal, const void *suds)
 	default:
 		break;
 	}
-	if (l != 0 || sa->sa_family == PF_UNIX) {
+	if (l != 0) {
 		ALLOC_OBJ(sua, SUCKADDR_MAGIC);
 		if (sua == NULL)
 			return (NULL);
 		sua->sa_family = sa->sa_family;
-		if (sa->sa_family != PF_UNIX)
-			memcpy(&sua->sa, s, l);
-		else
-			sua->sa.sau = suds;
+		memcpy(&sua->sa, s, l);
 	}
 	return (sua);
 }

--- a/lib/libvarnish/vsa.c
+++ b/lib/libvarnish/vsa.c
@@ -310,6 +310,30 @@ VSA_Malloc_UDS(const struct suckaddr *uds, void **uds_sockaddr)
 	return (sua);
 }
 
+/*
+ * 'd' SHALL point to vsa_suckaddr_len aligned bytes of storage,
+ * 's' is a sockaddr_un whose storage is "owned" by the caller, who is
+ * responsible for freeing it.
+ * Store the suckaddr in d that points to the sockaddr_un storage, and
+ * return a pointer to the suckaddr.
+ */
+struct suckaddr *
+VSA_Build_UDS(void *d, const void *s)
+{
+	struct suckaddr *sua = d;
+	const struct sockaddr_un *sa = s;
+
+	AN(d);
+	AN(s);
+	assert(sa->sun_family == PF_UNIX);
+
+	memset(sua, 0, sizeof *sua);
+	sua->magic = SUCKADDR_MAGIC;
+	sua->sa_family = PF_UNIX;
+	sua->sa.sau = sa;
+	return (sua);
+}
+
 const void *
 VSA_Get_Sockaddr(const struct suckaddr *sua, socklen_t *sl)
 {

--- a/lib/libvarnish/vsa.c
+++ b/lib/libvarnish/vsa.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <netinet/in.h>
 
 #include "vdef.h"
@@ -165,11 +166,12 @@
 struct suckaddr {
 	unsigned			magic;
 #define SUCKADDR_MAGIC			0x4b1e9335
+	sa_family_t			sa_family;
 	union {
-		struct sockaddr		sa;
-		struct sockaddr_in	sa4;
-		struct sockaddr_in6	sa6;
-	};
+		struct sockaddr_in		sa4;
+		struct sockaddr_in6		sa6;
+		const struct sockaddr_un	*sau;
+	}				sa;
 };
 
 const int vsa_suckaddr_len = sizeof(struct suckaddr);
@@ -188,15 +190,19 @@ VRT_VSA_GetPtr(const struct suckaddr *sua, const unsigned char ** dst)
 		return (-1);
 	CHECK_OBJ_NOTNULL(sua, SUCKADDR_MAGIC);
 
-	switch (sua->sa.sa_family) {
+	switch (sua->sa_family) {
 	case PF_INET:
-		assert(sua->sa.sa_family == sua->sa4.sin_family);
-		*dst = (const unsigned char *)&sua->sa4.sin_addr;
-		return (sua->sa4.sin_family);
+		assert(sua->sa_family == sua->sa.sa4.sin_family);
+		*dst = (const unsigned char *)&sua->sa.sa4.sin_addr;
+		return (sua->sa.sa4.sin_family);
 	case PF_INET6:
-		assert(sua->sa.sa_family == sua->sa6.sin6_family);
-		*dst = (const unsigned char *)&sua->sa6.sin6_addr;
-		return (sua->sa6.sin6_family);
+		assert(sua->sa_family == sua->sa.sa6.sin6_family);
+		*dst = (const unsigned char *)&sua->sa.sa6.sin6_addr;
+		return (sua->sa.sa6.sin6_family);
+	case PF_UNIX:
+		assert(sua->sa_family == sua->sa.sau->sun_family);
+		*dst = (const unsigned char *)sua->sa.sau->sun_path;
+		return (sua->sa.sau->sun_family);
 	default:
 		*dst = NULL;
 		return (-1);
@@ -208,7 +214,7 @@ VRT_VSA_GetPtr(const struct suckaddr *sua, const unsigned char ** dst)
  */
 
 struct suckaddr *
-VSA_Malloc(const void *s, unsigned  sal)
+VSA_Malloc(const void *s, unsigned  sal, const void *suds)
 {
 	struct suckaddr *sua = NULL;
 	const struct sockaddr *sa = s;
@@ -217,27 +223,32 @@ VSA_Malloc(const void *s, unsigned  sal)
 	AN(s);
 	switch (sa->sa_family) {
 	case PF_INET:
-		if (sal == sizeof sua->sa4)
+		if (sal == sizeof sua->sa.sa4)
 			l = sal;
 		break;
 	case PF_INET6:
-		if (sal == sizeof sua->sa6)
+		if (sal == sizeof sua->sa.sa6)
 			l = sal;
 		break;
 	default:
 		break;
 	}
-	if (l != 0) {
+	if (l != 0 || sa->sa_family == PF_UNIX) {
 		ALLOC_OBJ(sua, SUCKADDR_MAGIC);
-		if (sua != NULL)
+		if (sua == NULL)
+			return (NULL);
+		sua->sa_family = sa->sa_family;
+		if (sa->sa_family != PF_UNIX)
 			memcpy(&sua->sa, s, l);
+		else
+			sua->sa.sau = suds;
 	}
 	return (sua);
 }
 
 /* 'd' SHALL point to vsa_suckaddr_len aligned bytes of storage */
 struct suckaddr *
-VSA_Build(void *d, const void *s, unsigned sal)
+VSA_Build(void *d, const void *s, unsigned sal, const void *suds)
 {
 	struct suckaddr *sua = d;
 	const struct sockaddr *sa = s;
@@ -247,20 +258,24 @@ VSA_Build(void *d, const void *s, unsigned sal)
 	AN(s);
 	switch (sa->sa_family) {
 	case PF_INET:
-		if (sal == sizeof sua->sa4)
+		if (sal == sizeof sua->sa.sa4)
 			l = sal;
 		break;
 	case PF_INET6:
-		if (sal == sizeof sua->sa6)
+		if (sal == sizeof sua->sa.sa6)
 			l = sal;
 		break;
 	default:
 		break;
 	}
-	if (l != 0) {
+	if (l != 0 || sa->sa_family == PF_UNIX) {
 		memset(sua, 0, sizeof *sua);
 		sua->magic = SUCKADDR_MAGIC;
-		memcpy(&sua->sa, s, l);
+		sua->sa_family = sa->sa_family;
+		if (sa->sa_family != PF_UNIX)
+			memcpy(&sua->sa, s, l);
+		else
+			sua->sa.sau = suds;
 		return (sua);
 	}
 	return (NULL);
@@ -272,17 +287,19 @@ VSA_Get_Sockaddr(const struct suckaddr *sua, socklen_t *sl)
 
 	CHECK_OBJ_NOTNULL(sua, SUCKADDR_MAGIC);
 	AN(sl);
-	switch (sua->sa.sa_family) {
+	switch (sua->sa_family) {
 	case PF_INET:
-		*sl = sizeof sua->sa4;
-		break;
+		*sl = sizeof sua->sa.sa4;
+		return (&sua->sa.sa4);
 	case PF_INET6:
-		*sl = sizeof sua->sa6;
-		break;
+		*sl = sizeof sua->sa.sa6;
+		return (&sua->sa.sa6);
+	case PF_UNIX:
+		*sl = sizeof *sua->sa.sau;
+		return (sua->sa.sau);
 	default:
 		return (NULL);
 	}
-	return (&sua->sa);
 }
 
 int
@@ -290,7 +307,7 @@ VSA_Get_Proto(const struct suckaddr *sua)
 {
 
 	CHECK_OBJ_NOTNULL(sua, SUCKADDR_MAGIC);
-	return (sua->sa.sa_family);
+	return (sua->sa_family);
 }
 
 int
@@ -298,9 +315,10 @@ VSA_Sane(const struct suckaddr *sua)
 {
 	CHECK_OBJ_NOTNULL(sua, SUCKADDR_MAGIC);
 
-	switch (sua->sa.sa_family) {
+	switch (sua->sa_family) {
 	case PF_INET:
 	case PF_INET6:
+	case PF_UNIX:
 		return (1);
 	default:
 		return (0);
@@ -313,8 +331,14 @@ VSA_Compare(const struct suckaddr *sua1, const struct suckaddr *sua2)
 
 	CHECK_OBJ_NOTNULL(sua1, SUCKADDR_MAGIC);
 	CHECK_OBJ_NOTNULL(sua2, SUCKADDR_MAGIC);
+	if (sua1->sa_family == PF_UNIX)
+		return (sua2->sa_family == PF_UNIX
+			&& memcmp(sua1->sa.sau, sua2->sa.sau,
+				  sizeof(struct sockaddr_un)));
 	return (memcmp(sua1, sua2, vsa_suckaddr_len));
 }
+
+/* XXX For UDSen compare the paths. Maybe rename to VSA_Compare_Addr. */
 
 int
 VSA_Compare_IP(const struct suckaddr *sua1, const struct suckaddr *sua2)
@@ -323,16 +347,18 @@ VSA_Compare_IP(const struct suckaddr *sua1, const struct suckaddr *sua2)
 	assert(VSA_Sane(sua1));
 	assert(VSA_Sane(sua2));
 
-	if (sua1->sa.sa_family != sua2->sa.sa_family)
+	if (sua1->sa_family != sua2->sa_family)
 		return (-1);
 
-	switch (sua1->sa.sa_family) {
+	switch (sua1->sa_family) {
 	case PF_INET:
-		return (memcmp(&sua1->sa4.sin_addr,
-		    &sua2->sa4.sin_addr, sizeof(struct in_addr)));
+		return (memcmp(&sua1->sa.sa4.sin_addr,
+		    &sua2->sa.sa4.sin_addr, sizeof(struct in_addr)));
 	case PF_INET6:
-		return (memcmp(&sua1->sa6.sin6_addr,
-		    &sua2->sa6.sin6_addr, sizeof(struct in6_addr)));
+		return (memcmp(&sua1->sa.sa6.sin6_addr,
+		    &sua2->sa.sa6.sin6_addr, sizeof(struct in6_addr)));
+	case PF_UNIX:
+		return (strcmp(sua1->sa.sau->sun_path, sua2->sa.sau->sun_path));
 	default:
 		WRONG("Just plain insane");
 	}
@@ -343,11 +369,18 @@ struct suckaddr *
 VSA_Clone(const struct suckaddr *sua)
 {
 	struct suckaddr *sua2;
+	struct sockaddr_un *suds;
 
 	assert(VSA_Sane(sua));
 	sua2 = calloc(1, vsa_suckaddr_len);
 	XXXAN(sua2);
 	memcpy(sua2, sua, vsa_suckaddr_len);
+	if (sua->sa_family == PF_UNIX && sua->sa.sau != NULL) {
+		suds = calloc(1, sizeof(struct sockaddr_un));
+		XXXAN(suds);
+		memcpy(suds, sua->sa.sau, sizeof(struct sockaddr_un));
+		sua2->sa.sau = suds;
+	}
 	return (sua2);
 }
 
@@ -356,12 +389,30 @@ VSA_Port(const struct suckaddr *sua)
 {
 
 	CHECK_OBJ_NOTNULL(sua, SUCKADDR_MAGIC);
-	switch (sua->sa.sa_family) {
+	switch (sua->sa_family) {
 	case PF_INET:
-		return (ntohs(sua->sa4.sin_port));
+		return (ntohs(sua->sa.sa4.sin_port));
 	case PF_INET6:
-		return (ntohs(sua->sa6.sin6_port));
+		return (ntohs(sua->sa.sa6.sin6_port));
+	case PF_UNIX:
 	default:
 		return (0);
 	}
+}
+
+const char *
+VSA_Path(const struct suckaddr *sua)
+{
+
+	CHECK_OBJ_NOTNULL(sua, SUCKADDR_MAGIC);
+	switch (sua->sa_family) {
+	case PF_INET:
+	case PF_INET6:
+		return (NULL);
+	case PF_UNIX:
+		return (sua->sa.sau->sun_path);
+	default:
+		WRONG("invalid sockaddr family");
+	}
+	NEEDLESS(return(NULL));
 }

--- a/lib/libvarnish/vsa.c
+++ b/lib/libvarnish/vsa.c
@@ -246,7 +246,7 @@ VSA_Malloc(const void *s, unsigned  sal)
 
 /* 'd' SHALL point to vsa_suckaddr_len aligned bytes of storage */
 struct suckaddr *
-VSA_Build(void *d, const void *s, unsigned sal, const void *suds)
+VSA_Build(void *d, const void *s, unsigned sal)
 {
 	struct suckaddr *sua = d;
 	const struct sockaddr *sa = s;
@@ -254,6 +254,7 @@ VSA_Build(void *d, const void *s, unsigned sal, const void *suds)
 
 	AN(d);
 	AN(s);
+	assert(sa->sa_family != PF_UNIX);
 	switch (sa->sa_family) {
 	case PF_INET:
 		if (sal == sizeof sua->sa.sa4)
@@ -266,14 +267,11 @@ VSA_Build(void *d, const void *s, unsigned sal, const void *suds)
 	default:
 		break;
 	}
-	if (l != 0 || sa->sa_family == PF_UNIX) {
+	if (l != 0) {
 		memset(sua, 0, sizeof *sua);
 		sua->magic = SUCKADDR_MAGIC;
 		sua->sa_family = sa->sa_family;
-		if (sa->sa_family != PF_UNIX)
-			memcpy(&sua->sa, s, l);
-		else
-			sua->sa.sau = suds;
+		memcpy(&sua->sa, s, l);
 		return (sua);
 	}
 	return (NULL);

--- a/lib/libvarnish/vss.c
+++ b/lib/libvarnish/vss.c
@@ -136,7 +136,7 @@ VSS_resolver(const char *addr, const char *def_port, vss_resolved_f *func,
 		return (-1);
 	}
 	for (res = res0; res != NULL; res = res->ai_next) {
-		vsa = VSA_Malloc(res->ai_addr, res->ai_addrlen, NULL);
+		vsa = VSA_Malloc(res->ai_addr, res->ai_addrlen);
 		if (vsa != NULL) {
 			ret = func(priv, vsa);
 			free(vsa);

--- a/lib/libvarnish/vss.c
+++ b/lib/libvarnish/vss.c
@@ -153,6 +153,7 @@ VSS_unix(const char *path, vss_resolved_f *func, void *priv, const char **err)
 {
 	struct sockaddr_un uds;
 	struct suckaddr *vsa;
+	void *p;
 	int ret = 0;
 
 	AN(path);
@@ -165,13 +166,12 @@ VSS_unix(const char *path, vss_resolved_f *func, void *priv, const char **err)
 	}
 	strcpy(uds.sun_path, path);
 	uds.sun_family = PF_UNIX;
-	vsa = VSA_Malloc(&uds, sizeof(uds), &uds);
-	if (vsa == NULL) {
-		*err = "Could not allocate socket address";
-		return(-1);
-	}
+	p = malloc(vsa_suckaddr_len);
+	AN(p);
+	vsa = VSA_Build_UDS(p, &uds);
+	AN(vsa);
 	if (func != NULL)
 		ret = func(priv, vsa);
-	free(vsa);
+	free(p);
 	return(ret);
 }

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -294,7 +294,8 @@ VTCP_connect(const struct suckaddr *name, int msec)
 		(void)VTCP_nonblocking(s);
 
 	val = 1;
-	AZ(setsockopt(s, IPPROTO_TCP, TCP_NODELAY, &val, sizeof val));
+	if (VSA_Get_Proto(name) != PF_UNIX)
+		AZ(setsockopt(s, IPPROTO_TCP, TCP_NODELAY, &val, sizeof val));
 
 	i = connect(s, sa, sl);
 	if (i == 0)

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -403,8 +403,11 @@ VTCP_open(const char *addr, const char *def_port, double timeout,
 	if (errp != NULL)
 		*errp = NULL;
 	assert(timeout >= 0);
-	error = VSS_resolver(addr, def_port, vtcp_open_callback,
-	    &timeout, &err);
+	if (addr[0] != '/')
+		error = VSS_resolver(addr, def_port, vtcp_open_callback,
+				     &timeout, &err);
+	else
+		error = VSS_unix(addr, vtcp_open_callback, &timeout, &err);
 	if (err != NULL) {
 		if (errp != NULL)
 			*errp = err;
@@ -541,7 +544,10 @@ VTCP_listen_on(const char *addr, const char *def_port, int depth,
 	h.depth = depth;
 	h.errp = errp;
 
-	sock = VSS_resolver(addr, def_port, vtcp_lo_cb, &h, errp);
+	if (addr[0] != '/')
+		sock = VSS_resolver(addr, def_port, vtcp_lo_cb, &h, errp);
+	else
+		sock = VSS_unix(addr, vtcp_lo_cb, &h, errp);
 	if (*errp != NULL)
 		return (-1);
 	return(sock);

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -59,14 +59,16 @@ static void
 vtcp_sa_to_ascii(const void *sa, socklen_t l, char *abuf, unsigned alen,
     char *pbuf, unsigned plen)
 {
-	const struct sockaddr *soa = sa;
+	const struct sockaddr *soa;
 	int i;
 
+	AN(sa);
 	assert(abuf == NULL || alen > 0);
 	assert(pbuf == NULL || plen > 0);
 
+	soa = sa;					//lint !e826
 	if (soa->sa_family == PF_UNIX) {
-		const struct sockaddr_un *suds = sa;
+		const struct sockaddr_un *suds = sa;	//lint !e826
 
 		(void)snprintf(abuf, alen, "%s", suds->sun_path);
 		(void)snprintf(pbuf, plen, "<none>");

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -71,7 +71,7 @@ vtcp_sa_to_ascii(const void *sa, socklen_t l, char *abuf, unsigned alen,
 		const struct sockaddr_un *suds = sa;	//lint !e826
 
 		(void)snprintf(abuf, alen, "%s", suds->sun_path);
-		(void)snprintf(pbuf, plen, "<none>");
+		(void)snprintf(pbuf, plen, "-");
 		return;
 	}
 
@@ -108,7 +108,8 @@ VTCP_name(const struct suckaddr *addr, char *abuf, unsigned alen,
 
 	if (VSA_Get_Proto(addr) == PF_UNIX) {
 		(void)snprintf(abuf, alen, "%s", VSA_Path(addr));
-		(void)snprintf(pbuf, plen, "<none>");
+		(void)snprintf(pbuf, plen, "-");
+		return;
 	}
 	sa = VSA_Get_Sockaddr(addr, &sl);
 	vtcp_sa_to_ascii(sa, sl, abuf, alen, pbuf, plen);

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -125,7 +125,7 @@ VTCP_my_suckaddr(int sock)
 
 	l = sizeof addr_s;
 	AZ(getsockname(sock, (void *)&addr_s, &l));
-	return (VSA_Malloc(&addr_s, l, NULL)); /* XXX malloc uds? */
+	return (VSA_Malloc(&addr_s, l));
 }
 
 /*--------------------------------------------------------------------*/

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -218,6 +218,15 @@ vardef('server.ip',
 	connection was received.
 	"""
 )
+vardef('local.path',
+       'STRING',
+       ('both',),
+       (), """
+       The socket path at which a client request was
+       received, if it is a Unix domain socket. NULL
+       if the request was received at an IP address.
+       """
+)
 vardef('server.hostname',
 	'STRING',
 	('all',),

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -691,6 +691,14 @@ vardef('beresp.backend.ip',
 	IP of the backend this response was fetched from.
 	"""
 )
+vardef('beresp.backend.path',
+       'STRING',
+       ('backend_response',),
+       (), """
+       Socket path of the backend this response was fetched from,
+       if it was a Unix domain socket. NULL if it was an IP.
+       """
+)
 vardef('beresp.storage',
 	'STEVEDORE',
 	('backend_response', 'backend_error'),

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -81,20 +81,21 @@ Emit_Sockaddr(struct vcc *tl, const struct token *t_host,
 		Fb(tl, 0, "\t.ipv6_addr = \"%s\",\n", ipv6a);
 	}
 	Fb(tl, 0, "\t.port = \"%s\",\n", pa);
+	Fb(tl, 0, "\t.path = (void *) 0,\n");
 }
 
 /*--------------------------------------------------------------------
- * Parse a backend probe specification
+ * Disallow mutually exclusive field definitions.
  */
 
 static void
-vcc_ProbeRedef(struct vcc *tl, struct token **t_did,
-    struct token *t_field)
+vcc_Redef(struct vcc *tl, const char *redef, struct token **t_did,
+	  struct token *t_field)
 {
 	/* .url and .request are mutually exclusive */
 
 	if (*t_did != NULL) {
-		VSB_printf(tl->sb, "Probe request redefinition at:\n");
+		VSB_printf(tl->sb, "%s redefinition at:\n", redef);
 		vcc_ErrWhere(tl, t_field);
 		VSB_printf(tl->sb, "Previous definition:\n");
 		vcc_ErrWhere(tl, *t_did);
@@ -102,6 +103,10 @@ vcc_ProbeRedef(struct vcc *tl, struct token **t_did,
 	}
 	*t_did = t_field;
 }
+
+/*--------------------------------------------------------------------
+ * Parse a backend probe specification
+ */
 
 static void
 vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **name)
@@ -152,7 +157,7 @@ vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **name)
 		vcc_IsField(tl, &t_field, fs);
 		ERRCHK(tl);
 		if (vcc_IdIs(t_field, "url")) {
-			vcc_ProbeRedef(tl, &t_did, t_field);
+			vcc_Redef(tl, "Probe request", &t_did, t_field);
 			ERRCHK(tl);
 			ExpectErr(tl, CSTR);
 			Fh(tl, 0, "\t.url = ");
@@ -160,7 +165,7 @@ vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **name)
 			Fh(tl, 0, ",\n");
 			vcc_NextToken(tl);
 		} else if (vcc_IdIs(t_field, "request")) {
-			vcc_ProbeRedef(tl, &t_did, t_field);
+			vcc_Redef(tl, "Probe request", &t_did, t_field);
 			ERRCHK(tl);
 			ExpectErr(tl, CSTR);
 			Fh(tl, 0, "\t.request =\n");
@@ -294,8 +299,10 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	struct token *t_val;
 	struct token *t_host = NULL;
 	struct token *t_port = NULL;
+	struct token *t_path = NULL;
 	struct token *t_hosthdr = NULL;
 	struct symbol *pb;
+	struct token *t_did = NULL;
 	struct fld_spec *fs;
 	struct inifin *ifp;
 	struct vsb *vsb;
@@ -304,8 +311,9 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	double t;
 
 	fs = vcc_FldSpec(tl,
-	    "!host",
+	    "?host",
 	    "?port",
+	    "?path",
 	    "?host_header",
 	    "?connect_timeout",
 	    "?first_byte_timeout",
@@ -345,6 +353,8 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 		vcc_IsField(tl, &t_field, fs);
 		ERRCHK(tl);
 		if (vcc_IdIs(t_field, "host")) {
+			vcc_Redef(tl, "Address", &t_did, t_field);
+			ERRCHK(tl);
 			ExpectErr(tl, CSTR);
 			assert(tl->t->dec != NULL);
 			t_host = tl->t;
@@ -354,6 +364,14 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 			ExpectErr(tl, CSTR);
 			assert(tl->t->dec != NULL);
 			t_port = tl->t;
+			vcc_NextToken(tl);
+			SkipToken(tl, ';');
+		} else if (vcc_IdIs(t_field, "path")) {
+			vcc_Redef(tl, "Address", &t_did, t_field);
+			ERRCHK(tl);
+			ExpectErr(tl, CSTR);
+			assert(tl->t->dec != NULL);
+			t_path = tl->t;
 			vcc_NextToken(tl);
 			SkipToken(tl, ';');
 		} else if (vcc_IdIs(t_field, "host_header")) {
@@ -430,9 +448,19 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	vcc_FieldsOk(tl, fs);
 	ERRCHK(tl);
 
-	/* Check that the hostname makes sense */
-	assert(t_host != NULL);
-	Emit_Sockaddr(tl, t_host, t_port);
+	if (t_host == NULL && t_path == NULL) {
+		VSB_printf(tl->sb, "Expected .host or .path.\n");
+		vcc_ErrWhere(tl, t_be);
+		return;
+	}
+
+	assert(t_host != NULL || t_path != NULL);
+	if (t_host != NULL)
+		/* Check that the hostname makes sense */
+		Emit_Sockaddr(tl, t_host, t_port);
+	else
+		/* Check that the path can be a legal UDS */
+		Emit_Sockaddr_Un(tl, t_path, "Backend path");
 	ERRCHK(tl);
 
 	ExpectErr(tl, '}');
@@ -440,11 +468,14 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	/* We have parsed it all, emit the ident string */
 
 	/* Emit the hosthdr field, fall back to .host if not specified */
+	/* XXX If .path is specified, set "localhost". */
 	Fb(tl, 0, "\t.hosthdr = ");
 	if (t_hosthdr != NULL)
 		EncToken(tl->fb, t_hosthdr);
-	else
+	else if (t_host != NULL)
 		EncToken(tl->fb, t_host);
+	else
+		Fb(tl, 0, "\"localhost\"");
 	Fb(tl, 0, ",\n");
 
 	/* Close the struct */

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -314,6 +314,8 @@ void Resolve_Sockaddr(struct vcc *tl, const char *host, const char *defport,
     const char **ipv4, const char **ipv4_ascii, const char **ipv6,
     const char **ipv6_ascii, const char **p_ascii, int maxips,
     const struct token *t_err, const char *errid);
+void Emit_Sockaddr_Un(struct vcc *tl, const struct token *t_path,
+		      const char *errid);
 double vcc_TimeUnit(struct vcc *);
 void vcc_ByteVal(struct vcc *, double *);
 void vcc_NumVal(struct vcc *, double *, int *);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -693,6 +693,13 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 	case CSTR:
 		assert(fmt != VOID);
 		if (fmt == IP) {
+			if (tl->t->dec[0] == '/') {
+				VSB_printf(tl->sb,
+					"Cannot convert to an IP address: ");
+				vcc_ErrToken(tl, tl->t);
+				vcc_ErrWhere(tl, tl->t);
+				return;
+			}
 			Resolve_Sockaddr(tl, tl->t->dec, "80",
 			    &ip, NULL, &ip, NULL, NULL, 1,
 			    tl->t, "IP constant");

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -33,6 +33,10 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
 
 #include "vcc_compile.h"
 
@@ -161,6 +165,7 @@ rs_callback(void *priv, const struct suckaddr *vsa)
 	assert(VSA_Sane(vsa));
 
 	v = VSA_Get_Proto(vsa);
+	assert(v != AF_UNIX);
 	VTCP_name(vsa, a, sizeof a, p, sizeof p);
 	VSB_printf(rss->vsb, "\t%s:%s\n", a, p);
 	if (v == AF_INET) {
@@ -250,6 +255,41 @@ Resolve_Sockaddr(struct vcc *tl,
 	}
 	VSB_destroy(&rss->vsb);
 	FREE_OBJ(rss);
+}
+
+/*
+ * For UDS, we defer creation of the VSA until VRT_new_backend is called.
+ * Check if it's an absolute path, can be accessed, and is a socket. If
+ * so, just emit the path field and set the IP suckaddrs to NULL.
+ */
+void
+Emit_Sockaddr_Un(struct vcc *tl, const struct token *t_path, const char *errid)
+{
+	struct stat st;
+
+	AN(t_path->dec);
+
+	if (t_path->dec[0] != '/') {
+		VSB_printf(tl->sb,
+			   "%s: Must be an absolute path:\n", errid);
+		vcc_ErrWhere(tl, t_path);
+		return;
+	}
+	errno = 0;
+	if (stat(t_path->dec, &st) != 0) {
+		VSB_printf(tl->sb, "%s: Cannot stat: %s\n", errid,
+			   strerror(errno));
+		vcc_ErrWhere(tl, t_path);
+		return;
+	}
+	if (! S_ISSOCK(st.st_mode)) {
+		VSB_printf(tl->sb, "%s: Not a socket:\n", errid);
+		vcc_ErrWhere(tl, t_path);
+		return;
+	}
+	Fb(tl, 0, "\t.path = \"%s\",\n", t_path->dec);
+	Fb(tl, 0, "\t.ipv4_suckaddr = (void *) 0,\n");
+	Fb(tl, 0, "\t.ipv6_suckaddr = (void *) 0,\n");
 }
 
 /*--------------------------------------------------------------------
@@ -405,4 +445,3 @@ vcc_ByteVal(struct vcc *tl, double *d)
 	vcc_NextToken(tl);
 	*d = v * sc;
 }
-

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -267,6 +267,7 @@ Emit_Sockaddr_Un(struct vcc *tl, const struct token *t_path, const char *errid)
 {
 	struct stat st;
 
+	AN(t_path);
 	AN(t_path->dec);
 
 	if (t_path->dec[0] != '/') {

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -157,6 +157,19 @@ $Method VOID .refresh(STRING addr, STRING port)
 
 Dynamically refresh & (always!) replace the backend by a new one.
 
+$Object dyn_uds(STRING path)
+
+Dynamically create a single-backend director listening at a Unix
+domain socket, path must not be empty.
+
+$Method BACKEND .backend()
+
+Return the dynamic UDS backend.
+
+$Method VOID .refresh(STRING path)
+
+Dynamically refresh & (always!) replace the backend by a new UDS backend.
+
 $Function VOID workspace_allocate(ENUM { client, backend, session, thread },
 	  INT size)
 

--- a/lib/libvmod_debug/vmod_debug_dyn.c
+++ b/lib/libvmod_debug/vmod_debug_dyn.c
@@ -71,7 +71,7 @@ dyn_dir_init(VRT_CTX, struct xyzzy_debug_dyn *dyn,
 	AZ(getaddrinfo(addr, port, &hints, &res));
 	XXXAZ(res->ai_next);
 
-	sa = VSA_Malloc(res->ai_addr, res->ai_addrlen);
+	sa = VSA_Malloc(res->ai_addr, res->ai_addrlen, NULL);
 	AN(sa);
 	if (VSA_Get_Proto(sa) == AF_INET) {
 		vrt.ipv4_addr = addr;

--- a/lib/libvmod_debug/vmod_debug_dyn.c
+++ b/lib/libvmod_debug/vmod_debug_dyn.c
@@ -180,7 +180,7 @@ xyzzy_dyn_refresh(VRT_CTX, struct xyzzy_debug_dyn *dyn,
 	dyn_dir_init(ctx, dyn, addr, port);
 }
 
-int
+static int
 dyn_uds_init(VRT_CTX, struct xyzzy_debug_dyn_uds *uds, VCL_STRING path)
 {
 	struct director *dir, *dir2;

--- a/lib/libvmod_debug/vmod_debug_dyn.c
+++ b/lib/libvmod_debug/vmod_debug_dyn.c
@@ -262,7 +262,7 @@ xyzzy_dyn_uds__fini(struct xyzzy_debug_dyn_uds **udsp)
 	free(uds->vcl_name);
 	AZ(pthread_mutex_destroy(&uds->mtx));
 	FREE_OBJ(uds);
-	udsp = NULL;
+	*udsp = NULL;
 }
 
 VCL_BACKEND v_matchproto_(td_debug_dyn_uds_backend)

--- a/lib/libvmod_debug/vmod_debug_dyn.c
+++ b/lib/libvmod_debug/vmod_debug_dyn.c
@@ -32,6 +32,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
 
 #include "cache/cache.h"
 #include "cache/cache_director.h"
@@ -42,6 +46,14 @@
 struct xyzzy_debug_dyn {
 	unsigned		magic;
 #define VMOD_DEBUG_DYN_MAGIC	0x9b77ccbd
+	pthread_mutex_t		mtx;
+	char			*vcl_name;
+	struct director		*dir;
+};
+
+struct xyzzy_debug_dyn_uds {
+	unsigned		magic;
+#define VMOD_DEBUG_UDS_MAGIC	0x6c7370e6
 	pthread_mutex_t		mtx;
 	char			*vcl_name;
 	struct director		*dir;
@@ -166,4 +178,106 @@ xyzzy_dyn_refresh(VRT_CTX, struct xyzzy_debug_dyn *dyn,
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(dyn, VMOD_DEBUG_DYN_MAGIC);
 	dyn_dir_init(ctx, dyn, addr, port);
+}
+
+int
+dyn_uds_init(VRT_CTX, struct xyzzy_debug_dyn_uds *uds, VCL_STRING path)
+{
+	struct director *dir, *dir2;
+	struct vrt_backend vrt;
+	struct stat st;
+
+	if (path == NULL) {
+		VRT_fail(ctx, "path is NULL");
+		return (-1);
+	}
+	if (*path != '/') {
+		VRT_fail(ctx, "path must be an absolute path: %s", path);
+		return (-1);
+	}
+	errno = 0;
+	if (stat(path, &st) != 0) {
+		VRT_fail(ctx, "Cannot stat path %s: %s", path, strerror(errno));
+		return (-1);
+	}
+	if (! S_ISSOCK(st.st_mode)) {
+		VRT_fail(ctx, "%s is not a socket", path);
+		return (-1);
+	}
+
+	INIT_OBJ(&vrt, VRT_BACKEND_MAGIC);
+	vrt.path = path;
+	vrt.vcl_name = uds->vcl_name;
+	vrt.hosthdr = "localhost";
+	vrt.ipv4_suckaddr = NULL;
+	vrt.ipv6_suckaddr = NULL;
+
+	if ((dir = VRT_new_backend(ctx, &vrt)) == NULL)
+		return (-1);
+
+	AZ(pthread_mutex_lock(&uds->mtx));
+	dir2 = uds->dir;
+	uds->dir = dir;
+	AZ(pthread_mutex_unlock(&uds->mtx));
+
+	if (dir2 != NULL)
+		VRT_delete_backend(ctx, &dir2);
+	return (0);
+}
+
+VCL_VOID v_matchproto_(td_debug_dyn_uds__init)
+xyzzy_dyn_uds__init(VRT_CTX, struct xyzzy_debug_dyn_uds **udsp,
+		    const char *vcl_name, VCL_STRING path)
+{
+	struct xyzzy_debug_dyn_uds *uds;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(udsp);
+	AZ(*udsp);
+	AN(vcl_name);
+
+	ALLOC_OBJ(uds, VMOD_DEBUG_UDS_MAGIC);
+	AN(uds);
+	REPLACE(uds->vcl_name, vcl_name);
+	AZ(pthread_mutex_init(&uds->mtx, NULL));
+
+	if (dyn_uds_init(ctx, uds, path) != 0) {
+		free(uds->vcl_name);
+		AZ(pthread_mutex_destroy(&uds->mtx));
+		FREE_OBJ(uds);
+		return;
+	}
+	*udsp = uds;
+}
+
+VCL_VOID v_matchproto_(td_debug_dyn_uds__fini)
+xyzzy_dyn_uds__fini(struct xyzzy_debug_dyn_uds **udsp)
+{
+	struct xyzzy_debug_dyn_uds *uds;
+
+	if (udsp == NULL || *udsp == NULL)
+		return;
+	CHECK_OBJ(*udsp, VMOD_DEBUG_UDS_MAGIC);
+	uds = *udsp;
+	free(uds->vcl_name);
+	AZ(pthread_mutex_destroy(&uds->mtx));
+	FREE_OBJ(uds);
+	udsp = NULL;
+}
+
+VCL_BACKEND v_matchproto_(td_debug_dyn_uds_backend)
+xyzzy_dyn_uds_backend(VRT_CTX, struct xyzzy_debug_dyn_uds *uds)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(uds, VMOD_DEBUG_UDS_MAGIC);
+	AN(uds->dir);
+	return (uds->dir);
+}
+
+VCL_VOID v_matchproto_(td_debug_dyn_uds_refresh)
+xyzzy_dyn_uds_refresh(VRT_CTX, struct xyzzy_debug_dyn_uds *uds, VCL_STRING path)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(uds, VMOD_DEBUG_UDS_MAGIC);
+	(void) dyn_uds_init(ctx, uds, path);
 }

--- a/lib/libvmod_debug/vmod_debug_dyn.c
+++ b/lib/libvmod_debug/vmod_debug_dyn.c
@@ -83,7 +83,7 @@ dyn_dir_init(VRT_CTX, struct xyzzy_debug_dyn *dyn,
 	AZ(getaddrinfo(addr, port, &hints, &res));
 	XXXAZ(res->ai_next);
 
-	sa = VSA_Malloc(res->ai_addr, res->ai_addrlen, NULL);
+	sa = VSA_Malloc(res->ai_addr, res->ai_addrlen);
 	AN(sa);
 	if (VSA_Get_Proto(sa) == AF_INET) {
 		vrt.ipv4_addr = addr;

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -54,8 +54,15 @@ VCL_VOID v_matchproto_(td_std_set_ip_tos)
 vmod_set_ip_tos(VRT_CTX, VCL_INT tos)
 {
 	int itos = tos;
+	struct suckaddr *sa;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AZ(SES_Get_local_addr(ctx->req->sp, &sa));
+	if (VSA_Get_Proto(sa) == PF_UNIX) {
+		VRT_fail(ctx, "std.set_ip_tos() cannot be applied to a Unix "
+			 "domain socket");
+		return;
+	}
 	VTCP_Assert(setsockopt(ctx->req->sp->fd,
 	    IPPROTO_IP, IP_TOS, &itos, sizeof(itos)));
 }

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -106,7 +106,8 @@ vmod_ip(VRT_CTX, VCL_STRING s, VCL_IP d, VCL_BOOL n)
 		error = getaddrinfo(s, "80", &hints, &res0);
 		if (!error) {
 			for (res = res0; res != NULL; res = res->ai_next) {
-				r = VSA_Build(p, res->ai_addr, res->ai_addrlen);
+				r = VSA_Build(p, res->ai_addr, res->ai_addrlen,
+					      NULL);
 				if (r != NULL)
 					break;
 			}

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -109,8 +109,7 @@ vmod_ip(VRT_CTX, VCL_STRING s, VCL_IP d, VCL_BOOL n)
 		error = getaddrinfo(s, "80", &hints, &res0);
 		if (!error) {
 			for (res = res0; res != NULL; res = res->ai_next) {
-				r = VSA_Build(p, res->ai_addr, res->ai_addrlen,
-					      NULL);
+				r = VSA_Build(p, res->ai_addr, res->ai_addrlen);
 				if (r != NULL)
 					break;
 			}

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -86,8 +86,11 @@ vmod_ip(VRT_CTX, VCL_STRING s, VCL_IP d, VCL_BOOL n)
 	const struct suckaddr *r;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	AN(d);
-	assert(VSA_Sane(d));
+	/* XXX VRT_Fail on one or both of these conditions? */
+	if (d != NULL)
+		assert(VSA_Sane(d));
+	if (s[0] == '/')
+		return d;
 
 	p = WS_Alloc(ctx->ws, vsa_suckaddr_len);
 	if (p == NULL) {


### PR DESCRIPTION
This is a partial implementation of the ideas proposed in VIP17.

In VIP17 but not implemented yet:
* UDS addresses for varnishadm and the CLI (``-T`` and ``-M`` args).
* param ``uds_path`` as a search path for relative paths in backend definitions.
  * At the moment, all paths for a UDS are required to begin with a ``/``.
* Obtaining credentials of the peer over the UDS (uid, gid) and making them available via VMOD std.
* Named listen addresses (@Dridi will be working on that separately).

**Update**: At the end of VIP17 (section "Implementation"), I've written down some proposals for how these features could be implemented -- ``-T`` and ``-M``, ``uds_path``, and additions to VMOD std.

The big picture: ``-a`` addresses can be specified as:
```
-a /path/to/uds[,[PROXY,][user=<user>,][group=<group>,][mode=<mode>]]
```
If you specify any of ``user``, ``group`` and/or ``mode`` (mode in octal), then the path will be created with those permissions. (The sub-args can appear in any order.)

A backend definition may have:
```
backend foo { .path = "/path/to/uds"; }
```
``.path`` XOR ``.host`` must be specified for a backend.

You can also use ``-b /path/to/uds`` to define a backend on the command line.

This code has been tested on:
* Linux 3.16 (Debian jessie 3.16.43-2+deb8u2) and 4.9 (Debian jessie 8.9, 4.9.30-2+deb9u2~bpo8+1)
* FreeBSD 11.0-RELEASE-p9
* SunOS 5.11 (joyent_20160317T000621Z)

There are quite a few details and issues worth considering for a review. So as to break it up into small pieces, I'll add more comments about those issues (and point out some interesting quirks about UDSen that I discovered along the way).

**Update**: Branches with the fork rebased to Varnish 5.2.0 and 5.2.1 live here:
* https://github.com/slimhazard/varnish-cache/tree/5.2.0-uds
* https://github.com/slimhazard/varnish-cache/tree/5.2.1-uds

RPMs for el7 for the two forks live at: https://packagecloud.io/uplex/varnish-uds