### PR TITLE
First byte timeout fixes

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -178,13 +178,15 @@ vbe_dir_finish(const struct director *d, struct worker *wrk,
 	CAST_OBJ_NOTNULL(vtp, bo->htc->priv, VTP_MAGIC);
 	bo->htc->priv = NULL;
 	if (vtp->state != VTP_STATE_USED)
-		VTP_Wait(wrk, vtp);
+		assert(bo->htc->doclose == SC_TX_PIPE);
 	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0) {
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s", vtp->fd,
 		    bp->director->display_name);
 		VTP_Close(&vtp);
+		AZ(vtp);
 		Lck_Lock(&bp->mtx);
 	} else {
+		assert (vtp->state == VTP_STATE_USED);
 		VSLb(bo->vsl, SLT_BackendReuse, "%d %s", vtp->fd,
 		    bp->director->display_name);
 		Lck_Lock(&bp->mtx);

--- a/bin/varnishd/cache/cache_tcp_pool.h
+++ b/bin/varnishd/cache/cache_tcp_pool.h
@@ -91,7 +91,7 @@ struct vtp *VTP_Get(struct tcp_pool *, double tmo, struct worker *,
 	 * Get a (possibly) recycled connection.
 	 */
 
-void VTP_Wait(struct worker *, struct vtp *);
+int VTP_Wait(struct worker *, struct vtp *, double tmo);
 	/*
 	 * If the connection was recycled (state != VTP_STATE_USED) call this
 	 * function before attempting to receive on the connection.

--- a/bin/varnishtest/tests/r01772.vtc
+++ b/bin/varnishtest/tests/r01772.vtc
@@ -1,0 +1,24 @@
+varnishtest "#1772: Honor first_byte_timeout on a recycled connection"
+
+server s1 {
+	rxreq
+	expect req.url == "/first"
+	txresp
+
+	rxreq
+	expect req.url == "/second"
+	delay 2
+	txresp
+} -start
+
+varnish v1 -arg "-p first_byte_timeout=1" -vcl+backend {} -start
+
+client c1 {
+	txreq -url "/first"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/second"
+	rxresp
+	expect resp.status == 503
+} -run


### PR DESCRIPTION
This PR fixes the case where `first_byte_timeout` is not respected for recycled backend connections. 

- First commit teaches `VPT_Close` to also handle connections in state `VTP_STATE_STOLEN`. 

- Second commit removes a `VTP_Wait` that was only used for piped connections that are about to be closed. This is no longer necessary, since `VTP_Close` can now deal with also STOLEN connections.

- Third commit adds a timeout in `VTP_Wait` and bails out to let `vbe_dir_finish` do the necessary `VTP_Close`. Failure to respond within `first_byte_timeout` lands you in `vcl_backend_error`.

Fixes: #1772 
Supersedes: #2347 
