### PR TITLE
add debug bit to count contended locks

### DIFF
--- a/bin/varnishd/VSC_lck.vsc
+++ b/bin/varnishd/VSC_lck.vsc
@@ -30,5 +30,15 @@
 	:oneliner:	Lock Operations
 
 
+.. varnish_vsc:: busy
+	:type:	counter
+	:level:	debug
+	:oneliner:	Contended locks
+
+	For trylock operations, counts the number of EBUSY returns.
+
+	If the LCK debug bit is enabled, all lock operations are
+	changed to issue a trylock first to report contended locks.
+
 .. varnish_vsc_end::	lck
 

--- a/bin/varnishd/cache/cache_lck.c
+++ b/bin/varnishd/cache/cache_lck.c
@@ -112,6 +112,9 @@ Lck__Lock(struct lock *lck, const char *p, int l)
 	CAST_OBJ_NOTNULL(ilck, lck->priv, ILCK_MAGIC);
 	if (DO_DEBUG(DBG_WITNESS))
 		Lck_Witness_Lock(ilck, p, l, "");
+	else if (DO_DEBUG(DBG_LCK) &&
+		 Lck__Trylock(lck, p, l) == 0)
+		return;
 	AZ(pthread_mutex_lock(&ilck->mtx));
 	AZ(ilck->held);
 	ilck->stat->locks++;
@@ -163,6 +166,8 @@ Lck__Trylock(struct lock *lck, const char *p, int l)
 		ilck->held = 1;
 		ilck->stat->locks++;
 		ilck->owner = pthread_self();
+	} else {
+		ilck->stat->busy++;
 	}
 	return (r);
 }

--- a/include/tbl/debug_bits.h
+++ b/include/tbl/debug_bits.h
@@ -51,6 +51,7 @@ DEBUG_BIT(VMOD_SO_KEEP,		vmod_so_keep,	"Keep copied VMOD libraries")
 DEBUG_BIT(PROCESSORS,		processors,	"Fetch/Deliver processors")
 DEBUG_BIT(PROTOCOL,		protocol,	"Protocol debugging")
 DEBUG_BIT(FAILRESCHED,		failresched,	"Fail from waiting list")
+DEBUG_BIT(LCK,			lck,		"Additional lock statistics")
 #undef DEBUG_BIT
 
 /*lint -restore */


### PR DESCRIPTION
As the only way to find relevant contended locks is to get statistics from production systems, we should have a runtime switch to enable gathering of more statistics.
