### PR TITLE
Ignore req.ttl when keeping track of epired objects

### DIFF
--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -461,7 +461,8 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 			*ocp = oc;
 			return (HSH_HIT);
 		}
-		if (oc->t_origin > exp_t_origin) {
+		if (EXP_Ttl(NULL, oc) < req->t_req && /* ignore req.ttl */
+		    oc->t_origin > exp_t_origin) {
 			/* record the newest object */
 			exp_oc = oc;
 			exp_t_origin = oc->t_origin;


### PR DESCRIPTION
The goal of `req.ttl` is to allow lower requirements for known
transactions (since this has to be done in VCL) but objects with
a TTL lower than `req.ttl` would always be considered expired
during lookup even if their actual TTL (obj.ttl) is still positive.

Ignoring `req.ttl` gives a better control over explicit refreshes
made to optimize latency and greatly reduces the risk of running
into #1799 (for a subset of use cases).