### PR TITLE
Run include/generate.py only when needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -729,6 +729,9 @@ AC_SUBST(VSC_GEN_H)
 # Make sure this include dir exists
 AC_CONFIG_COMMANDS([mkdir], [$MKDIR_P doc/sphinx/include])
 
+# In order to reliably generate vcs_version.h
+AM_CONDITIONAL([REFRESH_VCS], [test -e ${srcdir}/.git])
+
 # Generate output
 AC_CONFIG_FILES([
     Makefile

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -123,15 +123,23 @@ GENERATED_H = vcl.h $(GEN_H)
 ## vcs_version.h / vmod_abi.h need to be up-to-date with every build
 ## except when building from a distribution
 
-vcs_version.h:
-	$(AM_V_GEN) if test -d $(top_srcdir)/.git ; then \
-	    @PYTHON@ $(srcdir)/generate.py \
-		$(top_srcdir) $(top_builddir) ; \
-	fi
+if REFRESH_VCS
+.git_head:
+	@git rev-parse HEAD >.git_head_new 2>/dev/null || :
+	@diff .git_head .git_head_new >/dev/null 2>&1 || \
+	       touch $(srcdir)/generate.py
+	@mv .git_head_new .git_head
+
+.PHONY: .git_head
+
+$(srcdir)/generate.py: .git_head
+endif
+
+vcs_version.h: generate.py
+	$(AM_V_GEN) $(PYTHON) $(srcdir)/generate.py \
+		$(top_srcdir) $(top_builddir)
 
 vmod_abi.h: vcs_version.h
-
-.PHONY: vcs_version.h
 
 ##
 
@@ -139,6 +147,8 @@ BUILT_SOURCES = \
 	$(GENERATED_H) \
 	vcs_version.h \
 	vmod_abi.h
+
+EXTRA_DIST = generate.py
 
 MAINTAINERCLEANFILES = $(GENERATED_H)
 

--- a/include/generate.py
+++ b/include/generate.py
@@ -50,21 +50,17 @@ def file_header(fo):
 	fo.write("""/*
  * NB:  This file is machine generated, DO NOT EDIT!
  *
- * Edit and run lib/libvcc/generate.py instead.
+ * Edit and run include/generate.py instead.
  */
 
 """)
 
 #######################################################################
 
-if os.path.isdir(os.path.join(srcroot, ".git")):
-	v = subprocess.check_output([
-		"git --git-dir=" + os.path.join(srcroot, ".git") +
-		" show -s --pretty=format:%H"
-	], shell=True, universal_newlines=True)
-	v = v.strip()
-else:
-	v = "NOGIT"
+
+v = subprocess.check_output([
+    "git rev-parse HEAD 2>/dev/null || echo NOGIT"
+    ], shell=True, universal_newlines=True).strip()
 
 vcsfn = os.path.join(srcroot, "include", "vcs_version.h")
 


### PR DESCRIPTION
In order to do that reliably, it needs to be figured out at configure time. We should also not assume that .git is a directory, it can also be a regular file.

When REFRESH_VCS is true, the logic to see whether the Git HEAD changed moved to the Makefile and could be removed from the python script. We may still want to keep it on both sides to stay extra careful.

We need a .PHONY target to always check the Git HEAD but on the other hand we don't want generate.py to also always run. Otherwise we'd always see this in the output even when it doesn't really happen:

    GEN     vcs_version.h

To solve that, we make generate.py depend on the .PHONY target and just touch it when the Git HEAD changed. This forces us to add generate.py as a source for vcs_version.h, which is actually the case.

When building outside of a Git clone, this is either a dist/release archive and it already contains a vcs_version.h that won't be updated, or it contains none and generate.py will make a NOGIT one.

Finally, instead of trying to be smart about the NOGIT case, it's a trivial fallback to the git rev-parse command. As a side effect, a full SHA1 hash is always used to describe the commit and aligns with the decision made in #2468 for VMODs metadata.

Fixes #2597