### PR TITLE
Add JSON ping output

### DIFF
--- a/bin/varnishd/cache/cache_cli.c
+++ b/bin/varnishd/cache/cache_cli.c
@@ -111,7 +111,7 @@ CLI_Run(void)
 /*--------------------------------------------------------------------*/
 
 static struct cli_proto cli_cmds[] = {
-	{ CLICMD_PING,	"i", VCLS_func_ping },
+	{ CLICMD_PING,	"i", VCLS_func_ping, VCLS_func_ping_json },
 	{ CLICMD_HELP,	"i", VCLS_func_help, VCLS_func_help_json },
 	{ NULL }
 };

--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -327,7 +327,7 @@ mcf_help_json(struct cli *cli, const char * const *av, void *priv)
 
 static struct cli_proto cli_auth[] = {
 	{ CLICMD_HELP,		"", mcf_help, mcf_help_json },
-	{ CLICMD_PING,		"", VCLS_func_ping },
+	{ CLICMD_PING,		"", VCLS_func_ping, VCLS_func_ping_json },
 	{ CLICMD_AUTH,		"", mcf_auth },
 	{ CLICMD_QUIT,		"", VCLS_func_close },
 	{ NULL }

--- a/bin/varnishtest/tests/b00008.vtc
+++ b/bin/varnishtest/tests/b00008.vtc
@@ -1,4 +1,4 @@
-varnishtest "Test CLI help and parameter functions"
+varnishtest "Test CLI commands and parameter functions"
 
 varnish v1 -arg "-b ${bad_ip}:9080"
 
@@ -27,6 +27,14 @@ varnish v1 -start
 varnish v1 -cliok "help"
 
 varnish v1 -clijson "help -j"
+
+varnish v1 -cliok "backend.list"
+
+varnish v1 -clijson "backend.list -j"
+
+varnish v1 -cliok "ping"
+
+varnish v1 -clijson "ping -j"
 
 varnish v1 -clierr 106 "param.set waiter HASH(0x8839c4c)"
 

--- a/include/vcli_serve.h
+++ b/include/vcli_serve.h
@@ -105,3 +105,4 @@ cli_func_t	VCLS_func_close;
 cli_func_t	VCLS_func_help;
 cli_func_t	VCLS_func_help_json;
 cli_func_t	VCLS_func_ping;
+cli_func_t	VCLS_func_ping_json;

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -103,6 +103,16 @@ VCLS_func_ping(struct cli *cli, const char * const *av, void *priv)
 	VCLI_Out(cli, "PONG %jd 1.0", (intmax_t)t);
 }
 
+void v_matchproto_(cli_func_t)
+VCLS_func_ping_json(struct cli *cli, const char * const *av, void *priv)
+{
+	(void)av;
+	(void)priv;
+	VCLI_JSON_begin(cli, 2, av);
+	VCLI_Out(cli, ", \"PONG\"\n");
+	VCLI_JSON_end(cli);
+}
+
 /*--------------------------------------------------------------------*/
 
 void v_matchproto_(cli_func_t)


### PR DESCRIPTION
This adds -j support to the command

varnishadm ping -j

Tested on RFC4627/RFC7159/ECMA404 standards (all valid JSON)