### PR TITLE
New way of calculating TTLs in VCL.

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -510,6 +510,7 @@ struct req {
 	double			t_first;	/* First timestamp logged */
 	double			t_prev;		/* Previous timestamp logged */
 	double			t_req;		/* Headers complete */
+	double			t_restart;	/* Time of last restart */
 
 	struct http_conn	htc[1];
 	struct vfp_ctx		*vfc;

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -167,6 +167,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 
 	req->req_step = R_STP_RECV;
 	req->t_req = preq->t_req;
+	req->t_restart = preq->t_restart;
 	assert(isnan(req->t_first));
 	assert(isnan(req->t_prev));
 

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -590,13 +590,12 @@ hsh_rush2(struct worker *wrk, struct rush *r)
  */
 
 unsigned
-HSH_Purge(struct worker *wrk, struct objhead *oh, double ttl, double grace,
-double keep)
+HSH_Purge(struct worker *wrk, struct objhead *oh, double ttl_now, double ttl,
+double grace, double keep)
 {
 	struct objcore *oc, **ocp;
 	unsigned spc, ospc, nobj, n, n_tot = 0;
 	int more = 0;
-	double now;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
@@ -623,7 +622,6 @@ double keep)
 		ocp = (void*)wrk->aws->f;
 		Lck_Lock(&oh->mtx);
 		assert(oh->refcnt > 0);
-		now = VTIM_real();
 		VTAILQ_FOREACH(oc, &oh->objcs, hsh_list) {
 			CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 			assert(oc->objhead == oh);
@@ -663,7 +661,7 @@ double keep)
 		for (n = 0; n < nobj; n++) {
 			oc = ocp[n];
 			CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
-			EXP_Rearm(oc, now, ttl, grace, keep);
+			EXP_Rearm(oc, ttl_now, ttl, grace, keep);
 			(void)HSH_DerefObjCore(wrk, &oc, 0);
 		}
 		n_tot += nobj;

--- a/bin/varnishd/cache/cache_objhead.h
+++ b/bin/varnishd/cache/cache_objhead.h
@@ -73,7 +73,7 @@ enum lookup_e HSH_Lookup(struct req *, struct objcore **, struct objcore **,
     int always_insert);
 void HSH_Ref(struct objcore *o);
 void HSH_AddString(struct req *, void *ctx, const char *str);
-unsigned HSH_Purge(struct worker *, struct objhead *, double ttl, double grace,
-    double keep);
+unsigned HSH_Purge(struct worker *, struct objhead *, double ttl_now,
+    double ttl, double grace, double keep);
 struct objcore *HSH_Private(const struct worker *wrk);
 void HSH_Abandon(struct objcore *oc);

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -141,6 +141,7 @@ Req_New(const struct worker *wrk, struct sess *sp)
 	req->t_first = NAN;
 	req->t_prev = NAN;
 	req->t_req = NAN;
+	req->t_restart = NAN;
 
 	VRTPRIV_init(req->privs);
 
@@ -219,6 +220,7 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 	req->t_first = NAN;
 	req->t_prev = NAN;
 	req->t_req = NAN;
+	req->t_restart = NAN;
 	req->req_body_status = REQ_BODY_INIT;
 
 	req->hash_always_miss = 0;

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -935,7 +935,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 /*--------------------------------------------------------------------
  * Find the objhead, purge it.
  *
- * XXX: We should ask VCL if we should fetch a new copy of the object.
+ * In VCL, a restart is necessary to get a new object
  */
 
 static enum req_fsm_nxt
@@ -960,7 +960,7 @@ cnt_purge(struct worker *wrk, struct req *req)
 	CHECK_OBJ_NOTNULL(boc, OBJCORE_MAGIC);
 	VRY_Finish(req, DISCARD);
 
-	(void)HSH_Purge(wrk, boc->objhead, 0, 0, 0);
+	(void)HSH_Purge(wrk, boc->objhead, req->t_req, 0, 0, 0);
 
 	AZ(HSH_DerefObjCore(wrk, &boc, 1));
 

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -747,8 +747,10 @@ cnt_restart(struct worker *wrk, struct req *req)
 		req->err_code = 503;
 		req->req_step = R_STP_SYNTH;
 	} else {
+		double now = W_TIM_real(wrk);
+		req->t_restart = now;
 		// XXX: ReqEnd + ReqAcct ?
-		VSLb_ts_req(req, "Restart", W_TIM_real(wrk));
+		VSLb_ts_req(req, "Restart", now);
 		VSL_ChgId(req->vsl, "req", "restart",
 		    VXID_Get(wrk, VSL_CLIENTMARKER));
 		VSLb_ts_req(req, "Start", req->t_prev);

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -1117,9 +1117,14 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 		ctx.req = req;
 		ctx.sp = req->sp;
 		ctx.now = req->t_prev;
+		ctx.ttl_now = req->t_req;
+		if (!isnan(req->t_restart))
+			ctx.ttl_now = req->t_restart;
 		ctx.ws = req->ws;
 	}
 	if (bo != NULL) {
+		if(req)
+			assert(method == VCL_MET_PIPE);
 		CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 		CHECK_OBJ_NOTNULL(bo->vcl, VCL_MAGIC);
 		vsl = bo->vsl;
@@ -1129,8 +1134,11 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 		ctx.bo = bo;
 		ctx.sp = bo->sp;
 		ctx.now = bo->t_prev;
+		ctx.ttl_now = bo->t_prev;
 		ctx.ws = bo->ws;
 	}
