### PR TITLE
mark workspace overflows where some WS_Reserve() was insufficient

### DIFF
--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -379,6 +379,7 @@ http_CollectHdrSep(struct http *hp, const char *hdr, const char *sep)
 			if (b + x >= e) {
 				http_fail(hp);
 				VSLb(hp->vsl, SLT_LostHeader, "%s", hdr + 1);
+				WS_MarkOverflow(hp->ws);
 				WS_Release(hp->ws, 0);
 				return;
 			}

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -207,6 +207,10 @@ VRT_String(struct ws *ws, const char *h, const char *p, va_list ap)
 	}
 	b = VRT_StringList(b, e > b ? e - b : 0, p, ap);
 	if (b == NULL || b == e) {
+		/*
+		 * NO WS_MarkOverflow here because the caller might have a
+		 * fallback
+		 */
 		WS_Release(ws, 0);
 		return (NULL);
 	}


### PR DESCRIPTION
motivated by #2488 but unrelated to it:
We missed to mark some workspace overflow when a `WS_Reserve()` turned out to be insufficient.