### PR TITLE
thread ws from heap and v1l from thread ws

### DIFF
--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -98,7 +98,6 @@ WRK_Thread(struct pool *qp, size_t stacksize, unsigned thread_workspace)
 {
 	struct worker *w, ww;
 	struct VSC_main ds;
-	unsigned char ws[thread_workspace];
 
 	AN(qp);
 	AN(stacksize);
@@ -112,7 +111,7 @@ WRK_Thread(struct pool *qp, size_t stacksize, unsigned thread_workspace)
 	w->stats = &ds;
 	AZ(pthread_cond_init(&w->cond, NULL));
 
-	WS_Init(w->aws, "wrk", ws, thread_workspace);
+	WS_Init(w->aws, "wrk", malloc(thread_workspace), thread_workspace);
 
 	VSL(SLT_WorkThread, 0, "%p start", w);
 
@@ -125,6 +124,8 @@ WRK_Thread(struct pool *qp, size_t stacksize, unsigned thread_workspace)
 	AZ(pthread_cond_destroy(&w->cond));
 	HSH_Cleanup(w);
 	Pool_Sumstat(w);
+	WS_Assert(w->aws);
+	free(w->aws->s);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -117,11 +117,22 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 	if (sendbody && req->resp_len != 0)
 		VDP_push(req, &v1d_vdp, NULL, 1);
 
-	AZ(req->wrk->v1l);
-	V1L_Reserve(req->wrk, req->ws, &req->sp->fd, req->vsl, req->t_prev);
-
 	if (WS_Overflowed(req->ws)) {
 		v1d_error(req, "workspace_client overflow");
+		return;
+	}
+
+	if (WS_Overflowed(req->sp->ws)) {
+		v1d_error(req, "workspace_session overflow");
+		return;
+	}
+
+	AZ(req->wrk->v1l);
+	V1L_Reserve(req->wrk, req->wrk->aws,
+		    &req->sp->fd, req->vsl, req->t_prev);
+
+	if (WS_Overflowed(req->wrk->aws)) {
+		v1d_error(req, "workspace_thread overflow");
 		AZ(req->wrk->v1l);
 		return;
 	}

--- a/bin/varnishtest/tests/c00071.vtc
+++ b/bin/varnishtest/tests/c00071.vtc
@@ -18,6 +18,7 @@ varnish v1 -vcl+backend {
 
 		if (req.url ~ "/bar") {
 			set resp.http.x-foo = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+			vtc.workspace_alloc(client, -10);
 		}
 		else if (req.url ~ "/baz") {
 			set resp.http.x-foo = regsub(req.url, "baz", "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz");

--- a/bin/varnishtest/tests/r02275.vtc
+++ b/bin/varnishtest/tests/r02275.vtc
@@ -1,5 +1,22 @@
 varnishtest "Chunked with no space for iov's on workspace"
 
+# For this test to work with iovecs on the thread workspace (where
+# they belong!), we would need to circumvent the very sensible vrt
+# check that vcl make no permanent reservations on the thread
+# workspace (see vcl_call_method()).
+#
+# One possible way would be to push a VDP just for this.
+#
+# For now, we consider this issue low priority because with v1l living
+# on the thread workspace, the case for hitting #2275 again is as
+# exotic as can be.
+#
+# The values used in this test have been carefully worked out and
+# tested with v1l on the session workspace, so they should work 1:1 on
+# the thread workspace.
+
+feature cmd false
+
 server s1 -repeat 2 {
 	rxreq
 	txresp -nolen -hdr "Transfer-encoding: chunked"
@@ -15,14 +32,19 @@ varnish v1 -vcl+backend {
 	import vtc;
 
 	sub vcl_deliver {
+		# struct v1l is 13 - 15 pointer-sizes,
+		# an iovec should be two pointer-sizes
+		#
+		# we want to hit the case where we got just not
+		# enough space for three iovecs
 		if (req.url == "/1") {
-			vtc.workspace_alloc(client,
-			    -1 * (32 + vtc.typesize("p") * 25));
+			vtc.workspace_alloc(thread,
+			    -1 * vtc.typesize("p") * (13 + 4));
 		} else {
-			vtc.workspace_alloc(client,
-			    -1 * (56 + vtc.typesize("p") * 25));
+			vtc.workspace_alloc(thread,
+			    -1 * vtc.typesize("p") * (15 + 6));
 		}
-		set resp.http.foo = vtc.workspace_free(client);
+		set resp.http.foo = vtc.workspace_free(thread);
 	}
 } -start
 
@@ -36,4 +58,3 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 } -run
-

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,10 @@ Varnish Cache Trunk (ongoing)
   less than the number of allowed restarts, it now is the number of
   ``return(restart)`` calls per request.
 
+* We have moved the allocation of ``workspace_thread`` from the stack
+  to the heap, so ``thread_pool_stack`` can now be reduced by
+  ``workspace_thread``. The default has been changed accordingly.
+
 ================================
 Varnish Cache 5.2.0 (2017-09-15)
 ================================

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1266,7 +1266,7 @@ PARAM(
 	/* typ */	bytes,
 	/* min */	"2k",
 	/* max */	NULL,
-	/* default */	"48k",
+	/* default */	"46k",
 	/* units */	"bytes",
 	/* flags */	EXPERIMENTAL,
 	/* s-text */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1690,9 +1690,12 @@ PARAM(
 	"Bytes of auxiliary workspace per thread.\n"
 	"This workspace is used for certain temporary data structures "
 	"during the operation of a worker thread.\n"
-	"One use is for the io-vectors for writing requests and responses "
-	"to sockets, having too little space will result in more writev(2) "
-	"system calls, having too much just wastes the space.",
+	"One use is for the IO-vectors used during delivery. Setting "
+	"this parameter too low may increase the number of writev() "
+	"syscalls, setting it too high just wastes space.  ~0.1k + "
+	"UIO_MAXIOV * sizeof(struct iovec) (typically = ~16k for 64bit) "
+	"is considered the maximum sensible value under any known "
+	"circumstances (excluding exotic vmod use).",
 	/* l-text */	"",
 	/* func */	NULL
 )


### PR DESCRIPTION
* Allocate thread_workspace from the heap rather than from the stack
* take v1l memory from the thread workspace
  * for ESIs, switch to a new thread ws when needed