### PR TITLE
Add Obj* records to the default vsl_mask

### DIFF
--- a/bin/varnishd/mgt/mgt_param_bits.c
+++ b/bin/varnishd/mgt/mgt_param_bits.c
@@ -131,6 +131,10 @@ tweak_vsl_mask(struct vsb *vsb, const struct parspec *par, const char *arg)
 			(void)bit(mgt_param.vsl_mask, SLT_H2TxHdr, BSET);
 			(void)bit(mgt_param.vsl_mask, SLT_H2RxBody, BSET);
 			(void)bit(mgt_param.vsl_mask, SLT_H2RxHdr, BSET);
+			(void)bit(mgt_param.vsl_mask, SLT_ObjHeader, BSET);
+			(void)bit(mgt_param.vsl_mask, SLT_ObjProtocol, BSET);
+			(void)bit(mgt_param.vsl_mask, SLT_ObjReason, BSET);
+			(void)bit(mgt_param.vsl_mask, SLT_ObjStatus, BSET);
 		} else {
 			return (bit_tweak(vsb, mgt_param.vsl_mask,
 			    SLT__Reserved, arg, VSL_tags,


### PR DESCRIPTION
They add up to a considerable chunk of the VSL traffic, especially when cookies are involved, while providing little value when troubleshooting. In an effort to reduce VSL cycles on heavy workloads I found these to be good candidates for several reasons:

- `obj.*` fields are immutable in VCL
- after a hit, we initially get the same `Resp*` records in `vcl_deliver`
- before `vcl_backend_response` returns, we can infer them from `Beresp*`

The main difference would be `ObjHeader:X-Varnish`, but it would be the same as `BerespHeader:X-Varnish`, and be part of the `RespHeader` counterpart in the case of a hit. That, and cache-related headers adjusted to the current time.

One case where they wouldn't appear is for example on a hit followed by a restart. I have yet to find a use case where I'd need to query them with `varnishlog` or some other VUT.