### PR TITLE
Support Unix domain sockets as backend addresses

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -136,8 +136,8 @@ vbe_dir_getfd(struct worker *wrk, struct backend *bp, struct busyobj *bo,
 	if (bp->proxy_header != 0)
 		VPX_Send_Proxy(*fdp, bp->proxy_header, bo->sp);
 
-	VTCP_myname(*fdp, abuf1, sizeof abuf1, pbuf1, sizeof pbuf1);
-	VTCP_hisname(*fdp, abuf2, sizeof abuf2, pbuf2, sizeof pbuf2);
+	PFD_LocalName(pfd, abuf1, sizeof abuf1, pbuf1, sizeof pbuf1);
+	PFD_RemoteName(pfd, abuf2, sizeof abuf2, pbuf2, sizeof pbuf2);
 	VSLb(bo->vsl, SLT_BackendOpen, "%d %s %s %s %s %s",
 	    *fdp, bp->director->display_name, abuf2, pbuf2, abuf1, pbuf1);
 

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -212,6 +212,7 @@ vbe_dir_gethdrs(const struct director *d, struct worker *wrk,
 	int i, extrachance = 1;
 	struct backend *bp;
 	struct pfd *pfd;
+	char abuf[VTCP_ADDRBUFSIZE], pbuf[VTCP_PORTBUFSIZE];
 
 	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
@@ -234,8 +235,9 @@ vbe_dir_gethdrs(const struct director *d, struct worker *wrk,
 		if (PFD_State(pfd) != PFD_STATE_STOLEN)
 			extrachance = 0;
 
+		PFD_RemoteName(pfd, abuf, sizeof abuf, pbuf, sizeof pbuf);
 		i = V1F_SendReq(wrk, bo, &bo->acct.bereq_hdrbytes,
-				&bo->acct.bereq_bodybytes, 0);
+				&bo->acct.bereq_bodybytes, 0, abuf, pbuf);
 
 		if (PFD_State(pfd) != PFD_STATE_USED) {
 			if (VTP_Wait(wrk, pfd, VTIM_real() +
@@ -300,6 +302,7 @@ vbe_dir_http1pipe(const struct director *d, struct req *req, struct busyobj *bo)
 	struct backend *bp;
 	struct v1p_acct v1a;
 	struct pfd *pfd;
+	char abuf[VTCP_ADDRBUFSIZE], pbuf[VTCP_PORTBUFSIZE];
 
 	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
@@ -320,7 +323,9 @@ vbe_dir_http1pipe(const struct director *d, struct req *req, struct busyobj *bo)
 		retval = SC_TX_ERROR;
 	} else {
 		CHECK_OBJ_NOTNULL(bo->htc, HTTP_CONN_MAGIC);
-		i = V1F_SendReq(req->wrk, bo, &v1a.bereq, &v1a.out, 1);
+		PFD_RemoteName(pfd, abuf, sizeof abuf, pbuf, sizeof pbuf);
+		i = V1F_SendReq(req->wrk, bo, &v1a.bereq, &v1a.out, 1, abuf,
+				pbuf);
 		VSLb_ts_req(req, "Pipe", W_TIM_real(req->wrk));
 		if (i == 0)
 			V1P_Process(req, *PFD_Fd(pfd), &v1a);
@@ -437,7 +442,12 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(vrt, VRT_BACKEND_MAGIC);
-	assert(vrt->ipv4_suckaddr != NULL || vrt->ipv6_suckaddr != NULL);
+	if (vrt->path == NULL)
+		assert(vrt->ipv4_suckaddr != NULL
+		       || vrt->ipv6_suckaddr != NULL);
+	else
+		assert(vrt->ipv4_suckaddr == NULL
+		       && vrt->ipv6_suckaddr == NULL);
 
 	vcl = ctx->vcl;
 	AN(vcl);
@@ -480,7 +490,7 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 	VTAILQ_INSERT_TAIL(&backends, be, list);
 	VSC_C_main->n_backend++;
 	be->tcp_pool = VTP_Ref(vrt->ipv4_suckaddr, vrt->ipv6_suckaddr,
-	    vbe_proto_ident);
+	    vrt->path, vbe_proto_ident);
 	Lck_Unlock(&backends_mtx);
 
 	if (vbp != NULL) {

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -283,7 +283,9 @@ vbp_poke(struct vbp_target *vt)
 	}
 
 	i = VSA_Get_Proto(sa);
-	if (i == AF_INET)
+	if (VSA_Compare(sa, bogo_ip) == 0)
+		vt->good_unix |= 1;
+	else if (i == AF_INET)
 		vt->good_ipv4 |= 1;
 	else if (i == AF_INET6)
 		vt->good_ipv6 |= 1;

--- a/bin/varnishd/cache/cache_tcp_pool.h
+++ b/bin/varnishd/cache/cache_tcp_pool.h
@@ -51,11 +51,12 @@ void PFD_RemoteName(const struct pfd *, char *, unsigned, char *, unsigned);
  */
 
 struct tcp_pool *VTP_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6,
-    const void *id);
+    const char *uds, const void *id);
 	/*
-	 * Get a reference to a TCP pool.  Either ip4 or ip6 arg must be
-	 * non-NULL. If recycling is to be used, the id pointer distinguishes
-	 * the pool per protocol.
+	 * Get a reference to a TCP pool. Either one or both of ip4 or
+	 * ip6 arg must be non-NULL, or uds must be non-NULL. If recycling
+	 * is to be used, the id pointer distinguishes the pool per
+	 * protocol.
 	 */
 
 void VTP_AddRef(struct tcp_pool *);

--- a/bin/varnishd/cache/cache_tcp_pool.h
+++ b/bin/varnishd/cache/cache_tcp_pool.h
@@ -42,6 +42,8 @@ struct pfd;
 
 unsigned PFD_State(const struct pfd *);
 int *PFD_Fd(struct pfd *);
+void PFD_LocalName(const struct pfd *, char *, unsigned, char *, unsigned);
+void PFD_RemoteName(const struct pfd *, char *, unsigned, char *, unsigned);
 
 /*---------------------------------------------------------------------
 

--- a/bin/varnishd/http1/cache_http1.h
+++ b/bin/varnishd/http1/cache_http1.h
@@ -31,7 +31,7 @@ struct VSC_vbe;
 
 /* cache_http1_fetch.c [V1F] */
 int V1F_SendReq(struct worker *, struct busyobj *, uint64_t *ctr_hdrbytes,
-    uint64_t *ctr_bodybytes, int onlycached);
+    uint64_t *ctr_bodybytes, int onlycached, char *addr, char *port);
 int V1F_FetchRespHdr(struct busyobj *);
 int V1F_Setup_Fetch(struct vfp_ctx *vfc, struct http_conn *htc);
 

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -70,7 +70,7 @@ vbf_iter_req_body(void *priv, int flush, const void *ptr, ssize_t l)
 
 int
 V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
-    uint64_t *ctr_bodybytes, int onlycached)
+    uint64_t *ctr_bodybytes, int onlycached, char *abuf, char *pbuf)
 {
 	struct http *hp;
 	int j;
@@ -78,8 +78,6 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	uint64_t bytes, hdrbytes;
 	struct http_conn *htc;
 	int do_chunked = 0;
-	char abuf[VTCP_ADDRBUFSIZE];
-	char pbuf[VTCP_PORTBUFSIZE];
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
@@ -98,7 +96,6 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 		do_chunked = 1;
 	}
 
