### PR TITLE
Fix problem with purging and the n_obj_purged counter

### DIFF
--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -590,7 +590,7 @@ HSH_Purge(struct worker *wrk, struct objhead *oh, double ttl, double grace,
 double keep)
 {
 	struct objcore *oc, **ocp;
-	unsigned spc, ospc, nobj, n;
+	unsigned spc, ospc, nobj, n, n_tot = 0;
 	int more = 0;
 	double now;
 
@@ -598,6 +598,20 @@ double keep)
 	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
 	ospc = WS_Reserve(wrk->aws, 0);
 	assert(ospc >= sizeof *ocp);
+	/*
+	 * Because of "soft" purges, there might be oc's in the list that has
+	 * the OC_F_PURGED flag set. We do not want to let these slip through,
+	 * so we need to clear the flag before entering the do..while loop.
+	 */
+	Lck_Lock(&oh->mtx);
+	assert(oh->refcnt > 0);
+	VTAILQ_FOREACH(oc, &oh->objcs, hsh_list) {
+		CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+		assert(oc->objhead == oh);
+		oc->flags &= ~OC_F_PURGED;
+	}
+	Lck_Unlock(&oh->mtx);
+
 	do {
 		more = 0;
 		spc = ospc;
@@ -621,6 +635,15 @@ double keep)
 			}
 			if (oc->flags & OC_F_DYING)
 				continue;
+			if (oc->flags & OC_F_PURGED) {
+				/*
+				 * We have already called EXP_Rearm on this
+				 * object, and we do not want to do it
+				 * again. Plus the space in the ocp array may
+				 * be limited.
+				 */
+				continue;
+			}
 			if (spc < sizeof *ocp) {
 				/* Iterate if aws is not big enough */
 				more = 1;
@@ -629,6 +652,7 @@ double keep)
 			oc->refcnt++;
 			spc -= sizeof *ocp;
 			ocp[nobj++] = oc;
+			oc->flags |= OC_F_PURGED;
 		}
 		Lck_Unlock(&oh->mtx);
 
@@ -638,9 +662,10 @@ double keep)
 			EXP_Rearm(oc, now, ttl, grace, keep);
 			(void)HSH_DerefObjCore(wrk, &oc, 0);
 		}
+		n_tot += nobj;
 	} while (more);
 	WS_Release(wrk->aws, 0);
-	Pool_PurgeStat(nobj);
+	Pool_PurgeStat(n_tot);
 }
 
 /*---------------------------------------------------------------------

--- a/bin/varnishtest/tests/r02372.vtc
+++ b/bin/varnishtest/tests/r02372.vtc
@@ -1,0 +1,32 @@
+varnishtest "Count purges when there are many variants"
+
+server s1 -repeat 40 {
+	rxreq
+	txresp -hdr "Vary: foo"
+} -start
+
+varnish v1 -arg "-p workspace_thread=256" -vcl+backend {
+	import std;
+
+	sub vcl_recv {
+		if (req.method == "PURGE") {
+			return (purge);
+		}
+		set req.http.foo = "x" + std.random(1,10) * 1000000000;
+	}
+} -start
+
+client c1 -repeat 40 {
+	txreq
+	rxresp
+} -run
+
+client c2 {
+	txreq -req "PURGE"
+	rxresp
+} -run
+
+varnish v1 -expect n_lru_nuked == 0
+varnish v1 -expect cache_hit == 0
+varnish v1 -expect n_purges == 1
+varnish v1 -expect n_obj_purged == 40

--- a/include/tbl/oc_flags.h
+++ b/include/tbl/oc_flags.h
@@ -28,6 +28,7 @@
 
 /*lint -save -e525 -e539 */
 
+OC_FLAG(PURGED,		purged,		(1<<0))
 OC_FLAG(BUSY,		busy,		(1<<1))
 OC_FLAG(PASS,		pass,		(1<<2))
 OC_FLAG(HFP,		hfp,		(1<<3))


### PR DESCRIPTION
The events leading to this patch started with me looking at different counters and their documentation. I realized that the counter `n_obj_purged` is not correctly implemented. Unfortunately, the bug is worse than this, as described in the commit message. The test on the `oc->ttl` is ugly, but it is there because the `oc->flags` is just 8 bits, and they are all taken. A "competing" patch is in https://github.com/hermunn/varnish-cache/tree/master-unpopular-fix-n_obj_purged, but, as you can see from the name of the branch, I do not think it will be popular. Please have a look at both before commenting.

The two fixes (this and the unpolular) causes different behavior in the following scenario:
* A "soft purge" sets the TTL of the object to 30 seconds.
* Shortly after, a "soft purge" sets the TTL to 60 seconds.
(keep and grace are set to the same value in the two "soft purge" calls).

In the unpopular branch the resulting TTL will be 60 seconds, while on this it will be 30 seconds, and `n_obj_purged` will be the number of times the TTL changed.
