### PR TITLE
Introduce obj.storage for VCL

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -261,8 +261,7 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 
 	AZ(bo->storage);
-
-	bo->storage = STV_next();
+	bo->storage = bo->do_pass ? stv_transient : STV_next();
 
 	if (bo->retries > 0)
 		http_Unset(bo->bereq, "\012X-Varnish:");

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -366,6 +366,16 @@ VRT_l_beresp_storage(VRT_CTX, VCL_STEVEDORE stv)
 
 /*--------------------------------------------------------------------*/
 
+VCL_STEVEDORE
+VRT_r_obj_storage(VRT_CTX)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+	return (ctx->req->objcore->stobj->stevedore);
+}
+
+/*--------------------------------------------------------------------*/
+
 #define REQ_VAR_L(nm, elem, type,extra)					\
 									\
 void									\

--- a/bin/varnishtest/tests/v00052.vtc
+++ b/bin/varnishtest/tests/v00052.vtc
@@ -1,0 +1,49 @@
+varnishtest "obj.storage coverage"
+
+server s1 {
+	rxreq
+	txresp
+
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_hit {
+		set req.http.Hit-Storage = obj.storage;
+	}
+
+	sub vcl_backend_response {
+		set beresp.http.Default-Storage = beresp.storage;
+		if (bereq.method == "GET") {
+			set beresp.storage = storage.Transient;
+		}
+	}
+
+	sub vcl_deliver {
+		set resp.http.Deliver-Storage = obj.storage;
+		if (req.http.Hit-Storage) {
+			set resp.http.Hit-Storage = req.http.Hit-Storage;
+		}
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.Default-Storage == storage.s0
+	expect resp.http.Deliver-Storage == storage.Transient
+	expect resp.http.Hit-Storage == <undef>
+
+	txreq
+	rxresp
+	expect resp.http.Default-Storage == storage.s0
+	expect resp.http.Deliver-Storage == storage.Transient
+	expect resp.http.Hit-Storage == storage.Transient
+
+	txreq -req POST
+	rxresp
+	expect resp.http.Default-Storage == storage.Transient
+	expect resp.http.Deliver-Storage == storage.Transient
+	expect resp.http.Hit-Storage == <undef>
+} -run

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -745,6 +745,13 @@ sp_variables = [
 		hit-for-miss).
 		"""
 	),
+	('obj.storage',
+		'STEVEDORE',
+		('hit', 'deliver'),
+		(), """
+		The storage backend used to save this object.
+		"""
+	),
 	('resp',
 		'HTTP',
 		('deliver', 'synth'),


### PR DESCRIPTION
In addition, instead of always initializing a transaction's storage
backend using the round-robin selection, pick Transient when we know
in advance that beresp will be uncacheable.

Closes #2533