### PR TITLE
Expose the varnishd optstring via -x

### DIFF
--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -74,6 +74,8 @@ static struct vpf_fh *pfh2 = NULL;
 static struct vfil_path *vcl_path = NULL;
 static VTAILQ_HEAD(,f_arg) f_args = VTAILQ_HEAD_INITIALIZER(f_args);
 
+static const char opt_spec[] = "a:b:Cdf:Fh:i:I:j:l:M:n:P:p:r:S:s:T:t:VW:x:";
+
 int optreset;	// Some has it, some doesn't.  Cheaper than auto*
 
 /*--------------------------------------------------------------------*/
@@ -106,6 +108,7 @@ usage(void)
 	printf(FMT, "-x vsl", "VSL record documentation");
 	printf(FMT, "-x cli", "CLI command documentation");
 	printf(FMT, "-x builtin", "Builtin VCL program");
+	printf(FMT, "-x optstring", "List of getopt options");
 
 	printf("\nOperations options:\n");
 
@@ -297,6 +300,8 @@ mgt_x_arg(const char *x_arg)
 		mgt_DumpRstCli();
 	else if (!strcmp(x_arg, "builtin"))
 		mgt_DumpBuiltin();
+	else if (!strcmp(x_arg, "optstring"))
+		(void)printf("%s\n", opt_spec);
 	else
 		ARGV_ERR("Invalid -x argument\n");
 }
@@ -422,8 +427,6 @@ mgt_f_read(const char *fn)
 	fa->src = f;
 	VTAILQ_INSERT_TAIL(&f_args, fa, list);
 }
-
-static const char opt_spec[] = "a:b:Cdf:Fh:i:I:j:l:M:n:P:p:r:S:s:T:t:VW:x:";
 
 int
 main(int argc, char * const *argv)

--- a/doc/sphinx/reference/varnish-cli.rst
+++ b/doc/sphinx/reference/varnish-cli.rst
@@ -90,10 +90,6 @@ Commands may not end with a newline when a shell-style *here document*
 naturally in the following *here document*. Traditionally EOF or END is
 used.
 
-When using the here document style of input there are no restrictions
-on length. When using newline-terminated commands maximum length is
-limited by the varnishd parameter *cli_buffer*.
-
 Quoting pitfalls
 ----------------
 

--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -17,7 +17,7 @@ SYNOPSIS
 
 varnishd [-a [name=][address][:port][,PROTO]] [-b host[:port]] [-C] [-d] [-F] [-f config] [-h type[,options]] [-I clifile] [-i identity] [-j jail[,jailoptions]] [-l vsl[,vsm]] [-M address:port] [-n name] [-P file] [-p param=value] [-r param[,param...]] [-S secret-file] [-s [name=]kind[,options]] [-T address[:port]] [-t TTL] [-V] [-W waiter]
 
-varnishd [-x parameter|vsl|cli|builtin]
+varnishd [-x parameter|vsl|cli|builtin|optstring]
 
 varnishd [-?]
 
@@ -122,6 +122,11 @@ outputs documentation in reStructuredText, aka RST).
 -x builtin
 
   Print the contents of the default VCL program ``builtin.vcl``.
+
+-x optstring
+
+  Print the optstring parameter to ``getopt(3)`` to help writing
+  wrapper scripts.
 
 Operations options
 ------------------

--- a/doc/sphinx/users-guide/run_cli.rst
+++ b/doc/sphinx/users-guide/run_cli.rst
@@ -145,12 +145,10 @@ but they can also be examined and changed on the fly from the CLI::
 In general it is not a good idea to modify parameters unless you
 have a good reason, such as performance tuning or security configuration.
 
-Most parameters will take effect instantly, or with a natural delay
-of some duration,
-
 .. XXX: Natural delay of some duration sounds vague. benc
 
-but a few of them requires you to restart the
+Most parameters will take effect instantly, or with a natural delay
+of some duration, but a few of them requires you to restart the
 child process before they take effect. This is always noted in the
 description of the parameter.
 

--- a/doc/sphinx/users-guide/run_cli.rst
+++ b/doc/sphinx/users-guide/run_cli.rst
@@ -3,46 +3,46 @@
 CLI - bossing Varnish around
 ============================
 
-Once `varnishd` is started, you can control it using the command line
+Once ``varnishd`` is started, you can control it using the command line
 interface.
 
-The easiest way to do this, is using `varnishadm` on the
-same machine as `varnishd` is running::
+The easiest way to do this, is using ``varnishadm`` on the
+same machine as ``varnishd`` is running::
 
 	varnishadm help
 
-If you want to run `varnishadm` from a remote system, you can do it
+If you want to run ``varnishadm`` from a remote system, you can do it
 two ways.
 
-You can SSH into the `varnishd` computer and run `varnishadm`::
+You can SSH into the ``varnishd`` computer and run ``varnishadm``::
 
 	ssh $http_front_end varnishadm help
 