-	VTCP_hisname(*htc->rfd, abuf, sizeof abuf, pbuf, sizeof pbuf);
 	VSLb(bo->vsl, SLT_BackendStart, "%s %s", abuf, pbuf);
 
 	(void)VTCP_blocking(*htc->rfd);	/* XXX: we should timeout instead */

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -593,7 +593,12 @@ main(int argc, char * const *argv)
 			AN(vsb);
 			VSB_printf(vsb, "vcl 4.0;\n");
 			VSB_printf(vsb, "backend default {\n");
-			VSB_printf(vsb, "    .host = \"%s\";\n", optarg);
+			if (*optarg != '/')
+				VSB_printf(vsb, "    .host = \"%s\";\n",
+					   optarg);
+			else
+				VSB_printf(vsb, "    .path = \"%s\";\n",
+					   optarg);
 			VSB_printf(vsb, "}\n");
 			AZ(VSB_finish(vsb));
 			fa->src = strdup(VSB_data(vsb));

--- a/bin/varnishtest/tests/b00053.vtc
+++ b/bin/varnishtest/tests/b00053.vtc
@@ -1,6 +1,6 @@
 varnishtest "Does anything get through Unix domain sockets at all ?"
 
-server s1 {
+server s1 -listen "${tmpdir}/s1.sock" {
 	rxreq
 	txresp -body "012345\n"
 } -start

--- a/bin/varnishtest/tests/b00057.vtc
+++ b/bin/varnishtest/tests/b00057.vtc
@@ -1,7 +1,7 @@
 varnishtest "Test orderly connection closure of a UDS listen socket"
 
 
-server s1 {
+server s1 -listen "${tmpdir}/s1.sock" {
 	rxreq
 	txresp -nolen -hdr "Transfer-encoding: chunked"
 	delay .2

--- a/bin/varnishtest/tests/b00059.vtc
+++ b/bin/varnishtest/tests/b00059.vtc
@@ -1,6 +1,6 @@
 varnishtest "Run a lot of transactions through Unix domain sockets"
 
-server s0 {
+server s0 -listen "${tmpdir}/s1.sock" {
 	loop 10 {
 		rxreq
 		txresp -body "foo1"

--- a/bin/varnishtest/tests/b00060.vtc
+++ b/bin/varnishtest/tests/b00060.vtc
@@ -1,12 +1,13 @@
 varnishtest "VSL tags affected by the use of UDS addresses"
 
-varnish v1 -arg "-a foo=${tmpdir}/foo.sock -a bar=${tmpdir}/bar.sock" -vcl {
-	backend b { .host = "${bad_ip}"; }
-
-	sub vcl_recv { return(synth(200)); }
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp
 } -start
 
-client c1 -connect "${tmpdir}/foo.sock" {
+varnish v1 -arg "-a foo=${tmpdir}/v1.sock" -vcl+backend {} -start
+
+client c1 -connect "${tmpdir}/v1.sock" {
 	txreq
 	rxresp
 } -run
@@ -16,45 +17,12 @@ logexpect l1 -v v1 -d 1 -g session {
 	expect 0 =	SessOpen	"^0.0.0.0 0 foo 0.0.0.0 0"
 } -run
 
-logexpect l2 -v v1 -d 1 -g vxid {
+logexpect l2 -v v1 -d 1 -g vxid -c {
 	expect 0 1001	Begin
-	expect * =	ReqStart	"^0.0.0.0 0 foo$"
+	expect * =	ReqStart	"^0.0.0.0 0$"
 } -run
 
-logexpect l1 -v v1 -d 0 -g session {
-	expect 0 *	Begin
-	expect 0 =	SessOpen	"^0.0.0.0 0 bar 0.0.0.0 0"
-} -start
-
-logexpect l2 -v v1 -d 0 -g vxid {
-	expect 0 *	Begin
-	expect * =	ReqStart	"^0.0.0.0 0 bar"
-} -start
-
-client c1 -connect "${tmpdir}/bar.sock" {
-	txreq
-	rxresp
-} -run
-
-logexpect l1 -wait
-logexpect l2 -wait
-
-varnish v1 -stop
-
-# For completeness, also test the endpoint name field in ReqStart when
-# Varnish listens at an IP address.
-varnish v2 -vcl {
-	backend b { .host = "${bad_ip}"; }
-
-	sub vcl_recv { return(synth(200)); }
-} -start
-
-client c2 -connect ${v2_sock} {
-	txreq
-	rxresp
-} -run
-
-logexpect l3 -v v2 -d 1 -g vxid {
-	expect 0 1001	Begin
-	expect * =	ReqStart	"^${v2_addr} [0-9]+ a0$"
+logexpect l2 -v v1 -d 1 -g vxid -b {
+	expect 0 1002	Begin
+	expect * =	BackendOpen	"${s1_sock} - - -$"
 } -run

--- a/bin/varnishtest/tests/b00061.vtc
+++ b/bin/varnishtest/tests/b00061.vtc
@@ -1,0 +1,15 @@
+varnishtest "-b arg with a Unix domain socket"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -hdr "s1: got it"
+} -start
+
+varnish v1 -arg "-b ${s1_sock}" -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.s1 == "got it"
+} -run

--- a/bin/varnishtest/tests/c00087.vtc
+++ b/bin/varnishtest/tests/c00087.vtc
@@ -1,6 +1,6 @@
 varnishtest "VCL *.ip vars as bogo-IPs when -a is UDS, and test ACL matches"
 
-server s1 {
+server s1 -listen "${tmpdir}/s1.sock" {
 	rxreq
 	txresp
 } -start

--- a/bin/varnishtest/tests/c00088.vtc
+++ b/bin/varnishtest/tests/c00088.vtc
@@ -1,0 +1,44 @@
+varnishtest "Dropping polling of a backend that listens at UDS"
+
+server s1 -listen "${tmpdir}/s1.sock" -repeat 40 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	probe default {
+		.window = 8;
+		.initial = 7;
+		.threshold = 8;
+		.interval = 0.1s;
+	}
+	backend s1 {
+		.path = "${s1_sock}";
+	}
+} -start
+
+delay 1
+
+varnish v1 -vcl+backend { } -cliok "vcl.use vcl2" -cliok "vcl.discard vcl1"
+
+delay 1
+
+varnish v1 -cliok "vcl.list"
+varnish v1 -cliok "backend.list -p"
+
+server s1 -break {
+	rxreq
+	expect req.url == /foo
+	txresp -bodylen 4
+} -start
+
+delay 1
+
+client c1 {
+	txreq -url /foo
+	rxresp
+	txreq -url /foo
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 4
+} -run

--- a/bin/varnishtest/tests/c00089.vtc
+++ b/bin/varnishtest/tests/c00089.vtc
@@ -1,0 +1,33 @@
+varnishtest "Backend close retry with a UDS"
+
+server s1 -listen "${tmpdir}/s1.sock" -repeat 1 {
+	rxreq
+	txresp -bodylen 5
+
+	rxreq
+	accept
+
+	rxreq
+	txresp -bodylen 6
+
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return(pass);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 5
+
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 6
+} -run
+
+varnish v1 -expect backend_retry == 1

--- a/bin/varnishtest/tests/c00090.vtc
+++ b/bin/varnishtest/tests/c00090.vtc
@@ -1,0 +1,65 @@
+varnishtest "Forcing health of backends listening at UDS"
+
+server s1 -listen "${tmpdir}/s1.sock" -repeat 3 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	backend s1 {
+		.path = "${s1_sock}";
+		.probe = {
+			.window = 8;
+			.initial = 7;
+			.threshold = 8;
+			.interval = 10s;
+		}
+	}
+
+	sub vcl_recv {
+		return(pass);
+	}
+
+} -start
+
+delay 1
+
+varnish v1 -cliok "vcl.list"
+varnish v1 -cliok "backend.list -p"
+varnish v1 -cliok "backend.set_health s1 auto"
+varnish v1 -cliok "backend.list -p"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cliok "backend.list"
+varnish v1 -cliok "backend.set_health s1 sick"
+varnish v1 -cliok "backend.list"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+varnish v1 -cliok "backend.list"
+varnish v1 -cliok "backend.set_health s1 healthy"
+varnish v1 -cliok "backend.list"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -clierr 106 "backend.set_health s1 foo"
+varnish v1 -clierr 106 "backend.set_health s2 foo"
+varnish v1 -clierr 106 "backend.set_health s2 auto"
+varnish v1 -cliok "vcl.list"
+varnish v1 -cliok "backend.list *"
+varnish v1 -cliok "backend.list *.foo"
+varnish v1 -cliok "backend.list vcl1.*"
+

--- a/bin/varnishtest/tests/c00091.vtc
+++ b/bin/varnishtest/tests/c00091.vtc
@@ -1,0 +1,50 @@
+varnishtest	"vcl_backend_response{} retry with a UDS backend"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -hdr "foo: 1"
+	accept
+	rxreq
+	txresp -hdr "foo: 2"
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv { return (pass); }
+	sub vcl_backend_response {
+		set beresp.http.bar = bereq.retries;
+		if (beresp.http.foo != bereq.http.stop) {
+			return (retry);
+		}
+	}
+} -start
+
+varnish v1 -cliok "param.set debug +syncvsl"
+
+client c1 {
+	txreq -hdr "stop: 2"
+	rxresp
+	expect resp.http.foo == 2
+} -run
+
+delay .1
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -hdr "foo: 1"
+	accept
+	rxreq
+	txresp -hdr "foo: 2"
+	accept
+	rxreq
+	txresp -hdr "foo: 3"
+} -start
+
+varnish v1 -cliok "param.set max_retries 2"
+
+client c1 {
+	txreq -hdr "stop: 3"
+	rxresp
+	expect resp.http.foo == 3
+} -run
+
+# XXX: Add a test which exceeds max_retries and gets 503 back

--- a/bin/varnishtest/tests/c00092.vtc
+++ b/bin/varnishtest/tests/c00092.vtc
@@ -1,0 +1,32 @@
+varnishtest "Check aborted backend body with a backend listening at UDS"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -nolen -hdr "Transfer-encoding: chunked"
+	chunked {<HTML>}
+	barrier b1 sync
+	chunked {<HTML>}
+	barrier b2 sync
+} -start
+
+varnish v1 -cliok "param.set debug +syncvsl" -vcl+backend {
+
+} -start
+
+
+client c1 {
+	txreq
+	rxresphdrs
+	expect resp.status == 200
+	rxchunk
+	barrier b1 sync
+	rxchunk
+	barrier b2 sync
+	expect_close
+} -run
+
+
+

--- a/bin/varnishtest/tests/c00093.vtc
+++ b/bin/varnishtest/tests/c00093.vtc
@@ -1,0 +1,39 @@
+varnishtest "Test resp.is_streaming with a UDS backend"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -nolen -hdr "Content-Length: 10"
+	delay 1
+	send "1234567890"
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.url == "/synth") {
+			return(synth(200, "OK"));
+		}
+	}
+	sub vcl_synth {
+		set resp.http.streaming = resp.is_streaming;
+	}
+	sub vcl_deliver {
+		set resp.http.streaming = resp.is_streaming;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.streaming == "true"
+
+	delay 0.1
+
+	txreq
+	rxresp
+	expect resp.http.streaming == "false"
+
+	txreq -url /synth
+	rxresp
+	expect resp.http.streaming == "false"
+} -run
+

--- a/bin/varnishtest/tests/c00094.vtc
+++ b/bin/varnishtest/tests/c00094.vtc
@@ -1,0 +1,51 @@
+varnishtest "Test Backend Polling with a backend listening at a UDS"
+
+barrier b1 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	# Probes
+	loop 8 {
+		rxreq
+		expect req.url == "/"
+		txresp -hdr "Bar: foo" -body "foobar"
+		accept
+	}
+
+	loop 3 {
+		rxreq
+		expect req.url == "/"
+		txresp -status 404 -hdr "Bar: foo" -body "foobar"
+		accept
+	}
+	loop 2 {
+		rxreq
+		expect req.url == "/"
+		txresp -proto "FROBOZ" -status 200 -hdr "Bar: foo" -body "foobar"
+		accept
+	}
+	loop 2 {
+		rxreq
+		expect req.url == "/"
+		send "HTTP/1.1 200 \r\n"
+		accept
+	}
+
+	barrier b1 sync
+} -start
+
+varnish v1 -vcl {
+
+	backend foo {
+		.path = "${s1_sock}";
+		.probe = {
+			.timeout = 1 s;
+			.interval = 0.1 s;
+		}
+	}
+
+} -start
+
+barrier b1 sync
+
+varnish v1 -cliexpect "^CLI RX|  -+U+ Good UNIX" "backend.list -p"
+varnish v1 -cliexpect "^CLI RX|  -+H{10}-{5}H{2}-{0,5} Happy" "backend.list -p"

