### PR TITLE
Fix and test objhead refcount for hit-for-pass

### DIFF
--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -381,6 +381,9 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
 	Lck_AssertHeld(&oh->mtx);
 
+	if (DO_DEBUG(DBG_REFCNT))
+		VSLb(req->vsl, SLT_Debug, "oh %p refcnt %d", oh, oh->refcnt);
+
 	if (always_insert) {
 		/* XXX: should we do predictive Vary in this case ? */
 		/* Insert new objcore in objecthead and release mutex */
@@ -457,9 +460,11 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 					oc->hits++;
 			}
 			Lck_Unlock(&oh->mtx);
+			if (*bocp == NULL)
+				assert(HSH_DerefObjHead(wrk, &oh));
+
 			if (oc == NULL)
 				return (HSH_MISS);
-			assert(HSH_DerefObjHead(wrk, &oh));
 			*ocp = oc;
 			return (HSH_HIT);
 		}

--- a/bin/varnishtest/tests/c00081.vtc
+++ b/bin/varnishtest/tests/c00081.vtc
@@ -4,7 +4,11 @@ server s1 {
 	rxreq
 	txresp -hdr "foo: 1"
 	rxreq
-	txresp -hdr "foo: 2"
+	txresp -hdr "foo: 2a"
+	rxreq
+	txresp -hdr "foo: 2b"
+	rxreq
+	txresp -hdr "foo: 2c"
 	rxreq
 	txresp -hdr "foo: 3"
 } -start
@@ -29,8 +33,31 @@ varnish v1 -vcl+backend {
 
 } -start
 
+varnish v1 -cliok "param.set debug +refcnt"
+
 logexpect l1 -v v1 -g vxid {
-	expect * 1003	HitPass "^1002 1"
+	expect * 1001	Debug		"^oh.*refcnt 1$"
+	expect 0 =	VCL_call	"^MISS"
+} -start
+
+logexpect l2 -v v1 -g vxid {
+	expect * 1003	Debug		"^oh.*refcnt 2$"
+	expect 0 =	HitPass	"^1002 1"
+} -start
+
+logexpect l3 -v v1 -g vxid {
+	expect * 1005	Debug		"^oh.*refcnt 2$"
+	expect 0 =	HitPass	"^1002 1"
+} -start
+
+logexpect l4 -v v1 -g vxid {
+	expect * 1007	Debug		"^oh.*refcnt 2$"
+	expect 0 =	HitPass	"^1002 1"
+} -start
+
+logexpect l5 -v v1 -g vxid {
+	expect * 1009	Debug		"^oh.*refcnt 1$"
+	expect 0 =	VCL_call	"^MISS"
 } -start
 
 client c1 {
@@ -38,6 +65,12 @@ client c1 {
 	rxresp
 	expect resp.http.miss == True
 
+	txreq
+	rxresp
+	expect resp.http.pass == True
+	txreq
+	rxresp
+	expect resp.http.pass == True
 	txreq
 	rxresp
 	expect resp.http.pass == True
@@ -50,7 +83,11 @@ client c1 {
 } -run
 
 logexpect l1 -wait
+logexpect l2 -wait
+logexpect l3 -wait
+logexpect l4 -wait
+logexpect l5 -wait
 
-varnish v1 -expect MAIN.cache_hitpass == 1
+varnish v1 -expect MAIN.cache_hitpass == 3
 varnish v1 -expect MAIN.cache_miss == 2
 varnish v1 -expect MAIN.cache_hitmiss == 0

--- a/include/tbl/debug_bits.h
+++ b/include/tbl/debug_bits.h
@@ -50,6 +50,7 @@ DEBUG_BIT(H2_NOCHECK,		h2_nocheck,	"Disable various H2 checks")
 DEBUG_BIT(VMOD_SO_KEEP,		vmod_so_keep,	"Keep copied VMOD libraries")
 DEBUG_BIT(PROCESSORS,		processors,	"Fetch/Deliver processors")
 DEBUG_BIT(PROTOCOL,		protocol,	"Protocol debugging")
+DEBUG_BIT(REFCNT,		refcnt,		"Reference count debugging")
 #undef DEBUG_BIT
 
 /*lint -restore */


### PR DESCRIPTION
For hit-for-pass (HFP), we failed to return the objhead reference we gained from lookup