-But you can also configure `varnishd` to accept remote CLI connections
+But you can also configure ``varnishd`` to accept remote CLI connections
 (using the '-T' and '-S' arguments)::
 
 	varnishd -T :6082 -S /etc/varnish_secret
 
-And then on the remote system run `varnishadm`::
+And then on the remote system run ``varnishadm``::
 
 	varnishadm -T $http_front_end -S /etc/copy_of_varnish_secret help
 
 but as you can see, SSH is much more convenient.
 
-If you run `varnishadm` without arguments, it will read CLI commands from
-`stdin`, if you give it arguments, it will treat those as the single
+If you run ``varnishadm`` without arguments, it will read CLI commands from
+``stdin``, if you give it arguments, it will treat those as the single
 CLI command to execute.
 
 The CLI always returns a status code to tell how it went:  '200'
 means OK, anything else means there were some kind of trouble.
 
-`varnishadm` will exit with status 1 and print the status code on
+``varnishadm`` will exit with status 1 and print the status code on
 standard error if it is not 200.
 
 What can you do with the CLI
 ----------------------------
 
-The CLI gives you almost total control over `varnishd` some of the more important tasks you can perform are:
+The CLI gives you almost total control over ``varnishd`` some of the more important tasks you can perform are:
 
 * load/use/discard VCL programs
 * ban (invalidate) cache content
@@ -166,7 +166,7 @@ and::
 
 	varnish> start
 
-If you start `varnishd` with the '-d' (debugging) argument, you will
+If you start ``varnishd`` with the '-d' (debugging) argument, you will
 always need to start the child process explicitly.
 
 Should the child process die, the master process will automatically

--- a/doc/sphinx/users-guide/run_cli.rst
+++ b/doc/sphinx/users-guide/run_cli.rst
@@ -169,3 +169,47 @@ always need to start the child process explicitly.
 
 Should the child process die, the master process will automatically
 restart it, but you can disable that with the 'auto_restart' parameter.
+
+The shell, the other CLI
+------------------------
+
+Besides accessing the CLI via its interface or via ``varnishadm`` there
+is the matter of actually running the ``varnishd`` command line, usually
+via a shell. See :ref:`run_security` for security concerns around the
+``varnishd`` command line. See also :ref:`ref_syntax` about the CLI
+syntax and quoting pitfalls when using ``varnishadm``.
+
+The programs shipped with Varnish can expose their *optstring* in order
+to help writing wrapper scripts, in particular to get an opportunity to
+hook a task before a program daemonizes. With the exception of
+``varnishtest`` and ``varnishadm``, you can write Shell wrappers for
+``varnishd`` using the ``-x`` option and other programs using the
+``--optstring`` long option.
+
+This way, when writing a wrapper script you don't need to maintain the
+*optstring* in sync when you only need a subset of the options, usually
+``-n`` or ``-P``::
+
+    optstring=$(varnishd -x optstring)
+
+    while getopts "$optstring" opt
+    do
+        case $opt in
+        n)
+            # handle $OPTARG
+            ;;
+        # handle other options
+        *)
+            # ignore unneeded options
+            ;;
+        esac
+    done
+
+    varnishd "$@"
+
+    # do something with the options
+
+You can for example write a wrapper script that blocks until the shared
+memory is ready or when the child is started if you need that kind of
+synchronization. You can also prevent ``varnishd`` from starting if the
+``-S`` option is inadvertently set to not challenge access to the CLI.

--- a/lib/libvarnishapi/vut.c
+++ b/lib/libvarnishapi/vut.c
@@ -212,6 +212,10 @@ VUT_Init(const char *progname, int argc, char * const *argv,
 		exit(vut_synopsis(voc));
 	if (argc == 2 && !strcmp(argv[1], "--options"))
 		exit(vut_options(voc));
+	if (argc == 2 && !strcmp(argv[1], "--optstring")) {
+		(void)printf("%s\n", voc->vopt_optstring);
+		exit(0);
+	}
 
 	vut->progname = progname;
 	vut->g_arg = VSL_g_vxid;

--- a/lib/libvarnishapi/vut.c
+++ b/lib/libvarnishapi/vut.c
@@ -489,5 +489,8 @@ vut_options(const struct vopt_spec *voc)
 
 	for (i = 0; i < voc->vopt_list_n; i++)
 		print_opt(&voc->vopt_list[i]);
+	printf("--optstring\n"
+	    "\tPrint the optstring parameter to ``getopt(3)`` to help"
+	    " writing wrapper scripts.\n\n");
 	return (0);
 }


### PR DESCRIPTION
This helps write scripts like this:

    optstring=$(varnishd -x optstring)

    while getopts $optstring opt
    do
        case $opt in
        n)
            # handle $OPTARG
            ;;
        # handle other options
        *)
            # ignore unneeded options
            ;;
        esac
    done

    varnishd "$@"

Otherwise if optstring is not kept in sync, getopts will stop processing
options if it encounters one that is not specified.