### PR TITLE
director refcounting

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -421,6 +421,7 @@ struct busyobj {
 	const struct director	*director_req;
 	const struct director	*director_resp;
 	enum director_state_e	director_state;
+	struct vdi_coollist	*vdi_coollist;
 	struct vcl		*vcl;
 
 	struct vsl_log		vsl[1];
@@ -477,6 +478,7 @@ struct req {
 	const struct stevedore	*storage;
 
 	const struct director	*director_hint;
+	struct vdi_coollist	*vdi_coollist;
 	struct vcl		*vcl;
 
 	uintptr_t		ws_req;		/* WS above request data */

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -639,12 +639,12 @@ VBP_Control(const struct backend *be, int enable)
 
 	Lck_Lock(&vbp_mtx);
 	if (enable) {
-		assert(vt->heap_idx == BINHEAP_NOIDX);
-		vt->due = VTIM_real();
-		binheap_insert(vbp_heap, vt);
-		AZ(pthread_cond_signal(&vbp_cond));
-	} else {
-		assert(vt->heap_idx != BINHEAP_NOIDX);
+		if (vt->heap_idx == BINHEAP_NOIDX) {
+			vt->due = VTIM_real();
+			binheap_insert(vbp_heap, vt);
+			AZ(pthread_cond_signal(&vbp_cond));
+		}
+	} else if (vt->heap_idx != BINHEAP_NOIDX) {
 		binheap_delete(vbp_heap, vt->heap_idx);
 	}
 	Lck_Unlock(&vbp_mtx);

--- a/bin/varnishd/cache/cache_cli.c
+++ b/bin/varnishd/cache/cache_cli.c
@@ -75,7 +75,6 @@ cli_cb_before(const struct cli *cli)
 	ASSERT_CLI();
 	VSL(SLT_CLI, 0, "Rd %s", VSB_data(cli->cmd));
 	VCL_Poll();
-	VBE_Poll();
 	Lck_Lock(&cli_mtx);
 }
 

--- a/bin/varnishd/cache/cache_director.h
+++ b/bin/varnishd/cache/cache_director.h
@@ -31,16 +31,23 @@
  *
  */
 
+struct vdi_coollist;
+struct vcldir_list;
+
 struct vcldir {
 	unsigned			magic;
 #define VCLDIR_MAGIC			0xbf726c7d
 	struct director			*dir;
 	struct vcl			*vcl;
 	const struct vdi_methods	*methods;
+	// vcl->director list or vdi_coollist->director_list
 	VTAILQ_ENTRY(vcldir)		list;
 	const struct vdi_ahealth	*admin_health;
 	double				health_changed;
 	char				*cli_name;
+	/* protected by global vdi_cool_mtx */
+	unsigned			refcnt;
+	struct vdi_coollist		*coollist;
 };
 
 #define VBE_AHEALTH_LIST					\
@@ -52,3 +59,7 @@ struct vcldir {
 #define VBE_AHEALTH(l,u,h) extern const struct vdi_ahealth * const VDI_AH_##u;
 VBE_AHEALTH_LIST
 #undef VBE_AHEALTH
+
+int VDI_Ref(VRT_CTX, struct vcldir *vdir);
+void VDI_Dyn(VRT_CTX, struct vcldir *vdir);
+int VDI_Unref(VRT_CTX, struct vcldir *vdir, struct vcldir_list *oldlist);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -93,7 +93,6 @@ void VCA_Shutdown(void);
 
 /* cache_backend_cfg.c */
 void VBE_InitCfg(void);
-void VBE_Poll(void);
 
 /* cache_backend_tcp.c */
 void VTP_Init(void);
@@ -123,6 +122,9 @@ enum sess_close VDI_Http1Pipe(struct req *, struct busyobj *);
 void VDI_Panic(const struct director *, struct vsb *, const char *nm);
 void VDI_Event(const struct director *d, enum vcl_event_e ev);
 void VDI_Init(void);
+void VDI_Cool_Flush(void);
+void VDI_Cool_Unref(struct vdi_coollist **coolp);
+struct vdi_coollist * VDI_Cool_Ref(double now);
 
 /* cache_exp.c */
 double EXP_Ttl(const struct req *, const struct objcore *);
@@ -313,7 +315,7 @@ int Pool_Task_Any(struct pool_task *task, enum task_prio prio);
 void VRG_dorange(struct req *req, const char *r);
 
 /* cache_req.c */
-struct req *Req_New(const struct worker *, struct sess *);
+struct req *Req_New(struct worker *, struct sess *);
 void Req_Release(struct req *);
 void Req_Rollback(struct req *req);
 void Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req);

--- a/bin/varnishd/cache/cache_vcl.h
+++ b/bin/varnishd/cache/cache_vcl.h
@@ -34,7 +34,7 @@
 struct vfp_filter;
 
 VTAILQ_HEAD(vfp_filter_head, vfp_filter);
-
+VTAILQ_HEAD(vcldir_list,vcldir);
 
 struct vcl {
 	unsigned		magic;
@@ -48,7 +48,7 @@ struct vcl {
 	unsigned		discard;
 	const char		*temp;
 	pthread_rwlock_t	temp_rwl;
-	VTAILQ_HEAD(,vcldir)	director_list;
+	struct vcldir_list	director_list;
 	VTAILQ_HEAD(,vclref)	ref_list;
 	int			nrefs;
 	struct vcl		*label;

--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -225,7 +225,7 @@ void H2_Send(struct worker *, struct h2_req *,
     h2_frame type, uint8_t flags, uint32_t len, const void *);
 
 /* cache_http2_proto.c */
-struct h2_req * h2_new_req(const struct worker *, struct h2_sess *,
+struct h2_req * h2_new_req(struct worker *, struct h2_sess *,
     unsigned stream, struct req *);
 void h2_del_req(struct worker *, const struct h2_req *);
 void h2_kill_req(struct worker *, const struct h2_sess *,

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -159,7 +159,7 @@ h2_tx_rst(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2,
  */
 
 struct h2_req *
-h2_new_req(const struct worker *wrk, struct h2_sess *h2,
+h2_new_req(struct worker *wrk, struct h2_sess *h2,
     unsigned stream, struct req *req)
 {
 	struct h2_req *r2;

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -96,7 +96,7 @@ h2_local_settings(struct h2_settings *h2s)
  */
 
 static struct h2_sess *
-h2_init_sess(const struct worker *wrk, struct sess *sp,
+h2_init_sess(struct worker *wrk, struct sess *sp,
     struct h2_sess *h2s, struct req *srq, struct h2h_decode *decode)
 {
 	uintptr_t *up;

--- a/bin/varnishtest/tests/d00011.vtc
+++ b/bin/varnishtest/tests/d00011.vtc
@@ -32,11 +32,7 @@ varnish v1 -vcl {
 		set bereq.backend = s1.backend();
 		# hot swap should happen while we sleep
 		vtc.sleep(2s);
-		if (std.healthy(bereq.backend)) {
-			return(abandon);
-		} else {
-			set bereq.backend = s1.backend();
-		}
+		set bereq.backend = s1.backend();
 	}
 } -start
 

--- a/bin/varnishtest/tests/d00013.vtc
+++ b/bin/varnishtest/tests/d00013.vtc
@@ -29,11 +29,7 @@ varnish v1 -vcl {
 		set req.backend_hint = s1.backend();
 		# hot swap should happen while we sleep
 		vtc.sleep(2s);
-		if (std.healthy(req.backend_hint)) {
-			return(synth(800));
-		} else {
-			set req.backend_hint = s1.backend();
-		}
+		set req.backend_hint = s1.backend();
 	}
 } -start
 

--- a/bin/varnishtest/tests/d00036.vtc
+++ b/bin/varnishtest/tests/d00036.vtc
@@ -32,11 +32,7 @@ varnish v1 -vcl {
 		set bereq.backend = s1.backend();
 		# hot swap should happen while we sleep
 		vtc.sleep(2s);
-		if (std.healthy(bereq.backend)) {
-			return(abandon);
-		} else {
-			set bereq.backend = s1.backend();
-		}
+		set bereq.backend = s1.backend();
 	}
 } -start
 

--- a/bin/varnishtest/tests/d00038.vtc
+++ b/bin/varnishtest/tests/d00038.vtc
@@ -29,11 +29,7 @@ varnish v1 -vcl {
 		set req.backend_hint = s1.backend();
 		# hot swap should happen while we sleep
 		vtc.sleep(2s);
-		if (std.healthy(req.backend_hint)) {
-			return(synth(800));
-		} else {
-			set req.backend_hint = s1.backend();
-		}
+		set req.backend_hint = s1.backend();
 	}
 } -start
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1883,6 +1883,25 @@ PARAM(
 	/* func */      NULL
 )
 
+PARAM(
+	/* name */	director_gc_interval,
+	/* typ */	timeout,
+	/* min */	"0.1",
+	/* max */	NULL,
+	/* default */	"60",
+	/* units */	"seconds",
+	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
+	/* s-text */
+	"We collect unused directors on a cool list which, when all tasks "
+	"using it are finished, gets garbage collected.\n"
+	"This timeout specifies the lifespan of the cool list.\n"
+	"Setting it to shorter values will make unused backends to be cleaned "
+	"out sooner and cause somehow increased overhead, but probably not "
+	"significantly.",
+	/* l-text */	"",
+	/* func */	NULL
+)
+
 #undef PARAM
 
 /*lint -restore */

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -415,7 +415,6 @@ VCL_BACKEND VRT_new_backend(VRT_CTX, const struct vrt_backend *);
 VCL_BACKEND VRT_new_backend_clustered(VRT_CTX,
     struct vsmw_cluster *, const struct vrt_backend *);
 size_t VRT_backend_vsm_need(VRT_CTX);
-void VRT_delete_backend(VRT_CTX, VCL_BACKEND *);
 
 /* VSM related */
 struct vsmw_cluster *VRT_VSM_Cluster_New(VRT_CTX, size_t);
@@ -461,11 +460,15 @@ struct director {
 };
 
 VCL_BOOL VRT_Healthy(VRT_CTX, VCL_BACKEND, VCL_TIME *);
+VCL_BACKEND VRT_DynDirector(VRT_CTX, const struct vdi_methods *m, void *priv,
+    const char *fmt, ...);
+void VRT_RefDirector(VRT_CTX, VCL_BACKEND d);
 VCL_BACKEND VRT_AddDirector(VRT_CTX, const struct vdi_methods *,
     void *, const char *, ...) v_printflike_(4, 5);
 void VRT_SetHealth(VCL_BACKEND d, int health);
-void VRT_DisableDirector(VCL_BACKEND);
-void VRT_DelDirector(VCL_BACKEND *);
+int VRT_UnrefDirector(VRT_CTX, VCL_BACKEND);
+int VRT_DelDirector(VRT_CTX, VCL_BACKEND *);
+void VRT_FlushDirectors(void);
 
 /* Suckaddr related */
 int VRT_VSA_GetPtr(const struct suckaddr *sua, const unsigned char ** dst);

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -500,7 +500,7 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	    "\t%s =\n\t    VRT_new_backend_clustered(ctx, vsc_cluster,\n"
 	    "\t\t&vgc_dir_priv_%s);",
 	    vgcname, vgcname);
-	VSB_printf(ifp->fin, "\t\tVRT_delete_backend(ctx, &%s);", vgcname);
+	VSB_printf(ifp->fin, "\t\tVRT_DelDirector(ctx, &%s);", vgcname);
 }
 
 /*--------------------------------------------------------------------

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -322,8 +322,12 @@ vcc_ParseImport(struct vcc *tl)
 	VSB_printf(tl->fi, "%s VMOD %s ./vmod_cache/_vmod_%.*s.%s */\n",
 	    VCC_INFO_PREFIX, fnp, PF(mod), vmd->file_id);
 
+	/* would only be needed once for the last import of a director vmod */
+	VSB_printf(ifp->fin, "\t\tVRT_FlushDirectors();\n");
+
 	/* XXX: zero the function pointer structure ?*/
-	VSB_printf(ifp->fin, "\t\tVRT_priv_fini(&vmod_priv_%.*s);\n", PF(mod));
+	VSB_printf(ifp->fin, "\t\t\tVRT_priv_fini(&vmod_priv_%.*s);\n",
+		   PF(mod));
 	VSB_printf(ifp->fin, "\t\t\tVRT_Vmod_Fini(&VGC_vmod_%.*s);", PF(mod));
 
 	vj = vjsn_parse(vmd->json, &p);

--- a/lib/libvmod_directors/fall_back.c
+++ b/lib/libvmod_directors/fall_back.c
@@ -125,7 +125,7 @@ vmod_fallback__fini(struct vmod_directors_fallback **fbp)
 	struct vmod_directors_fallback *fb;
 
 	TAKE_OBJ_NOTNULL(fb, fbp, VMOD_DIRECTORS_FALLBACK_MAGIC);
-	VRT_DelDirector(&fb->vd->dir);
+	VRT_DelDirector(NULL, &fb->vd->dir);
 }
 
 VCL_VOID v_matchproto_()

--- a/lib/libvmod_directors/hash.c
+++ b/lib/libvmod_directors/hash.c
@@ -84,7 +84,7 @@ vmod_hash__fini(struct vmod_directors_hash **rrp)
 	struct vmod_directors_hash *rr;
 
 	TAKE_OBJ_NOTNULL(rr, rrp, VMOD_DIRECTORS_HASH_MAGIC);
-	VRT_DelDirector(&rr->vd->dir);
+	VRT_DelDirector(NULL, &rr->vd->dir);
 }
 
 VCL_VOID v_matchproto_()

--- a/lib/libvmod_directors/random.c
+++ b/lib/libvmod_directors/random.c
@@ -112,7 +112,7 @@ vmod_random__fini(struct vmod_directors_random **rrp)
 	struct vmod_directors_random *rr;
 
 	TAKE_OBJ_NOTNULL(rr, rrp, VMOD_DIRECTORS_RANDOM_MAGIC);
-	VRT_DelDirector(&rr->vd->dir);
+	VRT_DelDirector(NULL, &rr->vd->dir);
 }
 
 VCL_VOID v_matchproto_()

