### PR TITLE
Upgrade brew's Python to avoid linking errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ notifications:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew update;
+      brew upgrade python;
       brew install docutils sphinx-doc nghttp2;
     fi
   - if [[ -n "$CLANG" ]]; then


### PR DESCRIPTION
See: https://github.com/Homebrew/homebrew-core/issues/26358

After Python's formula was recently updated, macOS builds have been failing with the error:

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-2
Target /usr/local/bin/2to3-2 is a symlink belonging to python. 
```

For example: https://travis-ci.org/varnishcache/varnish-cache/jobs/370937346

Until Python is upgraded in the Travis base image, the workaround would be to manually do so during the steps of the build.

Hope this helps!