### PR TITLE
http1 chunked encoding trailers support & other improvements

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -192,6 +192,8 @@ struct http_conn {
 	char			*rxbuf_e;
 	char			*pipeline_b;
 	char			*pipeline_e;
+	char			*rxra_b;
+	char			*rxra_e;
 	ssize_t			content_length;
 	void			*priv;
 

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -173,6 +173,12 @@ struct http {
  *
  */
 
+enum htc_blocking {
+	_HTC_BLK_UNKNOWN = 0,
+	HTC_NONBLOCKING,
+	HTC_BLOCKING
+};
+
 struct http_conn {
 	unsigned		magic;
 #define HTTP_CONN_MAGIC		0x3e19edd1
@@ -180,6 +186,7 @@ struct http_conn {
 	int			*rfd;
 	enum sess_close		doclose;
 	enum body_status	body_status;
+	enum htc_blocking	blocking;
 	struct ws		*ws;
 	char			*rxbuf_b;
 	char			*rxbuf_e;
@@ -847,6 +854,8 @@ void HTC_RxInit(struct http_conn *htc, struct ws *ws);
 void HTC_RxPipeline(struct http_conn *htc, void *);
 enum htc_status_e HTC_RxStuff(struct http_conn *, htc_complete_f *,
     double *t1, double *t2, double ti, double tn, int maxbytes);
+int HTC_blocking(struct http_conn *);
+int HTC_nonblocking(struct http_conn *);
 
 #define SESS_ATTR(UP, low, typ, len)					\
 	int SES_Set_##low(const struct sess *sp, const typ *src);	\

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -707,6 +707,8 @@ void http_Unset(struct http *hp, const char *hdr);
 unsigned http_CountHdr(const struct http *hp, const char *hdr);
 void http_CollectHdr(struct http *hp, const char *hdr);
 void http_CollectHdrSep(struct http *hp, const char *hdr, const char *sep);
+void http_VSLH(const struct http *hp, const unsigned hdr);
+void http_VSLH_del(const struct http *hp, const unsigned hdr);
 void http_VSL_log(const struct http *hp);
 void HTTP_Merge(struct worker *, struct objcore *, struct http *to);
 uint16_t HTTP_GetStatusPack(struct worker *, struct objcore *oc);

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -719,6 +719,7 @@ enum sess_close http_DoConnection(struct http *hp);
 /* cache_http1_proto.c */
 
 htc_complete_f HTTP1_Complete;
+uint16_t HTTP1_DissectHdrs(struct http *, char **, const char *, const unsigned);
 uint16_t HTTP1_DissectRequest(struct http_conn *, struct http *);
 uint16_t HTTP1_DissectResponse(struct http_conn *, struct http *resp,
     const struct http *req);

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -155,6 +155,7 @@ struct http {
 
 	/* NB: ->nhd and below zeroed/initialized by http_Teardown */
 	uint16_t		nhd;		/* Next free hd */
+	uint16_t		thd;		/* First trailer hd 0 = none */
 
 	enum VSL_tag_e		logtag;		/* Must be SLT_*Method */
 	struct vsl_log		*vsl;

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -53,8 +53,8 @@ const char H__Reason[]	= "\010:reason:";
  * get the SLT_ to use.
  */
 
-static void
-http_VSLH(const struct http *hp, unsigned hdr)
+void
+http_VSLH(const struct http *hp, const unsigned hdr)
 {
 	int i;
 
@@ -68,8 +68,8 @@ http_VSLH(const struct http *hp, unsigned hdr)
 	}
 }
 
-static void
-http_VSLH_del(const struct http *hp, unsigned hdr)
+void
+http_VSLH_del(const struct http *hp, const unsigned hdr)
 {
 	int i;
 

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -194,6 +194,8 @@ pan_htc(struct vsb *vsb, const struct http_conn *htc)
 	    htc->rxbuf_b, htc->rxbuf_e);
 	VSB_printf(vsb, "{pipeline_b, pipeline_e} = {%p, %p},\n",
 	    htc->pipeline_b, htc->pipeline_e);
+	VSB_printf(vsb, "{rxra_b, rxra_e} = {%p, %p},\n",
+	    htc->rxra_b, htc->rxra_e);
 	VSB_printf(vsb, "content_length = %jd,\n",
 	    (intmax_t)htc->content_length);
 	VSB_printf(vsb, "body_status = %s,\n",

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -204,6 +204,8 @@ HTC_RxInit(struct http_conn *htc, struct ws *ws)
 		htc->pipeline_b = NULL;
 		htc->pipeline_e = NULL;
 	}
+	htc->rxra_b = NULL;
+	htc->rxra_e = NULL;
 }
 
 void
@@ -212,13 +214,13 @@ HTC_RxPipeline(struct http_conn *htc, void *p)
 
 	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
 	if (p == NULL || (char*)p == htc->rxbuf_e) {
-		htc->pipeline_b = NULL;
-		htc->pipeline_e = NULL;
+		htc->rxra_b = htc->pipeline_b = NULL;
+		htc->rxra_e = htc->pipeline_e = NULL;
 	} else {
 		assert((char*)p >= htc->rxbuf_b);
 		assert((char*)p < htc->rxbuf_e);
-		htc->pipeline_b = p;
-		htc->pipeline_e = htc->rxbuf_e;
+		htc->rxra_b = htc->pipeline_b = p;
+		htc->rxra_e = htc->pipeline_e = htc->rxbuf_e;
 	}
 }
 

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -188,6 +188,7 @@ HTC_RxInit(struct http_conn *htc, struct ws *ws)
 	ssize_t l;
 
 	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
+	htc->blocking = _HTC_BLK_UNKNOWN;
 	htc->ws = ws;
 	(void)WS_Reserve(htc->ws, 0);
 	htc->rxbuf_b = ws->f;
@@ -317,6 +318,28 @@ HTC_RxStuff(struct http_conn *htc, htc_complete_f *func,
 			}
 		}
 	}
