### PR TITLE
Move the cli buffer to malloc (from stack)

### DIFF
--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -66,6 +66,8 @@ static int		cli_i = -1, cli_o = -1;
 struct VCLS		*mgt_cls;
 static const char	*secret_file;
 
+struct vsb		*cli_buf = NULL;
+
 /*--------------------------------------------------------------------*/
 
 static void
@@ -176,24 +178,30 @@ mgt_cli_askchild(unsigned *status, char **resp, const char *fmt, ...)
 	int i, j;
 	va_list ap;
 	unsigned u;
-	char buf[mgt_param.cli_buffer], *p;
+
+	if (cli_buf == NULL) {
+		cli_buf = VSB_new_auto();
+		AN(cli_buf);
+	} else {
+		VSB_clear(cli_buf);
+	}
 
 	if (resp != NULL)
 		*resp = NULL;
 	if (status != NULL)
 		*status = 0;
-	if (cli_i < 0|| cli_o < 0) {
+	if (cli_i < 0 || cli_o < 0) {
 		if (status != NULL)
 			*status = CLIS_CANT;
 		return (CLIS_CANT);
 	}
 	va_start(ap, fmt);
-	vbprintf(buf, fmt, ap);
+	AZ(VSB_vprintf(cli_buf, fmt, ap));
 	va_end(ap);
-	p = strchr(buf, '\0');
-	assert(p != NULL && p > buf && p[-1] == '\n');
-	i = p - buf;
-	j = write(cli_o, buf, i);
+	VSB_finish(cli_buf);
+	i = VSB_len(cli_buf);
+	assert(i > 0 && VSB_data(cli_buf)[i - 1] == '\n');
+	j = write(cli_o, VSB_data(cli_buf), i);
 	if (j != i) {
 		if (status != NULL)
 			*status = CLIS_COMMS;

--- a/bin/varnishtest/tests/r02382.vtc
+++ b/bin/varnishtest/tests/r02382.vtc
@@ -1,0 +1,21 @@
+varnishtest "Very very big cli_buffer"
+
+# If the cli_buffer is on the stack, setting it very big can crash varnish
+
+server s1 {
+       rxreq
+       expect req.url == "/1"
+       txresp
+} -start
+
+varnish v1 -arg "-p cli_buffer=32M" -vcl+backend {
+} -start
+
+varnish v1 -cliok "ping"
+
+delay .5
+
+client c1 {
+       txreq -url /1
+       rxresp
+} -run

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -294,10 +294,8 @@ PARAM(
 	/* units */	"bytes",
 	/* flags */	0,
 	/* s-text */
-	"Size of buffer for CLI command input.\n"
-	"You may need to increase this if you have big VCL files and use "
-	"the vcl.inline CLI command.\n"
-	"NB: Must be specified with -p to have effect.",
+	"DEPRECATED: This parameter is ignored.\n"
+	"Memory for the CLI command buffer is now dynamically allocated.",
 	/* l-text */	"",
 	/* func */	NULL
 )


### PR DESCRIPTION
If the cli buffer is allocated on the stack, the mgt process will crash
hard for big values of this parameter. Instead we allocate on the heap.

A new error is introduced, "CLI buffer overrun", when the buffer is too
small for the payload.

(I will change the file name for the test as soon as a number is assigned)