### PR TITLE
Changes to better report child socket initialization errors

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -631,7 +631,12 @@ ccf_start(struct cli *cli, const char * const *av, void *priv)
 			    ls->endpoint, strerror(errno));
 			return;
 		}
-		AZ(listen(ls->sock, cache_param->listen_depth));
+		if (listen(ls->sock, cache_param->listen_depth)) {
+			VCLI_SetResult(cli, CLIS_CANT);
+			VCLI_Out(cli, "Listen failed on socket '%s': %s",
+			    ls->endpoint, strerror(errno));
+			return;
+		}
 		vca_tcp_opt_set(ls, 1);
 		if (cache_param->accept_filter && VTCP_filter_http(ls->sock)) {
 			VCLI_SetResult(cli, CLIS_CANT);

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -586,38 +586,8 @@ vca_acct(void *arg)
 	(void)arg;
 
 	t0 = VTIM_real();
-
 	vca_periodic(t0);
-	(void)vca_tcp_opt_init();
 
-	AZ(pthread_mutex_lock(&shut_mtx));
-	VTAILQ_FOREACH(ls, &heritage.socks, list) {
-		CHECK_OBJ_NOTNULL(ls->transport, TRANSPORT_MAGIC);
-		if (ls->sock == -2)
-			continue;	// VCA_Shutdown
-		assert (ls->sock > 0);	// We know where stdin is
-		if (cache_param->tcp_fastopen) {
-			int i;
-			i = VTCP_fastopen(ls->sock, cache_param->listen_depth);
-			if (i)
-				VSL(SLT_Error, ls->sock,
-				    "Kernel TCP Fast Open: sock=%d, ret=%d %s",
-				    ls->sock, i, strerror(errno));
-		}
-		AZ(listen(ls->sock, cache_param->listen_depth));
-		vca_tcp_opt_set(ls, 1);
-		if (cache_param->accept_filter) {
-			int i;
-			i = VTCP_filter_http(ls->sock);
-			if (i)
-				VSL(SLT_Error, ls->sock,
-				    "Kernel filtering: sock=%d, ret=%d %s",
-				    ls->sock, i, strerror(errno));
-		}
-	}
-	AZ(pthread_mutex_unlock(&shut_mtx));
-
-	need_test = 1;
 	pool_accepting = 1;
 
 	while (1) {
@@ -642,10 +612,38 @@ vca_acct(void *arg)
 static void v_matchproto_(cli_func_t)
 ccf_start(struct cli *cli, const char * const *av, void *priv)
 {
+	struct listen_sock *ls;
 
 	(void)cli;
 	(void)av;
 	(void)priv;
+
+	(void)vca_tcp_opt_init();
+
+	VTAILQ_FOREACH(ls, &heritage.socks, list) {
+		CHECK_OBJ_NOTNULL(ls->transport, TRANSPORT_MAGIC);
+		assert (ls->sock > 0);	// We know where stdin is
+		if (cache_param->tcp_fastopen) {
+			int i;
+			i = VTCP_fastopen(ls->sock, cache_param->listen_depth);
+			if (i)
+				VSL(SLT_Error, ls->sock,
+				    "Kernel TCP Fast Open: sock=%d, ret=%d %s",
+				    ls->sock, i, strerror(errno));
+		}
+		AZ(listen(ls->sock, cache_param->listen_depth));
+		vca_tcp_opt_set(ls, 1);
+		if (cache_param->accept_filter) {
+			int i;
+			i = VTCP_filter_http(ls->sock);
+			if (i)
+				VSL(SLT_Error, ls->sock,
+				    "Kernel filtering: sock=%d, ret=%d %s",
+				    ls->sock, i, strerror(errno));
+		}
+	}
+
+	need_test = 1;
 
 	AZ(pthread_create(&VCA_thread, NULL, vca_acct, NULL));
 }

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -213,7 +213,7 @@ char *mgt_VccCompile(struct cli *, struct vclprog *, const char *vclname,
 void mgt_vcl_init(void);
 void mgt_vcl_startup(struct cli *, const char *vclsrc, const char *origin,
     const char *vclname, int Cflag);
-int mgt_push_vcls_and_start(struct cli *, unsigned *status, char **p);
+int mgt_push_vcls(struct cli *, unsigned *status, char **p);
 void mgt_vcl_export_labels(struct vcc *);
 int mgt_has_vcl(void);
 void mgt_vcl_depends(struct vclprog *vp1, const char *name);

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -538,15 +538,19 @@ mgt_reap_child(void)
 
 	MGT_Complain(C_DEBUG, "Child cleanup complete");
 
-	/*
-	 * XXX exit mgr if we fail even with retries?
-	 * number of retries? interval?
-	 */
+	/* XXX number of retries? interval? */
 	for (i = 0; i < 3; i++) {
 		if (MAC_reopen_sockets() == 0)
 			break;
 		/* error already logged */
 		(void)sleep(1);
+	}
+	if (i == 3) {
+		/* We failed to reopen our listening sockets. No choice
+		 * but to exit. */
+		MGT_Complain(C_ERR,
+		    "Could not reopen listening sockets. Exiting.");
+		exit(1);
 	}
 
 	if (child_state == CH_DIED && mgt_param.auto_restart)

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -492,17 +492,6 @@ mgt_reap_child(void)
 		fprintf(stderr, "WAIT 0x%jd\n", (intmax_t)r);
 	assert(r == child_pid);
 
-	/*
-	 * XXX exit mgr if we fail even with retries?
-	 * number of retries? interval?
-	 */
-	for (i = 0; i < 3; i++) {
-		if (MAC_reopen_sockets() == 0)
-			break;
-		/* error already logged */
-		(void)sleep(1);
-	}
-
 	VSB_printf(vsb, "Child (%jd) %s", (intmax_t)r,
 	    status ? "died" : "ended");
 	if (WIFEXITED(status) && WEXITSTATUS(status)) {
@@ -548,6 +537,17 @@ mgt_reap_child(void)
 	child_pid = -1;
 
 	MGT_Complain(C_DEBUG, "Child cleanup complete");
+
+	/*
+	 * XXX exit mgr if we fail even with retries?
+	 * number of retries? interval?
+	 */
+	for (i = 0; i < 3; i++) {
+		if (MAC_reopen_sockets() == 0)
+			break;
+		/* error already logged */
+		(void)sleep(1);
+	}
 
 	if (child_state == CH_DIED && mgt_param.auto_restart)
 		mgt_launch_child(NULL);

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -395,15 +395,25 @@ mgt_launch_child(struct cli *cli)
 
 	mgt_cli_start_child(child_cli_in, child_cli_out);
 	child_pid = pid;
-	if (mgt_push_vcls_and_start(cli, &u, &p)) {
+	child_state = CH_RUNNING;
+
+	if (mgt_push_vcls(cli, &u, &p)) {
 		VCLI_SetResult(cli, u);
 		MGT_Complain(C_ERR, "Child (%jd) Pushing vcls failed:\n%s",
 		    (intmax_t)child_pid, p);
 		free(p);
-		child_state = CH_RUNNING;
 		MCH_Stop_Child();
-	} else
-		child_state = CH_RUNNING;
+		return;
+	}
+
+	if (mgt_cli_askchild(&u, &p, "start\n")) {
+		VCLI_SetResult(cli, u);
+		MGT_Complain(C_ERR, "Child (%jd) Acceptor start failed:\n%s",
+		    (intmax_t)child_pid, p);
+		free(p);
+		MCH_Stop_Child();
+		return;
+	}
 }
 
 /*=====================================================================

--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -545,7 +545,7 @@ mgt_vcl_export_labels(struct vcc *vcc)
 /*--------------------------------------------------------------------*/
 
 int
-mgt_push_vcls_and_start(struct cli *cli, unsigned *status, char **p)
+mgt_push_vcls(struct cli *cli, unsigned *status, char **p)
 {
 	struct vclprog *vp;
 	struct vcldep *vd;
@@ -591,10 +591,6 @@ mgt_push_vcls_and_start(struct cli *cli, unsigned *status, char **p)
 	} while (!done);
 
 	if (mgt_cli_askchild(status, p, "vcl.use \"%s\"\n", active_vcl->name))
-		return (1);
-	free(*p);
-	*p = NULL;
-	if (mgt_cli_askchild(status, p, "start\n"))
 		return (1);
 	free(*p);
 	*p = NULL;

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -134,6 +134,14 @@ Fixed bugs which may influence VCL behaviour
 Fixed bugs
 ----------
 
+* Problems during late socket initialization performed by the Varnish
+  child process are now reported back to the management process with an
+  error message, including errors experienced when executing the listen()
+  system call and failures on executing on the ``accept_filter`` and
+  ``tcp_fastopen`` parameters. (2551_)
+
+.. _2551: https://github.com/varnishcache/varnish-cache/issues/2551
+
 **TODO**
 
 ================================


### PR DESCRIPTION
This patch set enables the child process to report down to management (over CLI) if it fails to do its part of the socket initialization. Errors are reported over the CLI. If the child is auto-started on management startup, the daemonize code will notice and report error exit on failures.

The tcp_fastopen and cache_filter parameters will now cause error messages and fail if they can't be applied (instead of silently ignored).

Failures to execute listen() will cause failure (fixing #2551).