### PR TITLE
Changes in timestamps, prepare for 2519

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -747,8 +747,10 @@ cnt_restart(struct worker *wrk, struct req *req)
 		req->err_code = 503;
 		req->req_step = R_STP_SYNTH;
 	} else {
+		double now = W_TIM_real(wrk);
+		req->t_req = now;
 		// XXX: ReqEnd + ReqAcct ?
-		VSLb_ts_req(req, "Restart", W_TIM_real(wrk));
+		VSLb_ts_req(req, "Restart", now);
 		VSL_ChgId(req->vsl, "req", "restart",
 		    VXID_Get(wrk, VSL_CLIENTMARKER));
 		VSLb_ts_req(req, "Start", req->t_prev);

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -552,7 +552,7 @@ VRT_r_##which##_##fld(VRT_CTX)					\
 }
 
 VRT_DO_EXP_R(obj, ctx->req->objcore, ttl,
-    ctx->now - ctx->req->objcore->t_origin)
+    fmax(0, ctx->req->t_req - ctx->req->objcore->t_origin))
 VRT_DO_EXP_R(obj, ctx->req->objcore, grace, 0)
 VRT_DO_EXP_R(obj, ctx->req->objcore, keep, 0)
 

--- a/bin/varnishtest/tests/c00012.vtc
+++ b/bin/varnishtest/tests/c00012.vtc
@@ -30,7 +30,7 @@ client c1 {
 	expect resp.http.x-varnish == "1001"
 	expect resp.http.o_age >= 0
 	expect resp.http.o_age < 0.5
-	expect resp.http.o_ttl <= -0
+	expect resp.http.o_ttl <= 0
 	expect resp.http.o_ttl > -0.5
 	expect resp.http.o_grace == "0.000"
 	expect resp.http.o_keep == "0.000"
@@ -42,7 +42,7 @@ client c1 {
 	expect resp.http.x-varnish == "1003"
 	expect resp.http.o_age >= 0
 	expect resp.http.o_age < 0.5
-	expect resp.http.o_ttl <= -0
+	expect resp.http.o_ttl <= 0
 	expect resp.http.o_ttl > -0.5
 	expect resp.http.o_grace == "0.000"
 	expect resp.http.o_keep == "0.000"

--- a/bin/varnishtest/tests/r02519.vtc
+++ b/bin/varnishtest/tests/r02519.vtc
@@ -1,0 +1,66 @@
+varnishtest "Expiry during processing"
+
+# When a object runs out of ttl+grace during processing of a
+# request, we want the calculation in the builtin VCL to match
+# the calculation of hit+grace in the C code.
+
+barrier b1 sock 2
+barrier b2 sock 2
+
+server s1 {
+	rxreq
+	expect req.url == "/1"
+	txresp
+	# if we get a second request to /1 here, it will be because a hit was became
+	# a miss in the builtin sub vcl_hit, but this should not happen after the fix
+	# of #1799.
+	rxreq
+	expect req.url == "/2"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_recv {
+		if (req.http.Sleep) {
+			# This will make the object expire while inside this VCL sub
+			vtc.barrier_sync("${b1_sock}");
+			vtc.barrier_sync("${b2_sock}");
+		}
+		# Update the last timestamp inside varnish
+		std.timestamp("T");
+	}
+	sub vcl_hit {
+		set req.http.X-was-hit = "true";
+		# no return here. Will the builtin VCL take us to vcl_miss?
+	}
+	sub vcl_miss {
+		set req.http.X-was-miss = "true";
+	}
+	sub vcl_backend_response {
+		# Very little ttl, a lot of keep
+		set beresp.ttl = 1s;
+		set beresp.grace = 0s;
+		set beresp.keep = 1w;
+	}
+} -start
+
+client c1 {
+	delay .5
+	txreq -url "/1"
+	rxresp
+	txreq -url "/1" -hdr "Sleep: true"
+	rxresp
+	# Final request to verify that the right amount of requests got to the backend
+	txreq -url "/2"
+	rxresp
+} -start
+
+# help for sleeping inside of vcl
+barrier b1 sync
+delay 1.5
+barrier b2 sync
+
+client c1 -wait


### PR DESCRIPTION
These patches prepares for #2519. The first patch, "Update t_req on restart" is simple: `return (restart)` should reset the time for the request.

The second patch is a bug fix. Without it, the `ttl` variable will change during VCL processing, and taking a timestamp can change the result of VCL processing, which is just plain wrong. The test case demonstrates this - remove the `std.timestamp()`, and the test case passes (on master).

The bug was disvovered while working on #2519, and it is required to make it water tight. Unfortunately, the second patch + #2519 without the first patch will break `c00041.vtc` (test purging from vcl). For this reason I have updated #2519 to include the patches in this PR.

In other words, the first patch in this PR should be accepted because it is necessary when a PURGE request invalidates the object, and then uses `return (restart)` to fetch a new object from the backend.