### PR TITLE
Move the req-specific PRIV pointers to struct req

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -574,6 +574,8 @@ struct req {
 
 	/* Temporary accounting */
 	struct acct_req		acct;
+
+	struct vrt_privs	privs[1];
 };
 
 /*--------------------------------------------------------------------
@@ -611,8 +613,6 @@ struct sess {
 	/* Timestamps, all on TIM_real() timescale */
 	double			t_open;		/* fd accepted */
 	double			t_idle;		/* fd accepted or resp sent */
-
-	struct vrt_privs	privs[1];
 
 };
 

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -202,7 +202,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 		AZ(req->wrk);
 	}
 
-	VRTPRIV_dynamic_kill(sp->privs, (uintptr_t)req);
+	VRTPRIV_dynamic_kill(req->privs, (uintptr_t)req);
 
 	AZ(preq->vcl);
 	preq->vcl = req->vcl;

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -486,6 +486,8 @@ pan_req(struct vsb *vsb, const struct req *req)
 	VSB_indent(vsb, -2);
 	VSB_printf(vsb, "},\n");
 
+	pan_privs(vsb, req->privs);
+
 	VSB_indent(vsb, -2);
 	VSB_printf(vsb, "},\n");
 }
@@ -522,8 +524,6 @@ pan_sess(struct vsb *vsb, const struct sess *sp)
 	ci = SES_Get_String_Attr(sp, SA_CLIENT_IP);
 	cp = SES_Get_String_Attr(sp, SA_CLIENT_PORT);
 	VSB_printf(vsb, "client = %s %s,\n", ci, cp);
-
-	pan_privs(vsb, sp->privs);
 
 	VSB_indent(vsb, -2);
 	VSB_printf(vsb, "},\n");

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -134,6 +134,7 @@ Req_New(const struct worker *wrk, struct sess *sp)
 
 	req->vdpe_nxt = 0;
 	VTAILQ_INIT(&req->vdpe);
+	VRTPRIV_init(req->privs);
 
 	return (req);
 }
@@ -190,8 +191,9 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 		req->vcl = NULL;
 	}
 
-	VRTPRIV_dynamic_kill(sp->privs, (uintptr_t)req);
-	VRTPRIV_dynamic_kill(sp->privs, (uintptr_t)&req->top);
+	VRTPRIV_dynamic_kill(req->privs, (uintptr_t)req);
+	VRTPRIV_dynamic_kill(req->privs, (uintptr_t)&req->top);
+	assert(VTAILQ_EMPTY(&req->privs->privs));
 
 	/* Charge and log byte counters */
 	if (req->vsl->wid) {

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -349,7 +349,6 @@ SES_New(struct pool *pp)
 
 	sp->t_open = NAN;
 	sp->t_idle = NAN;
-	VRTPRIV_init(sp->privs);
 	Lck_New(&sp->mtx, lck_sess);
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 	return (sp);
@@ -545,7 +544,6 @@ SES_Delete(struct sess *sp, enum sess_close reason, double now)
 	if (reason == SC_NULL)
 		reason = (enum sess_close)-sp->fd;
 
-	assert(VTAILQ_EMPTY(&sp->privs->privs));
 	VSL(SLT_SessClose, sp->vxid, "%s %.3f",
 	    sess_close_2str(reason, 0), now - sp->t_open);
 	VSL(SLT_End, sp->vxid, "%s", "");

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -94,24 +94,14 @@ VRTPRIV_init(struct vrt_privs *privs)
 }
 
 static struct vmod_priv *
-vrt_priv_dynamic(VRT_CTX, uintptr_t id, uintptr_t vmod_id)
+vrt_priv_dynamic(VRT_CTX, struct vrt_privs *vps, uintptr_t id,
+    uintptr_t vmod_id)
 {
-	struct vrt_privs *vps;
 	struct vrt_priv *vp;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(vps, VRT_PRIVS_MAGIC);
 	AN(vmod_id);
-	if (ctx->req) {
-		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
-		CHECK_OBJ_NOTNULL(ctx->req->sp, SESS_MAGIC);
-		CAST_OBJ_NOTNULL(vps, ctx->req->sp->privs, VRT_PRIVS_MAGIC);
-	} else if (ctx->bo) {
-		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
-		CAST_OBJ_NOTNULL(vps, ctx->bo->privs, VRT_PRIVS_MAGIC);
-	} else {
-		ASSERT_CLI();
-		CAST_OBJ_NOTNULL(vps, cli_task_privs, VRT_PRIVS_MAGIC);
-	}
 
 	VTAILQ_FOREACH(vp, &vps->privs, list) {
 		CHECK_OBJ_NOTNULL(vp, VRT_PRIV_MAGIC);
@@ -150,32 +140,38 @@ struct vmod_priv *
 VRT_priv_task(VRT_CTX, const void *vmod_id)
 {
 	uintptr_t id;
+	struct vrt_privs *vps;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (ctx->req) {
 		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
 		id = (uintptr_t)ctx->req;
+		CAST_OBJ_NOTNULL(vps, ctx->req->privs, VRT_PRIVS_MAGIC);
 	} else if (ctx->bo) {
 		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
 		id = (uintptr_t)ctx->bo;
+		CAST_OBJ_NOTNULL(vps, ctx->bo->privs, VRT_PRIVS_MAGIC);
 	} else {
 		ASSERT_CLI();
 		id = (uintptr_t)cli_task_privs;
+		CAST_OBJ_NOTNULL(vps, cli_task_privs, VRT_PRIVS_MAGIC);
 	}
-	return (vrt_priv_dynamic(ctx, id, (uintptr_t)vmod_id));
+	return (vrt_priv_dynamic(ctx, vps, id, (uintptr_t)vmod_id));
 }
 
 struct vmod_priv *
 VRT_priv_top(VRT_CTX, const void *vmod_id)
 {
 	uintptr_t id;
+	struct vrt_privs *vps;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (ctx->req) {
 		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
 		CHECK_OBJ_NOTNULL(ctx->req->top, REQ_MAGIC);
 		id = (uintptr_t)&ctx->req->top->top;
-		return (vrt_priv_dynamic(ctx, id, (uintptr_t)vmod_id));
+		CAST_OBJ_NOTNULL(vps, ctx->req->top->privs, VRT_PRIVS_MAGIC);
+		return (vrt_priv_dynamic(ctx, vps, id, (uintptr_t)vmod_id));
 	} else
 		WRONG("PRIV_TOP is only accessible in client VCL context");
 	NEEDLESS(return NULL);


### PR DESCRIPTION
NB: This is an alternative solution to PR #2457 

This PR kills `sp->privs` and moves it over to `struct req`.

Keeping the privs list in struct sess would necessitate extra locking for h/2 where we have multiple reqs in flight concurrently.

Previously we used the `id` argument to tell apart pointers for different requests on the same session, this is still required for the very specific case where a VMOD would use both PRIV_TOP and PRIV_TASK.

Fixes: #2268