+}
+
+int
+HTC_blocking(struct http_conn *htc) {
+	if (htc->blocking == HTC_BLOCKING)
+		return 0;
+
+	int i = VTCP_blocking(*htc->rfd);
+	if (i == 0)
+		htc->blocking = HTC_BLOCKING;
+	return (i);
+}
+
+int
+HTC_nonblocking(struct http_conn *htc) {
+	if (htc->blocking == HTC_NONBLOCKING)
+		return 0;
+
+	int i = VTCP_nonblocking(*htc->rfd);
+	if (i == 0)
+		htc->blocking = HTC_NONBLOCKING;
+	return (i);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -98,7 +98,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr,
 	VTCP_hisname(*htc->rfd, abuf, sizeof abuf, pbuf, sizeof pbuf);
 	VSLb(bo->vsl, SLT_BackendStart, "%s %s", abuf, pbuf);
 
-	(void)VTCP_blocking(*htc->rfd);	/* XXX: we should timeout instead */
+	(void)HTC_blocking(htc);	/* XXX: we should timeout instead */
 	V1L_Reserve(wrk, wrk->aws, htc->rfd, bo->vsl, bo->t_prev);
 	*ctr += HTTP1_Write(wrk, hp, HTTP1_Req);
 

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -364,13 +364,7 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 	sp = req->sp;
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 
-	/*
-	 * Whenever we come in from the acceptor or waiter, we need to set
-	 * blocking mode.  It would be simpler to do this in the acceptor
-	 * or waiter, but we'd rather do the syscall in the worker thread.
-	 * On systems which return errors for ioctl, we close early
-	 */
-	if (http1_getstate(sp) == H1NEWREQ && VTCP_blocking(sp->fd)) {
+	if (HTC_blocking(req->htc)) {
 		AN(req->htc->ws->r);
 		if (errno == ECONNRESET)
 			SES_Close(sp, SC_REM_CLOSE);

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -162,11 +162,14 @@ v1f_pull_chunked(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 		if (u >= sizeof buf)
 			return (VFP_Error(vc, "chunked header too long"));
 
-		/* Skip trailing white space */
-		while (vct_islws(buf[u]) && buf[u] != '\n') {
-			lr = v1f_read(vc, htc, buf + u, 1);
-			if (lr <= 0)
+		/* ignore extensions until newline (no strict CRLF check) */
+		if (vct_islws(buf[u])) {
+			while (buf[u] != '\n') {
+				lr = v1f_read(vc, htc, buf + u, 1);
+				if (lr == 1)
+					continue;
 				return (VFP_Error(vc, "chunked read err"));
+			}
 		}
 
 		if (buf[u] != '\n')

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -169,8 +169,8 @@ v1f_trailer_part_process(struct http *hp, int filter)
 
 #define trail_err(vc, ws, str) do {					\
 		if (ws)						\
-			WS_Release(ws, 0);				\
-		return (VFP_Error(vc, str));				\
+			WS_Release((ws), 0);				\
+		return (VFP_Error((vc), (str)));			\
 	} while(0)
 
 static inline enum vfp_status

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -112,28 +112,121 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 	return (i + l);
 }
 
+/*--------------------------------------------------------------------
+ * check if header is in Trailer
+ * XXX could be more efficient by avoiding repeated GetHdr in GetHdrToken
+ */
+static int
+v1f_trailer_part_allowed(const struct http *hp, const char *hdr)
+{
+	const char *p = strchr(hdr, ':');
+	const int l = (int)pdiff(hdr, p);
+	char cp[l + 1];
+
+	(void)strncpy(cp, hdr, l);
+	cp[l] = '\0';
+
+	return (http_GetHdrToken(hp, H_Trailer, cp, NULL, NULL));
+}
+
+/*--------------------------------------------------------------------
+ * log and filter trailer parts based on Trailer header
+ *
+ * Ref: https://tools.ietf.org/html/rfc7230#section-4.4
+ *
+ * re-interpreting SHOULD as MUST: accept no trailer-part unless allowed in
+ * Trailer.
+ * To allow VCL control, we also accept "Tailer: *" for "allow any".
+ *
+ * code analoguos to http_Unset()
+ */
+void
+v1f_trailer_part_process(struct http *hp, uint16_t u, int filter)
+{
+	uint16_t v;
+
+	for (v = u; u < hp->nhd; u++) {
+		Tcheck(hp->hd[u]);
+
+		if (filter && ! v1f_trailer_part_allowed(hp, hp->hd[u].b)) {
+			http_VSLH_del(hp, u);
+			continue;
+		}
+		http_VSLH(hp, u);
+		if (v != u) {
+			memcpy(&hp->hd[v], &hp->hd[u], sizeof *hp->hd);
+			memcpy(&hp->hdf[v], &hp->hdf[u], sizeof *hp->hdf);
+		}
+		v++;
+	}
+	hp->nhd = v;
+}
 
 /*--------------------------------------------------------------------
  * Process chunked encoding trailer. Inherits buffer from caller, which
  * is pre-filled up to lim
  */
 
+#define trail_err(vc, ws, str) do {					\
+		if (ws)						\
+			WS_Release(ws, 0);				\
+		return (VFP_Error(vc, str));				\
+	} while(0)
+
 static inline enum vfp_status
 v1f_chunked_trailer(struct vfp_ctx *vc, struct vfp_entry *vfe,
     struct http_conn *htc,
-    char *buf, const size_t bufsz, char *lim)
+    char *buf, size_t bufsz, char *lim)
 {
-	char *q;
-	unsigned u = 0;
+	const char *q;
+	unsigned u, rdsz;
+
+	char *hdrs_b = NULL;
+	struct ws *ws = NULL;
+	struct http *hp = NULL;
+
+	enum {
+		DONT_SAVE = 0,
+		SAVE_FILTER,
+		SAVE_WILD
+	}
+	save = DONT_SAVE;
 
 	assert (bufsz >= 4);
 
+	hp = vc->req;
+	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
+	if (vc->resp && http_GetHdrToken(hp, H_TE, "trailers", NULL, NULL)) {
+		hp = vc->resp;
+		CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
+
+		if (http_GetHdr(hp, H_Trailer, &q))
+			save = (*q == '*') ? SAVE_WILD : SAVE_FILTER;
+	} else
+		hp = NULL;
+
+	if (save) {
+		u = pdiff(buf, lim);
+
+		ws = hp->ws;
+		bufsz = WS_Reserve(ws, 0);
+		if (bufsz < u + 4)
+			trail_err(vc, ws, "insufficient ws for save");
+
+		memcpy(ws->f, buf, u);
+		buf = ws->f;
+		lim = ws->f + u;
+		bufsz -= u;
+		hdrs_b = buf;
+	}
+
 	/*
-	 * Trailer: discard for now. Because the trailers are terminated by
-	 * CRLFCRLF, we try to read up to 4 characters, unless we have already
-	 * seen part of the termination sequence
+	 * Trailers are terminated by CRLFCRLF, we try to read up to 4
+	 * characters, unless we have already seen part of the termination
+	 * sequence
 	 */
 
+	u = 0;
 	while (1) {
 #ifdef DBG_V1F
 		VSLb(vc->wrk->vsl, SLT_Debug, "trailer u=%d %.*s",
@@ -144,35 +237,69 @@ v1f_chunked_trailer(struct vfp_ctx *vc, struct vfp_entry *vfe,
 			switch (*q) {
 			case '\r': {
 				if (u & 1)
-					return(VFP_Error(vc,
-					    "chunked trailer CRCR"));
+					trail_err(vc, ws,
+						  "chunked trailer CRCR");
 				u++;
 				break;
 			}
 			case '\n': {
 				if ((u & 1) == 0)
-					return(VFP_Error(vc,
-					    "chunked trailer LF no CR"));
+					trail_err(vc, ws,
+						  "chunked trailer LF no CR");
 				u++;
 				break;
 			}
 			default:
 				if (u & 1)
-					return(VFP_Error(vc,
-					    "chunked trailer CR no LF"));
+					trail_err(vc, ws,
+						  "chunked trailer CR no LF");
 				u = 0;
 			}
 			q++;
 		}
 		if (u >= 4)
 			break;
-		if (v1f_read(vc, htc, buf, 4 - u) != 4 - u)
-			return (VFP_Error(vc, "chunked trailer read err"));
-		lim = buf + 4 - u;
+		rdsz = 4 - u;
+		if (save) {
+			if (bufsz < rdsz)
+				trail_err(vc, ws, "insufficient ws for save");
+			buf = lim;
+			bufsz -= rdsz;
+		}
+		if (v1f_read(vc, htc, buf, rdsz) != rdsz)
+			trail_err(vc, ws, "chunked trailer read err");
+		lim = buf + rdsz;
 	}
 	assert(u == 4);
+
+	if (save) {
+		if (pdiff(hdrs_b, lim) <= 4) {
+			WS_Release(ws, 0);
+			return (VFP_END);
+		}
+
+		lim -= 2;
+
+		const uint16_t ohd = hp->nhd;
+
+		// note: Could also change hp->conds - irrelevant here
+		if (HTTP1_DissectHdrs(hp, &hdrs_b, lim,
+				      cache_param->http_resp_hdr_len))
+			trail_err(vc, ws, "chunked trailer dissect failed");
+
+		assert(hdrs_b <= lim);
+
+		v1f_trailer_part_process(hp, ohd, save == SAVE_FILTER);
+
+		if (hp->nhd == ohd)
+			WS_Release(ws, 0);
+		else
+			WS_ReleaseP(ws, TRUST_ME(hp->hd[hp->nhd - 1].e + 1));
+	}
 	return (VFP_END);
 }
+
+#undef trail_err
 
 /*--------------------------------------------------------------------
  * Read a chunked HTTP object.

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -140,7 +140,7 @@ v1f_trailer_part_allowed(const struct http *hp, const char *hdr)
  *
  * code analoguos to http_Unset()
  */
-void
+static void
 v1f_trailer_part_process(struct http *hp, int filter)
 {
 	uint16_t u, v;
@@ -174,8 +174,7 @@ v1f_trailer_part_process(struct http *hp, int filter)
 	} while(0)
 
 static inline enum vfp_status
-v1f_chunked_trailer(struct vfp_ctx *vc, struct vfp_entry *vfe,
-    struct http_conn *htc,
+v1f_chunked_trailer(struct vfp_ctx *vc, struct http_conn *htc,
     char *buf, size_t bufsz, char *lim)
 {
 	const char *q;
@@ -397,7 +396,7 @@ v1f_pull_chunked(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 			return (VFP_END);
 		return (VFP_Error(vc, "chunked tail CR no LF"));
 	}
-	return (v1f_chunked_trailer(vc, vfe, htc, buf, bufsz, buf + 2));
+	return (v1f_chunked_trailer(vc, htc, buf, bufsz, buf + 2));
 }
 
 static const struct vfp v1f_chunked = {

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -883,7 +883,7 @@ h2_rxframe(struct worker *wrk, struct h2_sess *h2)
 	char b[8];
 
 	ASSERT_RXTHR(h2);
-	(void)VTCP_blocking(*h2->htc->rfd);
+	(void)HTC_blocking(h2->htc);
 	h2->sess->t_idle = VTIM_real();
 	hs = HTC_RxStuff(h2->htc, h2_frame_complete,
 	    NULL, NULL, NAN,

--- a/bin/varnishtest/tests/b00007.vtc
+++ b/bin/varnishtest/tests/b00007.vtc
@@ -15,7 +15,8 @@ server s1 {
 	send "HTTP/1.1 200 OK\r\n"
 	send "Transfer-encoding: chunked\r\n"
 	send "\r\n"
-	send "00000004\r\n1234\r\n"
+	send {00000004 extname="extval"; another=val; justname}
+	send "\r\n1234\r\n"
 	chunked "1234"
 	chunked ""
 } -start

--- a/bin/varnishtest/tests/b00007.vtc
+++ b/bin/varnishtest/tests/b00007.vtc
@@ -23,6 +23,37 @@ server s1 {
 	send "But: Ignored\r\n"
 	send "\r\n"
 
+	rxreq
+	expect req.url == "/save"
+	expect req.http.TE == "trailers"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "Trailer: T-One, t-two\r\n"
+	send "\r\n"
+	send {00000004 extname="extval"; another=val; justname}
+	send "\r\n1234\r\n"
+	chunked "1234"
+	send "0\r\n"
+	send "Invalid: Trailer\r\n"
+	send "T-One: ready\r\n"
+	send "Also: Ignored\r\n"
+	send "T-Two: steady\r\n"
+	send "\r\n"
+
+	rxreq
+	expect req.url == "/save/wild"
+	expect req.http.TE == "trailers"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "Trailer: *\r\n"
+	send "\r\n"
+	send {00000004 extname="extval"; another=val; justname}
+	send "\r\n1234\r\n"
+	chunked "1234"
+	send "0\r\n"
+	send "No: matter\r\nThe: header\r\nIts: accepted\r\n"
+	send "\r\n"
+
 	# intentionally varying the trailer slightly in the following tests
 	rxreq
 	expect req.url == "/bad/trailer/CRCR"
@@ -69,9 +100,25 @@ server s1 {
 } -start
 
 varnish v1 -vcl+backend {
+	sub vcl_backend_fetch {
+	    if (bereq.url ~ "^/save") {
+		# we filter TE from the client, so trailers can only be
+		# enabled explicitly from vcl
+		set bereq.http.TE = "trailers";
+	    }
+	}
+
 	sub vcl_backend_response {
 	    if (bereq.url ~ "^/bad") {
-	       set beresp.do_stream = false;
+		# to get 503 for vtc instead of closed connection
+		set beresp.do_stream = false;
+	    }
+	    if (bereq.url ~ "^/save/wild") {
+		# Trailer: * removed by core code
+		if (beresp.http.Trailer) {
+		    return (abandon);
+		}
+		set beresp.http.Trailer = "*";
 	    }
 	}
 } -start
@@ -99,19 +146,43 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 	expect resp.bodylen == "4"
+
 	txreq -url "/foo"
 	rxresp
 	expect resp.status == 200
 	expect resp.bodylen == "8"
+	expect resp.http.Invalid == <undef>
+	expect resp.http.But == <undef>
+
+	txreq -url "/save"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == "8"
+	expect resp.http.Invalid == <undef>
+	expect resp.http.T-One == "ready"
+	expect resp.http.Also == <undef>
+	expect resp.http.T-Two == "steady"
+
+	txreq -url "/save/wild"
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == "8"
+	expect resp.http.No == "matter"
+	expect resp.http.The == "header"
+	expect resp.http.Its == "accepted"
+
 	txreq -url "/bad/trailer/CRCR"
 	rxresp
 	expect resp.status == 503
+
 	txreq -url "/bad/trailer/LFnoCR"
 	rxresp
 	expect resp.status == 503
+
 	txreq -url "/bad/trailer/CRnoLF"
 	rxresp
 	expect resp.status == 503
+
 	txreq -url "/bad/trailer/short"
 	rxresp
 	expect resp.status == 503

--- a/bin/varnishtest/tests/b00007.vtc
+++ b/bin/varnishtest/tests/b00007.vtc
@@ -18,10 +18,81 @@ server s1 {
 	send {00000004 extname="extval"; another=val; justname}
 	send "\r\n1234\r\n"
 	chunked "1234"
-	chunked ""
+	send "0\r\n"
+	send "Invalid: Trailer\r\n"
+	send "But: Ignored\r\n"
+	send "\r\n"
+
+	# intentionally varying the trailer slightly in the following tests
+	rxreq
+	expect req.url == "/bad/trailer/CRCR"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	send {00000004 foo=bar}
+	send "\r\n1234\r\n"
+	send "0\r\n"
+	send "Invalid: Trail\r\nBut: Ignored\r\r\n"
+
+	accept
+	rxreq
+	expect req.url == "/bad/trailer/LFnoCR"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	send {00000004 }
+	send "\r\n1234\r\n"
+	send "0\r\n"
+	send "Invalid: Traile\nBut: Ignored\r\n\r\n"
+
+	accept
+	rxreq
+	expect req.url == "/bad/trailer/CRnoLF"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	send {4}
+	send "\r\n1234\r\n"
+	send "0\r\n"
+	send "Invalid: Trailer\rBut: Ignored\r\n\r\n"
+
+	accept
+	rxreq
+	expect req.url == "/bad/trailer/short"
+	send "HTTP/1.1 200 OK\r\n"
+	send "Transfer-encoding: chunked\r\n"
+	send "\r\n"
+	send {00000004 extname="extval"; another=val; justname}
+	send "\r\n1234\r\n"
+	send "0\r\n"
+	send "Invalid: Trailer\r\nBut: Ignored\r\n\r"
 } -start
 
-varnish v1 -vcl+backend {} -start
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+	    if (bereq.url ~ "^/bad") {
+	       set beresp.do_stream = false;
+	    }
+	}
+} -start
+
+logexpect l1 -v v1 -g request {
+	expect * *	BereqURL	{^/bad/trailer/CRCR}
+	expect * =	Fetch_Body	{^2 chunked}
+	expect * =	FetchError	{^chunked trailer CRCR}
+
+	expect * *	BereqURL	{^/bad/trailer/LFnoCR}
+	expect * =	Fetch_Body	{^2 chunked}
+	expect * =	FetchError	{^chunked trailer LF no CR}
+
+	expect * *	BereqURL	{^/bad/trailer/CRnoLF}
+	expect * =	Fetch_Body	{^2 chunked}
+	expect * =	FetchError	{^chunked trailer CR no LF}
+
+	expect * *	BereqURL	{^/bad/trailer/short}
+	expect * =	Fetch_Body	{^2 chunked}
+	expect * =	FetchError	{^chunked trailer read err}
+} -start
 
 client c1 {
 	txreq -url "/bar"
@@ -32,4 +103,18 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 	expect resp.bodylen == "8"
+	txreq -url "/bad/trailer/CRCR"
+	rxresp
+	expect resp.status == 503
+	txreq -url "/bad/trailer/LFnoCR"
+	rxresp
+	expect resp.status == 503
+	txreq -url "/bad/trailer/CRnoLF"
+	rxresp
+	expect resp.status == 503
+	txreq -url "/bad/trailer/short"
+	rxresp
+	expect resp.status == 503
 } -run
+
+logexpect l1 -wait

--- a/include/tbl/bo_flags.h
+++ b/include/tbl/bo_flags.h
@@ -40,6 +40,7 @@ BO_FLAG(is_gzip,	0, 0, "")
 BO_FLAG(is_gunzip,	0, 0, "")
 BO_FLAG(was_304,	1, 0, "")
 BO_FLAG(is_bgfetch,	0, 0, "")
+BO_FLAG(do_trailers,	0, 0, "")
 #undef BO_FLAG
 
 /*lint -restore */


### PR DESCRIPTION
Overall documentation from 10d24f445bac7a520b0aa47385ddc4c35299f1c2:

## Usage / VCL
    
Trailer processing is enabled with ``set bereq.http.TE = "trailers";`` in ``vcl_backend_fetch{}``. Only then may the backend send a chunked response with trailers. Any ``TE`` client header remains filtered, so trailer processing is neither implicitly enabled nor would trailers ever be sent downstream (except in pipe mode).
    
The above only allows the backend to send trailers, whether or not it actually makes use of that capability (or if it even chooses chunked encoding) is up to the backend.
    
For processing of the backend response, we enable trailer handling only if a ``Trailers:`` backend response header is present - either from the backend or set in ``vcl_backend_response{}``. ``Trailers:`` must contain header names to be accepted in the chunked trailer. In addition, ``set beresp.http.Trailers = "*";`` can be used in vcl to instruct varnish to accept any header in the chunked trailer. ``Trailers: *`` is never accepted from a backend.
    
Any accepted trailer headers are copied into the object without additional VCL control. In other words, any headers allowed by the ``Trailers`` header are accepted as-are. Additional filtering is possible on the client side.

Trailer processing implicitly disables streaming. The backend response is read into cache and trailer headers are delivered as normal response headers.
    
## Implementation notes

The object API requires that the size of the attribute space is known at object creation time, so we need to guess the amount of space to reserve for trailers. For this initial implementation, the reserve is hardcoded as 1KB and we'll probably want some VCL control later.

For trailer processing, the setting OA_HEADERS now needs happen after reading the body, obviously. It is unclear if The Proprietary Stevedore (tm) supports this.

To avoid code duplication for header dissection, http1_dissect_hdrs() is now generalised and declared in cache.h as HTTP1_DissectHdrs()

For logging new/deleted headers from vbf, http_VSLH() and http_VSLH_del() are now declared in cache_http.h
