### PR TITLE
RFC: early peek at shard config rework specs

### DIFF
--- a/lib/libvmod_directors/vmod.vcc
+++ b/lib/libvmod_directors/vmod.vcc
@@ -409,7 +409,9 @@ $Method BACKEND .backend(
 	INT alt=0,
 	REAL warmup=-1,
 	BOOL rampup=1,
-	ENUM {CHOSEN, IGNORE, ALL} healthy="CHOSEN")
+	ENUM {CHOSEN, IGNORE, ALL} healthy="CHOSEN",
+	BLOB cfg=0,
+	ENUM {NOW, LAZY} resolve="NOW")
 
 
 Lookup a backend on the consistent hashing ring.
@@ -513,9 +515,103 @@ is _not_ the order given when backends are added.
     For `alt > 0`, return the `alt`-th alternative backend of all
     those healthy, the last healthy backend found or none.
 
+* `cfg`
+
+  default: unset
+
+  This argument only has an effect when used in backend context.
+
+  Take the shard configuration parameters which would otherwise be
+  passed as parameters (see above) from a `obj_shard_cfg`_ object.
+
+  The value of the `cfg` argument must be a call to the
+  `func_shard_cfg_use`_ method.
+
+  When a `cfg` argument is given, other parameters have no effect.
+
+  For ``resolve=LAZY``, a `cfg` argument remains associated and any
+  changes to the associated configuration affect the sharding decision
+  once the director resolves to an actual backend.
+
+  A call to the `func_shard_backend`_ method without a `cfg` argument
+  clears the association for the current backend request.
+
 $Method VOID .debug(INT)
 
 `intentionally undocumented`
+
+$Object shard_cfg(
+	ENUM {HASH, URL, KEY, BLOB} by="HASH",
+	INT key=0,
+	BLOB key_blob=0,
+	INT alt=0,
+	REAL warmup=-1,
+	BOOL rampup=1,
+	ENUM {CHOSEN, IGNORE, ALL} healthy="CHOSEN")
+
+Create a shard configuration. All arguments and their semantics are as
+documented for `func_shard_backend`_. They may be overridden per
+backend request using the methods documented below.
+
+$Method VOID .reset(
+	ENUM {HASH, URL, KEY, BLOB} by="HASH",
+	INT key=0,
+	BLOB key_blob=0,
+	INT alt=0,
+	REAL warmup=-1,
+	BOOL rampup=1,
+	ENUM {CHOSEN, IGNORE, ALL} healthy="CHOSEN")
+
+This method may only be used in backend context.
+
+Set the configuration paramters of shard directors associated with
+this configuration to those given as arguments or reset them to their
+respective default values. All arguments and their semantics are as
+documented for `func_shard_backend`_.
+
+$Method VOID .set(
+	ENUM {keep, HASH, URL, KEY, BLOB} by="undef",
+	INT key=0,
+	BLOB key_blob=0,
+	INT alt=0,
+	REAL warmup=-2,
+	BOOL rampup=65535,
+	ENUM {undef, CHOSEN, IGNORE, ALL} healthy="undef")
+
+This method may only be used in backend context.
+
+Set the given configuration paramters, keeping all others at their
+current values for the default values.
+
+All arguments and their semantics are as documented for
+`func_shard_backend`_.
+
+$Method STRING .get_by()
+
+XXX
+
+$Method INT .get_key()
+
+XXX
+
+$Method INT .get_alt()
+
+XXX
+
+$Method BOOL .get_rampup()
+
+XXX
+
+$Method BOOL .get_helthy()
+
+XXX
+
+$Method BLOB .use()
+
+This method may only be used in backend context.
+
+For use with the `cfg` argument of `func_shard_backend`_ to associate
+this shard config with a shard director.
 
 ACKNOWLEDGEMENTS
 ================

--- a/lib/libvmod_directors/vmod_shard.c
+++ b/lib/libvmod_directors/vmod_shard.c
@@ -55,6 +55,8 @@ vmod_shard__init(VRT_CTX, struct vmod_directors_shard **vshardp,
 	VCL_INT t1;
 	uint32_t t2a, t2b;
 
+	/* XXX ADD cfg argument */
+
 	/* see vmod_key comment */
 	assert(sizeof(VCL_INT) >= sizeof(uint32_t));
 	t2a = UINT32_MAX;
@@ -224,7 +226,8 @@ get_key(VRT_CTX, enum by_e by, VCL_INT key_int, VCL_BLOB key_blob)
 VCL_BACKEND __match_proto__(td_directors_shard_backend)
 vmod_shard_backend(VRT_CTX, struct vmod_directors_shard *vshard,
     VCL_ENUM by_s, VCL_INT key_int, VCL_BLOB key_blob, VCL_INT alt,
-    VCL_REAL warmup, VCL_BOOL rampup, VCL_ENUM healthy_s)
+    VCL_REAL warmup, VCL_BOOL rampup, VCL_ENUM healthy_s,
+    VCL_BLOB cfg, VCL_ENUM resolve_s)
 {
 	enum by_e	by	= parse_by_e(by_s);
 	enum healthy_e	healthy = parse_healthy_e(healthy_s);
@@ -233,6 +236,9 @@ vmod_shard_backend(VRT_CTX, struct vmod_directors_shard *vshard,
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(vshard, VMOD_SHARD_SHARD_MAGIC);
+
+	/* XXX cfg */
+	/* XXX resolve_s */
 
 	if (key_int && by != BY_KEY) {
 		shard_err(ctx, vshard->shardd,


### PR DESCRIPTION
No code here, just .vcc interface specs and some comments.

The plan is to make the shard director more useful and facilitate complex configurations where
* shard parameters are determined independent of the selection of the director (and probably before director selection)
* shards are to be layered below other directors and thus need to be configured by some other means than parameters to the `backend` method.

The goal is to enable lazy resolution as with the other directors.

Reviews/comments of the specs welcome.