--- a/lib/libvmod_directors/round_robin.c
+++ b/lib/libvmod_directors/round_robin.c
@@ -120,7 +120,7 @@ vmod_round_robin__fini(struct vmod_directors_round_robin **rrp)
 	struct vmod_directors_round_robin *rr;
 
 	TAKE_OBJ_NOTNULL(rr, rrp, VMOD_DIRECTORS_ROUND_ROBIN_MAGIC);
-	VRT_DelDirector(&rr->vd->dir);
+	VRT_DelDirector(NULL, &rr->vd->dir);
 }
 
 VCL_VOID v_matchproto_()

--- a/lib/libvmod_directors/vdir.c
+++ b/lib/libvmod_directors/vdir.c
@@ -72,8 +72,12 @@ void
 vdir_delete(struct vdir **vdp)
 {
 	struct vdir *vd;
+	unsigned u;
 
 	TAKE_OBJ_NOTNULL(vd, vdp, VDIR_MAGIC);
+
+	for (u = 0; u < vd->n_backend; u++)
+		VRT_UnrefDirector(NULL, vd->backend[u]);
 
 	AZ(vd->dir);
 	free(vd->backend);
@@ -118,6 +122,7 @@ vdir_add_backend(VRT_CTX, struct vdir *vd, VCL_BACKEND be, double weight)
 		return;
 	}
 	AN(be);
