### PR TITLE
Improve handling an unresponsive child (worker) process

### DIFF
--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -68,6 +68,16 @@ void MAC_Arg(const char *);
 void MAC_reopen_sockets(void);
 
 /* mgt_child.c */
+enum child_state_e {
+	CH_STOPPED = 0,
+	CH_STARTING = 1,
+	CH_RUNNING = 2,
+	CH_STOPPING = 3,
+	CH_NOT_RESPONDING = 4,
+	CH_DIED = 5
+};
+extern enum child_state_e child_state;
+
 void MCH_Init(void);
 int MCH_Running(void);
 void MCH_Stop_Child(void);

--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -213,7 +213,12 @@ mgt_cli_askchild(unsigned *status, char **resp, const char *fmt, ...)
 		return (CLIS_COMMS);
 	}
 
-	if (VCLI_ReadResult(cli_i, &u, resp, mgt_param.cli_timeout))
+	// For CH_NOT_RESPONDING, it's useless to wait for the full timeout
+	// again. XXX: better idea? Should be shorter than varnishadm default
+	// timeout
+	if (VCLI_ReadResult(cli_i, &u, resp,
+			    child_state == CH_NOT_RESPONDING ? 1 :
+			    mgt_param.cli_timeout))
 		MCH_Cli_Fail();
 	if (status != NULL)
 		*status = u;


### PR DESCRIPTION
(more info after the commit message)

auto_restart: Previously, we would not restart _yet still kill_ an unresponsive child. Now, we leave it alone for `auto_restart == false`

We now differentiate between the states `died` and `not responding`.

For a start command, any unresponsive child gets terminated irrespective of the `auto_restart` parameter.

* use case:

I wanted to halt a varnish worker process for testing and noticed that it still got killed even with `auto_restart == false`, which came as a surprise.

* demo (slightly edited for legibility)

```
$ sudo /tmp/sbin/varnishd -a 127.0.0.1:80 -b 127.0.0.1:8080
Debug: Platform: Linux,3.16.0-4-amd64,x86_64,-junix,-smalloc,-smalloc,-hcritbit
Debug: Child (22757) Started

$ sudo /tmp/bin/varnishadm param.set auto_restart false
$ sudo /tmp/bin/varnishadm param.set cli_timeout 5

$ vpid=$(pgrep -u vcache -f varnishd)
$ sudo kill -STOP $vpid &&
  sleep 10 &&
  sudo /tmp/bin/varnishadm status &&
  sudo kill -CONT $vpid
Child in state not responding

# some seconds later
$ sudo /tmp/bin/varnishadm status
Child in state running

# child did not get killed
$ sudo /tmp/bin/varnishstat -1 -f MGT.chi*
MGT.child_start              1         0.00 Child process started
MGT.child_exit               0         0.00 Child process normal exit
MGT.child_stop               0         0.00 Child process unexpected exit
MGT.child_died               0         0.00 Child process died (signal)
MGT.child_dump               0         0.00 Child process core dumped
MGT.child_panic              0         0.00 Child process panic

```