+	if (method == VCL_MET_DELIVER)
+		ctx.ttl_now = ctx.now;
 	assert(ctx.now != 0);
 	ctx.vsl = vsl;
 	ctx.specific = specific;

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -622,7 +622,7 @@ VRT_purge(VRT_CTX, double ttl, double grace, double keep)
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->req->wrk, WORKER_MAGIC);
 	return (HSH_Purge(ctx->req->wrk, ctx->req->objcore->objhead,
-	    ttl, grace, keep));
+	    ctx->ttl_now, ttl, grace, keep));
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -516,7 +516,7 @@ VRT_r_bereq_retries(VRT_CTX)
  *	ttl is relative to t_origin
  *	grace&keep are relative to ttl
  * In VCL:
- *	ttl is relative to now
+ *	ttl is relative to ttl_now (in struct vrt_ctx)
  *	grace&keep are relative to ttl
  */
 
@@ -551,14 +551,14 @@ VRT_r_##which##_##fld(VRT_CTX)					\
 }
 
 VRT_DO_EXP_R(obj, ctx->req->objcore, ttl,
-    ctx->now - ctx->req->objcore->t_origin)
+    ctx->ttl_now - ctx->req->objcore->t_origin)
 VRT_DO_EXP_R(obj, ctx->req->objcore, grace, 0)
 VRT_DO_EXP_R(obj, ctx->req->objcore, keep, 0)
 
 VRT_DO_EXP_L(beresp, ctx->bo->fetch_objcore, ttl,
-    ctx->now - ctx->bo->fetch_objcore->t_origin)
+    ctx->ttl_now - ctx->bo->fetch_objcore->t_origin)
 VRT_DO_EXP_R(beresp, ctx->bo->fetch_objcore, ttl,
-    ctx->now - ctx->bo->fetch_objcore->t_origin)
+    ctx->ttl_now - ctx->bo->fetch_objcore->t_origin)
 VRT_DO_EXP_L(beresp, ctx->bo->fetch_objcore, grace, 0)
 VRT_DO_EXP_R(beresp, ctx->bo->fetch_objcore, grace, 0)
 VRT_DO_EXP_L(beresp, ctx->bo->fetch_objcore, keep, 0)
@@ -574,7 +574,7 @@ VRT_r_##which##_##age(VRT_CTX)					\
 {								\
 								\
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);			\
-	return (ctx->now - oc->t_origin);			\
+	return (ctx->ttl_now - oc->t_origin);			\
 }
 
 VRT_DO_AGE_R(obj, ctx->req->objcore)

--- a/bin/varnishtest/tests/c00086.vtc
+++ b/bin/varnishtest/tests/c00086.vtc
@@ -1,0 +1,42 @@
+varnishtest "Effective TTL for for a slow backend"
+
+server s1 {
+	rxreq
+	delay 2
+	txresp -body "foo"
+
+	# The second request is never used, but is here to give a
+	# better error if varnish decides to fetch the object the
+	# second time
+
+	rxreq
+	txresp -body "bar"
+} -start
+
+varnish v1 -arg "-p default_ttl=3 -p default_grace=0" -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.http.X-ttl = beresp.ttl;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.body == "foo"
+	expect resp.http.x-ttl <= 3
+	expect resp.http.x-ttl >= 2
+	delay 2
+
+	# It is now 2 seconds since the first response was received
+	# from the backend, but 4 seconds since the first request was
+	# sent to the backend. Timeout is 3 seconds, and here we
+	# consider the object _not_ expired, and thus do not want a
+	# refetch.
+
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.body == "foo"
+} -run
+

--- a/bin/varnishtest/tests/c00087.vtc
+++ b/bin/varnishtest/tests/c00087.vtc
@@ -1,0 +1,28 @@
+varnishtest "setting ttl in vcl_backend_response for slow backends"
+
+server s1 {
+	rxreq
+	delay 2
+	txresp -body "foo"
+	# The second request is never used
+	rxreq
+	txresp -body "bar"
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.ttl = 10s;
+	}
+	sub vcl_deliver {
+		set resp.http.X-ttl = obj.ttl;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.body == "foo"
+	expect resp.http.X-ttl <= 10
+	expect resp.http.X-ttl >= 9
+} -run

