### PR TITLE
Add locking around client-side PRIV handling

### DIFF
--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -202,7 +202,9 @@ ved_include(struct req *preq, const char *src, const char *host,
 		AZ(req->wrk);
 	}
 
+	Lck_Lock(&sp->mtx);
 	VRTPRIV_dynamic_kill(sp->privs, (uintptr_t)req);
+	Lck_Unlock(&sp->mtx);
 
 	AZ(preq->vcl);
 	preq->vcl = req->vcl;

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -190,8 +190,10 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 		req->vcl = NULL;
 	}
 
+	Lck_Lock(&sp->mtx);
 	VRTPRIV_dynamic_kill(sp->privs, (uintptr_t)req);
 	VRTPRIV_dynamic_kill(sp->privs, (uintptr_t)&req->top);
+	Lck_Unlock(&sp->mtx);
 
 	/* Charge and log byte counters */
 	if (req->vsl->wid) {


### PR DESCRIPTION
With H/2 we now have multiple requests in flight concurrently for the same session, so we need to synchronize access to the `sp->privs` list.

Another option to this patch would be to move the `PRIV_{TASK,TOP}` priv pointers to `struct req`, which would avoid the locking introduced here.

Fixes: #2268