### PR TITLE
VDP API changes

### DIFF
--- a/bin/varnishd/VSC_main.vsc
+++ b/bin/varnishd/VSC_main.vsc
@@ -505,6 +505,16 @@
 
 	Number of session closes with Error VCL_FAILURE (VCL failure)
 
+.. varnish_vsc:: sc_vdp_error
+	:level: diag
+	:oneliner:	Session Err VDP_FAILURE
+
+	Number of times an object delivery failed due to errors reported in the VDP layer
+
+.. varnish_vsc:: sc_stream_failure
+	:level: diag
+	:oneliner:	Session Err VDP_ERROR_FETCH
+
 .. varnish_vsc:: shm_records
 	:level:	diag
 	:oneliner:	SHM records

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -673,12 +673,12 @@ void Lck_DestroyClass(struct vsc_seg **);
 #include "tbl/locks.h"
 
 /* cache_obj.c */
-
 int ObjHasAttr(struct worker *, struct objcore *, enum obj_attr);
 const void *ObjGetAttr(struct worker *, struct objcore *, enum obj_attr,
     ssize_t *len);
 
-typedef int objiterate_f(void *priv, int flush, const void *ptr, ssize_t len);
+typedef int objiterate_f(void *priv, int flush, int last,
+    const void *ptr, ssize_t len);
 
 int ObjIterate(struct worker *, struct objcore *,
     void *priv, objiterate_f *func, int final);

--- a/bin/varnishd/cache/cache_deliver_proc.c
+++ b/bin/varnishd/cache/cache_deliver_proc.c
@@ -137,8 +137,11 @@ VDP_close(struct req *req)
 /*--------------------------------------------------------------------*/
 
 static int v_matchproto_(objiterate_f)
-vdp_objiterator(void *priv, int flush, const void *ptr, ssize_t len)
+vdp_objiterator(void *priv, int flush, int last, const void *ptr, ssize_t len)
 {
+	if (last && len == 0)
+		return (0);	/* XXX: For now do not send empty last
+				 * events down the chain. */
 	return (VDP_bytes(priv, flush ? VDP_FLUSH : VDP_NULL, ptr, len));
 }
 

--- a/bin/varnishd/cache/cache_deliver_proc.c
+++ b/bin/varnishd/cache/cache_deliver_proc.c
@@ -79,6 +79,26 @@ VDP_bytes(struct req *req, enum vdp_flush flush, const void *ptr, ssize_t len)
 	return (vdc->status);
 }
 
