### PR TITLE
Enforce h2_max_concurrent_streams

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -864,6 +864,13 @@ h2_procframe(struct worker *wrk, struct h2_sess *h2,
 	if (r2 == NULL && h2f->act_sidle == 0) {
 		if (h2->rxf_stream <= h2->highest_stream)
 			return (H2CE_PROTOCOL_ERROR);	// rfc7540,l,1153,1158
+		if (h2->refcnt >= h2->local_settings.max_concurrent_streams) {
+			VSLb(h2->vsl, SLT_Debug,
+			     "H2: stream %u: Hit maximum number of "
+			     "concurrent streams", h2->rxf_stream);
+			// rfc7540,l,1200,1205
+			return (h2_tx_rst(wrk, h2, H2SE_REFUSED_STREAM));
+		}
 		h2->highest_stream = h2->rxf_stream;
 		r2 = h2_new_req(wrk, h2, h2->rxf_stream, NULL);
 		AN(r2);

--- a/bin/varnishtest/tests/t02012.vtc
+++ b/bin/varnishtest/tests/t02012.vtc
@@ -1,0 +1,63 @@
+varnishtest "Test max_concurrent_streams"
+
+barrier b1 sock 5
+barrier b2 sock 3
+barrier b3 cond 2
+barrier b4 cond 2
+
+server s1 {
+       rxreq
+       txresp
+} -start
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.set debug +syncvsl"
+varnish v1 -cliok "param.set h2_max_concurrent_streams 3"
+
+varnish v1 -vcl+backend {
+	import vtc;
+	sub vcl_deliver {
+		if (req.http.sync) {
+			vtc.barrier_sync("${b1_sock}");
+			vtc.barrier_sync("${b2_sock}");
+		}
+	}
+} -start
+
+client c1 {
+	stream 1 {
+		txreq -hdr "sync" "1"
+		barrier b3 sync
+		barrier b1 sync
+		rxresp
+		expect resp.status == 200
+	} -start
+
+	stream 3 {
+		barrier b3 sync
+		txreq -hdr "sync" "1"
+		barrier b4 sync
+		barrier b1 sync
+		rxresp
+		expect resp.status == 200
+	} -start
+
+	stream 5 {
+		barrier b4 sync
+		barrier b1 sync
+		txreq
+		rxrst
+		expect rst.err == REFUSED_STREAM
+		barrier b2 sync
+	} -run
+
+	stream 1 -wait
+	stream 3 -wait
+
+	stream 7 {
+		txreq
+		rxresp
+		expect resp.status == 200
+	} -run
+
+} -run


### PR DESCRIPTION
With this patch we fail new streams with a `REFUSED_STREAM` if h2_max_concurrent_streams is exceeded. New streams may be opened again after the count drops below the limit.

I'm using the value of `h2->refcnt` for the counting. If at some point we decide other bits will need to hold `h2_sess` refs, we will need to revisit this.

For the test case we need to keep N streams in flight while also making sure they are started in order, so I ended up using quite a few barriers to stabilize that.