### PR TITLE
Don't panic if we reembark with a request body

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -531,6 +531,8 @@ h2_end_headers(struct worker *wrk, struct h2_sess *h2,
 			req->req_body_status = REQ_BODY_WITH_LEN;
 	} else {
 		assert (req->req_body_status == REQ_BODY_NONE);
+		if (http_GetContentLength(req->http) > 0)
+			return (H2CE_PROTOCOL_ERROR); //rfc7540,l,1838,1840
 	}
 
 	req->req_step = R_STP_TRANSPORT;

--- a/bin/varnishtest/tests/r02305.vtc
+++ b/bin/varnishtest/tests/r02305.vtc
@@ -45,6 +45,27 @@ client c1 {
 	} -run
 } -run
 
+client c2 {
+	stream 1 {
+		txreq -hdr "content-length" "23"
+	} -run
+	stream 0 {
+		rxgoaway
+		expect goaway.err == PROTOCOL_ERROR
+		expect goaway.laststream == 1
+
+	} -run
+} -run
+
+# Allow content-length: 0
+client c2 {
+	stream 1 {
+		txreq -hdr "content-length" "0"
+		rxresp
+		expect resp.status == 200
+	} -run
+} -run
+
 varnish v1 -vsl_catchup
 varnish v1 -expect MEMPOOL.req0.live == 0
 varnish v1 -expect MEMPOOL.sess0.live == 0

--- a/bin/varnishtest/tests/r02305.vtc
+++ b/bin/varnishtest/tests/r02305.vtc
@@ -1,0 +1,52 @@
+varnishtest "#2305: h/2 reembark with a request body"
+
+barrier b1 cond 2
+barrier b2 sock 2
+
+server s1 {
+	rxreq
+	expect req.url == "/"
+	barrier b1 sync
+	delay 2
+	txresp
+} -start
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.set debug +syncvsl"
+varnish v1 -cliok "param.set debug +waitinglist"
+
+varnish v1 -vcl+backend {
+	import vtc;
+	sub vcl_recv {
+		return (hash);
+	}
+	sub vcl_deliver {
+		if (req.http.sync) {
+			vtc.barrier_sync("${b2_sock}");
+		}
+	}
+} -start
+
+client c1 {
+	stream 1 {
+		txreq
+		rxresp
+		expect resp.status == 200
+	} -start
+	stream 3 {
+		barrier b1 sync
+		txreq -req POST -hdr sync 1 -body "foo"
+		rxwinup
+		# barrier b2 is here to make HEADERS vs WINDOW_UPDATE
+		# less racy
+		barrier b2 sync
+		rxresp
+		expect resp.status == 200
+	} -run
+} -run
+
+varnish v1 -vsl_catchup
+varnish v1 -expect MEMPOOL.req0.live == 0
+varnish v1 -expect MEMPOOL.sess0.live == 0
+varnish v1 -expect MEMPOOL.req1.live == 0
+varnish v1 -expect MEMPOOL.sess1.live == 0


### PR DESCRIPTION
This moves the body status decision to h2_end_headers, to make sure that
it is only done once per request.

We also move the Cookie header concatenation to h2_end_headers, to avoid
stepping on any changes that may have taken place in VCL.

Fixes: #2305