### PR TITLE
bugfix : coredump causes by memcpy in vbf_stp_error

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -899,6 +899,7 @@ vbf_stp_error(struct worker *wrk, struct busyobj *bo)
 		l = ll;
 		if (VFP_GetStorage(bo->vfc, &l, &ptr) != VFP_OK)
 			break;
+		if (l > ll) l = ll;
 		memcpy(ptr, VSB_data(synth_body) + o, l);
 		VFP_Extend(bo->vfc, l);
 		ll -= l;


### PR DESCRIPTION
See the code in vbf_stp_error(cache_fetch.c). The variable of l is the storage size that has been got, while ll is the length of VSB_data(synth_body).

In this case, the third parameter of memcpy is 4096, but the actual length of VSB_data(synth_body) is only 284. If the memory from VSB_data(synth_body)+284 is unavailable, coredump will occur!