### PR TITLE
POC for early backend body fetches (from VCL)

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -410,6 +410,8 @@ struct busyobj {
 	 * is recycled.
 	 */
 	int			retries;
+	enum fetch_step		fetch_step_next;
+	unsigned		hdr_spc;
 	struct req		*req;
 	struct sess		*sp;
 	struct worker		*wrk;
@@ -659,6 +661,7 @@ enum vbf_fetch_mode_e {
 };
 void VBF_Fetch(struct worker *wrk, struct req *req,
     struct objcore *oc, struct objcore *oldoc, enum vbf_fetch_mode_e);
+int VBF_Fetchbody(struct busyobj *bo, int pass, unsigned hdrspc);
 
 /* cache_http.c */
 unsigned HTTP_estimate(unsigned nhttp);

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -931,7 +931,10 @@ HTTP_Decode(struct http *to, const uint8_t *fm)
 
 	CHECK_OBJ_NOTNULL(to, HTTP_MAGIC);
 	AN(to->vsl);
-	AN(fm);
+	if (fm == 0) {
+		VSLb(to->vsl, SLT_Error, "No headers in object");
+		return (-1);
+	}
 	if (vbe16dec(fm) <= to->shd) {
 		to->status = vbe16dec(fm + 2);
 		fm += 4;

--- a/bin/varnishtest/tests/e00008.vtc
+++ b/bin/varnishtest/tests/e00008.vtc
@@ -81,19 +81,16 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^ERR after 636 XML 1.0 Illegal attribute delimiter$}
 	expect 0 = ESI_xmlerror {^ERR after 665 ESI 1.0 </esi:include> illegal end-tag$}
 	expect 0 = ESI_xmlerror {^ERR after 767 XML 1.0 Missing end attribute delimiter$}
-	expect 0 = BackendReuse
 } -start
 
 logexpect l2 -v v1 -g vxid {
 	expect * * BereqURL	{^/body$}
 	expect * = ESI_xmlerror {^ERR after 30 VEP ended inside a tag$}
-	expect 0 = BackendReuse
 } -start
 
 logexpect l3 -v v1 -g vxid {
 	expect * * BereqURL	{^/body2$}
 	expect * = ESI_xmlerror {^ERR after 39 VEP ended inside a tag$}
-	expect 0 = BackendReuse
 } -start
 
 varnish v1 -cliok "param.set debug +esi_chop"

--- a/bin/varnishtest/tests/e00019.vtc
+++ b/bin/varnishtest/tests/e00019.vtc
@@ -63,7 +63,6 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^WARN after 107 ESI 1.0 <esi:include> lacks final '/'$}
 	expect 0 = ESI_xmlerror {^ERR after 130 ESI 1.0 <esi:bogus> element$}
 	expect 0 = ESI_xmlerror {^ERR after 131837 VEP ended inside a tag$}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/e00020.vtc
+++ b/bin/varnishtest/tests/e00020.vtc
@@ -27,7 +27,6 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^ERR after 3 ESI 1.0 <esi:include> element nested in <esi:remove>$}
 	expect 0 = ESI_xmlerror {^ERR after 3 ESI 1.0 Nested <!--esi element in <esi:remove>$}
 	expect 0 = Gzip         {^U}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/e00022.vtc
+++ b/bin/varnishtest/tests/e00022.vtc
@@ -33,7 +33,6 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^ERR after 24 ESI 1.0 Nested <!--esi element in <esi:remove>$}
 	expect 0 = Gzip         {^G}
 	expect 0 = Gzip         {^U}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/fetch_body.vtc
