### PR TITLE
Add parameters for various H/2 settings

### DIFF
--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -62,6 +62,16 @@ static const struct h2_settings H2_proto_settings = {
 #include "tbl/h2_settings.h"
 };
 
+static void
+h2_local_settings(struct h2_settings *h2s)
+{
+	*h2s = H2_proto_settings;
+#define H2_SETTINGS_PARAM_ONLY
+#define H2_SETTING(U, l, ...)			\
+	h2s->l = cache_param->h2_##l;
+#include "tbl/h2_settings.h"
+#undef H2_SETTINGS_PARAM_ONLY
+}
 
 /**********************************************************************
  * The h2_sess struct needs many of the same things as a request,
@@ -101,7 +111,7 @@ h2_new_sess(const struct worker *wrk, struct sess *sp, struct req *srq)
 		h2->rxthr = pthread_self();
 		VTAILQ_INIT(&h2->streams);
 		VTAILQ_INIT(&h2->txqueue);
-		h2->local_settings = H2_proto_settings;
+		h2_local_settings(&h2->local_settings);
 		h2->remote_settings = H2_proto_settings;
 
 		AZ(VHT_Init(h2->dectbl,

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -36,6 +36,7 @@
 #include "cache/cache_transport.h"
 #include "http2/cache_http2.h"
 
+#include "vend.h"
 #include "vtim.h"
 
 static const char h2_resp_101[] =
@@ -50,12 +51,25 @@ static const char H2_prism[24] = {
 	0x0d, 0x0a, 0x53, 0x4d, 0x0d, 0x0a, 0x0d, 0x0a
 };
 
-static const uint8_t H2_settings[] = {
-	0x00, 0x03,
-	0x00, 0x00, 0x00, 0x64,
-	0x00, 0x04,
-	0x00, 0x00, 0xff, 0xff
-};
+static size_t
+h2_enc_settings(const struct h2_settings *h2s, uint8_t *buf, size_t n)
+{
+	uint8_t *b;
+	size_t len = 0;
+
+	b = buf;
+#define H2_SETTING(U,l,v,d,...)				\
+	if (h2s->l != d) {				\
+		len += 6;					\
+		assert(len <= n);			\
+		vbe16enc(b, v);				\
+		b += 2;					\
+		vbe32enc(b, h2s->l);			\
+		b += 4;					\
+	}
+#include "tbl/h2_settings.h"
+	return (len);
+}
 
 static const struct h2_settings H2_proto_settings = {
 #define H2_SETTING(U,l,v,d,...) . l = d,
@@ -290,6 +304,8 @@ h2_new_session(struct worker *wrk, void *arg)
 	struct h2_req *r2, *r22;
 	uintptr_t wsp;
 	int again;
+	uint8_t settings[48];
+	size_t l;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CAST_OBJ_NOTNULL(req, arg, REQ_MAGIC);
@@ -315,9 +331,10 @@ h2_new_session(struct worker *wrk, void *arg)
 
 	THR_SetRequest(h2->srq);
 
+	l = h2_enc_settings(&h2->local_settings, settings, sizeof (settings));
 	H2_Send_Get(wrk, h2, h2->req0);
 	H2_Send_Frame(wrk, h2,
-	    H2_F_SETTINGS, H2FF_NONE, sizeof H2_settings, 0, H2_settings);
+	    H2_F_SETTINGS, H2FF_NONE, l, 0, settings);
 	H2_Send_Rel(h2, h2->req0);
 
 	/* and off we go... */

--- a/bin/varnishtest/tests/t02005.vtc
+++ b/bin/varnishtest/tests/t02005.vtc
@@ -15,7 +15,7 @@ varnish v1 -cliok "param.set debug +syncvsl"
 
 logexpect l1 -v v1 -g raw {
 	expect	* 1001 ReqAcct	"80 7 87 106 8 114"
-	expect	* 1000 ReqAcct	"45 8 53 72 28 100"
+	expect	* 1000 ReqAcct	"45 8 53 72 22 94"
 } -start
 
 client c1 {

--- a/include/tbl/h2_settings.h
+++ b/include/tbl/h2_settings.h
@@ -47,6 +47,7 @@ H2_SETTING(					// rfc7540,l,2097,2103
 	0xffffffff,
 	0
 )
+#ifndef H2_SETTINGS_PARAM_ONLY
 H2_SETTING(					// rfc7540,l,2105,2114
 	ENABLE_PUSH,
 	enable_push,
@@ -56,6 +57,7 @@ H2_SETTING(					// rfc7540,l,2105,2114
 	1,
 	H2CE_PROTOCOL_ERROR
 )
+#endif
 H2_SETTING(					// rfc7540,l,2116,2121
 	MAX_CONCURRENT_STREAMS,
 	max_concurrent_streams,

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1732,6 +1732,80 @@ PARAM(
 	/* func */	NULL
 )
 
+PARAM(
+	/* name */      h2_header_table_size,
+	/* typ */       bytes_u,
+	/* min */       "0",
+	/* max */       NULL,
+	/* default */   "4k",
+	/* units */     "bytes",
+	/* flags */     0,
+	/* s-text */
+	"HTTP2 header table size.\n"
+	"This is the size that will be used for the HPACK dynamic\n"
+	"decoding table.",
+	/* l-text */    "",
+	/* func */      NULL
+)
+
+PARAM(
+       /* name */      h2_max_concurrent_streams,
+       /* typ */       uint,
+       /* min */       "0",
+       /* max */       "4294967294",
+       /* default */   "100",
+       /* units */     "streams",
+       /* flags */     0,
+       /* s-text */
+       "HTTP2 Maximum number of concurrent streams.\n"
+       "This is the number of requests that can be active\n"
+       "at the same time for a single HTTP2 connection.",
+       /* l-text */    "",
+       /* func */      NULL
+)
+
+PARAM(
+	/* name */      h2_initial_window_size,
+	/* typ */       bytes_u,
+	/* min */       "0",
+	/* max */       "2147483647",
+	/* default */   "65535",
+	/* units */     "bytes",
+	/* flags */     0,
+	/* s-text */
+	"HTTP2 initial flow control window size.",
+	/* l-text */    "",
+	/* func */      NULL
+)
+
+PARAM(
+	/* name */      h2_max_frame_size,
+	/* typ */       bytes_u,
+	/* min */       "16384",
+	/* max */       "16777215",
+	/* default */   "16384",
+	/* units */     "bytes",
+	/* flags */     0,
+	/* s-text */
+	"HTTP2 maximum per frame payload size we are willing to accept.",
+	/* l-text */    "",
+	/* func */      NULL
+)
+
+PARAM(
+	/* name */      h2_max_header_list_size,
+	/* typ */       bytes_u,
+	/* min */       "0",
+	/* max */       NULL,
+	/* default */   "4294967295",
+	/* units */     "bytes",
+	/* flags */     0,
+	/* s-text */
+	"HTTP2 maximum size of an uncompressed header list.",
+	/* l-text */    "",
+	/* func */      NULL
+)
+
 #undef PARAM
 
 /*lint -restore */


### PR DESCRIPTION
This adds varnish parameters for all H2 settings except for `SETTINGS_ENABLE_PUSH` (that setting does not make sense from a server POV).

The next step here is to actually start enforcing the configured settings (max concurrent streams, max frame size, etc.). Currently the only one that is actually used is `SETTINGS_INITIAL_WINDOW_SIZE`.