### PR TITLE
VIP12 vmod function/method polymorphism

### DIFF
--- a/bin/varnishtest/tests/m00000.vtc
+++ b/bin/varnishtest/tests/m00000.vtc
@@ -33,6 +33,12 @@ varnish v1 -vcl+backend {
 		std.log("VCL" + " initiated " + "log");
 		std.syslog(8 + 7, "Somebody runs varnishtest");
 		debug.rot52(resp);
+		set resp.http.f_poly_int = debug.f_poly(42);
+		set resp.http.f_poly_real = debug.f_poly(30.12);
+		set resp.http.f_poly_string = debug.f_poly(33s + 3m);
+		set resp.http.m_poly_int = obj.m_poly(42);
+		set resp.http.m_poly_real = obj.m_poly(30.12);
+		set resp.http.m_poly_string = obj.m_poly(33s + 3m);
 	}
 } -start
 
@@ -62,6 +68,18 @@ logexpect l1 -v v1 -g raw -d 1 {
 	expect 0 =    RespHeader	{^not: -1}
 	expect 0 =    VCL_Log		{^VCL initiated log}
 	expect 0 =    RespHeader	{^Encrypted: ROT52}
+	expect 0 =    Debug		{^f_poly_int\(42\)}
+	expect 0 =    RespHeader	{^f_poly_int: 42$}
+	expect 0 =    Debug		{^f_poly_real\(30.120000\)}
+	expect 0 =    RespHeader	{^f_poly_real: 30$}
+	expect 0 =    Debug		{^f_poly_string\(213.000\)}
+	expect 0 =    RespHeader	{^f_poly_string: 213$}
+	expect 0 =    Debug		{^m_poly_int\(42\)}
+	expect 0 =    RespHeader	{^m_poly_int: 42$}
+	expect 0 =    Debug		{^m_poly_real\(30.120000\)}
+	expect 0 =    RespHeader	{^m_poly_real: 30$}
+	expect 0 =    Debug		{^m_poly_string\(213.000\)}
+	expect 0 =    RespHeader	{^m_poly_string: 213$}
 	expect 0 =    VCL_return	{^deliver}
 } -start
 

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -153,6 +153,8 @@ VCC_Symbol(struct vcc *tl, struct symbol *parent,
 			continue;
 		break;
 	}
