### PR TITLE
Remove cli buffer

### DIFF
--- a/bin/varnishd/cache/cache_cli.c
+++ b/bin/varnishd/cache/cache_cli.c
@@ -123,8 +123,7 @@ CLI_Init(void)
 	Lck_New(&cli_mtx, lck_cli);
 	cli_thread = pthread_self();
 
-	cls = VCLS_New(cli_cb_before, cli_cb_after,
-	    &cache_param->cli_buffer, &cache_param->cli_limit);
+	cls = VCLS_New(cli_cb_before, cli_cb_after, &cache_param->cli_limit);
 	AN(cls);
 	VCLS_Clone(cls, heritage.cls);
 

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -361,7 +361,7 @@ mgt_launch_child(struct cli *cli)
 	MCH_Fd_Inherit(heritage.cli_out, NULL);
 	closefd(&heritage.cli_out);
 
-	child_std_vlu = VLU_New(NULL, child_line, 0);
+	child_std_vlu = VLU_New(NULL, child_line);
 	AN(child_std_vlu);
 
 	AZ(ev_listen);

--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -365,7 +365,7 @@ mgt_cli_init_cls(void)
 {
 
 	mgt_cls = VCLS_New(mgt_cli_cb_before, mgt_cli_cb_after,
-	    &mgt_param.cli_buffer, &mgt_param.cli_limit);
+	    &mgt_param.cli_limit);
 	AN(mgt_cls);
 	VCLS_AddFunc(mgt_cls, MCF_NOAUTH, cli_auth);
 	VCLS_AddFunc(mgt_cls, MCF_AUTH, cli_proto);

--- a/bin/varnishtest/vtc_process.c
+++ b/bin/varnishtest/vtc_process.c
@@ -173,7 +173,7 @@ process_thread(void *priv)
 
 	CAST_OBJ_NOTNULL(p, priv, PROCESS_MAGIC);
 	if (p->fd_from > 0) {
-		vlu = VLU_New(p, process_vlu_func, 1024);
+		vlu = VLU_New(p, process_vlu_func);
 		while (!VLU_Fd(p->fd_from, vlu))
 			continue;
 		VLU_Destroy(vlu);

--- a/include/vcli_serve.h
+++ b/include/vcli_serve.h
@@ -93,7 +93,7 @@ void VCLI_SetResult(struct cli *cli, unsigned r);
 typedef void cls_cb_f(void *priv);
 typedef void cls_cbc_f(const struct cli*);
 struct VCLS *VCLS_New(cls_cbc_f *before, cls_cbc_f *after,
-    volatile unsigned *maxlen, volatile unsigned *limit);
+    volatile unsigned *limit);
 struct cli *VCLS_AddFd(struct VCLS *cs, int fdi, int fdo, cls_cb_f *closefunc,
     void *priv);
 void VCLS_AddFunc(struct VCLS *cs, unsigned auth, struct cli_proto *clp);

--- a/include/vlu.h
+++ b/include/vlu.h
@@ -31,7 +31,7 @@
 #define VLU_H_INCLUDED
 
 typedef int (vlu_f)(void *, const char *);
-struct vlu *VLU_New(void *priv, vlu_f *func, unsigned bufsize);
+struct vlu *VLU_New(void *priv, vlu_f *func);
 int VLU_Fd(int fd, struct vlu *l);
 void VLU_Destroy(struct vlu *l);
 #endif

--- a/include/vsb.h
+++ b/include/vsb.h
@@ -61,6 +61,7 @@ struct vsb	*VSB_new(struct vsb *, char *, int, int);
 #define		 VSB_new_auto()				\
 	VSB_new(NULL, NULL, 0, VSB_AUTOEXTEND)
 void		 VSB_clear(struct vsb *);
+void		 VSB_keepsome(struct vsb *, char *, unsigned);
 int		 VSB_bcat(struct vsb *, const void *, ssize_t);
 int		 VSB_cat(struct vsb *, const char *);
 int		 VSB_printf(struct vsb *, const char *, ...)

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -73,7 +73,6 @@ struct VCLS {
 	unsigned			nfd;
 	VTAILQ_HEAD(,cli_proto)		funcs;
 	cls_cbc_f			*before, *after;
-	volatile unsigned		*maxlen;
 	volatile unsigned		*limit;
 	struct cli_proto		*wildcard;
 };
@@ -400,8 +399,7 @@ cls_vlu(void *priv, const char *p)
 }
 
 struct VCLS *
-VCLS_New(cls_cbc_f *before, cls_cbc_f *after, volatile unsigned *maxlen,
-    volatile unsigned *limit)
+VCLS_New(cls_cbc_f *before, cls_cbc_f *after, volatile unsigned *limit)
 {
 	struct VCLS *cs;
 
@@ -411,7 +409,6 @@ VCLS_New(cls_cbc_f *before, cls_cbc_f *after, volatile unsigned *maxlen,
 	VTAILQ_INIT(&cs->funcs);
 	cs->before = before;
 	cs->after = after;
-	cs->maxlen = maxlen;
 	cs->limit = limit;
 	return (cs);
 }
@@ -431,7 +428,7 @@ VCLS_AddFd(struct VCLS *cs, int fdi, int fdo, cls_cb_f *closefunc, void *priv)
 	cfd->fdo = fdo;
 	cfd->cli = &cfd->clis;
 	cfd->cli->magic = CLI_MAGIC;
-	cfd->cli->vlu = VLU_New(cfd, cls_vlu, *cs->maxlen);
+	cfd->cli->vlu = VLU_New(cfd, cls_vlu);
 	cfd->cli->sb = VSB_new_auto();
 	cfd->cli->limit = cs->limit;
 	cfd->cli->priv = priv;

--- a/lib/libvarnish/vsb.c
+++ b/lib/libvarnish/vsb.c
@@ -251,6 +251,24 @@ VSB_clear(struct vsb *s)
 }
 
 /*
+ * Keep a bit of this VSB but clear the rest
+ */
+void
+VSB_keepsome(struct vsb *s, char *p, unsigned l)
+{
+
+	assert_VSB_integrity(s);
+	/* don't care if it's finished or not */
+
+	/* check that (p, l) represents a substring of this buffer */
+	assert(p >= s->s_buf);
+	assert(p + l <= s->s_buf + s->s_len);
+
+	memmove(s->s_buf, p, l);
+	VSB_CLEARFLAG(s, VSB_FINISHED);
+}
+
+/*
  * Append a byte to an vsb.  This is the core function for appending
  * to an vsb and is the main place that deals with extending the
  * buffer and marking overflow.

--- a/lib/libvarnish/vsub.c
+++ b/lib/libvarnish/vsub.c
@@ -126,7 +126,7 @@ VSUB_run(struct vsb *sb, vsub_func_f *func, void *priv, const char *name,
 		_exit(4);
 	}
 	closefd(&p[1]);
-	vlu = VLU_New(&sp, vsub_vlu, 0);
+	vlu = VLU_New(&sp, vsub_vlu);
 	while (!VLU_Fd(p[0], vlu))
 		continue;
 	closefd(&p[0]);


### PR DESCRIPTION
The pull request #2382 was not in fact completely removing `cli_buffer` parameter, and this should fix it. The addition to VSB might be controversial, and I would like to get feedback on what the new function should be called (if the functionality is accepted), and what parameters should be (pointers vs indices, start + length vs. start + end).