### PR TITLE
add debug bit to count contended locks

### DIFF
--- a/bin/varnishd/VSC_lck.vsc
+++ b/bin/varnishd/VSC_lck.vsc
@@ -30,5 +30,27 @@
 	:oneliner:	Lock Operations
 
 
+.. varnish_vsc:: dbg_busy
+	:type:	counter
+	:level:	debug
+	:oneliner:	Contended lock operations
+
+	If the ``lck`` debug bit is set: Lock operations which
+	returned EBUSY on the first locking attempt.
+
+	If the ``lck`` debug bit is unset, this counter will never be
+	incremented even if lock operations are contended.
+
+.. varnish_vsc:: dbg_try_fail
+	:type:	counter
+	:level:	debug
+	:oneliner:	Contended trylock operations
+
+	If the ``lck`` debug bit is set: Trylock operations which
+	returned EBUSY.
+
+	If the ``lck`` debug bit is unset, this counter will never be
+	incremented even if lock operations are contended.
+
 .. varnish_vsc_end::	lck
 

--- a/include/tbl/debug_bits.h
+++ b/include/tbl/debug_bits.h
@@ -51,6 +51,7 @@ DEBUG_BIT(VMOD_SO_KEEP,		vmod_so_keep,	"Keep copied VMOD libraries")
 DEBUG_BIT(PROCESSORS,		processors,	"Fetch/Deliver processors")
 DEBUG_BIT(PROTOCOL,		protocol,	"Protocol debugging")
 DEBUG_BIT(VCL_KEEP,		vcl_keep,	"Keep VCL C and so files")
+DEBUG_BIT(LCK,			lck,		"Additional lock statistics")
 #undef DEBUG_BIT
 
 /*lint -restore */


### PR DESCRIPTION
Follow-Up to #2635: separate stats for the lock and trylock case

I cannot quite follow phk's obscurity argument as this will only trigger additional questions. So instead, make clear in the name and documentation that the counters are only significant if the `lck` debug bit is set.