+	VRT_RefDirector(ctx, be);
 	vdir_wrlock(vd);
 	if (vd->n_backend >= vd->l_backend)
 		vdir_expand(vd, vd->l_backend + 16);
@@ -164,6 +169,7 @@ vdir_remove_backend(VRT_CTX, struct vdir *vd, VCL_BACKEND be, unsigned *cur)
 			*cur = 0;
 	}
 	vdir_unlock(vd);
+	VRT_UnrefDirector(ctx, be);
 }
 
 VCL_BOOL

--- a/lib/libvmod_directors/vmod_shard.c
+++ b/lib/libvmod_directors/vmod_shard.c
@@ -271,7 +271,7 @@ vmod_shard__fini(struct vmod_directors_shard **vshardp)
 	struct vmod_directors_shard *vshard;
 
 	TAKE_OBJ_NOTNULL(vshard, vshardp, VMOD_SHARD_SHARD_MAGIC);
-	VRT_DelDirector(&vshard->dir);
+	VRT_DelDirector(NULL, &vshard->dir);
 	FREE_OBJ(vshard);
 }
 


### PR DESCRIPTION
based upon #2723, description from the main commit's message:

This implementation is centered around the following insights:

* Full refcounting is expensive and tidious

* For directors, there exist mainly two types of references

  * long term, from a vcl or a director using another director as a backend

  * short term for the duration of a VCL task, such as an assignment to (be)req.backend

Based on these insights, we implement implicit and explicit references:
    
* Otherwise unreferenced VCL_BACKENDs are put on a cool list (as before for backends), but we now use many cool lists

* Each VCL task holds an implicit reference to all VCL_BACKENDs by referencing the current vdi_cool list, thus for any reference with a scope smaller or equal to a TASK, no explicit reference needs to and should be taken

* VRT_VDI_Ref/Unref must be called whenever a reference to a VCL_BACKEND with longer scope is kept, for example when adding/removing a VCL_BACKEND to/from a director.

Details on coollists:

* each task references the current coollist

* all VCL_BACKENDs with refcnt == 0 are put on the coollist ref'd by the current task. VCL_BACKENDs with refcnt > 0 are not on any coollist

* when a VCL_BACKEND is put on a coollist and the coollist has reached the minimum age, we start a new coollist which is then referenced by all new tasks. This way, the old coollist with the VCL_BACKEND(s) to be killed will eventually get unref'd

* We kill backends on unref'd coollists in the order of their creation

VCL Backends get created with one initial reference.

Dynamic backends get created on the coollist, so their initial scope is just the current task.
