### PR TITLE
VUT apps can be stopped cleanly via vtc process -stop.

### DIFF
--- a/bin/varnishtest/tests/r02649.vtc
+++ b/bin/varnishtest/tests/r02649.vtc
@@ -1,0 +1,14 @@
+varnishtest "Cleanly stop a VUT app via vtc process -stop"
+
+varnish v1 -vcl { backend b { .host="${bad_ip}"; } } -start
+
+process p1 {
+	varnishncsa -n ${v1_name} -P ${tmpdir}/ncsa.pid -w ${tmpdir}/ncsa.log
+} -start
+
+delay 1
+
+process p1 -expect-exit 0 -stop -wait
+
+# Expect empty stderr output
+shell -match {^0\b} "wc -c ${tmpdir}/p1/stderr"

--- a/lib/libvarnishapi/vut.c
+++ b/lib/libvarnishapi/vut.c
@@ -315,7 +315,8 @@ VUT_Fini(struct VUT **vutp)
 {
 	struct VUT *vut;
 
-	TAKE_OBJ_NOTNULL(vut, vutp, VUT_MAGIC);
+	vut = *vutp;
+	CHECK_OBJ_NOTNULL(vut, VUT_MAGIC);
 	AN(vut->progname);
 
 	free(vut->n_arg);
@@ -336,6 +337,7 @@ VUT_Fini(struct VUT **vutp)
 
 	memset(vut, 0, sizeof *vut);
 	FREE_OBJ(vut);
+	*vutp = NULL;
 }
 
 int


### PR DESCRIPTION
Don't NULL the vut handle before a signal handler needs it.

Fixes #2649