### PR TITLE
Use pkg-config for curses, if possible

### DIFF
--- a/bin/varnishhist/Makefile.am
+++ b/bin/varnishhist/Makefile.am
@@ -18,4 +18,4 @@ varnishhist_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 	-lm \
 	@SAN_LDFLAGS@ \
-	@CURSES_LIB@ ${RT_LIBS} ${PTHREAD_LIBS}
+	@CURSES_LIBS@ ${RT_LIBS} ${PTHREAD_LIBS}

--- a/bin/varnishstat/Makefile.am
+++ b/bin/varnishstat/Makefile.am
@@ -18,4 +18,4 @@ varnishstat_CFLAGS = \
 varnishstat_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 	@SAN_LDFLAGS@ \
-	@CURSES_LIB@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}
+	@CURSES_LIBS@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}

--- a/bin/varnishtop/Makefile.am
+++ b/bin/varnishtop/Makefile.am
@@ -17,4 +17,4 @@ varnishtop_CFLAGS = \
 varnishtop_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 	@SAN_LDFLAGS@ \
-	@CURSES_LIB@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}
+	@CURSES_LIBS@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}

--- a/configure.ac
+++ b/configure.ac
@@ -82,11 +82,6 @@ _VARNISH_CHECK_LIB(nsl, getaddrinfo)
 
 AC_SUBST(NET_LIBS, "${SOCKET_LIBS} ${NSL_LIBS}")
 
-AX_WITH_CURSES
-if test "x$ax_cv_curses" != xyes; then
-   AC_MSG_ERROR([requires an X/Open-compatible Curses library])
-fi
-
 # Userland slab allocator from Solaris, ported to other systems
 AC_CHECK_HEADERS([umem.h], [_VARNISH_CHECK_LIB(umem, umem_alloc)])
 
@@ -186,6 +181,21 @@ AC_CHECK_HEADERS([edit/readline/readline.h],
 		 LIBEDIT_LIBS="$ax_cv_lib_readline"
 		])
 	])
+
+PKG_CHECK_MODULES([CURSES], [ncursesw], [], [
+	PKG_CHECK_MODULES([CURSES], [ncurses], [], [
+		PKG_CHECK_MODULES([CURSES], [curses], [], [
+AX_WITH_CURSES
+if test "x$ax_cv_curses" != xyes; then
+	AC_MSG_ERROR([requires an X/Open-compatible Curses library])
+fi
+CURSES_LIBS="$CURSES_LIB"
+		])
+	])
+])
+AC_SUBST([CURSES_LIBS])
+
+AC_CHECK_HEADERS([ncursesw/curses.h ncursesw.h ncurses/curses.h ncurses.h curses.h])
 
 # Checks for header files.
 AC_HEADER_STDC


### PR DESCRIPTION
I hoped to get rid of m4/ax_with_curses.m4, but it needs to stays for platforms not shipping .pc files.
For for those that do however, it solves the issue of split libtinfo.