+++ b/bin/varnishtest/tests/fetch_body.vtc
@@ -1,0 +1,93 @@
+varnishtest "Check fetch_body from vcl_backend_response{}"
+
+server s1 {
+	rxreq
+	txresp
+
+	rxreq
+	expect req.url == "/body"
+	txresp -body "123"
+
+	rxreq
+	expect req.url == "/passnobody"
+	txresp
+
+	rxreq
+	expect req.url == "/pass"
+	txresp -body "123"
+
+	rxreq
+	expect req.url == "/nospc"
+	txresp -body "123"
+
+	rxreq
+	expect req.url == "/twice"
+	txresp -body "123"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_backend_response {
+		set beresp.http.b4 = "foo";
+		std.log("b4");
+		if (bereq.url ~ "^/pass") {
+		    set beresp.http.body = std.fetch_body(pass);
+		} else if (bereq.url  ~ "^/nospc") {
+		    set beresp.http.body = std.fetch_body(deliver, 0B);
+		} else {
+		    set beresp.http.body = std.fetch_body(deliver);
+		}
+		std.log("after");
+		set beresp.http.after = "bar";
+		if (bereq.url ~ "^/twice") {
+		    set beresp.http.body = std.fetch_body(deliver);
+		}
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.b4 == "foo"
+	expect resp.http.body == "false"
+	expect resp.http.after == "bar"
+	expect resp.bodylen == 0
+
+	txreq -url "/body"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.b4 == "foo"
+	expect resp.http.body == "true"
+	expect resp.http.after == "bar"
+	expect resp.bodylen == 3
+
+	txreq -url "/passnobody"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.b4 == "foo"
+	expect resp.http.body == "false"
+	expect resp.http.after == "bar"
+	expect resp.bodylen == 0
+
+	txreq -url "/pass"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.b4 == "foo"
+	expect resp.http.body == "true"
+	expect resp.http.after == "bar"
+	expect resp.bodylen == 3
+
+	txreq -url "/nospc"
+	rxresp
+	expect resp.status == 500
+
+	txreq -url "/twice"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.b4 == "foo"
+	expect resp.http.body == "false"
+	expect resp.http.after == "bar"
+	expect resp.bodylen == 3
+} -run

--- a/bin/varnishtest/tests/r00894.vtc
+++ b/bin/varnishtest/tests/r00894.vtc
@@ -14,7 +14,6 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g raw {
 	expect * * Fetch_Body
 	expect 0 = ESI_xmlerror {^ERR after 5 ESI 1.0 <esi:include> has multiple src= attributes$}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/r01092.vtc
+++ b/bin/varnishtest/tests/r01092.vtc
@@ -27,7 +27,6 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g raw {
 	expect * * Fetch_Body
 	expect 0 * ESI_xmlerror {^ERR after 66 ESI 1.0 Nested <!--esi element in <esi:remove>$}
-	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/r01355.vtc
+++ b/bin/varnishtest/tests/r01355.vtc
@@ -24,11 +24,9 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g raw {
 	expect * * Fetch_Body
 	expect 0 = ESI_xmlerror {^No ESI processing, first char not '<' but BOM. .See feature esi_remove_bom.$}
-	expect 0 = BackendReuse
 # XXX another logexpect weirdness - why can't we catch the second occurrence?
 #	expect * * Fetch_Body
 #	expect 0 = ESI_xmlerror {^No ESI processing, first char not '<' but BOM. .See feature esi_remove_bom.$}
-#	expect 0 = BackendReuse
 } -start
 
 client c1 {

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -338,6 +338,48 @@ Example
 	|	...
 	| }
 
+$Function BOOL fetch_body(ENUM {deliver, pass}, BYTES header_space=1024)
+
+Description
+	Initiate an early body fetch from `vcl_backend_fetch`. This
+	function may only be called once per backend request and may
+	not be used outside this vcl sub.
+
+	Normally, the backend response body is fetched after a
+	``return(deliver)`` or ``return(pass)`` from
+	`vcl_backend_fetch`. This function allows to fetch it before
+	returning from vcl with streaming disabled implicitly.
+
+	Valid first arguments are ``deliver`` and ``pass`` with
+	semantics identical to those of the ``return()`` dispositions
+	by the same name.
+
+	The optional `header_space` argument (default 1KB) specifies
+	an amount of storage to reserve for ``beresp.http.*``
+	modifications or additions after `std.fetch_body()` returns.
+
+	This reserve _must_ be sufficient, otherwise the backend
+	request will fail later with an ``Insufficient header space``
+	FetchError.
+
+	The amount of storage reserved through the `header_space`
+	argument which remained unused is reported through a ``Debug``
+	log line (see :ref:`vsl(7)`) in the format ``fetch_body %d
+	bytes wasted``. The reported wastage may exceed the
+	`header_space` reservation if headers are unset after a call
+	to `std.fetch_body()`.
+
+	_Note:_ Changing ``beresp.http.Vary`` after a call to
+	`std.fetch_body()` has no effect on the cache object.
+
+Example
+	| vcl_backend_fetch {
+	|	std.fetch_body(deliver, 2K);
+	|	set beresp.http.Header = "value";
+	|	# ...
+	|	return (deliver);
+	| }
+
 SEE ALSO
 ========
 


### PR DESCRIPTION
Take 2 1/2 on how support for early body fetches could look like, inclusive of a VCL demo.

`VBF_Fetchbody()` contains all the steps necessary to trigger a (non streaming) fetch from VCL. While I have not used an fsm inside out approach this time, I have still kept the fsm functions: we need to do the work in `vbf_stp_fetch()` and `vbf_stp_fetchbody()` somewhere and it does not seem to make much sense to just wrap the functions to get rid of the fetch_step enum.

So now `VBF_Fetchbody()` is a simplistic minimal fsm within the outer fsm, taking two steps (fetch and fetchbody) at a time.

`bo->fetch_step_next` is used to pass the state `VBF_Fetchbody()` has left off to the outer fsm.

Another issue is that we can now add headers (in vcl) after the fetch
is complete, so

* we need to postpone copying headers to the objects until later (latest possible time for streaming is earlier than for buffered)
* we need a guestimate of free space
* which we remember in `bo->hdr_spc`

If the reserved space does not suffice, we fail after returning from `vcl_backend_fetch()` *1)

`vbf_fetch_prep` consolidates all work to be done before the stevedore
object can be created based on a good `OA_HEADERS` size estimate.

some esi tests failed due to different log order, these would need adjustment before merge.

*1)

A theoretical alternative would be to recreate the object, but the object layer is interwoven with the busy object in a way which, IMHO after having attempted an implementation, prevents clean and simple solutions at the moment:

We would need to signal `BOS_FINISHED,` which, in the obj layer, triggers the bos condvar while in fact the busy object is not ready