### PR TITLE
Add the listener endpoint name as a third field to ReqStart.

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -46,6 +46,7 @@
 
 #include "hash/hash_slinger.h"
 #include "storage/storage.h"
+#include "common/heritage.h"
 #include "vcl.h"
 #include "vsha256.h"
 #include "vtim.h"
@@ -814,7 +815,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 {
 	unsigned recv_handling;
 	struct VSHA256Context sha256ctx;
-	const char *ci, *cp;
+	const char *ci, *cp, *endpname;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
@@ -829,7 +830,10 @@ cnt_recv(struct worker *wrk, struct req *req)
 
 	ci = SES_Get_String_Attr(req->sp, SA_CLIENT_IP);
 	cp = SES_Get_String_Attr(req->sp, SA_CLIENT_PORT);
-	VSLb(req->vsl, SLT_ReqStart, "%s %s", ci, cp);
+	CHECK_OBJ_NOTNULL(req->sp->listen_sock, LISTEN_SOCK_MAGIC);
+	endpname = req->sp->listen_sock->name;
+	AN(endpname);
+	VSLb(req->vsl, SLT_ReqStart, "%s %s %s", ci, cp, endpname);
 
 	http_VSL_log(req->http);
 

--- a/bin/varnishtest/tests/b00060.vtc
+++ b/bin/varnishtest/tests/b00060.vtc
@@ -1,12 +1,12 @@
 varnishtest "VSL tags affected by the use of UDS addresses"
 
-varnish v1 -arg "-a foo=${tmpdir}/v1.sock" -vcl {
+varnish v1 -arg "-a foo=${tmpdir}/foo.sock -a bar=${tmpdir}/bar.sock" -vcl {
 	backend b { .host = "${bad_ip}"; }
 
 	sub vcl_recv { return(synth(200)); }
 } -start
 
-client c1 -connect "${tmpdir}/v1.sock" {
+client c1 -connect "${tmpdir}/foo.sock" {
 	txreq
 	rxresp
 } -run
@@ -18,5 +18,43 @@ logexpect l1 -v v1 -d 1 -g session {
 
 logexpect l2 -v v1 -d 1 -g vxid {
 	expect 0 1001	Begin
-	expect * =	ReqStart	"^0.0.0.0 0$"
+	expect * =	ReqStart	"^0.0.0.0 0 foo$"
+} -run
+
+logexpect l1 -v v1 -d 0 -g session {
+	expect 0 *	Begin
+	expect 0 =	SessOpen	"^0.0.0.0 0 bar 0.0.0.0 0"
+} -start
+
+logexpect l2 -v v1 -d 0 -g vxid {
+	expect 0 *	Begin
+	expect * =	ReqStart	"^0.0.0.0 0 bar"
+} -start
+
+client c1 -connect "${tmpdir}/bar.sock" {
+	txreq
+	rxresp
+} -run
+
+logexpect l1 -wait
+logexpect l2 -wait
+
+varnish v1 -stop
+
+# For completeness, also test the endpoint name field in ReqStart when
+# Varnish listens at an IP address.
+varnish v2 -vcl {
+	backend b { .host = "${bad_ip}"; }
+
+	sub vcl_recv { return(synth(200)); }
+} -start
+
+client c2 -connect ${v2_sock} {
+	txreq
+	rxresp
+} -run
+
+logexpect l3 -v v2 -d 1 -g vxid {
+	expect 0 1001	Begin
+	expect * =	ReqStart	"^${v2_addr} [0-9]+ a0$"
 } -run


### PR DESCRIPTION
Makes it possible to distinguish listeners in a VSL client transaction. Especially if there is more than one UDS listen address, since all of them are logged as the bogo-IP 0.0.0.0:0 where addresses are logged.

We have the endpoint name in SessOpen, but that is only seen with `-g session`, not with any of `-g vxid`, `-g request` or `-c`. `-g session` is not possible for varnishncsa, and rarely used for any of the other log readers.