### PR TITLE
Restarts cleanup & consistent vcl_recv state with vcl switching

### DIFF
--- a/bin/varnishtest/tests/c00009.vtc
+++ b/bin/varnishtest/tests/c00009.vtc
@@ -12,8 +12,20 @@ server s2 {
 	txresp -body "foobar"
 } -start
 
-varnish v1 -vcl+backend {
+varnish v1 -arg "-smysteve=malloc,1m" -vcl+backend {
 	sub vcl_recv {
+		if (req.restarts == 0) {
+			set req.url = "/foo";
+			set req.method = "POST";
+			set req.proto = "HTTP/1.2";
+			set req.http.preserveme = "1";
+			set req.storage = storage.mysteve;
+			set req.ttl = 42m;
+			set req.esi = false;
+			set req.backend_hint = s2;
+			set req.hash_ignore_busy = true;
+			set req.hash_always_miss = true;
+		}
 		set req.http.restarts = req.restarts;
 	}
 	sub vcl_backend_fetch {
@@ -35,14 +47,36 @@ varnish v1 -vcl+backend {
 		if (resp.status != 200) {
 			return (restart);
 		}
+		set resp.http.method = req.method;
+		set resp.http.url = req.url;
+		set resp.http.proto = req.proto;
+		set resp.http.preserveme = req.http.preserveme;
+		set resp.http.restarts = req.restarts;
+		set resp.http.storage = req.storage;
+		set resp.http.ttl = req.ttl;
+		set resp.http.esi = req.esi;
+		set resp.http.backend_hint = req.backend_hint;
+		set resp.http.hash-ignore-busy = req.hash_ignore_busy;
+		set resp.http.hash-always-miss = req.hash_always_miss;
 	}
 } -start
 
 client c1 {
-	txreq -url "/foo"
+	txreq -url "/"
 	rxresp
 	expect resp.status == 200
 	expect resp.bodylen == 6
+	expect resp.http.method == POST
+	expect resp.http.url == /foo
+	expect resp.http.proto == HTTP/1.2
+	expect resp.http.preserveme == 1
+	expect resp.http.restarts == 1
+	expect resp.http.storage == storage.mysteve
+	expect resp.http.ttl == 2520.000
+	expect resp.http.esi == false
+	expect resp.http.backend_hint == s2
+	expect resp.http.hash-ignore-busy == true
+	expect resp.http.hash-always-miss == true
 }
 
 client c1 -run

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,10 @@ Varnish Cache Trunk (ongoing)
   less than the number of allowed restarts, it now is the number of
   ``return(restart)`` calls per request.
 
+* Fix behaviour of restarts to how it was originally intended:
+  Restarts now leave all the request properties in place except for
+  ``req.restarts`` and ``req.xid``, which need to change by design.
+
 ================================
 Varnish Cache 5.2.0 (2017-09-15)
 ================================

--- a/doc/sphinx/users-guide/vcl-built-in-subs.rst
+++ b/doc/sphinx/users-guide/vcl-built-in-subs.rst
@@ -59,6 +59,10 @@ common return keywords
     parameter, control is passed to :ref:`vcl_synth` as for
     ``return(synth(503, "Too many restarts"))``
 
+    For a restart, all modifications to ``req`` attributes are
+    preserved except for ``req.restarts`` and ``req.xid``, which need
+    to change by design.
+
 -----------
 client side
 -----------

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -270,7 +270,7 @@ sp_variables = [
 	),
 	('req.storage',
 		'STEVEDORE',
-		('recv',),
+		('client',),
 		('recv',), """
 		The storage backend to use to save this request body.
 		"""
@@ -336,7 +336,7 @@ sp_variables = [
 	),
 	('req.hash_ignore_busy',
 		'BOOL',
-		('recv',),
+		('client',),
 		('recv',), """
 		Ignore any busy object during cache lookup. You
 		would want to do this if you have two server looking
@@ -345,7 +345,7 @@ sp_variables = [
 	),
 	('req.hash_always_miss',
 		'BOOL',
-		('recv',),
+		('client',),
 		('recv',), """
 		Force a cache miss for this request. If set to true
 		Varnish will disregard any existing objects and

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -330,8 +330,6 @@ sp_variables = [
 		or the director otherwise.
 		When used in string context, returns the name of the director
 		or backend, respectively.
-		Note: backend_hint gets reset to the default backend by
-		restarts!
 		"""
 	),
 	('req.hash_ignore_busy',


### PR DESCRIPTION
* first patch is just to get access to all req properties in deliver - I don't see how this could cause any harm (famous last words(tm))
* fix the client side of #2405 (keep req attributes across restarts)
* side issue: notices that vcl switching will call the label vcl's vcl_recv with the other init from cnt_recv missing, so moved that to a common cnt_recv_prep