### PR TITLE
chunked processing fixes and reduce v1f syscalls

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -192,6 +192,8 @@ struct http_conn {
 	char			*rxbuf_e;
 	char			*pipeline_b;
 	char			*pipeline_e;
+	char			*rxra_b;
+	char			*rxra_e;
 	ssize_t			content_length;
 	void			*priv;
 

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -173,6 +173,12 @@ struct http {
  *
  */
 
+enum htc_blocking {
+	_HTC_BLK_UNKNOWN = 0,
+	HTC_NONBLOCKING,
+	HTC_BLOCKING
+};
+
 struct http_conn {
 	unsigned		magic;
 #define HTTP_CONN_MAGIC		0x3e19edd1
@@ -180,6 +186,7 @@ struct http_conn {
 	int			*rfd;
 	enum sess_close		doclose;
 	enum body_status	body_status;
+	enum htc_blocking	blocking;
 	struct ws		*ws;
 	char			*rxbuf_b;
 	char			*rxbuf_e;
@@ -847,6 +854,8 @@ void HTC_RxInit(struct http_conn *htc, struct ws *ws);
 void HTC_RxPipeline(struct http_conn *htc, void *);
 enum htc_status_e HTC_RxStuff(struct http_conn *, htc_complete_f *,
     double *t1, double *t2, double ti, double tn, int maxbytes);
+int HTC_blocking(struct http_conn *);
+int HTC_nonblocking(struct http_conn *);
 
 #define SESS_ATTR(UP, low, typ, len)					\
 	int SES_Set_##low(const struct sess *sp, const typ *src);	\

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -194,6 +194,8 @@ pan_htc(struct vsb *vsb, const struct http_conn *htc)
 	    htc->rxbuf_b, htc->rxbuf_e);
 	VSB_printf(vsb, "{pipeline_b, pipeline_e} = {%p, %p},\n",
 	    htc->pipeline_b, htc->pipeline_e);
+	VSB_printf(vsb, "{rxra_b, rxra_e} = {%p, %p},\n",
+	    htc->rxra_b, htc->rxra_e);
 	VSB_printf(vsb, "content_length = %jd,\n",
 	    (intmax_t)htc->content_length);
 	VSB_printf(vsb, "body_status = %s,\n",

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -204,6 +204,8 @@ HTC_RxInit(struct http_conn *htc, struct ws *ws)
 		htc->pipeline_b = NULL;
 		htc->pipeline_e = NULL;
 	}
+	htc->rxra_b = NULL;
+	htc->rxra_e = NULL;
 }
 
 void
@@ -212,13 +214,13 @@ HTC_RxPipeline(struct http_conn *htc, void *p)
 
 	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
 	if (p == NULL || (char*)p == htc->rxbuf_e) {
-		htc->pipeline_b = NULL;
-		htc->pipeline_e = NULL;
+		htc->rxra_b = htc->pipeline_b = NULL;
+		htc->rxra_e = htc->pipeline_e = NULL;
 	} else {
 		assert((char*)p >= htc->rxbuf_b);
 		assert((char*)p < htc->rxbuf_e);
-		htc->pipeline_b = p;
-		htc->pipeline_e = htc->rxbuf_e;
+		htc->rxra_b = htc->pipeline_b = p;
+		htc->rxra_e = htc->pipeline_e = htc->rxbuf_e;
 	}
 }
 

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -188,6 +188,7 @@ HTC_RxInit(struct http_conn *htc, struct ws *ws)
 	ssize_t l;
 
 	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
+	htc->blocking = _HTC_BLK_UNKNOWN;
 	htc->ws = ws;
 	(void)WS_Reserve(htc->ws, 0);
 	htc->rxbuf_b = ws->f;
@@ -317,6 +318,28 @@ HTC_RxStuff(struct http_conn *htc, htc_complete_f *func,
 			}
 		}
 	}
