### PR TITLE
Symbolic status for HTC FetchError

### DIFF
--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -182,6 +182,21 @@ SES_Get_String_Attr(const struct sess *sp, enum sess_attr a)
 
 /*--------------------------------------------------------------------*/
 
+const char *
+HTC_Status(enum htc_status_e e)
+{
+	switch (e) {
+#define HTC_STATUS(e, n, s, l)				\
+		case HTC_S_ ## e:	return (s);
+#include "tbl/htc.h"
+	default:
+		WRONG("HTC_Status");
+	}
+	NEEDLESS(return (NULL));
+}
+
+/*--------------------------------------------------------------------*/
+
 void
 HTC_RxInit(struct http_conn *htc, struct ws *ws)
 {

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -343,6 +343,7 @@ void SES_Ref(struct sess *sp);
 void SES_Rel(struct sess *sp);
 int SES_Reschedule_Req(struct req *, enum task_prio);
 
+const char * HTC_Status(enum htc_status_e);
 void HTC_RxInit(struct http_conn *htc, struct ws *ws);
 void HTC_RxPipeline(struct http_conn *htc, void *);
 enum htc_status_e HTC_RxStuff(struct http_conn *, htc_complete_f *,
@@ -356,15 +357,8 @@ void SES_Set_String_Attr(struct sess *sp, enum sess_attr a, const char *src);
 
 
 enum htc_status_e {
-	HTC_S_JUNK =		-5,
-	HTC_S_CLOSE =		-4,
-	HTC_S_TIMEOUT =		-3,
-	HTC_S_OVERFLOW =	-2,
-	HTC_S_EOF =		-1,
-	HTC_S_EMPTY =		 0,
-	HTC_S_MORE =		 1,
-	HTC_S_COMPLETE =	 2,
-	HTC_S_IDLE =		 3,
+#define HTC_STATUS(e, n, s, l) HTC_S_ ## e = n,
+#include "tbl/htc.h"
 };
 
 /* cache_shmlog.c */

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -192,7 +192,8 @@ V1F_FetchRespHdr(struct busyobj *bo)
 			htc->doclose = SC_RX_OVERFLOW;
 			break;
 		default:
-			VSLb(bo->vsl, SLT_FetchError, "HTC status %d", hs);
+			VSLb(bo->vsl, SLT_FetchError, "HTC %s (%d)",
+			     HTC_Status(hs), hs);
 			htc->doclose = SC_RX_BAD;
 			break;
 		}

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -98,7 +98,8 @@ nobase_noinst_HEADERS = \
 	vss.h \
 	vtcp.h \
 	vtree.h \
-	vus.h
+	vus.h \
+	tbl/htc.h
 
 ## keep in sync with lib/libvcc/Makefile.am
 vcl.h: \

--- a/include/tbl/htc.h
+++ b/include/tbl/htc.h
@@ -1,0 +1,45 @@
+/*-
+ * Copyright (c) 2006 Verdens Gang AS
+ * Copyright (c) 2006-2015 Varnish Software AS
+ * All rights reserved.
+ *
+ * Author: Poul-Henning Kamp <phk@phk.freebsd.dk>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * HTC status values
+ */
+
+/*lint -save -e525 -e539 */
+
+// enum htc_status_e	n	short		long
+HTC_STATUS(JUNK,	-5,	"junk",		"Received unexpected data")
+HTC_STATUS(CLOSE,	-4,	"close",	"Connection closed") // unused?
+HTC_STATUS(TIMEOUT,	-3,	"timeout",	"Timed out")
+HTC_STATUS(OVERFLOW,	-2,	"overflow",	"Buffer too small")
+HTC_STATUS(EOF,	-1,	"eof",		"EOF received")
+HTC_STATUS(EMPTY,	 0,	"empty",	"Empty response")
+HTC_STATUS(MORE,	 1,	"more",	"More data required")
+HTC_STATUS(COMPLETE,	 2,	"complete",	"Data complete")
+HTC_STATUS(IDLE,	 3,	"idle",	"Return to waiter")
+#undef HTC_STATUS
+/*lint -restore */


### PR DESCRIPTION
Right now, we output a user-unfriendly integer for fetch errors caused by HTC.
This patch moves the enum definition to a table file which also holds a short and long description.
The long description is not currently used but intended for auto-generated documentation (tbc if the PR gets accepted)