### PR TITLE
Refuse h2 streams that can't be scheduled

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -294,9 +294,13 @@ enum task_prio {
 	TASK_QUEUE_BO,
 #define TASK_QUEUE_RESERVE	TASK_QUEUE_BO
 	TASK_QUEUE_REQ,
+	TASK_QUEUE_STR,
 	TASK_QUEUE_VCA,
 	TASK_QUEUE_END
 };
+
+#define TASK_QUEUE_CLIENT(prio) \
+	(prio == TASK_QUEUE_REQ || prio == TASK_QUEUE_STR)
 
 /*--------------------------------------------------------------------*/
 

--- a/bin/varnishd/cache/cache_pool.h
+++ b/bin/varnishd/cache/cache_pool.h
@@ -50,7 +50,8 @@ struct pool {
 	unsigned			nthr;
 	unsigned			dry;
 	unsigned			lqueue;
-	uintmax_t			ndropped;
+	uintmax_t			sdropped;
+	uintmax_t			rdropped;
 	uintmax_t			nqueued;
 	struct dstat			*a_stat;
 	struct dstat			*b_stat;

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -269,8 +269,8 @@ Pool_Task(struct pool *pp, struct pool_task *task, enum task_prio prio)
 	 * work is vital and needs do be done at the earliest
 	 */
 	if (prio != TASK_QUEUE_REQ ||
-	    pp->lqueue < cache_param->wthread_max +
-	    cache_param->wthread_queue_limit + pp->nthr) {
+	    pp->lqueue + pp->nthr < cache_param->wthread_max +
+	    cache_param->wthread_queue_limit) {
 		pp->nqueued++;
 		pp->lqueue++;
 		VTAILQ_INSERT_TAIL(&pp->queues[prio], task, list);

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -530,7 +530,8 @@ h2_end_headers(struct worker *wrk, const struct h2_sess *h2,
 	req->task.func = h2_do_req;
 	req->task.priv = req;
 	r2->scheduled = 1;
-	XXXAZ(Pool_Task(wrk->pool, &req->task, TASK_QUEUE_REQ));
+	if (Pool_Task(wrk->pool, &req->task, TASK_QUEUE_REQ) != 0)
+		return (H2SE_REFUSED_STREAM); //rfc7540,l,3326,3329
 	return (0);
 }
 

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -530,7 +530,7 @@ h2_end_headers(struct worker *wrk, const struct h2_sess *h2,
 	req->task.func = h2_do_req;
 	req->task.priv = req;
 	r2->scheduled = 1;
-	if (Pool_Task(wrk->pool, &req->task, TASK_QUEUE_REQ) != 0)
+	if (Pool_Task(wrk->pool, &req->task, TASK_QUEUE_STR) != 0)
 		return (H2SE_REFUSED_STREAM); //rfc7540,l,3326,3329
 	return (0);
 }

--- a/bin/varnishd/main.vsc
+++ b/bin/varnishd/main.vsc
@@ -240,8 +240,14 @@
 .. varnish_vsc:: sess_dropped
 	:oneliner:	Sessions dropped for thread
 
-	Number of times session was dropped because the queue were too long
-	already. See also parameter thread_queue_limit.
+	Number of times an HTTP/1 session was dropped because the queue was
+	too long already. See also parameter thread_queue_limit.
+
+.. varnish_vsc:: req_dropped
+	:oneliner:	Requests dropped
+
+	Number of times an HTTP/2 stream was refused because the queue was
+	too long already. See also parameter thread_queue_limit.
 
 .. varnish_vsc:: n_object
 	:type:	gauge

--- a/bin/varnishtest/tests/t02011.vtc
+++ b/bin/varnishtest/tests/t02011.vtc
@@ -1,0 +1,68 @@
+varnishtest "Can't schedule stream"
+
+barrier b1 sock 3
+barrier b2 sock 3
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+# We need to confirm that a refused stream doesn't harm other streams, so we
+# want a round trip to the backend to ensure that. This requires 3 threads to
+# be busy simultaneously before a stream can be refused:
+#
+# - one for c1's session
+# - one for stream 1
+# - one for the backend request
+#
+# To work around the reserve's default logic, an additional thread can be
+# created, but won't be consumed for stream 3 because the pool will reserve
+# it for a backend transaction. Otherwise it could starve the pool and dead
+# lock v1.
+
+varnish v1 -cliok "param.set thread_pools 1"
+varnish v1 -cliok "param.set thread_pool_min 4"
+varnish v1 -cliok "param.set thread_pool_max 4"
+varnish v1 -cliok "param.set thread_pool_reserve 1"
+varnish v1 -cliok "param.set thread_queue_limit 0"
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.set debug +syncvsl"
+
+varnish v1 -vcl+backend {
+	import vtc;
+
+	sub vcl_recv {
+		if (req.http.should == "reset") {
+			return (fail);
+		}
+	}
+
+	sub vcl_backend_fetch {
+		vtc.barrier_sync("${b1_sock}");
+		vtc.barrier_sync("${b2_sock}");
+	}
+} -start
+
+client c1 {
+	txpri
+	stream 0 rxsettings -run
+
+	stream 1 {
+		txreq -hdr should sync
+		barrier b1 sync
+		barrier b2 sync
+		rxresp
+		expect resp.status == 200
+	} -start
+
+	barrier b1 sync
+
+	stream 3 {
+		txreq -hdr should reset
+		rxrst
+		expect rst.err == REFUSED_STREAM
+	} -run
+
+	barrier b2 sync
+} -run

--- a/bin/varnishtest/tests/t02011.vtc
+++ b/bin/varnishtest/tests/t02011.vtc
@@ -26,6 +26,7 @@ varnish v1 -cliok "param.set thread_pool_min 4"
 varnish v1 -cliok "param.set thread_pool_max 4"
 varnish v1 -cliok "param.set thread_pool_reserve 1"
 varnish v1 -cliok "param.set thread_queue_limit 0"
+varnish v1 -cliok "param.set thread_stats_rate 1"
 varnish v1 -cliok "param.set feature +http2"
 varnish v1 -cliok "param.set debug +syncvsl"
 
@@ -66,3 +67,10 @@ client c1 {
 
 	barrier b2 sync
 } -run
+
+# trigger an update of the stats
+varnish v1 -cliok "param.set thread_pool_min 3"
+delay 1
+varnish v1 -expect sess_drop == 0
+varnish v1 -expect sess_dropped == 0
+varnish v1 -expect req_dropped == 1


### PR DESCRIPTION
The initial plan was a one-liner to get rid of an `XXXAZ` assert (2nd patch) but testing this case proved to be hard because of a bug in the thread pools (fixed in 1st patch) and while I was playing a bit with h2 resets I realized that the `sess_drop` counters includes streams so I introduced a new `req_drop` counter (3rd patch).

I expect the 3rd patch to be potentially controversial, but I tried to keep the changes to a minimum.

As a side note, since we are breaking libvarnishapi, it may be a good occasion to sort the counters. For example `sess_drop` and `sess_dropped` could be next to each other.