### PR TITLE
Clarify and test object slimming for hfp+hfm

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -417,7 +417,9 @@ cnt_transmit(struct worker *wrk, struct req *req)
 
 	VSLb_ts_req(req, "Resp", W_TIM_real(wrk));
 
-	if (req->objcore->flags & (OC_F_PRIVATE | OC_F_PASS)) {
+	if (req->objcore->flags & (OC_F_PRIVATE | OC_F_PASS | OC_F_HFP)) {
+		if (req->objcore->flags & OC_F_HFP)
+			AN(req->objcore->flags & OC_F_PASS);
 		if (boc != NULL) {
 			HSH_Abandon(req->objcore);
 			ObjWaitState(req->objcore, BOS_FINISHED);

--- a/bin/varnishtest/tests/r01821.vtc
+++ b/bin/varnishtest/tests/r01821.vtc
@@ -1,4 +1,6 @@
-varnishtest "Slim down hit-for-miss objects"
+varnishtest "Slim down hit-for-miss / hit-for-miss objects"
+
+# see also #2768
 
 server s1 -repeat 2 {
 	rxreq
@@ -7,20 +9,32 @@ server s1 -repeat 2 {
 
 varnish v1 -arg "-s Transient=default" -vcl+backend {
 	sub vcl_backend_response {
-		set beresp.uncacheable = true;
+		if (bereq.url == "/hfm") {
+			set beresp.uncacheable = true;
+		} else if (bereq.url == "/hfp") {
+			return (pass(1m));
+		}
 	}
 } -start
 
-logexpect l1 -v v1 {
+logexpect l1 -v v1 -g raw {
+	expect * *	Storage		"Transient"
 	expect * *	Storage		"Transient"
 } -start
 
 client c1 {
-	txreq
+	txreq -url "/hfm"
+	rxresp
+} -start
+
+client c2 {
+	txreq -url "/hfp"
 	rxresp
 } -run
 
+client c1 -wait
+
 logexpect l1 -wait
 
-varnish v1 -expect SM?.Transient.c_bytes != 0
+varnish v1 -expect SM?.Transient.c_bytes > 131072
 varnish v1 -expect SM?.Transient.g_bytes < 65536


### PR DESCRIPTION
issuing PR with respect to the pre-release freez-ish period

The previous code was correct already, but we can make it clearer that HFP implies OC_F_PASS

Also test explicitly that both HFM and HFP have their objects slimmed.

Closes #2768
