### PR TITLE
Make H/2 VSL less chatty by default

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -253,10 +253,11 @@ h2_vsl_frame(const struct h2_sess *h2, const void *ptr, size_t len)
 	}
 	AZ(VSB_finish(vsb));
 	Lck_Lock(&h2->sess->mtx);
-	VSLb_bin(h2->vsl, SLT_H2RxHdr, 9, b);
-	if (len > 9)
-		VSLb_bin(h2->vsl, SLT_H2RxBody, len - 9, b + 9);
-
+	if (DO_DEBUG(DBG_H2_RAW)) {
+		VSLb_bin(h2->vsl, SLT_H2RxHdr, 9, b);
+		if (len > 9)
+			VSLb_bin(h2->vsl, SLT_H2RxBody, len - 9, b + 9);
+	}
 	VSLb(h2->vsl, SLT_Debug, "H2RXF %s", VSB_data(vsb));
 	Lck_Unlock(&h2->sess->mtx);
 	VSB_destroy(&vsb);

--- a/include/tbl/debug_bits.h
+++ b/include/tbl/debug_bits.h
@@ -50,6 +50,7 @@ DEBUG_BIT(H2_NOCHECK,		h2_nocheck,	"Disable various H2 checks")
 DEBUG_BIT(VMOD_SO_KEEP,		vmod_so_keep,	"Keep copied VMOD libraries")
 DEBUG_BIT(PROCESSORS,		processors,	"Fetch/Deliver processors")
 DEBUG_BIT(PROTOCOL,		protocol,	"Protocol debugging")
+DEBUG_BIT(H2_RAW,		h2_raw,		"VSL H/2 frames")
 #undef DEBUG_BIT
 
 /*lint -restore */


### PR DESCRIPTION
Logging every single bit transferred is a bit excessive, so we add a debug flag for enabling this.

This commit adds (`-p debug=+h2_raw`) that enables logging of the raw H/2 frame bytes (H2TxHdr, H2TxBody, H2RxHdr, H2RxBody).