### PR TITLE
Pass delivery abandoned does not qualify as an error

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -451,8 +451,8 @@ vbf_stp_fetchbody(struct worker *wrk, struct busyobj *bo)
 			 * objects to be created.
 			 */
 			AN(vfc->oc->flags & OC_F_PASS);
-			VSLb(wrk->vsl, SLT_FetchError,
-			    "Pass delivery abandoned");
+			VSLb(wrk->vsl, SLT_Debug,
+			    "Fetch: Pass delivery abandoned");
 			bo->htc->doclose = SC_RX_BODY;
 			break;
 		}


### PR DESCRIPTION
... so log it under the Debug tag.

FetchErrors should be actual errors which can be addressed. In this case,
nothing is wrong in any way, the fact that we abort a fetch if we don't
need the body is a varnish internal optimization (which makes sense, but
comes at the cost of closing a connection).