### PR TITLE
Add cache_grace_hit counter

### DIFF
--- a/bin/varnishd/VSC_main.vsc
+++ b/bin/varnishd/VSC_main.vsc
@@ -56,6 +56,13 @@
 	Count of cache hits.  A cache hit indicates that an object has been
 	delivered to a client without fetching it from a backend server.
 
+.. varnish_vsc:: cache_hit_grace
+	:oneliner:	Cache grace hits
+
+	Count of cache hits with grace. A cache hit with grace is a cache
+	hit where the object is expired. Note that such hits are also
+	included in the cache_hit counter.
+
 .. varnish_vsc:: cache_hitpass
 	:oneliner:	Cache hits for pass.
 

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -523,6 +523,8 @@ cnt_lookup(struct worker *wrk, struct req *req)
 		}
 		wrk->stats->cache_hit++;
 		req->is_hit = 1;
+		if (lr == HSH_EXP || lr == HSH_EXPBUSY)
+			wrk->stats->cache_hit_grace++;
 		req->req_step = R_STP_DELIVER;
 		return (REQ_FSM_MORE);
 	case VCL_RET_MISS:

--- a/bin/varnishtest/tests/b00099.vtc
+++ b/bin/varnishtest/tests/b00099.vtc
@@ -1,0 +1,52 @@
+varnishtest "The grace_hit_counter"
+
+server s1 {
+	# normal fetch
+	rxreq
+	expect req.url == "/1"
+	txresp -hdr "Age: 1" -hdr "Cache-Control: max-age=2" -body "1"
+
+	# background fetch:
+	rxreq
+	expect req.url == "/1"
+	txresp -body "2"
+
+	# normal fetch
+	rxreq
+	expect req.url == "/2"
+	txresp
+} -start
+
+varnish v1 -vcl+backend { } -start
+
+client c1 {
+	txreq -url "/1"
+	rxresp
+	expect resp.body == "1"
+} -run
+
+delay 2
+
+# Get a grace hit, will trigger a background fetch
+
+client c2 {
+	txreq -url "/1"
+	rxresp
+	expect resp.body == "1"
+} -run
+
+delay 2
+
+client c3 {
+	txreq -url "/2"
+	rxresp
+	txreq -url "/1"
+	rxresp
+	expect resp.body == "2"
+} -run
+
+# Check that counters are correct:
+
+varnish v1 -expect cache_hit == 2
+varnish v1 -expect cache_hit_grace == 1
+varnish v1 -expect cache_miss == 2


### PR DESCRIPTION
The new `cache_grace_hit` counter keeps track of the number of grace hits. To be precise, it counts the number of times lookup returns an expired object, `vcl_hit` is called and decides to `return(deliver)`.

The test case has gotten a temporary name (bin/varnishtest/tests/b00099.vtc) to avoid potential crashes with other incoming patches. I will rename this before pushing if I get an OK.

Another note: Maybe lines like `varnish v1 -expect cache_grace_hit == 1` should be added to other test cases instead of adding this test case. However, to keep the discussion on track, I include the test case to demonstrate the functionality. I hope that we first can discuss the code (is this the correct interpretation of a *grace hit*?), and then try to reduce the number of test cases without testing less.