### PR TITLE
Accommodate musl libc that has a smaller stack

### DIFF
--- a/bin/varnishd/waiter/cache_waiter_epoll.c
+++ b/bin/varnishd/waiter/cache_waiter_epoll.c
@@ -33,6 +33,8 @@
 //lint -e{766}
 #include "config.h"
 
+#include <stdlib.h>
+
 #if defined(HAVE_EPOLL_CTL)
 
 #include <sys/epoll.h>
@@ -69,7 +71,7 @@ struct vwe {
 static void *
 vwe_thread(void *priv)
 {
-	struct epoll_event ev[NEEV], *ep;
+	struct epoll_event *ev, *ep;
 	struct waited *wp;
 	struct waiter *w;
 	double now, then;
@@ -82,6 +84,8 @@ vwe_thread(void *priv)
 	CHECK_OBJ_NOTNULL(w, WAITER_MAGIC);
 	THR_SetName("cache-epoll");
 	THR_Init();
+	ev = malloc(sizeof(struct epoll_event) * NEEV);
+	AN(ev);
 
 	now = VTIM_real();
 	while (1) {
@@ -146,6 +150,7 @@ vwe_thread(void *priv)
 		if (vwe->nwaited == 0 && vwe->die)
 			break;
 	}
+	free(ev);
 	closefd(&vwe->pipe[0]);
 	closefd(&vwe->pipe[1]);
 	closefd(&vwe->epfd);


### PR DESCRIPTION
reviving this: https://git.alpinelinux.org/cgit/aports/tree/main/varnish/musl-fix-stack-overflow.patch

Alpine uses musl libc that has a smaller stack, so Varnish compiles but can't run with that big a number of events (8192). phk offered that maybe the NEEV number could need to be revised and we should have a look at what others do.

- nginx has it configurable, set to 512 by default, and I found no recommendation about changing those.
- haproxy also has it configurable with a 200 default, and says this:

```
tune.maxpollevents <number>
  Sets the maximum amount of events that can be processed at once in a call to
  the polling system. The default value is adapted to the operating system. It
  has been noticed that reducing it below 200 tends to slightly decrease
  latency at the expense of network bandwidth, and increasing it above 200
  tends to trade latency for slightly increased bandwidth.
```

We are certainly a bit too ambitious with 8192, but I think that whatever the value is, we could do with a malloc approach to make sure those kind of issues don't break "obscure" platforms when we tweak it.