### PR TITLE
Changes in timestamps, purges get better at killing objects

### DIFF
--- a/bin/varnishd/cache/cache_expire.c
+++ b/bin/varnishd/cache/cache_expire.c
@@ -164,7 +164,9 @@ EXP_Rearm(struct objcore *oc, double now, double ttl, double grace, double keep)
 	VSL(SLT_ExpKill, 0, "EXP_Rearm p=%p E=%.9f e=%.9f f=0x%x", oc,
 	    oc->timer_when, when, oc->flags);
 
-	if (when < oc->t_origin || when < oc->timer_when)
+	if (ttl == 0. && grace == 0. && keep == 0.)
+		HSH_Kill(oc);
+	else if (when < oc->t_origin || when < oc->timer_when)
 		exp_mail_it(oc, OC_EF_MOVE);
 }
 

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -552,7 +552,7 @@ VRT_r_##which##_##fld(VRT_CTX)					\
 }
 
 VRT_DO_EXP_R(obj, ctx->req->objcore, ttl,
-    ctx->now - ctx->req->objcore->t_origin)
+    fmax(0, ctx->req->t_req - ctx->req->objcore->t_origin))
 VRT_DO_EXP_R(obj, ctx->req->objcore, grace, 0)
 VRT_DO_EXP_R(obj, ctx->req->objcore, keep, 0)
 

--- a/bin/varnishtest/tests/c00012.vtc
+++ b/bin/varnishtest/tests/c00012.vtc
@@ -30,7 +30,7 @@ client c1 {
 	expect resp.http.x-varnish == "1001"
 	expect resp.http.o_age >= 0
 	expect resp.http.o_age < 0.5
-	expect resp.http.o_ttl <= -0
+	expect resp.http.o_ttl <= 0
 	expect resp.http.o_ttl > -0.5
 	expect resp.http.o_grace == "0.000"
 	expect resp.http.o_keep == "0.000"
@@ -42,7 +42,7 @@ client c1 {
 	expect resp.http.x-varnish == "1003"
 	expect resp.http.o_age >= 0
 	expect resp.http.o_age < 0.5
-	expect resp.http.o_ttl <= -0
+	expect resp.http.o_ttl <= 0
 	expect resp.http.o_ttl > -0.5
 	expect resp.http.o_grace == "0.000"
 	expect resp.http.o_keep == "0.000"

--- a/bin/varnishtest/tests/r02519.vtc
+++ b/bin/varnishtest/tests/r02519.vtc
@@ -1,0 +1,66 @@
+varnishtest "Expiry during processing"
+
+# When a object runs out of ttl+grace during processing of a
+# request, we want the calculation in the builtin VCL to match
+# the calculation of hit+grace in the C code.
+
+barrier b1 sock 2
+barrier b2 sock 2
+
+server s1 {
+	rxreq
+	expect req.url == "/1"
+	txresp
+	# if we get a second request to /1 here, it will be because a hit was became
+	# a miss in the builtin sub vcl_hit, but this should not happen after the fix
+	# of #1799.
+	rxreq
+	expect req.url == "/2"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_recv {
+		if (req.http.Sleep) {
+			# This will make the object expire while inside this VCL sub
+			vtc.barrier_sync("${b1_sock}");
+			vtc.barrier_sync("${b2_sock}");
+		}
+		# Update the last timestamp inside varnish
+		std.timestamp("T");
+	}
+	sub vcl_hit {
+		set req.http.X-was-hit = "true";
+		# no return here. Will the builtin VCL take us to vcl_miss?
+	}
+	sub vcl_miss {
+		set req.http.X-was-miss = "true";
+	}
+	sub vcl_backend_response {
+		# Very little ttl, a lot of keep
+		set beresp.ttl = 1s;
+		set beresp.grace = 0s;
+		set beresp.keep = 1w;
+	}
+} -start
+
+client c1 {
+	delay .5
+	txreq -url "/1"
+	rxresp
+	txreq -url "/1" -hdr "Sleep: true"
+	rxresp
+	# Final request to verify that the right amount of requests got to the backend
+	txreq -url "/2"
+	rxresp
+} -start
+
+# help for sleeping inside of vcl
+barrier b1 sync
+delay 1.5
+barrier b2 sync
+
+client c1 -wait


### PR DESCRIPTION
This is slightly different than #2547, and I think I found the right way to not cause problems with `c00041.vtc` like #2547 does.

The only question is if a call to `EXP_Rearm` now should use `t_req` for `now` in all cases. In core varnish all rearms are purges, but there are VMODs that use `EXP_Rearm` for *soft purges*.