+}
+
+int
+HTC_blocking(struct http_conn *htc) {
+	if (htc->blocking == HTC_BLOCKING)
+		return 0;
+
+	int i = VTCP_blocking(*htc->rfd);
+	if (i == 0)
+		htc->blocking = HTC_BLOCKING;
+	return (i);
+}
+
+int
+HTC_nonblocking(struct http_conn *htc) {
+	if (htc->blocking == HTC_NONBLOCKING)
+		return 0;
+
+	int i = VTCP_nonblocking(*htc->rfd);
+	if (i == 0)
+		htc->blocking = HTC_NONBLOCKING;
+	return (i);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -98,7 +98,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr,
 	VTCP_hisname(*htc->rfd, abuf, sizeof abuf, pbuf, sizeof pbuf);
 	VSLb(bo->vsl, SLT_BackendStart, "%s %s", abuf, pbuf);
 
-	(void)VTCP_blocking(*htc->rfd);	/* XXX: we should timeout instead */
+	(void)HTC_blocking(htc);	/* XXX: we should timeout instead */
 	V1L_Reserve(wrk, wrk->aws, htc->rfd, bo->vsl, bo->t_prev);
 	*ctr += HTTP1_Write(wrk, hp, HTTP1_Req);
 

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -364,13 +364,7 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 	sp = req->sp;
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 
-	/*
-	 * Whenever we come in from the acceptor or waiter, we need to set
-	 * blocking mode.  It would be simpler to do this in the acceptor
-	 * or waiter, but we'd rather do the syscall in the worker thread.
-	 * On systems which return errors for ioctl, we close early
-	 */
-	if (http1_getstate(sp) == H1NEWREQ && VTCP_blocking(sp->fd)) {
+	if (HTC_blocking(req->htc)) {
 		AN(req->htc->ws->r);
 		if (errno == ECONNRESET)
 			SES_Close(sp, SC_REM_CLOSE);

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -45,7 +45,8 @@
 #include "vct.h"
 
 /*--------------------------------------------------------------------
- * Read up to len bytes, returning pipelined data first.
+ * Read up to len bytes, returning pipelined data first,
+ * read ahead for very small reads if we got a buffer
  */
 
 static ssize_t
@@ -60,6 +61,14 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 	assert(len > 0);
 	l = 0;
 	p = d;
+
+#ifdef DBG_V1F
+	VSLb(vc->wrk->vsl, SLT_Debug, "v1f_read rxra %p->%p = %u "
+	     "pipeline %p->%p = %u",
+	     htc->rxra_b, htc->rxra_e, pdiff(htc->rxra_b, htc->rxra_e),
+	     htc->pipeline_b, htc->pipeline_e,
+	     pdiff(htc->pipeline_b, htc->pipeline_e));
+#endif
 	if (htc->pipeline_b) {
 		l = htc->pipeline_e - htc->pipeline_b;
 		assert(l > 0);
@@ -73,6 +82,25 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 			htc->pipeline_b = htc->pipeline_e = NULL;
 	}
 	if (len > 0) {
+		while (htc->pipeline_b == NULL) {
+			i = htc->rxra_e - htc->rxra_b;
+			if (i <= len)
+				break;
+
+			HTC_nonblocking(htc);
+			i = read(*htc->rfd, htc->rxra_b, i);
+			// on nonblocking error, fall through to blocking
+			if (i <= 0)
+				break;
+
+			htc->pipeline_b = htc->rxra_b;
+			htc->pipeline_e = htc->rxra_b + i;
+			i = v1f_read(vc, htc, p, len);
+			if (i < 0)
+				return i;
+			return (l + i);
+		}
+		HTC_blocking(htc);
 		i = read(*htc->rfd, p, len);
 		if (i < 0) {
 			// XXX: VTCP_Assert(i); // but also: EAGAIN

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -207,7 +207,7 @@ v1f_pull_chunked(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 	if (buf[0] == '\r') {
 		if (buf[1] == '\n')
 			return (VFP_END);
-		VFP_Error(vc, "chunked tail CR no LF");
+		return (VFP_Error(vc, "chunked tail CR no LF"));
 	}
 
 	/*
@@ -227,21 +227,22 @@ v1f_pull_chunked(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 			switch (*q) {
 			case '\r': {
 				if (u & 1)
-					VFP_Error(vc, "chunked trailer CRCR");
+					return(VFP_Error(vc,
+					    "chunked trailer CRCR"));
 				u++;
 				break;
 			}
 			case '\n': {
 				if ((u & 1) == 0)
-					VFP_Error(vc,
-						  "chunked trailer LF no CR");
+					return(VFP_Error(vc,
+					    "chunked trailer LF no CR"));
 				u++;
 				break;
 			}
 			default:
 				if (u & 1)
-					VFP_Error(vc,
-						  "chunked trailer CR no LF");
+					return(VFP_Error(vc,
+					    "chunked trailer CR no LF"));
 				u = 0;
 			}
 			q++;

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -164,11 +164,14 @@ v1f_pull_chunked(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 		if (u >= sizeof buf)
 			return (VFP_Error(vc, "chunked header too long"));
 
-		/* Skip trailing white space */
-		while (vct_islws(buf[u]) && buf[u] != '\n') {
-			lr = v1f_read(vc, htc, buf + u, 1);
-			if (lr <= 0)
+		/* ignore extensions until newline (no strict CRLF check) */
+		if (vct_islws(buf[u])) {
+			while (buf[u] != '\n') {
+				lr = v1f_read(vc, htc, buf + u, 1);
+				if (lr == 1)
+					continue;
 				return (VFP_Error(vc, "chunked read err"));
+			}
 		}
 
 		if (buf[u] != '\n')

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -125,7 +125,7 @@ v1f_pull_chunked(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 {
 	struct http_conn *htc;
 	char buf[20];		/* XXX: 20 is arbitrary */
-	char *q;
+	char *q, *lim;
 	unsigned u;
 	uintmax_t cll;
 	ssize_t cl, l, lr;
@@ -201,12 +201,58 @@ v1f_pull_chunked(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 		return (VFP_OK);
 	}
 	AZ(vfe->priv2);
-	if (v1f_read(vc, htc, buf, 1) <= 0)
+
+	if (v1f_read(vc, htc, buf, 2) != 2)
 		return (VFP_Error(vc, "chunked read err"));
-	if (buf[0] == '\r' && v1f_read(vc, htc, buf, 1) <= 0)
-		return (VFP_Error(vc, "chunked read err"));
-	if (buf[0] != '\n')
-		return (VFP_Error(vc, "chunked tail no NL"));
+	if (buf[0] == '\r') {
+		if (buf[1] == '\n')
+			return (VFP_END);
+		VFP_Error(vc, "chunked tail CR no LF");
+	}
+
+	/*
+	 * Trailer: discard for now. Because the trailers are terminated by
+	 * CRLFCRLF, we try to read up to 4 characters, unless we have already
+	 * seen part of the termination sequence
+	 */
+	u = 0;
+	lim = buf + 2;
+	while (1) {
+#ifdef DBG_V1F
+		VSLb(vc->wrk->vsl, SLT_Debug, "trailer u=%d %.*s",
+		     u, (int)(lim - buf), buf);
+#endif
+		q = buf;
+		while (q < lim) {
+			switch (*q) {
+			case '\r': {
+				if (u & 1)
+					VFP_Error(vc, "chunked trailer CRCR");
+				u++;
+				break;
+			}
+			case '\n': {
+				if ((u & 1) == 0)
+					VFP_Error(vc,
+						  "chunked trailer LF no CR");
+				u++;
+				break;
+			}
+			default:
+				if (u & 1)
+					VFP_Error(vc,
+						  "chunked trailer CR no LF");
+				u = 0;
+			}
+			q++;
+		}
+		if (u >= 4)
+			break;
+		if (v1f_read(vc, htc, buf, 4 - u) != 4 - u)
+			return (VFP_Error(vc, "chunked trailer read err"));
+		lim = buf + 4 - u;
+	}
+	assert(u == 4);
 	return (VFP_END);
 }
 

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -883,7 +883,7 @@ h2_rxframe(struct worker *wrk, struct h2_sess *h2)
 	char b[8];
 
 	ASSERT_RXTHR(h2);
-	(void)VTCP_blocking(*h2->htc->rfd);
+	(void)HTC_blocking(h2->htc);
 	h2->sess->t_idle = VTIM_real();
 	hs = HTC_RxStuff(h2->htc, h2_frame_complete,
 	    NULL, NULL, NAN,

--- a/bin/varnishtest/tests/b00007.vtc
+++ b/bin/varnishtest/tests/b00007.vtc
@@ -15,7 +15,8 @@ server s1 {
 	send "HTTP/1.1 200 OK\r\n"
 	send "Transfer-encoding: chunked\r\n"
 	send "\r\n"
-	send "00000004\r\n1234\r\n"
+	send {00000004 extname="extval"; another=val; justname}
+	send "\r\n1234\r\n"
 	chunked "1234"
 	chunked ""
 } -start

--- a/bin/varnishtest/tests/b00007.vtc
+++ b/bin/varnishtest/tests/b00007.vtc
@@ -18,10 +18,81 @@ server s1 {
 	send {00000004 extname="extval"; another=val; justname}
 	send "\r\n1234\r\n"
 	chunked "1234"
-	chunked ""
+	send "0\r\n"
+	send "Invalid: Trailer\r\n"
+	send "But: Ignored\r\n"
+	send "\r\n"
+
+	# intentionally varying the trailer slightly in the following tests
+	rxreq
+	expect req.url == "/bad/trailer/CRCR"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	send {00000004 foo=bar}
+	send "\r\n1234\r\n"
+	send "0\r\n"
+	send "Invalid: Trail\r\nBut: Ignored\r\r\n"
+
+	accept
+	rxreq
+	expect req.url == "/bad/trailer/LFnoCR"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	send {00000004 }
+	send "\r\n1234\r\n"
+	send "0\r\n"
+	send "Invalid: Traile\nBut: Ignored\r\n\r\n"
+
+	accept
+	rxreq
+	expect req.url == "/bad/trailer/CRnoLF"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	send {4}
+	send "\r\n1234\r\n"
+	send "0\r\n"
+	send "Invalid: Trailer\rBut: Ignored\r\n\r\n"
+
+	accept
+	rxreq
+	expect req.url == "/bad/trailer/short"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	send {00000004 extname="extval"; another=val; justname}
+	send "\r\n1234\r\n"
+	send "0\r\n"
+	send "Invalid: Trailer\r\nBut: Ignored\r\n\r"
 } -start
 
-varnish v1 -vcl+backend {} -start
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+	    if (bereq.url ~ "^/bad") {
+	       set beresp.do_stream = false;
+	    }
+	}
+} -start
+
+logexpect l1 -v v1 -g request {
+	expect * *	BereqURL	{^/bad/trailer/CRCR}
+	expect * =	Fetch_Body	{^2 chunked}
+	expect * =	FetchError	{^chunked trailer CRCR}
+
+	expect * *	BereqURL	{^/bad/trailer/LFnoCR}
+	expect * =	Fetch_Body	{^2 chunked}
+	expect * =	FetchError	{^chunked trailer LF no CR}
+
+	expect * *	BereqURL	{^/bad/trailer/CRnoLF}
+	expect * =	Fetch_Body	{^2 chunked}
+	expect * =	FetchError	{^chunked trailer CR no LF}
+
+	expect * *	BereqURL	{^/bad/trailer/short}
+	expect * =	Fetch_Body	{^2 chunked}
+	expect * =	FetchError	{^chunked trailer read err}
+} -start
 
 client c1 {
 	txreq -url "/bar"
@@ -32,4 +103,18 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 	expect resp.bodylen == "8"
+	txreq -url "/bad/trailer/CRCR"
+	rxresp
+	expect resp.status == 503
+	txreq -url "/bad/trailer/LFnoCR"
+	rxresp
+	expect resp.status == 503
+	txreq -url "/bad/trailer/CRnoLF"
+	rxresp
+	expect resp.status == 503
+	txreq -url "/bad/trailer/short"
+	rxresp
+	expect resp.status == 503
 } -run
+
+logexpect l1 -wait


### PR DESCRIPTION
* v1f performance:
v1f called reads even on one-byte buffers. As we normally have a bit of pipeline buffer space from session init, we can re-use it for some readahead. As the readahead must not block, we need to switch blocking on and off more frequently, so we move blocking to the HTC layer and cache the current blocking state.
* chunked:
  * fix parsing of chunk extensions (as required by httpbis)
  * fix handing of trailers (by ignoring them for now, but I want to add full trailer support)

I have *intentionally* left in two disabled Debug VSLs to make life easier for reviewers.