### PR TITLE
Allow to not have randomness in file_id

### DIFF
--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -36,6 +36,7 @@ Read the vmod.vcc file (inputvcc) and produce:
 # This script should work with both Python 2 and Python 3.
 from __future__ import print_function
 
+import hashlib
 import os
 import sys
 import re
@@ -988,8 +989,14 @@ class vcc(object):
         # VCC and VRT_Vmod_Init() dlopens the same file
         #
         fo.write("\t.file_id =\t\"")
-        for i in range(32):
-            fo.write("%c" % random.randint(0x40, 0x5a))
+        if os.getenv("SOURCE_DATE_EPOCH"):
+            m = hashlib.md5()
+            m.update(self.modname.encode('utf-8'))
+            m.update(os.getenv("SOURCE_DATE_EPOCH").encode('utf-8'))
+            fo.write(m.hexdigest())
+        else:
+            for i in range(32):
+                fo.write("%c" % random.randint(0x40, 0x5a))
         fo.write("\",\n")
         fo.write("};\n")
 


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Debian is approaching this with
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=835061
which fixes the rand seed, but I was afraid that this might produce
different files with identical file_id values.

There could be a third approach possible where all relevant inputs
are hashed into the file_id value, so that it differs when inputs change
but remains the same otherwise.