### PR TITLE
Do not possibly underflow rlen

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -340,8 +340,10 @@ vbp_poke(struct vbp_target *vt)
 			    sizeof vt->resp_buf - rlen);
 		else
 			i = read(s, buf, sizeof buf);
+		if (i <= 0)
+			break;
 		rlen += i;
-	} while (i > 0);
+	} while (1);
 
 	VTCP_close(&s);
 


### PR DESCRIPTION
for i < 0, rlen could underflow. We are safe because of the check for i < 0 further down, so this change is just a minor cleanup.
    
Fixes #2444