### PR TITLE
Add VRT functions for STRANDS.

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -339,6 +339,114 @@ VRT_CollectString(VRT_CTX, const char *p, ...)
 	return (b);
 }
 
+/*--------------------------------------------------------------------
+ * Collapse STRANDS into the space provided, or return NULL
+ */
+
+char *
+VRT_Strands(char *d, unsigned dl, VCL_STRANDS s)
+{
+	char *b;
+	const char *e;
+	unsigned x;
+
+	b = d;
+	e = b + dl;
+	for (int i = 0; i < s->n && b < e; i++)
+		if (s->p[i] != NULL && *s->p[i] != '\0') {
+			x = strlen(s->p[i]);
+			if (b + x < e)
+				memcpy(b, s->p[i], x);
+			b += x;
+		}
+	if (b >= e)
+		return (NULL);
+	*b++ = '\0';
+	return (b);
+}
+
+/*--------------------------------------------------------------------
+ * Copy and merge STRANDS into a workspace.
+ */
+
+VCL_STRING
+VRT_StrandsWS(struct ws *ws, const char *h, VCL_STRANDS s)
+{
+	char *b;
+	const char *q = NULL, *e;
+	VCL_STRING r;
+	unsigned u, x;
+	int i;
+
+	u = WS_Reserve(ws, 0);
+
+	for (i = 0; i < s->n; i++)
+		if (s->p[i] != NULL && *s->p[i] != '\0') {
+			q = s->p[i];
+			break;
+		}
+
+	if (h != NULL && q == NULL && WS_Inside(ws, h, NULL)) {
+		WS_Release(ws, 0);
+		return (h);
+	}
+
+	if (h == NULL) {
+		if (q == NULL) {
+			WS_Release(ws, 0);
+			return ("");
+		}
+		if (WS_Inside(ws, q, NULL)) {
+			for (i++; i < s->n; i++)
+				if (s->p[i] != NULL && *s->p[i] != '\0')
+					break;
+			if (i == s->n) {
+				WS_Release(ws, 0);
+				return (q);
+			}
+		}
+	}
+
+	b = WS_Front(ws);
+	e = b + u;
+
+	if (h != NULL) {
+		x = strlen(h);
+		if (b + x < e)
+			memcpy(b, h, x);
+		b += x;
+		if (b < e)
+			*b = ' ';
+		b++;
+	}
+	r = VRT_Strands(b, e > b ? e - b : 0, s);
+	if (r == NULL || r == e) {
+		WS_MarkOverflow(ws);
+		WS_Release(ws, 0);
+		return (NULL);
+	}
+	b = WS_Front(ws);
+	WS_Release(ws, r - b);
+	return (b);
+}
+
+/*--------------------------------------------------------------------
+ * Copy and merge STRANDS on the current workspace
+ */
+
+VCL_STRING
+VRT_CollectStrands(VRT_CTX, VCL_STRANDS s)
+{
+	const char *b;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
+	b = VRT_StrandsWS(ctx->ws, NULL, s);
+	if (b == NULL)
+		VRT_fail(ctx, "Workspace overflow");
+	return (b);
+}
+
 /*--------------------------------------------------------------------*/
 
 VCL_VOID

