### PR TITLE
move logic of VDI_Resolve() to VRT as VRT_DirectorResolve()

### DIFF
--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -103,14 +103,17 @@ VDI_Resolve(VRT_CTX)
 		return (NULL);
 	}
 
-	CHECK_OBJ_ORNULL(d, DIRECTOR_MAGIC);
 	if (d == NULL) {
 		VSLb(bo->vsl, SLT_FetchError, "No backend");
-	} else {
-		AN(d->vdir);
+		return (NULL);
+	}
 
-		if (d->vdir->admin_health->health == 0)
-			d = NULL;
+	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+	AN(d->vdir);
+	if (d->vdir->admin_health->health == 0) {
+		VSLb(bo->vsl, SLT_FetchError,
+		     "Director %s is administratively unhealthy", d->vcl_name);
+		return (NULL);
 	}
 
 	return (d);

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -96,9 +96,11 @@ VDI_Resolve(VRT_CTX)
 		CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
 		AN(d->vdir);
 		d2 = d->vdir->methods->resolve(ctx, d);
-		if (d2 == NULL)
-			VSLb(bo->vsl, SLT_FetchError,
-			    "Director %s returned no backend", d->vcl_name);
+		if (d2 != NULL)
+			continue;
+		VSLb(bo->vsl, SLT_FetchError,
+		     "Director %s returned no backend", d->vcl_name);
+		return (NULL);
 	}
 
 	CHECK_OBJ_ORNULL(d, DIRECTOR_MAGIC);

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -288,12 +288,12 @@ VRT_LookupDirector(VRT_CTX, VCL_STRING name)
 VCL_BACKEND
 VRT_DirectorResolve(VRT_CTX, VCL_BACKEND d)
 {
-	VCL_BACKEND d2;
-
-	for (; d != NULL && d->vdir->methods->resolve != NULL; d = d2) {
+	while (d != NULL) {
 		CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
 		AN(d->vdir);
-		d2 = d->vdir->methods->resolve(ctx, d);
+		if (d->vdir->methods->resolve == NULL)
+			break;
+		d = d->vdir->methods->resolve(ctx, d);
 	}
 	CHECK_OBJ_ORNULL(d, DIRECTOR_MAGIC);
 	if (d != NULL)

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -286,6 +286,24 @@ VRT_LookupDirector(VRT_CTX, VCL_STRING name)
 /*--------------------------------------------------------------------*/
 
 VCL_BACKEND
+VRT_DirectorResolve(VRT_CTX, VCL_BACKEND d)
+{
+	VCL_BACKEND d2;
+
+	for (; d != NULL && d->vdir->methods->resolve != NULL; d = d2) {
+		CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+		AN(d->vdir);
+		d2 = d->vdir->methods->resolve(ctx, d);
+	}
+	CHECK_OBJ_ORNULL(d, DIRECTOR_MAGIC);
+	if (d != NULL)
+		AN(d->vdir);
+	return (d);
+}
+
+/*--------------------------------------------------------------------*/
+
+VCL_BACKEND
 VCL_DefaultDirector(const struct vcl *vcl)
 {
 

--- a/bin/varnishtest/tests/d00021.vtc
+++ b/bin/varnishtest/tests/d00021.vtc
@@ -1,16 +1,16 @@
 varnishtest "shard director LAZY and layering"
 
-server s1 -repeat 2 {
+server s1 -repeat 3 {
 	rxreq
 	txresp -body "ech3Ooj"
 } -start
 
-server s2 -repeat 2 {
+server s2 -repeat 3 {
 	rxreq
 	txresp -body "ieQu2qua"
 } -start
 
-server s3 -repeat 2 {
+server s3 -repeat 3 {
 	rxreq
 	txresp -body "xiuFi3Pe"
 } -start
@@ -54,6 +54,10 @@ varnish v1 -vcl+backend {
 	}
 
 	sub vcl_recv {
+	    # coverage
+	    set req.backend_hint = directors.resolve(vd.backend());
+	    set req.backend_hint = directors.resolve(l.backend());
+	    set req.backend_hint = directors.resolve(ll.backend());
 	    return(pass);
 	}
 
@@ -86,7 +90,10 @@ varnish v1 -vcl+backend {
 	}
 
 	sub vcl_backend_fetch {
-	    if (bereq.http.layered) {
+	    if (bereq.http.resolve) {
+		call backend_fetch_layered;
+		set bereq.backend = directors.resolve(bereq.backend);
+	    } else if (bereq.http.layered) {
 		call backend_fetch_layered;
 	    } else {
 		call backend_fetch_direct;
@@ -147,5 +154,26 @@ client c1 {
 	expect resp.body == "xiuFi3Pe"
 	expect resp.http.healthy == "true"
 	expect resp.http.director == "ll"
+	expect resp.http.backend == "s3"
+
+	txreq -url /1 -hdr "resolve: true"
+	rxresp
+	expect resp.body == "ech3Ooj"
+	expect resp.http.healthy == "true"
+	expect resp.http.director == "s1"
+	expect resp.http.backend == "s1"
+
+	txreq -url /2 -hdr "resolve: true"
+	rxresp
+	expect resp.body == "ieQu2qua"
+	expect resp.http.healthy == "true"
+	expect resp.http.director == "s2"
+	expect resp.http.backend == "s2"
+
+	txreq -url /3 -hdr "resolve: true"
+	rxresp
+	expect resp.body == "xiuFi3Pe"
+	expect resp.http.healthy == "true"
+	expect resp.http.director == "s3"
 	expect resp.http.backend == "s3"
 } -run

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -61,6 +61,7 @@
  *	VRT_l_beresp_body() changed
  *	VRT_Format_Proxy() added	// transitional interface
  *	VRT_AllocStrandsWS() added
+ *	VRT_DirectorResolve() added	// consider UNSTABLE for now
  * 10.0 (2019-09-15)
  *	VRT_UpperLowerStrands added.
  *	VRT_synth_page now takes STRANDS argument

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -558,6 +558,7 @@ VCL_BACKEND VRT_AddDirector(VRT_CTX, const struct vdi_methods *,
 void VRT_DisableDirector(VCL_BACKEND);
 VCL_BACKEND VRT_LookupDirector(VRT_CTX, VCL_STRING);
 void VRT_DelDirector(VCL_BACKEND *);
+VCL_BACKEND VRT_DirectorResolve(VRT_CTX, VCL_BACKEND);
 
 /* Suckaddr related */
 int VRT_VSA_GetPtr(VRT_CTX, VCL_IP sua, const unsigned char ** dst);

--- a/lib/libvmod_directors/misc.c
+++ b/lib/libvmod_directors/misc.c
@@ -33,6 +33,8 @@
 #include "vdef.h"
 #include "vrt.h"
 #include "vcl.h"
+#include "vas.h"
+#include "miniobj.h"
 
 #include "vcc_if.h"
 
@@ -46,4 +48,12 @@ VPFX(lookup)(VRT_CTX, VCL_STRING name)
 	}
 
 	return (VRT_LookupDirector(ctx, name));
+}
+
+VCL_BACKEND
+VPFX(resolve)(VRT_CTX, VCL_BACKEND d)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	return (VRT_DirectorResolve(ctx, d));
 }

--- a/lib/libvmod_directors/vmod.vcc
+++ b/lib/libvmod_directors/vmod.vcc
@@ -711,6 +711,28 @@ Lookup a backend by its name.
 
 This function can only be used from ``vcl_init{}`` and  ``vcl_fini{}``.
 
+$Function BACKEND resolve(BACKEND)
+
+Return a backend which any layer of directors resolves to.
+
+Most ``.backend()`` methods of varnish directors return a reference to
+the director itself (basically, all except ``shard`` with
+``resolve=NOW``). Only when it is time to make an actual connection is
+the decision on which backend to contact made.
+
+This function allows to have that decision made early, it returns a
+final ("real") backend which the given director argument would
+return.
+
+Notice that this decision is not saved, in other words, repeated calls
+to `directors.resolve()`_ may return different values, and the implicit
+resolution may use a different value yet again.
+
+To make a resolution decision permanent, it has to be saved
+explicitly, for example by assignment to ``(be)req.backend`` as in::
+
+	set bereq.backend = directors.resolve(bereq.backend);
+
 ACKNOWLEDGEMENTS
 ================
 


### PR DESCRIPTION
VDI_Resolve() remains for error handling for calls from VDI_GetHdr() and VDI_Http1Pipe()