--- a/bin/varnishtest/tests/d00031.vtc
+++ b/bin/varnishtest/tests/d00031.vtc
@@ -1,0 +1,86 @@
+varnishtest "Test round robin director with UDS backends"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp -body "1"
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	txresp -body "22"
+} -start
+
+server s3 -listen "${tmpdir}/s3.sock" {
+	rxreq
+	txresp -body "333"
+} -start
+
+server s4 -listen "${tmpdir}/s4.sock" {
+	rxreq
+	txresp -body "4444"
+} -start
+
+varnish v1 -vcl+backend {
+	import directors;
+
+	sub vcl_init {
+		new rr = directors.round_robin();
+		rr.add_backend(s1);
+		rr.add_backend(s2);
+		rr.add_backend(s3);
+		rr.add_backend(s4);
+	}
+
+	sub vcl_recv {
+		if (req.method == "DELETE") {
+			rr.remove_backend(s1);
+			rr.remove_backend(s2);
+			rr.remove_backend(s3);
+			return(synth(204));
+		}
+	}
+
+	sub vcl_backend_fetch {
+		set bereq.backend = rr.backend();
+	}
+} -start
+
+client c1 {
+	timeout 3
+	txreq -url "/foo1"
+	rxresp
+	expect resp.bodylen == 1
+	txreq -url "/foo2"
+	rxresp
+	expect resp.bodylen == 2
+	txreq -url "/foo3"
+	rxresp
+	expect resp.bodylen == 3
+	txreq -url "/foo4"
+	rxresp
+	expect resp.bodylen == 4
+} -run
+
+server s1 -start
+server s2 -start
+
+client c2 {
+	timeout 3
+	txreq -url "/foo11"
+	rxresp
+	expect resp.bodylen == 1
+	txreq -url "/foo22"
+	rxresp
+	expect resp.bodylen == 2
+} -run
+
+server s4 -start
+
+client c3 {
+	txreq -req "DELETE"
+	rxresp
+	expect resp.status == 204
+	txreq -url "/foo31"
+	rxresp
+	expect resp.bodylen == 4
+} -run

