### PR TITLE
Increasing libvarnishapi.so version from 1.0.6 to 2.0.0

### DIFF
--- a/lib/libvarnishapi/Makefile.am
+++ b/lib/libvarnishapi/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 
 lib_LTLIBRARIES = libvarnishapi.la
 
-libvarnishapi_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:6:0
+libvarnishapi_la_LDFLAGS = $(AM_LDFLAGS) -version-info 2:0:0
 
 libvarnishapi_la_SOURCES = \
 	vsl_api.h \


### PR DESCRIPTION
Fixes: libvarnishapi needs soname bump #2710

Should be backported to branches: 5.0, 5.1, 5.2, 6.0