### PR TITLE
Fix "TypeError: err() takes at most 2 arguments (4 given)"

### DIFF
--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -303,10 +303,10 @@ def lex(l):
             wl[-1] += c
             s = 1
         else:
-            err("Syntax error at char", i, "'%s'" % c, warn=False)
+            err("Syntax error at char %i, '%s'" % (i, c), warn=False)
 
     if s != 0:
-        err("Syntax error at char", i, "'%s'" % c, warn=False)
+        err("Syntax error at char %i, '%s'" % (i, c), warn=False)
     return wl
 
 


### PR DESCRIPTION
Err takes two arguments, 4 was sent.

```
TypeError: err() takes at most 2 arguments (4 given)
```