--- a/bin/varnishtest/tests/d00032.vtc
+++ b/bin/varnishtest/tests/d00032.vtc
@@ -1,0 +1,70 @@
+varnishtest "Test dynamic backends listening at Unix domain sockets"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_sock}");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = s1.backend();
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -errvcl {path must be an absolute path} {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("");
+	}
+}
+
+varnish v1 -errvcl {path must be an absolute path} {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("s1.sock");
+	}
+}
+
+shell { rm -f ${tmpdir}/foo }
+
+varnish v1 -errvcl {Cannot stat path} {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${tmpdir}/foo");
+	}
+}
+
+varnish v1 -errvcl {is not a socket} {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${tmpdir}");
+	}
+}

--- a/bin/varnishtest/tests/d00033.vtc
+++ b/bin/varnishtest/tests/d00033.vtc
@@ -1,0 +1,47 @@
+varnishtest "Test dynamic UDS backends hot swap"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	txresp
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/bar"
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_sock}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+		set req.backend_hint = s1.backend();
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+
+	txreq -req "SWAP" -hdr "X-Path: ${s2_sock}"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+} -run

--- a/bin/varnishtest/tests/d00034.vtc
+++ b/bin/varnishtest/tests/d00034.vtc
@@ -1,0 +1,58 @@
+varnishtest "Test dynamic UDS backends hot swap while being used"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/bar"
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_sock}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+		set req.backend_hint = s1.backend();
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+} -start
+
+client c2 {
+	barrier b1 sync
+	txreq -req "SWAP" -hdr "X-Path: ${s2_sock}"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+} -run
+
+client c1 -wait

--- a/bin/varnishtest/tests/d00035.vtc
+++ b/bin/varnishtest/tests/d00035.vtc
@@ -1,0 +1,59 @@
+varnishtest "Test dynamic UDS backends hot swap during a pipe"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/bar"
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_sock}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+		set req.backend_hint = s1.backend();
+		return (pipe);
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+} -start
+
+client c2 {
+	barrier b1 sync
+	txreq -req "SWAP" -hdr "X-Path: ${s2_sock}"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+} -run
+
+client c1 -wait

--- a/bin/varnishtest/tests/d00036.vtc
+++ b/bin/varnishtest/tests/d00036.vtc
@@ -1,0 +1,62 @@
+varnishtest "Test dynamic UDS backend hot swap after it was picked by a bereq"
+
+barrier b1 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import std;
+	import debug;
+	import vtc;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_sock}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+	}
+
+	sub vcl_backend_fetch {
+		set bereq.backend = s1.backend();
+		# hot swap should happen while we sleep
+		vtc.sleep(2s);
+		if (std.healthy(bereq.backend)) {
+			return(abandon);
+		} else {
+			set bereq.backend = s1.backend();
+		}
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq
+	barrier b1 sync
+	rxresp
+	expect resp.status == 200
+}
+
+client c2 {
+	barrier b1 sync
+	delay 0.1
+	txreq -req "SWAP" -hdr "X-Path: ${s2_sock}"
+	rxresp
+	expect resp.status == 200
+}
+
+client c1 -start
+client c2 -run
+client c1 -wait

