### PR TITLE
Release 6.1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.59)
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
 Copyright (c) 2006-2018 Varnish Software])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [6.1.0], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [trunk], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -26,6 +26,9 @@ http://varnish-cache.org/docs/trunk/whats-new/index.html and via
 individual releases. These documents are updated as part of the
 release process.
 
+=============================
+Varnish Cache trunk (ongoing)
+=============================
 
 ================================
 Varnish Cache 6.1.0 (2018-09-17)


### PR DESCRIPTION
This pull request consists of to patches:

* One that changes the version in `configure.ac` to 6.1.0.
* One that changes the version in `configure.ac` back to *trunk* and starts a new heading in changes.rst

Of course, the first one will be tagged varnish-6.1.0, made into an official release and turned into packages for the supported platforms.

I will rebase if there are more patches before the bugwash.