--- a/bin/varnishtest/tests/c00088.vtc
+++ b/bin/varnishtest/tests/c00088.vtc
@@ -1,0 +1,46 @@
+varnishtest "Correct obj.ttl is when backend and processing are slow"
+
+barrier b1 sock 2
+barrier b2 sock 2
+
+server s1 {
+	rxreq
+	delay 2
+	txresp -body "foo"
+	# The second request is never used
+	rxreq
+	txresp -body "bar"
+} -start
+
+varnish v1 -vcl+backend {
+	import vtc;
+	sub vcl_backend_response {
+		# Simulate processing for 1.5 sec
+		vtc.barrier_sync("${b1_sock}");
+		vtc.barrier_sync("${b2_sock}");
+
+		# Moving this above the processing should not change
+		# anything.
+
+		set beresp.ttl = 10s;
+	}
+	sub vcl_deliver {
+		set resp.http.X-ttl = obj.ttl;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.body == "foo"
+	expect resp.http.X-ttl <= 9
+	expect resp.http.X-ttl >= 8
+} -start
+
+# help for sleeping inside of vcl
+barrier b1 sync
+delay 1.5
+barrier b2 sync
+
+client c1 -wait

--- a/bin/varnishtest/tests/r02519.vtc
+++ b/bin/varnishtest/tests/r02519.vtc
@@ -1,0 +1,68 @@
+varnishtest "Expiry during processing"
+
+# When a object runs out of ttl+grace during processing of a
+# request, we want the calculation in the builtin VCL to match
+# the calculation of hit+grace in the C code.
+
+barrier b1 sock 2
+barrier b2 sock 2
+
+server s1 {
+	rxreq
+	expect req.url == "/1"
+	txresp
+
+	# If we get a second request to /1 here, it will be because a
+	# hit was became a miss in the builtin sub vcl_hit or because
+	# we never got to vcl_hit. We want a hit and a deliver.
+
+	rxreq
+	expect req.url == "/2"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_recv {
+		if (req.http.Sleep) {
+			# This will make the object expire while inside this VCL sub
+			vtc.barrier_sync("${b1_sock}");
+			vtc.barrier_sync("${b2_sock}");
+		}
+		# Update the last timestamp inside varnish
+		std.timestamp("T");
+	}
+	sub vcl_hit {
+		set req.http.X-was-hit = "true";
+		# no return here. Will the builtin VCL take us to vcl_miss?
+	}
+	sub vcl_miss {
+		set req.http.X-was-miss = "true";
+	}
+	sub vcl_backend_response {
+		# Very little ttl, a lot of keep
+		set beresp.ttl = 1s;
+		set beresp.grace = 0s;
+		set beresp.keep = 1w;
+	}
+} -start
+
+client c1 {
+	delay .5
+	txreq -url "/1"
+	rxresp
+	txreq -url "/1" -hdr "Sleep: true"
+	rxresp
+	# Final request to verify that the right amount of requests got to the backend
+	txreq -url "/2"
+	rxresp
+} -start
+
+# help for sleeping inside of vcl
+barrier b1 sync
+delay 1.5
+barrier b2 sync
+
+client c1 -wait

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -65,6 +65,7 @@
  *	VRT_l_beresp_storage_hint() removed - under discussion #2509
  *	VRT_blob() added
  *	VCL_STRANDS added
+ *	ttl_now added to struct ctx
  * 6.1 (2017-09-15 aka 5.2)
  *	http_CollectHdrSep added
  *	VRT_purge modified (may fail a transaction, signature changed)
@@ -182,6 +183,7 @@ struct vrt_ctx {
 	struct http			*http_beresp;
 
 	double				now;
+	double				ttl_now;
 
 	/*
 	 * method specific argument:


### PR DESCRIPTION
This PR supersedes #2548 and #2547 and is compatible with 71b93143d from #2519.

After looking closely at the available timestamps in varnish, I came to the conclusion that we need a new variable in `struct ctx` as a base for ttl calculations. I have named it `ttl_now`, but maybe `now_for_ttl`, `now_ttl` or `now_for_ttl_calculations` would be better. The reason is that the current use of `now` is problematic for reasons explained in #2548 and #2547 and demonstrated by the test cases.

If this PR is accepted, then, in this repository, only the shard director will use `now`. There are probably external vmods that also use it, and some of these will probably have to switch to `ttl_now` to work correctly.

As far as I can see it, the main discussion point for this PR will be what `obj.ttl` should be in `sub vcl_deliver`. For consistency maybe it should maybe be calculated from `t_req` or `t_restart` instead of `now`, but it is unclear. I hope the test cases covers the cases that we need to discuss.