### PR TITLE
New %{Varnish:date}x varnishncsa format

### DIFF
--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -568,11 +568,12 @@ addf_vsl(enum VSL_tag_e tag, long i, const char *prefix)
 {
 	struct vsl_watch *w;
 
-	ALLOC_OBJ(w, VSL_WATCH_MAGIC);
-	AN(w);
 	if (VSL_tagflags[tag])
 		VUT_Error(vut, 1, "Tag %s can contain control characters",
 		    VSL_tags[tag]);
+
+	ALLOC_OBJ(w, VSL_WATCH_MAGIC);
+	AN(w);
 	w->tag = tag;
 	assert(i <= INT_MAX);
 	w->idx = i;

--- a/bin/varnishtest/tests/u00003.vtc
+++ b/bin/varnishtest/tests/u00003.vtc
@@ -32,9 +32,11 @@ shell {
 delay 1
 
 client c1 {
-	txreq -url /1?foo=bar -hdr "authorization: basic dXNlcjpwYXNz"
+	txreq -url /1?foo=bar -hdr "authorization: basic dXNlcjpwYXNz" \
+	    -hdr "Date: Sun, 06 Nov 1994 08:49:37 GMT"
 	rxresp
-	txreq -url /1?foo=bar -hdr "baz: qux"
+	txreq -url /1?foo=bar -hdr "baz: qux" \
+	    -hdr "Date: Sunday, 06-Nov-94 08:49:37 GMT"
 	rxresp
 } -run
 
@@ -44,7 +46,7 @@ shell "mv ${tmpdir}/ncsa.log ${tmpdir}/ncsa.old.log"
 shell "kill -HUP `cat ${tmpdir}/ncsa.pid`"
 
 client c1 {
-	txreq -url /2
+	txreq -url /2 -hdr "Date: Sun Nov  6 08:49:37 1994"
 	rxresp
 } -run
 
@@ -132,12 +134,12 @@ shell -match {^100 \d+ HTTP/1.1 \d+.\d+.\d+.\d+ \d+ - - GET 0 \d+ (?#
 	{varnishncsa -n ${v1_name} -d -f ${tmpdir}/format}
 
 # extended variables
-shell -match {^\d+.\d{6} miss miss c 1001 quuz
-\d+.\d{6} miss synth c 1003\s
-\d+.\d{6} miss pipe c 1005\s$} \
+shell -match {^\d+.\d{6} miss miss c 1001 quuz 784111777.000
+\d+.\d{6} miss synth c 1003  784111777.000
+\d+.\d{6} miss pipe c 1005  784111777.000$} \
 	{varnishncsa -n ${v1_name} -d -F "%{Varnish:time_firstbyte}x \
 %{Varnish:hitmiss}x %{Varnish:handling}x %{Varnish:side}x \
-%{Varnish:vxid}x %{VCL_Log:quux}x"}
+%{Varnish:vxid}x %{VCL_Log:quux}x %{Varnish:date}x"}
 
 # %{VSL:..}x
 shell -match {^req (\d+) rxreq \1 \d{10}\.\d{6} (\d+\.\d{6}) \d+\.\d{6} \2 -

--- a/doc/sphinx/reference/varnishncsa.rst
+++ b/doc/sphinx/reference/varnishncsa.rst
@@ -172,6 +172,10 @@ Supported formatters are:
   Varnish:vxid
     The VXID of the varnish transaction.
 
+  Varnish:date
+    The date header of a client request or backend response formatted as a
+    timestamp comparable to a VSL Timestamp tag-record field.
+
   VCL_Log:key
     The value set by std.log("key:value") in VCL.
 


### PR DESCRIPTION
This format may help spot latency problems caused by other proxies sitting in front of Varnish, as long as they leave the original Date header unmodified. With this format it becomes more convenient to compare the Date header with the `Timestamp:Start[1]` entry of an rxreq transaction.

This feature was accepted in principle during the last VDD and this is my first time in the varnishncsa code base. I think I could polish a couple things here and there if this passes the review.

In particular, if there is no Date header this format falls back to a plain `-`. But looking at how other formats `strdup` the fallback string and check for its presence I think we have a (negligible) waste of resources and a bit of dead code.