### PR TITLE
Use libumem only as a storage allocator, not to override malloc etc.

### DIFF
--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -169,7 +169,7 @@ varnishd_LDADD = \
 	@SAN_LDFLAGS@ \
 	@JEMALLOC_LDADD@ \
 	@PCRE_LIBS@ \
-	${DL_LIBS} ${PTHREAD_LIBS} ${NET_LIBS} ${RT_LIBS} ${LIBM} ${UMEM_LIBS}
+	${DL_LIBS} ${PTHREAD_LIBS} ${NET_LIBS} ${RT_LIBS} ${LIBM}
 
 noinst_PROGRAMS = vhp_gen_hufdec
 vhp_gen_hufdec_SOURCES = hpack/vhp_gen_hufdec.c

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -136,7 +136,7 @@ usage(void)
 
 	printf(FMT, "-s [name=]kind[,options]", "Storage specification");
 	printf(FMT, "", "Can be specified multiple times.");
-#ifdef HAVE_LIBUMEM
+#ifdef HAVE_UMEM_H
 	printf(FMT, "", "  -s default (=umem)");
 	printf(FMT, "", "  -s umem");
 #else

--- a/bin/varnishd/storage/mgt_stevedore.c
+++ b/bin/varnishd/storage/mgt_stevedore.c
@@ -126,7 +126,7 @@ static const struct choice STV_choice[] = {
 	{ "deprecated_persistent",	&smp_stevedore },
 	{ "persistent",			&smp_fake_stevedore },
 #endif
-#if defined(HAVE_LIBUMEM)
+#if defined(HAVE_UMEM_H)
 	{ "umem",			&smu_stevedore },
 	{ "default",			&smu_stevedore },
 #else

--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ _VARNISH_CHECK_LIB(nsl, getaddrinfo)
 AC_SUBST(NET_LIBS, "${SOCKET_LIBS} ${NSL_LIBS}")
 
 # Userland slab allocator from Solaris, ported to other systems
-AC_CHECK_HEADERS([umem.h], [_VARNISH_CHECK_LIB(umem, umem_alloc)])
+AC_CHECK_HEADERS([umem.h])
 
 # XXX: This _may_ be for OS/X
 AC_CHECK_LIBM


### PR DESCRIPTION
We do this by not linking with libumem, but rather using dlopen/dlsym
to load the slab allocator interface, which is used by the stevedore.