### PR TITLE
POC for early backend body fetches (from VCL)

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -410,6 +410,8 @@ struct busyobj {
 	 * is recycled.
 	 */
 	int			retries;
+	enum fetch_step		fetch_step_next;
+	unsigned		hdr_spc;
 	struct req		*req;
 	struct sess		*sp;
 	struct worker		*wrk;
@@ -659,6 +661,7 @@ enum vbf_fetch_mode_e {
 };
 void VBF_Fetch(struct worker *wrk, struct req *req,
     struct objcore *oc, struct objcore *oldoc, enum vbf_fetch_mode_e);
+int VBF_Fetchbody(struct busyobj *bo, int pass);
 
 /* cache_http.c */
 unsigned HTTP_estimate(unsigned nhttp);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -38,6 +38,8 @@
 #include "vcl.h"
 #include "vtim.h"
 
+static int vbf_figure_out_vfp(struct busyobj *bo);
+
 /*--------------------------------------------------------------------
  * Allocate an object, with fall-back to Transient.
  * XXX: This somewhat overlaps the stuff in stevedore.c
@@ -53,6 +55,7 @@ vbf_allocobj(struct busyobj *bo, unsigned l)
 
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 	oc = bo->fetch_objcore;
+
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
 	lifetime = oc->ttl + oc->grace + oc->keep;
@@ -87,18 +90,55 @@ vbf_allocobj(struct busyobj *bo, unsigned l)
 }
 
 /*--------------------------------------------------------------------
+ * save headeres in obj
+ *
+ * XXX see VBF_Fetchbody() call to vbf_newobj():
+ * XXX for an early fetch (from vcl) we allocate a surplus of OA_HEADERS space
+ * for additional headers. Report here the surplus (if any) or fall back to
+ * copying the object if doesn't fit.
+ */
+static void
+vbf_headers2obj(struct busyobj *bo)
+{
+	uint8_t *bp;
+	const char *b;
+
+#ifdef DEBUG
+	VSLb(bo->vsl, SLT_Fetch_Body, "Headers2Obj spc=%ud est=%ud",
+	     bo->hdr_spc,
+	     http_EstimateWS(bo->beresp,
+			     bo->uncacheable ? HTTPH_A_PASS : HTTPH_A_INS));
+#endif
+	/* for HTTP_Encode() VSLH call */
+	bo->beresp->logtag = SLT_ObjMethod;
+
+	/* Filter into object */
+	bp = ObjSetAttr(bo->wrk, bo->fetch_objcore, OA_HEADERS,
+			bo->hdr_spc, NULL);
+	AN(bp);
+	HTTP_Encode(bo->beresp, bp, bo->hdr_spc,
+		    bo->uncacheable ? HTTPH_A_PASS : HTTPH_A_INS);
+
+	if (http_GetHdr(bo->beresp, H_Last_Modified, &b))
+		AZ(ObjSetDouble(bo->wrk, bo->fetch_objcore, OA_LASTMODIFIED,
+		    VTIM_parse(b)));
+	else
+		AZ(ObjSetDouble(bo->wrk, bo->fetch_objcore, OA_LASTMODIFIED,
+		    floor(bo->fetch_objcore->t_origin)));
+}
+
+/*--------------------------------------------------------------------
  * Turn the beresp into a obj
  */
 
 static int
-vbf_beresp2obj(struct busyobj *bo)
+vbf_newobj(struct busyobj *bo, unsigned hdr_spc)
 {
-	unsigned l, l2;
-	const char *b;
-	uint8_t *bp;
+	unsigned l;
 	struct vsb *vary = NULL;
 	int varyl = 0;
 
+	AZ(bo->hdr_spc);
 	l = 0;
 
 	/* Create Vary instructions */
@@ -123,15 +163,17 @@ vbf_beresp2obj(struct busyobj *bo)
 			AZ(vary);
 	}
 
-	l2 = http_EstimateWS(bo->beresp,
+	hdr_spc += http_EstimateWS(bo->beresp,
 	    bo->uncacheable ? HTTPH_A_PASS : HTTPH_A_INS);
-	l += l2;
+	l += hdr_spc;
 
 	if (bo->uncacheable)
 		bo->fetch_objcore->flags |= OC_F_PASS;
 
 	if (!vbf_allocobj(bo, l))
 		return (-1);
+
+	bo->hdr_spc = hdr_spc;
 
 	if (vary != NULL) {
 		AN(ObjSetAttr(bo->wrk, bo->fetch_objcore, OA_VARY, varyl,
@@ -140,22 +182,6 @@ vbf_beresp2obj(struct busyobj *bo)
 	}
 
 	AZ(ObjSetU32(bo->wrk, bo->fetch_objcore, OA_VXID, VXID(bo->vsl->wid)));
-
-	/* for HTTP_Encode() VSLH call */
-	bo->beresp->logtag = SLT_ObjMethod;
-
-	/* Filter into object */
-	bp = ObjSetAttr(bo->wrk, bo->fetch_objcore, OA_HEADERS, l2, NULL);
-	AN(bp);
-	HTTP_Encode(bo->beresp, bp, l2,
-	    bo->uncacheable ? HTTPH_A_PASS : HTTPH_A_INS);
-
-	if (http_GetHdr(bo->beresp, H_Last_Modified, &b))
-		AZ(ObjSetDouble(bo->wrk, bo->fetch_objcore, OA_LASTMODIFIED,
-		    VTIM_parse(b)));
-	else
-		AZ(ObjSetDouble(bo->wrk, bo->fetch_objcore, OA_LASTMODIFIED,
-		    floor(bo->fetch_objcore->t_origin)));
 
 	return (0);
 }
@@ -248,6 +274,43 @@ vbf_stp_retry(struct worker *wrk, struct busyobj *bo)
 	http_VSL_log(bo->bereq);
 
 	return (F_STP_STARTFETCH);
+}
+
+/*--------------------------------------------------------------------
+ * after startfetch, prep the bo
+ * before we allocate the object, we should have our headers complete.
+ * As the VFPs set beresp headers, push and open them here
+ */
+static int
+vbf_fetch_prep(struct worker *wrk, struct busyobj *bo, int pass)
+{
+	int r = 0;
+
+	assert(bo->fetch_objcore->boc->state <= BOS_REQ_DONE);
+	if (bo->fetch_objcore->boc->state != BOS_REQ_DONE) {
+		bo->req = NULL;
+		ObjSetState(wrk, bo->fetch_objcore, BOS_REQ_DONE);
+	}
+
+	if (bo->do_esi)
+		bo->do_stream = 0;
+	if (pass) {
+		bo->fetch_objcore->flags |= OC_F_HFP;
+		bo->uncacheable = 1;
+	}
+	if (bo->do_pass || bo->uncacheable)
+		bo->fetch_objcore->flags |= OC_F_PASS;
+
+	if (! bo->was_304)
+		r = vbf_figure_out_vfp(bo);
+	if (r)
+		return (r);
+
+	r = VFP_Open(bo->vfc);
+	if (r)
+		(void)VFP_Error(bo->vfc, "Fetch pipeline failed to open");
+
+	return (r);
 }
 
 /*--------------------------------------------------------------------
@@ -405,23 +468,29 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 		return (F_STP_ERROR);
 	}
 
-	assert(bo->fetch_objcore->boc->state <= BOS_REQ_DONE);
-	if (bo->fetch_objcore->boc->state != BOS_REQ_DONE) {
-		bo->req = NULL;
-		ObjSetState(wrk, bo->fetch_objcore, BOS_REQ_DONE);
+	assert(wrk->handling == VCL_RET_DELIVER ||
+	       wrk->handling == VCL_RET_PASS);
+
+	if (bo->fetch_step_next != F_STP_NONE) {
+		/* VBF_Fetchbody has run */
+		assert(wrk->handling == VCL_RET_DELIVER);
+		return (bo->fetch_step_next);
 	}
 
-	if (bo->do_esi)
-		bo->do_stream = 0;
-	if (wrk->handling == VCL_RET_PASS) {
-		bo->fetch_objcore->flags |= OC_F_HFP;
-		bo->uncacheable = 1;
-		wrk->handling = VCL_RET_DELIVER;
+	if (vbf_fetch_prep(wrk, bo, wrk->handling == VCL_RET_PASS)) {
+		(bo)->htc->doclose = SC_OVERLOAD;
+		VDI_Finish((bo)->wrk, bo);
+		return (F_STP_ERROR);
 	}
-	if (bo->do_pass || bo->uncacheable)
-		bo->fetch_objcore->flags |= OC_F_PASS;
 
-	assert(wrk->handling == VCL_RET_DELIVER);
+	if (vbf_newobj(bo, 0)) {
+		(void)VFP_Error(bo->vfc, "Could not get storage");
+		bo->htc->doclose = SC_OVERLOAD;
+		VDI_Finish(bo->wrk, bo);
+		return (F_STP_ERROR);
+	}
+
+	wrk->handling = VCL_RET_DELIVER;
 
 	return (bo->was_304 ? F_STP_CONDFETCH : F_STP_FETCH);
 }
@@ -572,33 +641,10 @@ vbf_stp_fetch(struct worker *wrk, struct busyobj *bo)
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 	CHECK_OBJ_NOTNULL(bo->fetch_objcore, OBJCORE_MAGIC);
 
-	assert(wrk->handling == VCL_RET_DELIVER);
-
-	if (vbf_figure_out_vfp(bo)) {
-		(bo)->htc->doclose = SC_OVERLOAD;
-		VDI_Finish((bo)->wrk, bo);
-		return (F_STP_ERROR);
-	}
-
 	if (bo->fetch_objcore->flags & OC_F_PRIVATE)
 		AN(bo->uncacheable);
 
 	bo->fetch_objcore->boc->len_so_far = 0;
-
-	if (VFP_Open(bo->vfc)) {
-		(void)VFP_Error(bo->vfc, "Fetch pipeline failed to open");
-		bo->htc->doclose = SC_RX_BODY;
-		VDI_Finish(bo->wrk, bo);
-		return (F_STP_ERROR);
-	}
-
-	if (vbf_beresp2obj(bo)) {
-		(void)VFP_Error(bo->vfc, "Could not get storage");
-		bo->htc->doclose = SC_RX_BODY;
-		VFP_Close(bo->vfc);
-		VDI_Finish(bo->wrk, bo);
-		return (F_STP_ERROR);
-	}
 
 	if (bo->do_esi)
 		ObjSetFlag(bo->wrk, bo->fetch_objcore, OF_ESIPROC, 1);
@@ -630,6 +676,7 @@ vbf_stp_fetch(struct worker *wrk, struct busyobj *bo)
 	assert(bo->fetch_objcore->boc->state == BOS_REQ_DONE);
 
 	if (bo->do_stream) {
+		vbf_headers2obj(bo);	// counterpart in fetchend
 		ObjSetState(wrk, bo->fetch_objcore, BOS_PREP_STREAM);
 		HSH_Unbusy(wrk, bo->fetch_objcore);
 		ObjSetState(wrk, bo->fetch_objcore, BOS_STREAM);
@@ -660,6 +707,7 @@ vbf_stp_fetchend(struct worker *wrk, struct busyobj *bo)
 	if (bo->do_stream)
 		assert(bo->fetch_objcore->boc->state == BOS_STREAM);
 	else {
+		vbf_headers2obj(bo);	// counterpart in fetch
 		assert(bo->fetch_objcore->boc->state == BOS_REQ_DONE);
 		HSH_Unbusy(wrk, bo->fetch_objcore);
 	}
@@ -673,6 +721,59 @@ vbf_stp_fetchend(struct worker *wrk, struct busyobj *bo)
 	if (bo->stale_oc != NULL)
 		HSH_Kill(bo->stale_oc);
 	return (F_STP_DONE);
+}
+
+/*
+ * for use from VRT in vcl_backend_response
+ */
+int
+VBF_Fetchbody(struct busyobj *bo, int pass)
+{
+	struct worker *wrk;
+
+	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
+	wrk = bo->wrk;
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+
+	if (bo->was_304) {
+		VSLb(bo->vsl, SLT_VCL_Error, "Not for 304");
+		return (0);
+	}
+	if (bo->fetch_step_next != F_STP_NONE) {
+		VSLb(bo->vsl, SLT_VCL_Error, "Next step invalid");
+		return (0);
+	}
+
+	bo->do_stream = 0;
+
+	if (vbf_fetch_prep(wrk, bo, pass)) {
+		(bo)->htc->doclose = SC_OVERLOAD;
+		VDI_Finish((bo)->wrk, bo);
+		bo->fetch_step_next = F_STP_ERROR;
+		return (0);
+	}
+
+	// XXX 1K surplus configurable
+	if (vbf_newobj(bo, 1024)) {
+		VSLb(bo->vsl, SLT_VCL_Error, "No storage");
+		(void)VFP_Error(bo->vfc, "Could not get storage");
+		bo->htc->doclose = SC_OVERLOAD;
+		VDI_Finish(bo->wrk, bo);
+		bo->fetch_step_next = F_STP_ERROR;
+		return (0);
+	}
+
+	bo->fetch_step_next = vbf_stp_fetch(wrk, bo);
+	if (bo->fetch_step_next != F_STP_FETCHBODY) {
+		return (0);
+	}
+
+	bo->fetch_step_next = vbf_stp_fetchbody(wrk, bo);
+	if (bo->fetch_step_next != F_STP_FETCHEND) {
+		return (0);
+	}
+
+	return (1);
 }
 
 /*--------------------------------------------------------------------
@@ -710,7 +811,7 @@ vbf_stp_condfetch(struct worker *wrk, struct busyobj *bo)
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 
-	AZ(vbf_beresp2obj(bo));
+	vbf_headers2obj(bo);
 
 	if (ObjHasAttr(bo->wrk, bo->stale_oc, OA_ESIDATA))
 		AZ(ObjCopyAttr(bo->wrk, bo->fetch_objcore, bo->stale_oc,
@@ -761,8 +862,10 @@ vbf_stp_error(struct worker *wrk, struct busyobj *bo)
 	now = W_TIM_real(wrk);
 	VSLb_ts_busyobj(bo, "Error", now);
 
-	if (bo->fetch_objcore->stobj->stevedore != NULL)
+	if (bo->fetch_objcore->stobj->stevedore != NULL) {
 		ObjFreeObj(bo->wrk, bo->fetch_objcore);
+		bo->hdr_spc = 0;
+	}
 
 	if (bo->storage == NULL)
 		bo->storage = STV_next();
@@ -819,11 +922,12 @@ vbf_stp_error(struct worker *wrk, struct busyobj *bo)
 	assert(bo->vfc->resp == bo->beresp);
 	assert(bo->vfc->req == bo->bereq);
 
-	if (vbf_beresp2obj(bo)) {
+	if (vbf_newobj(bo, 0)) {
 		(void)VFP_Error(bo->vfc, "Could not get storage");
 		VSB_destroy(&synth_body);
 		return (F_STP_FAIL);
 	}
+	vbf_headers2obj(bo);
 
 	ll = VSB_len(synth_body);
 	o = 0;

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -931,7 +931,10 @@ HTTP_Decode(struct http *to, const uint8_t *fm)
 
 	CHECK_OBJ_NOTNULL(to, HTTP_MAGIC);
 	AN(to->vsl);
-	AN(fm);
+	if (fm == 0) {
+		VSLb(to->vsl, SLT_Error, "No headers in object");
+		return (-1);
+	}
 	if (vbe16dec(fm) <= to->shd) {
 		to->status = vbe16dec(fm + 2);
 		fm += 4;

--- a/bin/varnishtest/tests/e00008.vtc
+++ b/bin/varnishtest/tests/e00008.vtc
@@ -81,19 +81,16 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^ERR after 636 XML 1.0 Illegal attribute delimiter$}
 	expect 0 = ESI_xmlerror {^ERR after 665 ESI 1.0 </esi:include> illegal end-tag$}
 	expect 0 = ESI_xmlerror {^ERR after 767 XML 1.0 Missing end attribute delimiter$}
-	expect 0 = BackendReuse
 } -start
 
 logexpect l2 -v v1 -g vxid {
 	expect * * BereqURL	{^/body$}
 	expect * = ESI_xmlerror {^ERR after 30 VEP ended inside a tag$}
-	expect 0 = BackendReuse
 } -start
 
 logexpect l3 -v v1 -g vxid {
 	expect * * BereqURL	{^/body2$}
 	expect * = ESI_xmlerror {^ERR after 39 VEP ended inside a tag$}
-	expect 0 = BackendReuse
 } -start
 
 varnish v1 -cliok "param.set debug +esi_chop"

--- a/bin/varnishtest/tests/e00019.vtc
+++ b/bin/varnishtest/tests/e00019.vtc
@@ -63,7 +63,6 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^WARN after 107 ESI 1.0 <esi:include> lacks final '/'$}
 	expect 0 = ESI_xmlerror {^ERR after 130 ESI 1.0 <esi:bogus> element$}
 	expect 0 = ESI_xmlerror {^ERR after 131837 VEP ended inside a tag$}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/e00020.vtc
+++ b/bin/varnishtest/tests/e00020.vtc
@@ -27,7 +27,6 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^ERR after 3 ESI 1.0 <esi:include> element nested in <esi:remove>$}
 	expect 0 = ESI_xmlerror {^ERR after 3 ESI 1.0 Nested <!--esi element in <esi:remove>$}
 	expect 0 = Gzip         {^U}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/e00022.vtc
+++ b/bin/varnishtest/tests/e00022.vtc
@@ -33,7 +33,6 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^ERR after 24 ESI 1.0 Nested <!--esi element in <esi:remove>$}
 	expect 0 = Gzip         {^G}
 	expect 0 = Gzip         {^U}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/fetch_body.vtc
+++ b/bin/varnishtest/tests/fetch_body.vtc
@@ -7,6 +7,14 @@ server s1 {
 	rxreq
 	expect req.url == "/body"
 	txresp -body "123"
+
+	rxreq
+	expect req.url == "/passnobody"
+	txresp
+
+	rxreq
+	expect req.url == "/pass"
+	txresp -body "123"
 } -start
 
 varnish v1 -vcl+backend {
@@ -16,7 +24,7 @@ varnish v1 -vcl+backend {
 	sub vcl_backend_response {
 		set beresp.http.b4 = "foo";
 		std.log("b4");
-		set beresp.http.ok = debug.fetch_body(pass=false);
+		set beresp.http.ok = debug.fetch_body(bereq.url ~ "^/pass");
 		std.log("after");
 		set beresp.http.after = "bar";
 	}
@@ -31,6 +39,20 @@ client c1 {
 	expect resp.http.after == "bar"
 
 	txreq -url "/body"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.b4 == "foo"
+	expect resp.http.ok == "true"
+	expect resp.http.after == "bar"
+
+	txreq -url "/passnobody"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.b4 == "foo"
+	expect resp.http.ok == "false"
+	expect resp.http.after == "bar"
+
+	txreq -url "/pass"
 	rxresp
 	expect resp.status == 200
 	expect resp.http.b4 == "foo"

--- a/bin/varnishtest/tests/fetch_body.vtc
+++ b/bin/varnishtest/tests/fetch_body.vtc
@@ -1,0 +1,39 @@
+varnishtest "Check fetch_body from vcl_backend_response{}"
+
+server s1 {
+	rxreq
+	txresp
+
+	rxreq
+	expect req.url == "/body"
+	txresp -body "123"
+} -start
+
+varnish v1 -vcl+backend {
+	import debug;
+	import std;
+
+	sub vcl_backend_response {
+		set beresp.http.b4 = "foo";
+		std.log("b4");
+		set beresp.http.ok = debug.fetch_body(pass=false);
+		std.log("after");
+		set beresp.http.after = "bar";
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.b4 == "foo"
+	expect resp.http.ok == "false"
+	expect resp.http.after == "bar"
+
+	txreq -url "/body"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.b4 == "foo"
+	expect resp.http.ok == "true"
+	expect resp.http.after == "bar"
+} -run

--- a/bin/varnishtest/tests/fetch_body.vtc
+++ b/bin/varnishtest/tests/fetch_body.vtc
@@ -24,7 +24,7 @@ varnish v1 -vcl+backend {
 	sub vcl_backend_response {
 		set beresp.http.b4 = "foo";
 		std.log("b4");
-		set beresp.http.ok = debug.fetch_body(bereq.url ~ "^/pass");
+		set beresp.http.body = debug.fetch_body(bereq.url ~ "^/pass");
 		std.log("after");
 		set beresp.http.after = "bar";
 	}
@@ -35,27 +35,27 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 	expect resp.http.b4 == "foo"
-	expect resp.http.ok == "false"
+	expect resp.http.body == "false"
 	expect resp.http.after == "bar"
 
 	txreq -url "/body"
 	rxresp
 	expect resp.status == 200
 	expect resp.http.b4 == "foo"
-	expect resp.http.ok == "true"
+	expect resp.http.body == "true"
 	expect resp.http.after == "bar"
 
 	txreq -url "/passnobody"
 	rxresp
 	expect resp.status == 200
 	expect resp.http.b4 == "foo"
-	expect resp.http.ok == "false"
+	expect resp.http.body == "false"
 	expect resp.http.after == "bar"
 
 	txreq -url "/pass"
 	rxresp
 	expect resp.status == 200
 	expect resp.http.b4 == "foo"
-	expect resp.http.ok == "true"
+	expect resp.http.body == "true"
 	expect resp.http.after == "bar"
 } -run

--- a/bin/varnishtest/tests/fetch_body.vtc
+++ b/bin/varnishtest/tests/fetch_body.vtc
@@ -37,6 +37,7 @@ client c1 {
 	expect resp.http.b4 == "foo"
 	expect resp.http.body == "false"
 	expect resp.http.after == "bar"
+	expect resp.bodylen == 0
 
 	txreq -url "/body"
 	rxresp
@@ -44,6 +45,7 @@ client c1 {
 	expect resp.http.b4 == "foo"
 	expect resp.http.body == "true"
 	expect resp.http.after == "bar"
+	expect resp.bodylen == 3
 
 	txreq -url "/passnobody"
 	rxresp
@@ -51,6 +53,7 @@ client c1 {
 	expect resp.http.b4 == "foo"
 	expect resp.http.body == "false"
 	expect resp.http.after == "bar"
+	expect resp.bodylen == 0
 
 	txreq -url "/pass"
 	rxresp
@@ -58,4 +61,5 @@ client c1 {
 	expect resp.http.b4 == "foo"
 	expect resp.http.body == "true"
 	expect resp.http.after == "bar"
+	expect resp.bodylen == 3
 } -run

--- a/bin/varnishtest/tests/r00894.vtc
+++ b/bin/varnishtest/tests/r00894.vtc
@@ -14,7 +14,6 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g raw {
 	expect * * Fetch_Body
 	expect 0 = ESI_xmlerror {^ERR after 5 ESI 1.0 <esi:include> has multiple src= attributes$}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/r01092.vtc
+++ b/bin/varnishtest/tests/r01092.vtc
@@ -27,7 +27,6 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g raw {
 	expect * * Fetch_Body
 	expect 0 * ESI_xmlerror {^ERR after 66 ESI 1.0 Nested <!--esi element in <esi:remove>$}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/r01355.vtc
+++ b/bin/varnishtest/tests/r01355.vtc
@@ -24,11 +24,9 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g raw {
 	expect * * Fetch_Body
 	expect 0 = ESI_xmlerror {^No ESI processing, first char not '<' but BOM. .See feature esi_remove_bom.$}
-	expect 0 = BackendReuse
 # XXX another logexpect weirdness - why can't we catch the second occurrence?
 #	expect * * Fetch_Body
 #	expect 0 = ESI_xmlerror {^No ESI processing, first char not '<' but BOM. .See feature esi_remove_bom.$}
-#	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -221,3 +221,5 @@ Add a vsc
 $Function VOID vsc_destroy()
 
 Remove a vsc
+
+$Function BOOL fetch_body(BOOL pass=0)

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -43,6 +43,7 @@
 #include "vtim.h"
 #include "vcc_if.h"
 #include "VSC_debug.h"
+#include "vcl.h"	// fetch_body()
 
 #include "common/common_param.h"
 
@@ -594,4 +595,15 @@ xyzzy_vsc_destroy(VRT_CTX)
 		VSC_debug_Destroy(&vsc);
 	AZ(vsc);
 	AZ(pthread_mutex_unlock(&vsc_mtx));
+}
+
+VCL_BOOL __match_proto__(td_debug_fetch_body)
+xyzzy_fetch_body(VRT_CTX, VCL_BOOL pass)
+{
+	if (ctx->method != VCL_MET_BACKEND_RESPONSE) {
+		VRT_fail(ctx, "debug.detch_body() "
+			 "only valid in vcl_backend_response");
+		return (0);
+	}
+	return (VBF_Fetchbody(ctx->bo, pass));
 }


### PR DESCRIPTION
Take 2 on how support for early body fetches could look like, this time inclusive of a VCL demo.

`VBF_Fetchbody()` contains all the steps necessary to trigger a (non streaming) Fetch from VCL. While I have not used an fsm inside out approach this time, I havekept the fsm functions: we simply need to do the work in `vbf_stp_fetch()` and `vbf_stp_fetchbody()` somewhere and it does not seem to make much sense to just wrap the functions to get rid of the `fetch_step`. Neither would we want code duplication.

So now `VBF_Fetchbody()` is a simplistic minimal fsm within the outer fsm, taking two steps (fetch and fetchbody) at a time and only once.

`bo->fetch_step_next` is used to pass the state `VBF_Fetchbody()` has left off to the fsm.

Another issue is that we can now add headers (in vcl) after the fetch is complete, so

* we need to postpone copying headers to the objects until later and
* we need a guestimate of free space
  * which we remember in `bo->hdr_spc`

The final code should have a fall back in case `hdr_spc` is not sufficient. In this case, we need to copy the object (on the stevedore level, not on the boc level or above), which should be fine because:

* this only can happen for the early body fetch case
* and only for do_stream = 0

For the inefficient copy case, we'd increase a statistic and log a warning. For the efficient "guestimate was sufficient" case we should create a log entry to get statistics about wasted space.

`vbf_fetch_prep` consolidates all work to be done before the stevedore object can be created based on a good `OA_HEADERS` size estimate.

some esi tests failed due to different log order, these would need adjustment before merge.