### PR TITLE
tbd alternative solution to the github tarball case?

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -124,7 +124,10 @@ GENERATED_H = vcl.h $(GEN_H)
 ## except when building from a distribution
 
 vcs_version.h:
-	$(AM_V_GEN) if test -d $(top_srcdir)/.git ; then \
+	$(AM_V_GEN) \
+	if test -e $(top_srcdir)/.git || \
+	 ! test -f vmod_abi.h || \
+	 ! test -f vcs_version.h ; then \
 	    @PYTHON@ $(srcdir)/generate.py \
 		$(top_srcdir) $(top_builddir) ; \
 	fi


### PR DESCRIPTION
Alternative suggestion to fix #2597

CON
* outputs `GEN` always: This can be viewed from two sides I think: Either "there is no output generated" or "the generator ran and produced no update"

PRO
* generate.py not in dist
* no duplication of git calls to shell
* simpler

Tested with builds from
* git
* dist
* github tarball
