### PR TITLE
Fix vmodtool with python3

### DIFF
--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -859,7 +859,7 @@ class vcc(object):
     def parse(self):
         global inputline
         a = "\n" + open(self.inputfile, "r").read()
-        self.file_id = hashlib.sha256(a).hexdigest()
+        self.file_id = hashlib.sha256(a.encode('utf-8')).hexdigest()
         s = a.split("\n$")
         self.copyright = s.pop(0).strip()
         while s:


### PR DESCRIPTION
Without this patch, it did
TypeError: Unicode-objects must be encoded before hashing

Fixes: #2436