### PR TITLE
initialize PRIV_TASK and PRIV_TOP vmod arguments once per subroutine

### DIFF
--- a/bin/varnishtest/tests/m00000.vtc
+++ b/bin/varnishtest/tests/m00000.vtc
@@ -20,7 +20,17 @@ varnish v1 -vcl+backend {
 		set req.http.overwrite = "the workspace " +
 		    "to ensure we notice any unfinished privs";
 	}
+
+	sub priv_task {
+		debug.test_priv_task("foo");
+	}
+
 	sub vcl_recv {
+		if (req.url == "/priv-task-no-mem") {
+			vtc.workspace_alloc(client, -4);
+			call priv_task;
+			return (fail);
+		}
 		if (req.url == "/fail") {
 			debug.test_priv_task("foo");
 			return (fail);
@@ -61,6 +71,12 @@ client c1 {
 	expect resp.http.what >= 16
 	expect resp.http.not == -1
 	txreq -url "/fail"
+	rxresp
+	expect resp.status == 503
+} -run
+
+client c1 {
+	txreq -url "/priv-task-no-mem"
 	rxresp
 	expect resp.status == 503
 } -run

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -104,6 +104,8 @@ vcc_NewProc(struct vcc *tl, struct symbol *sym)
 	AN(p);
 	VTAILQ_INIT(&p->calls);
 	VTAILQ_INIT(&p->uses);
+	VTAILQ_INIT(&p->priv_tasks);
+	VTAILQ_INIT(&p->priv_tops);
 	VTAILQ_INSERT_TAIL(&tl->procs, p, list);
 	p->prologue = VSB_new_auto();
 	AN(p->prologue);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -174,6 +174,7 @@ struct symbol {
 };
 
 VTAILQ_HEAD(tokenhead, token);
+VTAILQ_HEAD(procprivhead, procpriv);
 
 struct proc {
 	unsigned		magic;
@@ -181,6 +182,8 @@ struct proc {
 	const struct method	*method;
 	VTAILQ_HEAD(,proccall)	calls;
 	VTAILQ_HEAD(,procuse)	uses;
+	struct procprivhead	priv_tasks;
+	struct procprivhead	priv_tops;
 	VTAILQ_ENTRY(proc)	list;
 	struct token		*name;
 	unsigned		ret_bitmap;
@@ -389,6 +392,8 @@ int vcc_CheckAction(struct vcc *tl);
 void vcc_AddUses(struct vcc *, const struct token *, const struct token *,
      unsigned mask, const char *use);
 int vcc_CheckUses(struct vcc *tl);
+const char *vcc_MarkPriv(struct vcc *, struct procprivhead *,
+    const char *);
 
 #define ERRCHK(tl)      do { if ((tl)->err) return; } while (0)
 #define ErrInternal(tl) vcc__ErrInternal(tl, __func__, __LINE__)

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -39,6 +39,7 @@
 
 #include "config.h"
 
+#include <string.h>
 #include "vcc_compile.h"
 
 /*--------------------------------------------------------------------*/
@@ -57,6 +58,11 @@ struct procuse {
 	unsigned		mask;
 	const char		*use;
 	struct proc		*fm;
+};
+
+struct procpriv {
+	VTAILQ_ENTRY(procpriv)	list;
+	const char		*vmod;
 };
 
 /*--------------------------------------------------------------------*/
@@ -354,4 +360,29 @@ VCC_XrefTable(struct vcc *tl)
 	Fc(tl, 0, "\n/*\n * Symbol Table\n *\n");
 	VCC_WalkSymbols(tl, vcc_xreftable, SYM_NONE);
 	Fc(tl, 0, "*/\n\n");
+}
+
+/*---------------------------------------------------------------------
+ * mark vmod as referenced, return NULL if not yet marked, vmod if marked
+ */
+
+const char *
+vcc_MarkPriv(struct vcc *tl, struct procprivhead *head,
+    const char *vmod)
+{
+	struct procpriv *pp;
+
+	AN(vmod);
+
+	VTAILQ_FOREACH(pp, head, list) {
+		if (pp->vmod == vmod)
+			return (vmod);
+		AN(strcmp(pp->vmod, vmod));
+	}
+
+	pp = TlAlloc(tl, sizeof *pp);
+	assert(pp != NULL);
+	pp->vmod = vmod;
+	VTAILQ_INSERT_TAIL(head, pp, list);
+	return (NULL);
 }


### PR DESCRIPTION
... and fail the VCL unless successful.

Providing the PRIVs to vmods is a core function, so error handling should happen outside vmods.

Besides being safe, this initialization can be more efficient than previous code for PRIVs used frequently within the same subroutine.

An alternative approach would be to initialize all privs once per task / top request, but unless all privs are actually used in a VCL, this approach could impose significant overhead, both in terms of time
and memory. By initializing privs once per sub, we impose overhead for privs which are referenced but not actually used in a subroutine, but not for all of the vcl.

Fixes #2708