--- a/bin/varnishtest/tests/v00058.vtc
+++ b/bin/varnishtest/tests/v00058.vtc
@@ -1,0 +1,167 @@
+varnishtest "Test VRT STRANDS functions"
+
+varnish v1 -arg "-i foobar" -vcl {
+	import debug;
+	backend b { .host = "${bad_ip}"; }
+
+	sub vcl_init {
+		# tests VRT_Strands()
+		new c = debug.concat(server.identity + server.hostname + now);
+		new e = debug.concat("" + server.identity + "");
+	}
+
+	sub vcl_recv {
+		return (synth(200));
+	}
+
+	sub vcl_synth {
+		set resp.http.C = c.get();
+		set resp.http.E = e.get();
+
+		set req.http.Foo = "foo";
+		set req.http.Bar = "bar";
+		set req.http.Baz = "baz";
+
+		# test VRT_StrandsWS()
+		set resp.http.Concat-1
+			= debug.concatenate(req.http.Foo + req.http.Bar
+						+ req.http.Baz);
+		set resp.http.Concat-2
+			= debug.concatenate("" + req.http.Unset + req.http.Foo
+						+ req.http.Unset + ""
+						+ req.http.Bar + ""
+						+ req.http.Unset + ""
+						+ req.http.Baz + ""
+						+ req.http.Unset);
+		set resp.http.Concat-3
+			= debug.concatenate(req.http.Foo + req.http.Unset + "");
+		set resp.http.Concat-4
+			= debug.concatenate(req.http.Unset + "" + req.http.Foo);
+		set resp.http.Concat-5
+			= debug.concatenate(req.http.Foo + req.http.Unset
+						+ req.http.Bar);
+		set resp.http.Concat-6 = debug.concatenate(req.http.Foo);
+		set resp.http.Concat-7 = debug.concatenate(req.http.Unset);
+
+		# test VRT_StrandsCollect()
+		set resp.http.Collect-1
+			= debug.collect(req.http.Foo + req.http.Bar
+					+ req.http.Baz);
+		set resp.http.Collect-2
+			= debug.collect("" + req.http.Unset + req.http.Foo
+					+ req.http.Unset + "" + req.http.Bar
+					+ "" + req.http.Unset + ""
+					+ req.http.Baz + "" + req.http.Unset);
+		set resp.http.Collect-3
+			= debug.collect(req.http.Foo + req.http.Unset + "");
+		set resp.http.Collect-4
+			= debug.collect(req.http.Unset + "" + req.http.Foo);
+		set resp.http.Collect-5
+			= debug.collect(req.http.Foo + req.http.Unset
+					+ req.http.Bar);
+		set resp.http.Collect-6 = debug.collect(req.http.Foo);
+		set resp.http.Collect-7 = debug.collect(req.http.Unset);
+
+		# test a STRANDS version of VRT_SetHdr()
+		debug.sethdr(resp.http.Hdr-1, req.http.Foo + req.http.Bar
+						+ req.http.Baz);
+		debug.sethdr(resp.http.Hdr-2,
+				"" + req.http.Unset + req.http.Foo
+				+ req.http.Unset + "" + req.http.Bar + ""
+				+ req.http.Unset + "" + req.http.Baz + ""
+				+ req.http.Unset);
+		debug.sethdr(resp.http.Hdr-3,
+				req.http.Foo + req.http.Unset + "");
+		debug.sethdr(resp.http.Hdr-4,
+				req.http.Unset + "" + req.http.Foo);
+		debug.sethdr(resp.http.Hdr-5,
+				req.http.Foo + req.http.Unset + req.http.Bar);
+		debug.sethdr(resp.http.Hdr-6, req.http.Foo);
+		debug.sethdr(resp.http.Hdr-7, req.http.Unset);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.C ~ "^foobar"
+	expect resp.http.E == "foobar"
+	expect resp.http.Concat-1 == "foobarbaz"
+	expect resp.http.Concat-2 == "foobarbaz"
+	expect resp.http.Concat-3 == "foo"
+	expect resp.http.Concat-4 == "foo"
+	expect resp.http.Concat-5 == "foobar"
+	expect resp.http.Concat-6 == "foo"
+	expect resp.http.Concat-7 == ""
+	expect resp.http.Collect-1 == "foobarbaz"
+	expect resp.http.Collect-2 == "foobarbaz"
+	expect resp.http.Collect-3 == "foo"
+	expect resp.http.Collect-4 == "foo"
+	expect resp.http.Collect-5 == "foobar"
+	expect resp.http.Collect-6 == "foo"
+	expect resp.http.Collect-7 == ""
+	expect resp.http.Hdr-1 == "foobarbaz"
+	expect resp.http.Hdr-2 == "foobarbaz"
+	expect resp.http.Hdr-3 == "foo"
+	expect resp.http.Hdr-4 == "foo"
+	expect resp.http.Hdr-5 == "foobar"
+	expect resp.http.Hdr-6 == "foo"
+	expect resp.http.Hdr-7 == ""
+} -run
+
+# out of workspace
+server s1 {
+	rxreq
+	expect req.http.Foo == "foo"
+	expect req.http.Bar == "bar"
+	expect req.http.Baz == "baz"
+	expect req.http.Quux == "quux"
+	expect req.http.Result == <undef>
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import debug;
+	import vtc;
+
+	sub vcl_recv {
+		set req.http.Foo = "foo";
+		set req.http.Bar = "bar";
+		set req.http.Baz = "baz";
+		set req.http.Quux = "quux";
+
+		vtc.workspace_alloc(client, -12);
+
+		if (req.url == "/1") {
+			# VRT_StrandsWS() marks the WS as overflowed,
+			# returns NULL, but does not invoke VCL failure.
+			# Out-of-workspace doesn't happen until delivery.
+			set req.http.Result
+				= debug.concatenate(req.http.Foo + req.http.Bar
+							+ req.http.Baz
+							+ req.http.Quux);
+		}
+		elsif (req.url == "/2") {
+			# VRT_CollectStrands() invokes VCL failure.
+			set req.http.Result
+				= debug.collect(req.http.Foo + req.http.Bar
+						+ req.http.Baz
+						+ req.http.Quux);
+		}
+	}
+}
+
+client c1 {
+	txreq -url "/1"
+	rxresp
+	expect resp.status == 500
+	expect resp.reason == "Internal Server Error"
+} -run
+
+client c1 {
+	txreq -url "/2"
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
+} -run

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -53,6 +53,10 @@
  *
  *
  * TRUNK (2018-09-15)
+ *	VRT_Strands() added
+ *	VRT_StrandsWS() added
+ *	VRT_CollectStrands() added
+ *	VRT_STRANDS_string() removed from vrt.h (never implemented)
  *	VRT_Healthy() changed prototype
  * 7.0 (2018-03-15)
  *	lots of stuff moved from cache.h to cache_varnishd.h
@@ -502,6 +506,9 @@ VCL_STEVEDORE VRT_stevedore(const char *nm);
 VCL_STRANDS VRT_BundleStrands(int, struct strands *, char const **,
     const char *f, ...);
 int VRT_CompareStrands(VCL_STRANDS a, VCL_STRANDS b);
+char *VRT_Strands(char *, unsigned, VCL_STRANDS);
+VCL_STRING VRT_StrandsWS(struct ws *, const char *, VCL_STRANDS);
+VCL_STRING VRT_CollectStrands(VRT_CTX, VCL_STRANDS);
 
 VCL_STRING VRT_BACKEND_string(VCL_BACKEND);
 VCL_STRING VRT_BOOL_string(VCL_BOOL);
@@ -510,7 +517,6 @@ VCL_STRING VRT_INT_string(VRT_CTX, VCL_INT);
 VCL_STRING VRT_IP_string(VRT_CTX, VCL_IP);
 VCL_STRING VRT_REAL_string(VRT_CTX, VCL_REAL);
 VCL_STRING VRT_STEVEDORE_string(VCL_STEVEDORE);
-VCL_STRING VRT_STRANDS_string(VCL_STRANDS);
 VCL_STRING VRT_TIME_string(VRT_CTX, VCL_TIME);
 
 #ifdef va_start	// XXX: hackish

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -177,3 +177,26 @@ Update counter
 $Function VOID vsc_destroy()
 
 Remove a vsc
+
+$Object concat(STRANDS)
+
+Create an object that returns the string formed by concatenating the
+given strings.
+
+$Method STRING .get()
+
+Return the string formed from the concatenation in the constructor.
+
+$Function STRING concatenate(STRANDS)
+
+Return the string formed by concatenating the given strings.
+(Uses VRT_StrandsWS().)
+
+$Function STRING collect(STRANDS)
+
+Return the string formed by concatenating the given strings.
+(Uses VRT_CollectStrands().)
+
+$Function VOID sethdr(HEADER, STRANDS)
+
+Set the given header with the concatenation of the given strings.


### PR DESCRIPTION
Re-implementations of the current functions for STRING_LIST.

Also removes VRT_STRANDS_string() from vrt.h, which was never implemented.