### PR TITLE
Accurate ban statistics except for a few remaining corner cases

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -571,7 +571,7 @@ struct sess {
 struct ban_proto *BAN_Build(void);
 const char *BAN_AddTest(struct ban_proto *,
     const char *, const char *, const char *);
-const char *BAN_Commit(struct ban_proto *b);
+const char *BAN_Commit(struct ban_proto *b, struct VSC_main *stats);
 void BAN_Abandon(struct ban_proto *b);
 
 /* cache_cli.c [CLI] */

--- a/bin/varnishd/cache/cache_ban.h
+++ b/bin/varnishd/cache/cache_ban.h
@@ -109,7 +109,7 @@ extern pthread_cond_t	ban_lurker_cond;
 extern uint64_t bans_persisted_bytes;
 extern uint64_t bans_persisted_fragmentation;
 
-void ban_mark_completed(struct ban *b);
+void ban_mark_completed(struct ban *b, struct VSC_main *stats);
 unsigned ban_len(const uint8_t *banspec);
 void ban_info_new(const uint8_t *ban, unsigned len);
 void ban_info_drop(const uint8_t *ban, unsigned len);

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -557,6 +557,26 @@ VRT_synth_page(VRT_CTX, const char *str, ...)
 
 /*--------------------------------------------------------------------*/
 
+static struct VSC_main *
+vrt_stats(VRT_CTX)
+{
+	struct worker *wrk;
+
+	if (ctx->req) {
+		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+		wrk = ctx->req->wrk;
+	} else if (ctx->bo) {
+		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+		wrk = ctx->bo->wrk;
+	} else {
+		// XXX
+		return (VSC_C_main);
+	}
+
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	return (wrk->stats);
+}
+
 VCL_VOID
 VRT_ban_string(VRT_CTX, VCL_STRING str)
 {
@@ -612,7 +632,7 @@ VRT_ban_string(VRT_CTX, VCL_STRING str)
 			break;
 		}
 		if (av[++i] == NULL) {
-			err = BAN_Commit(bp);
+			err = BAN_Commit(bp, vrt_stats(ctx));
 			if (err == NULL)
 				bp = NULL;
 			else

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -125,6 +125,7 @@ struct vsc_seg;
 struct vsmw_cluster;
 struct vsl_log;
 struct ws;
+struct VSC_main;
 
 struct strands {
 	int		n;


### PR DESCRIPTION
Fixes #2716 for most cases.

Open questions:

* make `wstat` lock visible to ban code and hold it during cli ban?
* do the same for `vcl_init` / `vcl_fini`  or will we add a worker?

From the commit message:

For ban statistics, we updated VSC_C_main directly, so if we raced
Pool_Sumstat(), that could undo our changes.

This patch fixes statistics by using the per-worker statistics
cache except for the following remaining corner cases:

* bans_persisted_* counters receive absolut updates, which does
  not seem to fit the incremental updates via the per-worker stats.

  I've kept these cases untouched and marked with comments. Worst
  that should happen here are temporary inconsistencies until the
  next absolute update.

* For BAN_Reload(), my understanding is that it should only
  happen during init, so we continue to update VSC_C_main
  directly.

* For bans via the cli, we would need to grab the wstat lock,
  which, at the moment, is private to the worker implementation.

  Until we make a change here, we could miss a ban increment
  from the cli.

* for VCL bans from vcl_init / fini, we do not have access
  to the worker struct at the moment, so for now we also
  accept an inconsistency here.

Fixes #2716 for relevant cases