### PR TITLE
Expose to VCL whether or not a fetch is a background fetch

### DIFF
--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -203,6 +203,14 @@ VRT_r_beresp_##field(VRT_CTX)						\
 /*--------------------------------------------------------------------*/
 
 unsigned
+VRT_r_bereq_is_bgfetch(VRT_CTX)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+	return (ctx->bo->is_bgfetch);
+}
+
+unsigned
 VRT_r_bereq_uncacheable(VRT_CTX)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);

--- a/bin/varnishtest/tests/r01399.vtc
+++ b/bin/varnishtest/tests/r01399.vtc
@@ -4,6 +4,7 @@ barrier b1 cond 2
 
 server s1 {
 	rxreq
+	expect req.http.Is-bg == "false"
 	txresp -bodylen 1
 
 	barrier b1 sync
@@ -19,11 +20,15 @@ server s1 {
 	# And see if it has all its marbles still...
 	rxreq
 	expect req.url == "/"
+	expect req.http.Is-bg == "true"
 	txresp -bodylen 2
 
 } -start
 
 varnish v1 -vcl+backend {
+	sub vcl_backend_fetch {
+		set bereq.http.Is-bg = bereq.is_bgfetch;
+	}
 	sub vcl_backend_response {
 		set beresp.do_stream = false;
 		set beresp.ttl = 2s;

--- a/include/tbl/bo_flags.h
+++ b/include/tbl/bo_flags.h
@@ -39,6 +39,7 @@ BO_FLAG(uncacheable,	0, 0, "")
 BO_FLAG(is_gzip,	0, 0, "")
 BO_FLAG(is_gunzip,	0, 0, "")
 BO_FLAG(was_304,	1, 0, "")
+BO_FLAG(is_bgfetch,	0, 0, "")
 #undef BO_FLAG
 
 /*lint -restore */

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -478,6 +478,13 @@ sp_variables = [
 		backend.  Not available in pipe mode.
 		"""
 	),
+	('bereq.is_bgfetch',
+		'BOOL',
+		('backend', ),
+		(), """
+		True for background fetches.
+		"""
+	),
 	('beresp',
 		'HTTP',
 		('backend_response', 'backend_error'),


### PR DESCRIPTION
The use case are cluster requests: Intra-cluster bgfetches should trigger a synchronous fetch on the peer-varnish in order to avoid additional short-lived / expired objects being created. Or, in other words, a bgfetch should actually get a fresh object and not one in grace from another cache.