### PR TITLE
vmod references and handles

### DIFF
--- a/bin/varnishd/cache/cache_vrt_vmod.c
+++ b/bin/varnishd/cache/cache_vrt_vmod.c
@@ -85,7 +85,7 @@ int
 VRT_Vmod_Init(VRT_CTX, struct vmod **hdl, void *ptr, int len, const char *nm,
     const char *path, const char *file_id, const char *backup)
 {
-	struct vmod *v;
+	struct vmod *v, **vv;
 	const struct vmod_data *d;
 	char buf[256];
 
@@ -157,6 +157,11 @@ VRT_Vmod_Init(VRT_CTX, struct vmod **hdl, void *ptr, int len, const char *nm,
 
 		VSC_C_main->vmods++;
 		VTAILQ_INSERT_TAIL(&vmods, v, list);
+
+		bprintf(buf, "Vmod_%s_Handle", nm);
+		vv = dlsym(v->hdl, buf);
+		if (vv != NULL)
+			*vv = v;
 	}
 
 	assert(len == v->funclen);
@@ -226,6 +231,14 @@ VRT_Vmod_Unref(struct vmod **hdl)
 	FREE_OBJ(v);
 
 	return (ref);
+}
+
+/* for vmod_debug */
+const char *
+VRT_Vmod_Name(const struct vmod *v)
+{
+	CHECK_OBJ_NOTNULL(v, VMOD_MAGIC);
+	return (v->nm);
 }
 
 void

--- a/bin/varnishtest/tests/m00000.vtc
+++ b/bin/varnishtest/tests/m00000.vtc
@@ -36,6 +36,7 @@ varnish v1 -vcl+backend {
 		set resp.http.really = debug.author();
 		set resp.http.what = vtc.typesize("dfijlopsz");
 		set resp.http.not = vtc.typesize("*");
+		set resp.http.vmod = debug.name();
 		debug.test_priv_call();
 		debug.test_priv_vcl();
 		objx.test_priv_call();
@@ -47,6 +48,7 @@ varnish v1 -vcl+backend {
 } -start
 
 varnish v1 -expect DEBUG.count == 0
+varnish v1 -cliok "debug.vmod"
 
 client c1 {
 	txreq -url "/bar"
@@ -60,6 +62,7 @@ client c1 {
 	expect resp.http.encrypted == "ROT52"
 	expect resp.http.what >= 16
 	expect resp.http.not == -1
+	expect resp.http.vmod == "debug"
 	txreq -url "/fail"
 	rxresp
 	expect resp.status == 503
@@ -77,6 +80,7 @@ logexpect l1 -v v1 -g raw -d 1 {
 	expect 0 =    RespHeader	{^really: Poul-Henning}
 	expect 0 =    RespHeader	{^what: [1-9][0-9]}
 	expect 0 =    RespHeader	{^not: -1}
+	expect 0 =    RespHeader	{^vmod: debug}
 	expect 0 =    VCL_Log		{^VCL initiated log}
 	expect 0 =    RespHeader	{^Encrypted: ROT52}
 	expect 0 =    VCL_return	{^deliver}

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -472,7 +472,7 @@ int VRT_Vmod_Init(VRT_CTX, struct vmod **hdl, void *ptr, int len,
 void VRT_Vmod_Fini(struct vmod **hdl);
 int VRT_Vmod_Ref(struct vmod *v);
 int VRT_Vmod_Unref(struct vmod **v);
-
+const char *VRT_Vmod_Name(const struct vmod *v);
 
 /* VCL program related */
 VCL_VCL VRT_vcl_get(VRT_CTX, const char *);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -470,6 +470,9 @@ int VRT_VSA_GetPtr(const struct suckaddr *sua, const unsigned char ** dst);
 int VRT_Vmod_Init(VRT_CTX, struct vmod **hdl, void *ptr, int len,
     const char *nm, const char *path, const char *file_id, const char *backup);
 void VRT_Vmod_Fini(struct vmod **hdl);
+int VRT_Vmod_Ref(struct vmod *v);
+int VRT_Vmod_Unref(struct vmod **v);
+
 
 /* VCL program related */
 VCL_VCL VRT_vcl_get(VRT_CTX, const char *);

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -177,3 +177,7 @@ Update counter
 $Function VOID vsc_destroy()
 
 Remove a vsc
+
+$Function STRING name()
+
+Return the name of the vmod via the vmod handle

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -430,3 +430,13 @@ xyzzy_vsc_destroy(VRT_CTX)
 	vsc = NULL;
 	AZ(pthread_mutex_unlock(&vsc_mtx));
 }
+
+/* filled by VRT_Vmod_Init */
+struct vmod *Vmod_debug_Handle = NULL;
+
+VCL_STRING v_matchproto_(td_debug_name)
+xyzzy_name(VRT_CTX)
+{
+	(void) ctx;
+	return (VRT_Vmod_Name(Vmod_debug_Handle));
+}


### PR DESCRIPTION
* dlopen vmods only once and handle multiple _Inits via the refcount
* add a simple interface for taking references to vmods
* optionally hand vmods their own handle (opaque to them)