### PR TITLE
Fix gensequences for BusyBox awk

### DIFF
--- a/bin/varnishtest/gensequences
+++ b/bin/varnishtest/gensequences
@@ -61,7 +61,7 @@ while (getline > 0) {
 		l_prefix_parent[n] = prefix;
 		l_prefix_suffix[n] = sequence[i];
 		if (!l_prefix_name[n])
-			l_prefix_name[n] = "teken_state_" ++npr;
+			l_prefix_name[n] = "teken_state_" "" ++npr;
 		prefix = n;
 	}
 


### PR DESCRIPTION
I never thought that I'd have to fix a string concatenation problem in
a BusyBox awk program to generate VT100 code in a container, but here we
are:

echo | awk 'END {print "foo" "" ++a, "foo" ++a}'

should output "foo0 foo1", and for all the ?awk I tested, it does,
except for BusyBox awk who thought funny to output "0 foo1", breaking the
teken_state.h file.