### PR TITLE
Backend "extrachance" retry fixes

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -112,7 +112,7 @@ vbe_dir_getfd(struct worker *wrk, struct backend *bp, struct busyobj *bo)
 	bo->htc->doclose = SC_NULL;
 
 	FIND_TMO(connect_timeout, tmod, bo, bp);
-	vtp = VTP_Get(bp->tcp_pool, tmod, wrk);
+	vtp = VTP_Get(bp->tcp_pool, tmod, wrk, 0);
 	if (vtp == NULL) {
 		VSLb(bo->vsl, SLT_FetchError,
 		     "backend %s: fail", bp->director->display_name);

--- a/bin/varnishd/cache/cache_tcp_pool.c
+++ b/bin/varnishd/cache/cache_tcp_pool.c
@@ -366,7 +366,8 @@ VTP_Close(struct vtp **vtpp)
  */
 
 struct vtp *
-VTP_Get(struct tcp_pool *tp, double tmo, struct worker *wrk)
+VTP_Get(struct tcp_pool *tp, double tmo, struct worker *wrk,
+    unsigned force_fresh)
 {
 	struct vtp *vtp;
 
@@ -376,7 +377,7 @@ VTP_Get(struct tcp_pool *tp, double tmo, struct worker *wrk)
 	Lck_Lock(&tp->mtx);
 	vtp = VTAILQ_FIRST(&tp->connlist);
 	CHECK_OBJ_ORNULL(vtp, VTP_MAGIC);
-	if (vtp == NULL || vtp->state == VTP_STATE_STOLEN)
+	if (force_fresh || vtp == NULL || vtp->state == VTP_STATE_STOLEN)
 		vtp = NULL;
 	else {
 		assert(vtp->tcp_pool == tp);

--- a/bin/varnishd/cache/cache_tcp_pool.h
+++ b/bin/varnishd/cache/cache_tcp_pool.h
@@ -85,7 +85,8 @@ void VTP_Recycle(const struct worker *, struct vtp **);
 	 * Recycle an open connection.
 	 */
 
-struct vtp *VTP_Get(struct tcp_pool *, double tmo, struct worker *);
+struct vtp *VTP_Get(struct tcp_pool *, double tmo, struct worker *,
+    unsigned force_fresh);
 	/*
 	 * Get a (possibly) recycled connection.
 	 */

--- a/bin/varnishtest/tests/r02135.vtc
+++ b/bin/varnishtest/tests/r02135.vtc
@@ -1,0 +1,40 @@
+varnishtest "#2135: fetch retry logic"
+
+barrier b1 cond 2
+
+server s1 {
+	rxreq
+	txresp
+	rxreq
+	expect req.url == "/foo"
+	delay 2.5
+	send " "
+	expect_close
+	accept
+	rxreq
+	expect req.url == "/foo"
+	barrier b1 sync
+	delay 2.5
+	send " "
+	expect_close
+} -start
+
+varnish v1 -cliok "param.set between_bytes_timeout 1"
+varnish v1 -cliok "param.set first_byte_timeout 1"
+
+varnish v1 -vcl+backend {
+	sub vcl_backend_error {
+		set beresp.http.url = bereq.url;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == "200"
+	txreq -url "/foo"
+	barrier b1 sync
+	rxresp
+	expect resp.status == "503"
+	expect resp.http.url == "/foo"
+} -run


### PR DESCRIPTION
This PR addresses #2135 

We permit a single retry and force a fresh backend connection the second time around.

First commit adds a `force_fresh` parameter to `VTP_Get`. Second commit addresses the retry logic.

Failure will land us in `vcl_backend_error`, where the VCL user can choose to do further attempts via `return (retry);`.