--- a/bin/varnishtest/tests/d00037.vtc
+++ b/bin/varnishtest/tests/d00037.vtc
@@ -1,0 +1,76 @@
+varnishtest "Test a dynamic UDS backend discard during a request"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -arg "-p thread_pools=1" -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_sock}");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = s1.backend();
+	}
+} -start
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/bar"
+	txresp
+} -start
+
+barrier b1 sync
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s2 = debug.dyn_uds("${s2_sock}");
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = s2.backend();
+	}
+}
+
+varnish v1 -cli "vcl.discard vcl1"
+barrier b2 sync
+
+client c1 -wait
+delay 2
+
+varnish v1 -expect MAIN.n_backend == 4
+
+varnish v1 -expect n_vcl_avail == 1
+varnish v1 -expect n_vcl_discard == 1
+
+client c1 {
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cli "vcl.list"
+varnish v1 -expect n_vcl_avail == 1

--- a/bin/varnishtest/tests/d00038.vtc
+++ b/bin/varnishtest/tests/d00038.vtc
@@ -1,0 +1,61 @@
+varnishtest "Test a dynamic UDS backend hot swap after it was hinted to a req"
+
+barrier b1 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+} -start
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import std;
+	import debug;
+	import vtc;
+
+	backend dummy { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		new s1 = debug.dyn_uds("${s1_sock}");
+	}
+
+	sub vcl_recv {
+		if (req.method == "SWAP") {
+			s1.refresh(req.http.X-Path);
+			return (synth(200));
+		}
+		set req.backend_hint = s1.backend();
+		# hot swap should happen while we sleep
+		vtc.sleep(2s);
+		if (std.healthy(req.backend_hint)) {
+			return(synth(800));
+		} else {
+			set req.backend_hint = s1.backend();
+		}
+	}
+} -start
+
+varnish v1 -expect MAIN.n_backend == 2
+
+client c1 {
+	txreq
+	barrier b1 sync
+	rxresp
+	expect resp.status == 200
+}
+
+client c2 {
+	barrier b1 sync
+	delay 0.1
+	txreq -req "SWAP" -hdr "X-Path: ${s2_sock}"
+	rxresp
+	expect resp.status == 200
+}
+
+client c1 -start
+client c2 -run
+client c1 -wait
+
+varnish v1 -cli backend.list

--- a/bin/varnishtest/tests/m00046.vtc
+++ b/bin/varnishtest/tests/m00046.vtc
@@ -21,7 +21,7 @@ client c1 -connect "${tmpdir}/v2.sock" {
 	expect resp.http.v1_addr == "0.0.0.0"
 } -run
 