+/* VDP_push
+ *
+ * Add a VDP filter to the stack of filters to be run on delivery. If
+ * bottom is true, it will be added last. If bottom is false it will be
+ * added as the first filter to be run.
+ *
+ * priv is a function private pointer that will be passed to the VDP
+ * callback pointers.
+ *
+ * The vdp_init_f function of the inserted VDP will be run immediately
+ * upon successful VDP insertion.
+ *
+ * If the return value != VDP_OK the initialization of the filter
+ * failed. The reason for failure may be the fitler's vdp_init_f returning
+ * a non-VDP_OK value, or the result of workspace exhaustion or a previous
+ * filter having returned a non-VDP_OK value and this error status is
+ * latched. Note that on failures the filter's vdp_fini_f finalization
+ * function will NOT be run, and the calling code needs to free any
+ * resources attempted passed through the priv pointer.
+ */
 int
 VDP_push(struct req *req, const struct vdp *vdp, void *priv, int bottom)
 {

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -249,7 +249,7 @@ ved_decode_len(struct req *req, const uint8_t **pp)
 /*---------------------------------------------------------------------
  */
 
-static int v_matchproto_(vdp_bytes)
+static int v_matchproto_(vdp_bytes_f)
 ved_vdp(struct req *req, enum vdp_action act, void **priv,
     const void *ptr, ssize_t len)
 {
@@ -466,7 +466,7 @@ ved_bytes(struct req *req, struct req *preq, enum vdp_action act,
  * the stream with a bit more overhead.
  */
 
-static int v_matchproto_(vdp_bytes)
+static int v_matchproto_(vdp_bytes_f)
 ved_pretend_gzip(struct req *req, enum vdp_action act, void **priv,
     const void *pv, ssize_t l)
 {
@@ -768,7 +768,7 @@ ved_stripgzip(struct req *req, const struct boc *boc)
 
 /*--------------------------------------------------------------------*/
 
-static int v_matchproto_(vdp_bytes)
+static int v_matchproto_(vdp_bytes_f)
 ved_vdp_bytes(struct req *req, enum vdp_action act, void **priv,
     const void *ptr, ssize_t len)
 {

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -559,8 +559,8 @@ struct ved_foo {
 	uint8_t tailbuf[8];
 };
 
-static int
-ved_objiterate(void *priv, int flush, const void *ptr, ssize_t len)
+static int v_matchproto_(objiterate_f)
+ved_objiterate(void *priv, int flush, int last, const void *ptr, ssize_t len)
 {
 	struct ved_foo *foo;
 	const uint8_t *pp;
@@ -569,6 +569,7 @@ ved_objiterate(void *priv, int flush, const void *ptr, ssize_t len)
 
 	CAST_OBJ_NOTNULL(foo, priv, VED_FOO_MAGIC);
 	(void)flush;
+	(void)last;
 	pp = ptr;
 	if (len > 0) {
 		/* Skip over the GZIP header */

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -699,8 +699,8 @@ vbf_stp_fetchend(struct worker *wrk, struct busyobj *bo)
 /*--------------------------------------------------------------------
  */
 
-static int
-vbf_objiterator(void *priv, int flush, const void *ptr, ssize_t len)
+static int v_matchproto_(objiterate_f)
+vbf_objiterator(void *priv, int flush, int last, const void *ptr, ssize_t len)
 {
 	struct busyobj *bo;
 	ssize_t l;
@@ -708,6 +708,7 @@ vbf_objiterator(void *priv, int flush, const void *ptr, ssize_t len)
 	uint8_t *pd;
 
 	(void)flush;
+	(void)last;
 	CAST_OBJ_NOTNULL(bo, priv, BUSYOBJ_MAGIC);
 
 	while (len > 0) {

--- a/bin/varnishd/cache/cache_filter.h
+++ b/bin/varnishd/cache/cache_filter.h
@@ -100,12 +100,12 @@ enum vdp_action {
 	VDP_FLUSH,		/* Input buffer will be invalidated */
 };
 
-typedef int vdp_bytes(struct req *, enum vdp_action, void **priv,
+typedef int vdp_bytes_f(struct req *, enum vdp_action, void **priv,
     const void *ptr, ssize_t len);
 
 struct vdp {
 	const char		*name;
-	vdp_bytes		*func;
+	vdp_bytes_f		*func;
 };
 
 struct vdp_entry {

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -284,7 +284,7 @@ VGZ_Gzip(struct vgz *vg, const void **pptr, ssize_t *plen, enum vgz_flag flags)
  * VDP for gunzip'ing
  */
 
-static int v_matchproto_(vdp_bytes)
+static int v_matchproto_(vdp_bytes_f)
 vdp_gunzip(struct req *req, enum vdp_action act, void **priv,
     const void *ptr, ssize_t len)
 {

--- a/bin/varnishd/cache/cache_obj.h
+++ b/bin/varnishd/cache/cache_obj.h
@@ -34,8 +34,8 @@ typedef void objfree_f(struct worker *, struct objcore *);
 typedef void objsetstate_f(struct worker *, const struct objcore *,
     enum boc_state_e);
 
-typedef int objiterator_f(struct worker *, struct objcore *,
-    void *priv, objiterate_f *func, int final);
+typedef int objiterator_f(struct worker *, struct objcore *, void *priv,
+    objiterate_f *func, int final);
 typedef int objgetspace_f(struct worker *, struct objcore *,
      ssize_t *sz, uint8_t **ptr);
 typedef void objextend_f(struct worker *, struct objcore *, ssize_t l);

--- a/bin/varnishd/cache/cache_range.c
+++ b/bin/varnishd/cache/cache_range.c
@@ -44,7 +44,7 @@ struct vrg_priv {
 	ssize_t			range_off;
 };
 
-static int v_matchproto_(vdp_bytes)
+static int v_matchproto_(vdp_bytes_f)
 vrg_range_bytes(struct req *req, enum vdp_action act, void **priv,
     const void *ptr, ssize_t len)
 {

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -35,7 +35,7 @@
 
 /*--------------------------------------------------------------------*/
 
-static int v_matchproto_(vdp_bytes)
+static int v_matchproto_(vdp_bytes_f)
 v1d_bytes(struct req *req, enum vdp_action act, void **priv,
     const void *ptr, ssize_t len)
 {

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -46,11 +46,12 @@
  */
 
 static int v_matchproto_(objiterate_f)
-vbf_iter_req_body(void *priv, int flush, const void *ptr, ssize_t l)
+vbf_iter_req_body(void *priv, int flush, int last, const void *ptr, ssize_t l)
 {
 	struct busyobj *bo;
 
 	CAST_OBJ_NOTNULL(bo, priv, BUSYOBJ_MAGIC);
+	(void)last;
 
 	if (l > 0) {
 		(void)V1L_Write(bo->wrk, ptr, l);

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -72,7 +72,7 @@ V2D_Init(void)
 
 /**********************************************************************/
 
-static int v_matchproto_(vdp_bytes)
+static int v_matchproto_(vdp_bytes_f)
 h2_bytes(struct req *req, enum vdp_action act, void **priv,
     const void *ptr, ssize_t len)
 {

--- a/include/tbl/sess_close.h
+++ b/include/tbl/sess_close.h
@@ -47,6 +47,8 @@ SESS_CLOSE(PIPE_OVERFLOW, pipe_overflow,1,	"Session pipe overflow")
 SESS_CLOSE(RANGE_SHORT,   range_short,	1,	"Insufficient data for range")
 SESS_CLOSE(REQ_HTTP20,	  req_http20,	1,	"HTTP2 not accepted")
 SESS_CLOSE(VCL_FAILURE,	  vcl_failure,	1,	"VCL failure")
+SESS_CLOSE(VDP_ERROR,	  vdp_error,	1,	"VDP reported error")
+SESS_CLOSE(STREAM_FAILURE,stream_failure,1,	"Streamed fetch failure")
 #undef SESS_CLOSE
 
 /*lint -restore */


### PR DESCRIPTION
This PR changes the VDP API to enable some optimizations for VDPs that need to act differently when dealing with the very last data to be sent out (e.g. set the last frame marker in H/2, or an on-the-fly compressor adding its trailer data as part of the last data chunk).

The H/2 parts of the optimizations isn't finished yet, @daghf will be looking into that part. There are some comments in the code explaining those parts.