+	if (sym != NULL && create == 2 && q == e)
+		return (VCC_Symbol(tl, sym, b, e, kind, create));
 	if (sym == NULL && create == 0 && parent->wildcard != NULL) {
 		AN(parent->wildcard);
 		parent->wildcard(tl, parent, b, e);

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -242,7 +242,7 @@ vcc_ParseImport(struct vcc *tl)
 			    p, PF(mod));
 		} else if (!strcmp(p, "$FUNC")) {
 			p += strlen(p) + 1;
-			sym = VCC_Symbol(tl, NULL, p, NULL, SYM_FUNC, 1);
+			sym = VCC_Symbol(tl, NULL, p, NULL, SYM_FUNC, 2);
 			ERRCHK(tl);
 			AN(sym);
 			sym->vmod = msym->name;
@@ -335,7 +335,7 @@ vcc_ParseNew(struct vcc *tl)
 	while (*p != '\0') {
 		p += strlen(s_obj);
 		bprintf(buf2, "%s%s", sy1->name, p);
-		sy3 = VCC_Symbol(tl, NULL, buf2, NULL, SYM_FUNC, 1);
+		sy3 = VCC_Symbol(tl, NULL, buf2, NULL, SYM_FUNC, 2);
 		AN(sy3);
 		sy3->eval = vcc_Eval_SymFunc;
 		p += strlen(p) + 1;

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -122,6 +122,10 @@ same vmod - IOW the PRIV_* state is per vmod, not per object.
 
 $Method STRING .test_priv_top(PRIV_TOP, STRING)
 
+$Method INT .m_poly{_INT}(INT)
+$Method INT .m_poly{_REAL}(REAL)
+$Method INT .m_poly{_STRING}(STRING)
+
 $Function VOID rot52(HTTP hdr)
 
 Encrypt the HTTP header with quad-ROT13 encryption,
@@ -221,3 +225,7 @@ Add a vsc
 $Function VOID vsc_destroy()
 
 Remove a vsc
+
+$Function INT f_poly{_INT}(INT)
+$Function INT f_poly{_REAL}(REAL)
+$Function INT f_poly{_STRING}(STRING)

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -599,3 +599,24 @@ xyzzy_vsc_destroy(VRT_CTX)
 	AZ(vsc);
 	AZ(pthread_mutex_unlock(&vsc_mtx));
 }
+
+VCL_INT
+xyzzy_f_poly_INT(VRT_CTX, VCL_INT i)
+{
+	VSLb(ctx->vsl, SLT_Debug, "f_poly_int(%ld)", i);
+	return (i);
+}
+
+VCL_INT
+xyzzy_f_poly_REAL(VRT_CTX, VCL_REAL r)
+{
+	VSLb(ctx->vsl, SLT_Debug, "f_poly_real(%f)", r);
+	return ((int)r);
+}
+
+VCL_INT
+xyzzy_f_poly_STRING(VRT_CTX, VCL_STRING s)
+{
+	VSLb(ctx->vsl, SLT_Debug, "f_poly_string(%s)", s);
+	return (atoi(s));
+}

--- a/lib/libvmod_debug/vmod_debug_obj.c
+++ b/lib/libvmod_debug/vmod_debug_obj.c
@@ -149,3 +149,27 @@ xyzzy_obj_test_priv_top(VRT_CTX,
 	(void)o;
 	return (xyzzy_test_priv_top(ctx, priv, s));
 }
+
+VCL_INT v_matchproto_()
+xyzzy_obj_m_poly_INT(VRT_CTX, struct xyzzy_debug_obj *o, VCL_INT i)
+{
+	(void)o;
+	VSLb(ctx->vsl, SLT_Debug, "m_poly_int(%ld)", i);
+	return (i);
+}
+
+VCL_INT v_matchproto_()
+xyzzy_obj_m_poly_REAL(VRT_CTX, struct xyzzy_debug_obj *o, VCL_REAL r)
+{
+	(void)o;
+	VSLb(ctx->vsl, SLT_Debug, "m_poly_real(%f)", r);
+	return ((int)r);
+}
+
+VCL_INT v_matchproto_()
+xyzzy_obj_m_poly_STRING(VRT_CTX, struct xyzzy_debug_obj *o, VCL_STRING s)
+{
+	(void)o;
+	VSLb(ctx->vsl, SLT_Debug, "m_poly_string(%s)", s);
+	return (atoi(s));
+}


### PR DESCRIPTION
Ref: https://github.com/varnishcache/varnish-cache/wiki/VIP12:-vmod-polymorphism-(for-type-conversions)

We now allow definition of vmod function/methods by the same name but
different signatures.

VCC file:

For $Function/$Method names, we add a "poly suffix" {C_SUFFIX} which
is appended to the function names for the C-Interface, but not for the
VCL interface.

vmodtool:

The change to extract the poly suffix is straight forward. The
RST generation is unchanged for now. All information is contained,
but we might want to improve the documentation format for polymorphic
functions later.

vcc:

We hang polymorphic variants of the same symbol name as a chain of
children under the first symbol found. While using just one layer
below a primary symbol would be a bit more efficient for symbol
insertion, this way we do not need to break the rule of symbol names
being unique at each level.

In vcc_Eval_SymFunc(), the first matching variant is now looked up by
successively trying vcc_func() until success or symbols exhausted.

This implementation differs from the VIP in some regards:

* "for polymorphic arguments, STRING always needs to be supported"

I cannot see any more why we would want to be that strict. For string
arguments, a polymorphic function (as any function/method) effectively
takes any argument type through string folding, and a vmod might want
to not allow that.

* "at vcl compile time, vcc finds the best match ** arbitration
   left->right best match (e.g. stringification of rightmost arguments
   preferred)"

Such heuristic appears pretty arbitrary. Instead, the current
implementation just uses the first match found, in the order of
definition in the vcc file. This should give vmod authors maximum
flexibility - including varying argument counts.