### PR TITLE
Fix sourcing of varnish.m4 when building on FreeBSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4 -I .
 
 SUBDIRS = include lib bin etc doc man
 


### PR DESCRIPTION
Noticed when switching to Github for fetching source on FreeBSD and using autotools it never correctly sources varnish.m4 so configure fails with obtuse errors about missing functions which are defined in varnish.m4.