### PR TITLE
Fix memory leak of vary string on stevedore alloc fail

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -129,8 +129,12 @@ vbf_beresp2obj(struct busyobj *bo)
 	if (bo->uncacheable)
 		bo->fetch_objcore->flags |= OC_F_PASS;
 
-	if (!vbf_allocobj(bo, l))
+	if (!vbf_allocobj(bo, l)) {
+		if (vary != NULL)
+			VSB_destroy(&vary);
+		AZ(vary);
 		return (-1);
+	}
 
 	if (vary != NULL) {
 		AN(ObjSetAttr(bo->wrk, bo->fetch_objcore, OA_VARY, varyl,


### PR DESCRIPTION
If the stevedore failed the object creation, we would leak the temporary
VSB holding the computed vary string. This patch frees it.

Problem exists in 4.1 and later.