### PR TITLE
Add H/2 stream timeouts

### DIFF
--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -121,6 +121,8 @@ struct h2_req {
 	enum h2_stream_e		state;
 	struct h2_sess			*h2sess;
 	struct req			*req;
+	double				t_send;
+	double				t_winupd;
 	pthread_cond_t			*cond;
 	VTAILQ_ENTRY(h2_req)		list;
 	int64_t				t_window;

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -254,6 +254,8 @@ h2_deliver(struct req *req, struct boc *boc, int sendbody)
 	if (sendbody && req->resp_len == 0)
 		sendbody = 0;
 
+	r2->t_send = req->t_prev;
+
 	H2_Send_Get(req->wrk, r2->h2sess, r2);
 	H2_Send(req->wrk, r2, H2_F_HEADERS,
 	    (sendbody ? 0 : H2FF_HEADERS_END_STREAM) | H2FF_HEADERS_END_HEADERS,


### PR DESCRIPTION
Avoid keeping H/2 streams alive indefinitely.

This adds timeouts for:
  - How long we allow a stream to wait for a WINDOW_UPDATE, subject
    to idle_send_timeout
  - Total duration after we started transmitting a response,
    subject to send_timeout

Hitting a timeout sets `h2->error`, which will in turn initiate cleanup/wakeup.