### PR TITLE
Add n_lru_limited counter

### DIFF
--- a/bin/varnishd/VSC_main.vsc
+++ b/bin/varnishd/VSC_main.vsc
@@ -253,6 +253,12 @@
 	Number of times an HTTP/2 stream was refused because the queue was
 	too long already. See also parameter thread_queue_limit.
 
+.. varnish_vsc:: nuke_limited
+	:oneliner:	Reached nuke_limit
+
+	Number of times more storage space were needed, but limit was reached in
+	a nuke_limit. See also parameter nuke_limit.
+
 .. varnish_vsc:: n_object
 	:type:	gauge
 	:oneliner:	object structs made

--- a/bin/varnishd/VSC_main.vsc
+++ b/bin/varnishd/VSC_main.vsc
@@ -253,12 +253,6 @@
 	Number of times an HTTP/2 stream was refused because the queue was
 	too long already. See also parameter thread_queue_limit.
 
-.. varnish_vsc:: nuke_limited
-	:oneliner:	Reached nuke_limit
-
-	Number of times more storage space were needed, but limit was reached in
-	a nuke_limit. See also parameter nuke_limit.
-
 .. varnish_vsc:: n_object
 	:type:	gauge
 	:oneliner:	object structs made
@@ -312,6 +306,12 @@
 	:oneliner:	Number of LRU moved objects
 
 	Number of move operations done on the LRU list.
+
+.. varnish_vsc:: n_lru_limited
+	:oneliner:	Reached nuke_limit
+
+	Number of times more storage space were needed, but limit was reached in
+	a nuke_limit. See also parameter nuke_limit.
 
 .. varnish_vsc:: losthdr
 	:oneliner:	HTTP header overflows

--- a/bin/varnishd/storage/storage_lru.c
+++ b/bin/varnishd/storage/storage_lru.c
@@ -172,7 +172,7 @@ LRU_NukeOne(struct worker *wrk, struct lru *lru)
 
 	if (wrk->strangelove-- <= 0) {
 		VSLb(wrk->vsl, SLT_ExpKill, "LRU reached nuke_limit");
-		VSC_C_main->nuke_limited++;
+		VSC_C_main->n_lru_limited++;
 		return (0);
 	}
 

--- a/bin/varnishd/storage/storage_lru.c
+++ b/bin/varnishd/storage/storage_lru.c
@@ -172,6 +172,7 @@ LRU_NukeOne(struct worker *wrk, struct lru *lru)
 
 	if (wrk->strangelove-- <= 0) {
 		VSLb(wrk->vsl, SLT_ExpKill, "LRU reached nuke_limit");
+		VSC_C_main->nuke_limited++;
 		return (0);
 	}
 

--- a/bin/varnishtest/tests/r01764.vtc
+++ b/bin/varnishtest/tests/r01764.vtc
@@ -52,3 +52,5 @@ client c1 {
 	rxresp
 	expect resp.status == 503
 } -run
+
+varnish v1 -expect nuke_limited == 1

--- a/bin/varnishtest/tests/r01764.vtc
+++ b/bin/varnishtest/tests/r01764.vtc
@@ -53,4 +53,4 @@ client c1 {
 	expect resp.status == 503
 } -run
 
-varnish v1 -expect nuke_limited == 1
+varnish v1 -expect n_lru_limited == 1


### PR DESCRIPTION
I got a strange error the other day.
Status code is 200, but body was incomplete.
This error occurred because nuke_limit was reached.
I think this error is hard to notice.
I would like to add a new counter to make notice it.
I think it can see that need to increase nuke_limit by this counter.

related ml thread https://varnish-cache.org/lists/pipermail/varnish-misc/2018-February/026340.html

