### PR TITLE
Accurate byte counters

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -233,7 +233,8 @@ vbe_dir_gethdrs(const struct director *d, struct worker *wrk,
 		if (vtp->state != VTP_STATE_STOLEN)
 			extrachance = 0;
 
-		i = V1F_SendReq(wrk, bo, &bo->acct.bereq_hdrbytes, 0);
+		i = V1F_SendReq(wrk, bo, &bo->acct.bereq_hdrbytes,
+				&bo->acct.bereq_bodybytes, 0);
 
 		if (vtp->state != VTP_STATE_USED) {
 			if (VTP_Wait(wrk, vtp, VTIM_real() +
@@ -317,7 +318,8 @@ vbe_dir_http1pipe(const struct director *d, struct req *req, struct busyobj *bo)
 	if (vtp == NULL) {
 		retval = SC_TX_ERROR;
 	} else {
-		i = V1F_SendReq(req->wrk, bo, &v1a.bereq, 1);
+		CHECK_OBJ_NOTNULL(bo->htc, HTTP_CONN_MAGIC);
+		i = V1F_SendReq(req->wrk, bo, &v1a.bereq, &v1a.out, 1);
 		VSLb_ts_req(req, "Pipe", W_TIM_real(req->wrk));
 		if (i == 0)
 			V1P_Process(req, vtp->fd, &v1a);

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -63,8 +63,10 @@ Req_AcctLogCharge(struct VSC_main *ds, struct req *req)
 		    (uintmax_t)(a->resp_hdrbytes + a->resp_bodybytes));
 	}
 
+	/* Charge to main byte counters (except for ESI subrequests) */
 #define ACCT(foo)			\
-	ds->s_##foo += a->foo;		\
+	if (req->esi_level == 0)	\
+		ds->s_##foo += a->foo;	\
 	a->foo = 0;
 #include "tbl/acct_fields_req.h"
 }

--- a/bin/varnishd/http1/cache_http1.h
+++ b/bin/varnishd/http1/cache_http1.h
@@ -30,8 +30,8 @@
 struct VSC_vbe;
 
 /* cache_http1_fetch.c [V1F] */
-int V1F_SendReq(struct worker *, struct busyobj *, uint64_t *ctr,
-    int onlycached);
+int V1F_SendReq(struct worker *, struct busyobj *, uint64_t *ctr_hdrbytes,
+    uint64_t *ctr_bodybytes, int onlycached);
 int V1F_FetchRespHdr(struct busyobj *);
 int V1F_Setup_Fetch(struct vfp_ctx *vfc, struct http_conn *htc);
 
@@ -59,5 +59,5 @@ void V1L_EndChunk(const struct worker *w);
 void V1L_Open(struct worker *, struct ws *, int *fd, struct vsl_log *,
     double t0, unsigned niov);
 unsigned V1L_Flush(const struct worker *w);
-unsigned V1L_Close(struct worker *w);
+unsigned V1L_Close(struct worker *w, uint64_t *cnt);
 size_t V1L_Write(const struct worker *w, const void *ptr, ssize_t len);

--- a/bin/varnishd/http1/cache_http1_line.c
+++ b/bin/varnishd/http1/cache_http1_line.c
@@ -127,16 +127,18 @@ V1L_Open(struct worker *wrk, struct ws *ws, int *fd, struct vsl_log *vsl,
 }
 
 unsigned
-V1L_Close(struct worker *wrk)
+V1L_Close(struct worker *wrk, uint64_t *cnt)
 {
 	struct v1l *v1l;
 	unsigned u;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	AN(cnt);
 	u = V1L_Flush(wrk);
 	v1l = wrk->v1l;
 	wrk->v1l = NULL;
 	CHECK_OBJ_NOTNULL(v1l, V1L_MAGIC);
+	*cnt = v1l->cnt;
 	if (v1l->ws->r)
 		WS_Release(v1l->ws, 0);
 	WS_Reset(v1l->ws, v1l->res);

--- a/bin/varnishtest/tests/c00086.vtc
+++ b/bin/varnishtest/tests/c00086.vtc
@@ -1,0 +1,34 @@
+varnishtest "Accuratish bytes sent counters"
+
+server s1 {
+	rxreq
+	txresp -bodylen 1048576
+} -start
+
+varnish v1 -vcl+backend {
+	import vtc;
+	sub vcl_hit {
+		vtc.sleep(1s);
+	}
+} -start
+
+# Prime the cache with a larger than socket buffer object
+client c1 {
+	txreq
+	rxresp
+	expect resp.bodylen == 1048576
+} -run
+
+varnish v1 -expect s_resp_bodybytes == 1048576
+
+# Send a request and hang up immediately. Varnish will not notice the hang
+# up immediately due to the slow 1s hit, and start writing the response.
+# The write call will fail without having written the entire body.
+client c1 {
+	txreq
+} -run
+
+# Make sure that only parts of the 2nd request was counted. Exactly how
+# many bytes would show up as sent is hard to predict across platforms.
+varnish v1 -expect s_resp_bodybytes > 1048576
+varnish v1 -expect s_resp_bodybytes < 2097152

--- a/bin/varnishtest/tests/e00003.vtc
+++ b/bin/varnishtest/tests/e00003.vtc
@@ -32,7 +32,8 @@ varnish v1 -vcl+backend {
 
 logexpect l1 -v v1 -g request {
 	expect 0 1001   Begin   "^req .* rxreq"
-	expect * =	ReqAcct	"^18 0 18 187 75 262$"
+	# ReqAcct body counts include chunked overhead
+	expect * =	ReqAcct	"^18 0 18 187 104 291$"
 	expect 0 =      End
 } -start
 
@@ -54,7 +55,9 @@ logexpect l4 -v v1 -g request {
 
 logexpect l5 -v v1 -g request {
 	expect * 1005   Begin   "^req .* rxreq"
-	expect * =	ReqAcct	"^18 0 18 192 75 267$"
+	# ReqAcct body counts include chunked overhead
+	# Header bytes is 5 larger than in l1 due to two item X-Varnish hdr
+	expect * =	ReqAcct	"^18 0 18 192 104 296$"
 	expect 0 =      End
 } -start
 

--- a/bin/varnishtest/tests/l00003.vtc
+++ b/bin/varnishtest/tests/l00003.vtc
@@ -35,22 +35,34 @@ varnish v1 -vcl+backend {
 
 # Reponse:
 # HTTP/1.1 200 OK\r\n			17 bytes
+# Accept-Ranges: bytes\r\n		22 bytes
 # Transfer-Encoding: chunked\r\n	28 bytes
 # Connection: keep-alive\r\n		24 bytes
 # \r\n					 2 bytes
-# Total:				71 bytes
+# Total:				93 bytes
 
 # Response body:
-# 123\r\n				 5 bytes
-# abc\r\n				 5 bytes
-# 123\r\n				 5 bytes
-# def\r\n				 5 bytes
-# ghi\r\n				 5 bytes
-# Total:				15 bytes
+# Chunk len				 5 bytes
+# 123					 3 bytes
+# Chunk end				 2 bytes
+# Chunk len				 5 bytes
+# abc					 3 bytes
+# Chunk end				 2 bytes
+# Chunk len				 5 bytes
+# 123					 3 bytes
+# Chunk end				 2 bytes
+# Chunk len				 5 bytes
+# def					 3 bytes
+# Chunk end				 2 bytes
+# Chunk len				 5 bytes
+# ghi					 3 bytes
+# Chunk end				 2 bytes
+# Chunked end				 5 bytes
+# Total:				55 bytes
 
 logexpect l1 -v v1 -g request {
 	expect 0 1001	Begin	"^req .* rxreq"
-	expect * =	ReqAcct		"^18 0 18 93 15 108$"
+	expect * =	ReqAcct		"^18 0 18 93 55 148$"
 	expect 0 =	End
 	expect * 1003	Begin		"^req .* esi"
 	expect * =	ReqAcct		"^0 0 0 0 12 12$"
@@ -75,4 +87,4 @@ logexpect l1 -wait
 varnish v1 -expect s_req_hdrbytes == 18
 varnish v1 -expect s_req_bodybytes == 0
 varnish v1 -expect s_resp_hdrbytes == 93
-varnish v1 -expect s_resp_bodybytes == 33
+varnish v1 -expect s_resp_bodybytes == 55

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -57,6 +57,13 @@ Logging / statistics
 
 * added ``cache_hit_grace`` statisctics counter
 
+* The byte counters in ReqAcct now show the numbers reported from the
+  operating system rather than what we anticipated to send. This will give
+  more accurate numbers when e.g. the client hung up early without
+  receiving the entire response. Also these counters now show how many
+  bytes was attributed to the body, including any protocol overhead (ie
+  chunked encoding).
+
 C APIs (for vmod and utility authors)
 -------------------------------------
 

--- a/include/tbl/vsl_tags.h
+++ b/include/tbl/vsl_tags.h
@@ -475,9 +475,10 @@ SLTM(Timestamp, 0, "Timing information",
 
 SLTM(ReqAcct, 0, "Request handling byte counts",
 	"Contains byte counts for the request handling.\n"
-	"ESI sub-request counts are also added to their parent request.\n"
-	"The body bytes count does not include transmission "
-	"(ie: chunked encoding) overhead.\n"
+	"The body bytes count includes transmission overhead"
+	" (ie: chunked encoding).\n"
+	"ESI sub-requests show the body bytes this ESI fragment including"
+	" any subfragments contributed to the top level request.\n"
 	"The format is::\n\n"
 	"\t%d %d %d %d %d %d\n"
 	"\t|  |  |  |  |  |\n"


### PR DESCRIPTION
There was a regression from Varnish 4.0 to 4.1, where the response
bytes was counted as the number of bytes fed to the outgoing write
vector, rather than the bytes that was actually handed off to the OS'
socket buffer. This would cause for many cases the complete object
size counted as transmitted bytes, even though the client hung up the
connection early.

This patch changes the counters to show the amount of bytes sent as
reported from the write() system calls rather than the bytes we planned
and prepared to send. The counters will include any protocol overhead (ie
chunked encoding in HTTP/1 and the frame headers in HTTP/2).

ESI subrequests will as before in their log transactions report the number
of bytes it (and any subrequests below it) contributed to the total body
bytes produced.

Some test cases have been adjusted to account for the new counter behaviour.

One new test case added that attempts to catch this regression.