-varnish v2 -errvcl {IP constant '"${v1_addr}"'} {
+varnish v2 -errvcl {Cannot convert to an IP address: '"${v1_addr}"'} {
 	import std;
 
 	sub vcl_recv {

--- a/bin/varnishtest/tests/t02013.vtc
+++ b/bin/varnishtest/tests/t02013.vtc
@@ -1,6 +1,6 @@
 varnishtest	"Direct H2 start over Unix domain sockets"
 
-server s1 {
+server s1 -listen "${tmpdir}/s1.sock" {
 	rxreq
 	expect req.http.host == foo.bar
 	txresp \

--- a/bin/varnishtest/tests/u00013.vtc
+++ b/bin/varnishtest/tests/u00013.vtc
@@ -1,9 +1,12 @@
 varnishtest "varnishncsa outputs when UDS addresses are in use"
 
-# The -c %h formatter gets its value from ReqStart, which now may be
-# 0.0.0.0 for a UDS address.
+# The %h formatter gets its value from ReqStart or BackendStart,
+# which now may be a UDS address.
 
-server s1 {
+# For UDS backends without a .hosthdr setting, the Host header is
+# set to "localhost", which may appear in %r output.
+
+server s1 -listen "${tmpdir}/s1.sock" {
 	rxreq
 	txresp
 } -start
@@ -21,4 +24,12 @@ shell -expect "0.0.0.0" {
 
 shell -expect "http://localhost/" {
 	varnishncsa -n ${v1_name} -d -c -F "%r"
+}
+
+shell -expect "0.0.0.0" {
+	varnishncsa -n ${v1_name} -d -b -F "%h"
+}
+
+shell -expect "http://localhost/" {
+	varnishncsa -n ${v1_name} -d -b -F "%r"
 }

--- a/bin/varnishtest/tests/v00038.vtc
+++ b/bin/varnishtest/tests/v00038.vtc
@@ -87,7 +87,7 @@ varnish v1 -errvcl "Unknown field:" {
 	}
 }
 
-varnish v1 -errvcl "Mandatory field 'host' missing." {
+varnish v1 -errvcl "Expected .host or .path." {
 	backend b1 {
 		.port = "NONE";
 	}
@@ -108,4 +108,31 @@ varnish v1 -errvcl "Only one default director possible." {
 varnish v1 -errvcl "Unused backend b1, defined:" {
 	backend b1 { .host = "127.0.0.1"; }
 	backend default { .host = "127.0.0.1"; }
+}
+
+varnish v1 -errvcl "Address redefinition at:" {
+	backend b1 {
+		.host = "127.0.0.1";
+		.path = "/path/to/uds";
+	}
+}
+
+varnish v1 -errvcl "Must be an absolute path:" {
+	backend b1 {
+		.path = "server.sock";
+	}
+}
+
+shell { rm -f ${tmpdir}/foo }
+
+varnish v1 -errvcl "Cannot stat:" {
+	backend b1 {
+		.path = "${tmpdir}/foo";
+	}
+}
+
+varnish v1 -errvcl "Not a socket:" {
+	backend b1 {
+		.path = "${tmpdir}";
+	}
 }

--- a/bin/varnishtest/tests/v00055.vtc
+++ b/bin/varnishtest/tests/v00055.vtc
@@ -1,0 +1,41 @@
+varnishtest "Check backend connection limit with UDS backends"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -vcl {
+
+	backend default {
+		.path = "${s1_sock}";
+		.max_connections = 1;
+	}
+	sub vcl_recv {
+		return(pass);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -start
+
+
+client c2 {
+	barrier b1 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+barrier b2 sync
+client c1 -wait
+
+varnish v1 -expect backend_busy == 1

--- a/bin/varnishtest/tests/v00056.vtc
+++ b/bin/varnishtest/tests/v00056.vtc
@@ -1,0 +1,70 @@
+varnishtest "Check req.backend.healthy with UDS backends"
+
+barrier b1 cond 2
+barrier b2 cond 2
+barrier b3 cond 2
+barrier b4 cond 2
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	barrier b1 sync
+	expect req.url == "/"
+	txresp -body "slash"
+	accept
+	rxreq
+	barrier b2 sync
+	barrier b3 sync
+	expect req.url == "/"
+	txresp -body "slash"
+	accept
+	barrier b4 sync
+} -start
+
+varnish v1 -vcl {
+
+	import std;
+
+	probe foo {
+		.url = "/";
+		.timeout = 1s;
+		.interval = 1s;
+		.window = 3;
+		.threshold = 2;
+		.initial = 0;
+	}
+
+	backend default {
+		.path = "${s1_sock}";
+		.max_connections = 1;
+		.probe = foo;
+	}
+
+	sub vcl_recv {
+		if (std.healthy(default)) {
+			return(synth(200,"Backend healthy"));
+		} else {
+			return(synth(500,"Backend sick"));
+		}
+	}
+} -start
+
+varnish v1 -cliok "backend.list -p"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 500
+
+	barrier b1 sync
+
+	barrier b2 sync
+	txreq
+	rxresp
+	expect resp.status == 500
+
+	barrier b3 sync
+	barrier b4 sync
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run

--- a/bin/varnishtest/tests/v00057.vtc
+++ b/bin/varnishtest/tests/v00057.vtc
@@ -1,0 +1,41 @@
+varnishtest "Test backend .hosthdr with UDS backends"
+
+server s1 -listen "${tmpdir}/s1.sock" {
+	rxreq
+	expect req.url == "/foo"
+	expect req.http.host == "snafu"
+	txresp -body "foo1"
+
+	rxreq
+	expect req.url == "/bar"
+	expect req.http.host == "localhost"
+	txresp -body "foo1"
+} -start
+
+varnish v1 -vcl+backend { } -start
+
+client c1 {
+	txreq -url "/foo" -hdr "Host: snafu"
+	rxresp
+	txreq -url "/bar"
+	rxresp
+} -run
+
+server s2 -listen "${tmpdir}/s2.sock" {
+	rxreq
+	expect req.url == "/barf"
+	expect req.http.host == "FOObar"
+	txresp -body "foo1"
+} -start
+
+varnish v1 -vcl {
+	backend b1 {
+		.path = "${s2_sock}";
+		.host_header = "FOObar";
+	}
+}
+
+client c1 {
+	txreq -url "/barf"
+	rxresp
+} -run

--- a/bin/varnishtest/vtc_server.c
+++ b/bin/varnishtest/vtc_server.c
@@ -392,9 +392,15 @@ cmd_server_genvcl(struct vsb *vsb)
 
 	AZ(pthread_mutex_lock(&server_mtx));
 	VTAILQ_FOREACH(s, &servers, list) {
-		VSB_printf(vsb,
-		    "backend %s { .host = \"%s\"; .port = \"%s\"; }\n",
-		    s->name, s->aaddr, s->aport);
+		if (*s->listen != '/')
+			VSB_printf(vsb,
+				   "backend %s { .host = \"%s\"; "
+				   ".port = \"%s\"; }\n",
+				   s->name, s->aaddr, s->aport);
+		else
+			VSB_printf(vsb,
+				   "backend %s { .path = \"%s\"; }\n",
+				   s->name, s->listen);
 	}
 	AZ(pthread_mutex_unlock(&server_mtx));
 }

--- a/include/tbl/backend_poll.h
+++ b/include/tbl/backend_poll.h
@@ -31,6 +31,7 @@
 
 BITMAP(good_ipv4, '4', "Good IPv4", 0)
 BITMAP(good_ipv6, '6', "Good IPv6", 0)
+BITMAP(good_unix, 'U', "Good UNIX", 0)
 BITMAP( err_xmit, 'x', "Error Xmit", 0)
 BITMAP(good_xmit, 'X', "Good Xmit", 0)
 BITMAP( err_recv, 'r', "Error Recv", 0)

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -53,6 +53,7 @@
  *
  *
  * 6.2 (scheduled for: 2018-03-15)
+ *	path field added to struct vrt_backend
  *	VRT_Healthy() added
  *	VRT_VSC_Alloc() added
  *	VRT_VSC_Destroy() added
@@ -253,6 +254,7 @@ extern const void * const vrt_magic_string_unset;
 	rigid char			*ipv4_addr;		\
 	rigid char			*ipv6_addr;		\
 	rigid char			*port;			\
+	rigid char			*path;			\
 	rigid char			*hosthdr;		\
 	double				connect_timeout;	\
 	double				first_byte_timeout;	\
@@ -266,6 +268,7 @@ extern const void * const vrt_magic_string_unset;
 		DA(ipv4_addr);			\
 		DA(ipv6_addr);			\
 		DA(port);			\
+		DA(path);			\
 		DA(hosthdr);			\
 		DN(connect_timeout);		\
 		DN(first_byte_timeout);		\

--- a/include/vus.h
+++ b/include/vus.h
@@ -33,3 +33,4 @@ typedef int vus_resolved_f(void *priv, const struct sockaddr_un *);
 int VUS_resolver(const char *path, vus_resolved_f *func, void *priv,
 		 const char **err);
 int VUS_bind(const struct sockaddr_un *uds, const char **errp);
+int VUS_connect(const char *path, int msec);

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -81,20 +81,19 @@ Emit_Sockaddr(struct vcc *tl, const struct token *t_host,
 		Fb(tl, 0, "\t.ipv6_addr = \"%s\",\n", ipv6a);
 	}
 	Fb(tl, 0, "\t.port = \"%s\",\n", pa);
+	Fb(tl, 0, "\t.path = (void *) 0,\n");
 }
 
 /*--------------------------------------------------------------------
- * Parse a backend probe specification
+ * Disallow mutually exclusive field definitions
  */
 
 static void
-vcc_ProbeRedef(struct vcc *tl, struct token **t_did,
+vcc_Redef(struct vcc *tl, const char *redef, struct token **t_did,
     struct token *t_field)
 {
-	/* .url and .request are mutually exclusive */
-
 	if (*t_did != NULL) {
-		VSB_printf(tl->sb, "Probe request redefinition at:\n");
+		VSB_printf(tl->sb, "%s redefinition at:\n", redef);
 		vcc_ErrWhere(tl, t_field);
 		VSB_printf(tl->sb, "Previous definition:\n");
 		vcc_ErrWhere(tl, *t_did);
@@ -102,6 +101,10 @@ vcc_ProbeRedef(struct vcc *tl, struct token **t_did,
 	}
 	*t_did = t_field;
 }
+
+/*--------------------------------------------------------------------
+ * Parse a backend probe specification
+ */
 
 static void
 vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **name)
@@ -152,7 +155,7 @@ vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **name)
 		vcc_IsField(tl, &t_field, fs);
 		ERRCHK(tl);
 		if (vcc_IdIs(t_field, "url")) {
-			vcc_ProbeRedef(tl, &t_did, t_field);
+			vcc_Redef(tl, "Probe request", &t_did, t_field);
 			ERRCHK(tl);
 			ExpectErr(tl, CSTR);
 			Fh(tl, 0, "\t.url = ");
@@ -160,7 +163,7 @@ vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **name)
 			Fh(tl, 0, ",\n");
 			vcc_NextToken(tl);
 		} else if (vcc_IdIs(t_field, "request")) {
-			vcc_ProbeRedef(tl, &t_did, t_field);
+			vcc_Redef(tl, "Probe request", &t_did, t_field);
 			ERRCHK(tl);
 			ExpectErr(tl, CSTR);
 			Fh(tl, 0, "\t.request =\n");
@@ -294,8 +297,10 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	struct token *t_val;
 	struct token *t_host = NULL;
 	struct token *t_port = NULL;
+	struct token *t_path = NULL;
 	struct token *t_hosthdr = NULL;
 	struct symbol *pb;
+	struct token *t_did = NULL;
 	struct fld_spec *fs;
 	struct inifin *ifp;
 	struct vsb *vsb;
@@ -304,8 +309,9 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	double t;
 
 	fs = vcc_FldSpec(tl,
-	    "!host",
+	    "?host",
 	    "?port",
+	    "?path",
 	    "?host_header",
 	    "?connect_timeout",
 	    "?first_byte_timeout",
@@ -345,6 +351,8 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 		vcc_IsField(tl, &t_field, fs);
 		ERRCHK(tl);
 		if (vcc_IdIs(t_field, "host")) {
+			vcc_Redef(tl, "Address", &t_did, t_field);
+			ERRCHK(tl);
 			ExpectErr(tl, CSTR);
 			assert(tl->t->dec != NULL);
 			t_host = tl->t;
@@ -354,6 +362,14 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 			ExpectErr(tl, CSTR);
 			assert(tl->t->dec != NULL);
 			t_port = tl->t;
+			vcc_NextToken(tl);
+			SkipToken(tl, ';');
+		} else if (vcc_IdIs(t_field, "path")) {
+			vcc_Redef(tl, "Address", &t_did, t_field);
+			ERRCHK(tl);
+			ExpectErr(tl, CSTR);
+			assert(tl->t->dec != NULL);
+			t_path = tl->t;
 			vcc_NextToken(tl);
 			SkipToken(tl, ';');
 		} else if (vcc_IdIs(t_field, "host_header")) {
@@ -430,9 +446,19 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	vcc_FieldsOk(tl, fs);
 	ERRCHK(tl);
 
-	/* Check that the hostname makes sense */
-	assert(t_host != NULL);
-	Emit_Sockaddr(tl, t_host, t_port);
+	if (t_host == NULL && t_path == NULL) {
+		VSB_printf(tl->sb, "Expected .host or .path.\n");
+		vcc_ErrWhere(tl, t_be);
+		return;
+	}
+
+	assert(t_host != NULL || t_path != NULL);
+	if (t_host != NULL)
+		/* Check that the hostname makes sense */
+		Emit_Sockaddr(tl, t_host, t_port);
+	else
+		/* Check that the path can be a legal UDS */
+		Emit_UDS_Path(tl, t_path, "Backend path");
 	ERRCHK(tl);
 
 	ExpectErr(tl, '}');
@@ -440,11 +466,14 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	/* We have parsed it all, emit the ident string */
 
 	/* Emit the hosthdr field, fall back to .host if not specified */
+	/* XXX If .path is specified, set "localhost". */
 	Fb(tl, 0, "\t.hosthdr = ");
 	if (t_hosthdr != NULL)
 		EncToken(tl->fb, t_hosthdr);
-	else
+	else if (t_host != NULL)
 		EncToken(tl->fb, t_host);
+	else
+		Fb(tl, 0, "\"localhost\"");
 	Fb(tl, 0, ",\n");
 
 	/* Close the struct */

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -327,6 +327,8 @@ void Resolve_Sockaddr(struct vcc *tl, const char *host, const char *defport,
     const char **ipv4, const char **ipv4_ascii, const char **ipv6,
     const char **ipv6_ascii, const char **p_ascii, int maxips,
     const struct token *t_err, const char *errid);
+void Emit_UDS_Path(struct vcc *tl, const struct token *t_path,
+    const char *errid);
 double vcc_TimeUnit(struct vcc *);
 void vcc_ByteVal(struct vcc *, double *);
 void vcc_NumVal(struct vcc *, double *, int *);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -721,6 +721,19 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 	case CSTR:
 		assert(fmt != VOID);
 		if (fmt == IP) {
+			if (*tl->t->dec == '/') {
+				/*
+				 * On some platforms (e.g. FreeBSD),
+				 * getaddrinfo(3) may resolve a path to a
+				 * sockaddr_un if it happens to exist and
+				 * is a socket. So don't let that happen.
+				 */
+				VSB_printf(tl->sb,
+					"Cannot convert to an IP address: ");
+				vcc_ErrToken(tl, tl->t);
+				vcc_ErrWhere(tl, tl->t);
+				return;
+			}
 			Resolve_Sockaddr(tl, tl->t->dec, "80",
 			    &ip, NULL, &ip, NULL, NULL, 1,
 			    tl->t, "IP constant");

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -33,6 +33,10 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
 
 #include "vcc_compile.h"
 
@@ -161,6 +165,7 @@ rs_callback(void *priv, const struct suckaddr *vsa)
 	assert(VSA_Sane(vsa));
 
 	v = VSA_Get_Proto(vsa);
+	assert(v != AF_UNIX);
 	VTCP_name(vsa, a, sizeof a, p, sizeof p);
 	VSB_printf(rss->vsb, "\t%s:%s\n", a, p);
 	if (v == AF_INET) {
@@ -250,6 +255,42 @@ Resolve_Sockaddr(struct vcc *tl,
 	}
 	VSB_destroy(&rss->vsb);
 	FREE_OBJ(rss);
+}
+
+/*
+ * For UDS, we do not create a VSA. Check if it's an absolute path, can
+ * be accessed, and is a socket. If so, just emit the path field and set
+ * the IP suckaddrs to NULL.
+ */
+void
+Emit_UDS_Path(struct vcc *tl, const struct token *t_path, const char *errid)
+{
+	struct stat st;
+
+	AN(t_path);
+	AN(t_path->dec);
+
+	if (*t_path->dec != '/') {
+		VSB_printf(tl->sb,
+			   "%s: Must be an absolute path:\n", errid);
+		vcc_ErrWhere(tl, t_path);
+		return;
+	}
+	errno = 0;
+	if (stat(t_path->dec, &st) != 0) {
+		VSB_printf(tl->sb, "%s: Cannot stat: %s\n", errid,
+			   strerror(errno));
+		vcc_ErrWhere(tl, t_path);
+		return;
+	}
+	if (! S_ISSOCK(st.st_mode)) {
+		VSB_printf(tl->sb, "%s: Not a socket:\n", errid);
+		vcc_ErrWhere(tl, t_path);
+		return;
+	}
+	Fb(tl, 0, "\t.path = \"%s\",\n", t_path->dec);
+	Fb(tl, 0, "\t.ipv4_suckaddr = (void *) 0,\n");
+	Fb(tl, 0, "\t.ipv6_suckaddr = (void *) 0,\n");
 }
 
 /*--------------------------------------------------------------------

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -143,6 +143,19 @@ $Method VOID .refresh(STRING addr, STRING port)
 
 Dynamically refresh & (always!) replace the backend by a new one.
 
+$Object dyn_uds(STRING path)
+
+Dynamically create a single-backend director listening at a Unix
+domain socket, path must not be empty.
+
+$Method BACKEND .backend()
+
+Return the dynamic UDS backend.
+
+$Method VOID .refresh(STRING path)
+
+Dynamically refresh & (always!) replace the backend by a new UDS backend.
+
 $Function VOID vcl_release_delay(DURATION)
 
 Hold a reference to the VCL when it goes cold for the given delay.

--- a/lib/libvmod_debug/vmod_debug_dyn.c
+++ b/lib/libvmod_debug/vmod_debug_dyn.c
@@ -32,6 +32,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
 
 #include "cache/cache.h"
 #include "cache/cache_director.h"
@@ -42,6 +46,14 @@
 struct xyzzy_debug_dyn {
 	unsigned		magic;
 #define VMOD_DEBUG_DYN_MAGIC	0x9b77ccbd
+	pthread_mutex_t		mtx;
+	char			*vcl_name;
+	struct director		*dir;
+};
+
+struct xyzzy_debug_dyn_uds {
+	unsigned		magic;
+#define VMOD_DEBUG_UDS_MAGIC	0x6c7370e6
 	pthread_mutex_t		mtx;
 	char			*vcl_name;
 	struct director		*dir;
@@ -166,4 +178,106 @@ xyzzy_dyn_refresh(VRT_CTX, struct xyzzy_debug_dyn *dyn,
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(dyn, VMOD_DEBUG_DYN_MAGIC);
 	dyn_dir_init(ctx, dyn, addr, port);
+}
+
+static int
+dyn_uds_init(VRT_CTX, struct xyzzy_debug_dyn_uds *uds, VCL_STRING path)
+{
+	struct director *dir, *dir2;
+	struct vrt_backend vrt;
+	struct stat st;
+
+	if (path == NULL) {
+		VRT_fail(ctx, "path is NULL");
+		return (-1);
+	}
+	if (*path != '/') {
+		VRT_fail(ctx, "path must be an absolute path: %s", path);
+		return (-1);
+	}
+	errno = 0;
+	if (stat(path, &st) != 0) {
+		VRT_fail(ctx, "Cannot stat path %s: %s", path, strerror(errno));
+		return (-1);
+	}
+	if (! S_ISSOCK(st.st_mode)) {
+		VRT_fail(ctx, "%s is not a socket", path);
+		return (-1);
+	}
+
+	INIT_OBJ(&vrt, VRT_BACKEND_MAGIC);
+	vrt.path = path;
+	vrt.vcl_name = uds->vcl_name;
+	vrt.hosthdr = "localhost";
+	vrt.ipv4_suckaddr = NULL;
+	vrt.ipv6_suckaddr = NULL;
+
+	if ((dir = VRT_new_backend(ctx, &vrt)) == NULL)
+		return (-1);
+
+	AZ(pthread_mutex_lock(&uds->mtx));
+	dir2 = uds->dir;
+	uds->dir = dir;
+	AZ(pthread_mutex_unlock(&uds->mtx));
+
+	if (dir2 != NULL)
+		VRT_delete_backend(ctx, &dir2);
+	return (0);
+}
+
+VCL_VOID v_matchproto_(td_debug_dyn_uds__init)
+xyzzy_dyn_uds__init(VRT_CTX, struct xyzzy_debug_dyn_uds **udsp,
+		    const char *vcl_name, VCL_STRING path)
+{
+	struct xyzzy_debug_dyn_uds *uds;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(udsp);
+	AZ(*udsp);
+	AN(vcl_name);
+
+	ALLOC_OBJ(uds, VMOD_DEBUG_UDS_MAGIC);
+	AN(uds);
+	REPLACE(uds->vcl_name, vcl_name);
+	AZ(pthread_mutex_init(&uds->mtx, NULL));
+
+	if (dyn_uds_init(ctx, uds, path) != 0) {
+		free(uds->vcl_name);
+		AZ(pthread_mutex_destroy(&uds->mtx));
+		FREE_OBJ(uds);
+		return;
+	}
+	*udsp = uds;
+}
+
+VCL_VOID v_matchproto_(td_debug_dyn_uds__fini)
+xyzzy_dyn_uds__fini(struct xyzzy_debug_dyn_uds **udsp)
+{
+	struct xyzzy_debug_dyn_uds *uds;
+
+	if (udsp == NULL || *udsp == NULL)
+		return;
+	CHECK_OBJ(*udsp, VMOD_DEBUG_UDS_MAGIC);
+	uds = *udsp;
+	free(uds->vcl_name);
+	AZ(pthread_mutex_destroy(&uds->mtx));
+	FREE_OBJ(uds);
+	udsp = NULL;
+}
+
+VCL_BACKEND v_matchproto_(td_debug_dyn_uds_backend)
+xyzzy_dyn_uds_backend(VRT_CTX, struct xyzzy_debug_dyn_uds *uds)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(uds, VMOD_DEBUG_UDS_MAGIC);
+	AN(uds->dir);
+	return (uds->dir);
+}
+
+VCL_VOID v_matchproto_(td_debug_dyn_uds_refresh)
+xyzzy_dyn_uds_refresh(VRT_CTX, struct xyzzy_debug_dyn_uds *uds, VCL_STRING path)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(uds, VMOD_DEBUG_UDS_MAGIC);
+	(void) dyn_uds_init(ctx, uds, path);
 }


### PR DESCRIPTION
This has the same commits as #2571 for UDS -a addresses, and goes on to add UDS support for backends.