### PR TITLE
v1l should live on the session workspace

### DIFF
--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -117,11 +117,16 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 	if (sendbody && req->resp_len != 0)
 		VDP_push(req, &v1d_vdp, NULL, 1);
 
-	AZ(req->wrk->v1l);
-	V1L_Reserve(req->wrk, req->ws, &req->sp->fd, req->vsl, req->t_prev);
-
 	if (WS_Overflowed(req->ws)) {
 		v1d_error(req, "workspace_client overflow");
+		return;
+	}
+
+	AZ(req->wrk->v1l);
+	V1L_Reserve(req->wrk, req->sp->ws, &req->sp->fd, req->vsl, req->t_prev);
+
+	if (WS_Overflowed(req->sp->ws)) {
+		v1d_error(req, "workspace_session overflow");
 		AZ(req->wrk->v1l);
 		return;
 	}

--- a/bin/varnishtest/tests/c00071.vtc
+++ b/bin/varnishtest/tests/c00071.vtc
@@ -18,6 +18,7 @@ varnish v1 -vcl+backend {
 
 		if (req.url ~ "/bar") {
 			set resp.http.x-foo = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+			vtc.workspace_alloc(session, -10);
 		}
 		else if (req.url ~ "/baz") {
 			set resp.http.x-foo = regsub(req.url, "baz", "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz");

--- a/bin/varnishtest/tests/c00074.vtc
+++ b/bin/varnishtest/tests/c00074.vtc
@@ -10,16 +10,25 @@ varnish v1 -vcl+backend {
 	import vtc;
 
 	sub vcl_recv {
-		set req.http.ws-free = vtc.workspace_free(session);
-		vtc.workspace_alloc(session, std.integer(req.http.ws-free, 0));
+		set req.http.ws-free1 = vtc.workspace_free(session);
+		vtc.workspace_alloc(session, std.integer(req.http.ws-free1, 0));
+		set req.http.ws-free2 = vtc.workspace_free(session);
 		vtc.workspace_snapshot(session);
 		vtc.workspace_reset(session);
+		set req.http.ws-free3 = vtc.workspace_free(session);
 	}
+} -start
+
+logexpect l1 -v v1 -g request {
+	expect * * ReqHeader {^ws-free1:}
+	expect 0 = ReqHeader {^ws-free2: 0$}
+	expect 0 = ReqHeader {^ws-free3: 0$}
 } -start
 
 client c1 {
 	txreq -url /foo
 	rxresp
-	expect resp.status == 200
+	expect resp.status == 500
 } -run
 
+logexpect l1 -wait

--- a/bin/varnishtest/tests/r02275.vtc
+++ b/bin/varnishtest/tests/r02275.vtc
@@ -15,14 +15,19 @@ varnish v1 -vcl+backend {
 	import vtc;
 
 	sub vcl_deliver {
+		# struct v1l is 13 - 15 pointer-sizes,
+		# an iovec should be two pointer-sizes
+		#
+		# we want to hit the case where we got just not
+		# enough space for three iovecs
 		if (req.url == "/1") {
-			vtc.workspace_alloc(client,
-			    -1 * (32 + vtc.typesize("p") * 25));
+			vtc.workspace_alloc(session,
+			    -1 * vtc.typesize("p") * (13 + 4));
 		} else {
-			vtc.workspace_alloc(client,
-			    -1 * (56 + vtc.typesize("p") * 25));
+			vtc.workspace_alloc(session,
+			    -1 * vtc.typesize("p") * (15 + 6));
 		}
-		set resp.http.foo = vtc.workspace_free(client);
+		set resp.http.foo = vtc.workspace_free(session);
 	}
 } -start
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1667,13 +1667,18 @@ PARAM(
 	/* typ */	bytes_u,
 	/* min */	"0.25k",
 	/* max */	NULL,
-	/* default */	"0.50k",
+	/* default */	"2k",
 	/* units */	"bytes",
 	/* flags */	DELAYED_EFFECT,
 	/* s-text */
-	"Allocation size for session structure and workspace.    The "
-	"workspace is primarily used for TCP connection addresses.  If "
-	"larger than 4k, use a multiple of 4k for VM efficiency.",
+	"Allocation size for session structure and workspace.  This "
+	"workspace is primarily used for TCP connection addresses and "
+	"IO-vectors used during delivery. Setting this parameter too "
+	"low may increase the number of writev() syscalls. Setting it "
+	"to larger values than 0.25k + UIO_MAXIOV * sizeof(struct "
+	"iovec) (typically ~16k for 64bit) is likely a waste of "
+	"memory. For values >4k, use a multuple of 4k for VM "
+	"efficiency.",
 	/* l-text */	"",
 	/* func */	NULL
 )


### PR DESCRIPTION
The motivation is to remove the reservation from req->ws during delivery, but actually line delivery is a function of the session, thus memory required for it should also come from there:
    
* We avoid requiring to have an obscure surplus of workspace_client for delivery
  * which is also added for every subrequest though not required there
* We get predictable performance as the number of IO-vectors available is now only a function of workspace_session rather than the amount of memory which happens to be available on the request workspace.

As a sensible side effect, we now also fail with an internal 500 for workspace_session overflows (which we should have already, but as the session workspace was not used for much, this was not relevant).
    
We raise the default to 2k to accomodate the ~120 iovs to send 60 HTTP1 headers in a single writev() call.
