### PR TITLE
Allow PRIORITY frames on closed streams

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -923,6 +923,10 @@ h2_procframe(struct worker *wrk, struct h2_sess *h2, h2_frame h2f)
 		if (r2->stream == h2->rxf_stream)
 			break;
 
+	if (h2->new_req != NULL &&
+	    !(r2 && h2->new_req == r2->req && h2f == H2_F_CONTINUATION))
+		return (H2CE_PROTOCOL_ERROR);	// rfc7540,l,1859,1863
+
 	if (r2 == NULL && h2f->act_sidle == 0) {
 		if (h2->rxf_stream <= h2->highest_stream)
 			return (H2CE_PROTOCOL_ERROR);	// rfc7540,l,1153,1158
@@ -939,10 +943,6 @@ h2_procframe(struct worker *wrk, struct h2_sess *h2, h2_frame h2f)
 		r2 = h2_new_req(wrk, h2, h2->rxf_stream, NULL);
 		AN(r2);
 	}
-
-	if (h2->new_req != NULL &&
-	    !(r2 && h2->new_req == r2->req && h2f == H2_F_CONTINUATION))
-		return (H2CE_PROTOCOL_ERROR);	// rfc7540,l,1859,1863
 
 	h2e = h2f->rxfunc(wrk, h2, r2);
 	if (h2e == 0)

--- a/bin/varnishtest/tests/r02387.vtc
+++ b/bin/varnishtest/tests/r02387.vtc
@@ -30,7 +30,7 @@ client c1 {
 	} -run
 	stream 0 {
 		rxgoaway
-		expect goaway.laststream == "3"
+		expect goaway.laststream == "1"
 		expect goaway.err == PROTOCOL_ERROR
 	} -run
 } -run

--- a/bin/varnishtest/tests/r02775.vtc
+++ b/bin/varnishtest/tests/r02775.vtc
@@ -1,0 +1,23 @@
+varnishtest "Regression test for #2775: allow PRIORITY on closed stream"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {} -start
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.set debug +syncvsl"
+
+client c1 {
+	stream 1 {
+		txreq
+		rxresp
+
+		txprio
+	} -run
+	stream 3 {
+		txreq
+		rxresp
+	} -run
+} -run

--- a/bin/varnishtest/tests/t02003.vtc
+++ b/bin/varnishtest/tests/t02003.vtc
@@ -43,10 +43,10 @@ client c1 {
 		expect goaway.err == PROTOCOL_ERROR
 	} -start
 	stream 3 {
-		txprio
+		txreq
 	} -run
 	stream 1 {
-		txprio
+		txreq
 	} -run
 	stream 0 -wait
 } -run
@@ -63,13 +63,13 @@ varnish v1 -expect MEMPOOL.sess1.live == 0
 
 client c1 {
 	stream 1 {
-		txprio
+		txreq -nostrend
 		txwinup -size 0
 		rxrst
 		expect rst.err == PROTOCOL_ERROR
 	} -run
 	stream 3 {
-		txprio
+		txreq -nostrend
 		txwinup -size 0x40000000
 		txwinup -size 0x40000000
 		rxrst
@@ -81,7 +81,7 @@ client c1 {
 		expect goaway.err == FRAME_SIZE_ERROR
 	} -start
 	stream 5 {
-		txprio
+		txreq -nostrend
 		sendhex "000003 08 00 00000005"
 		delay .1
 		sendhex 01
@@ -167,7 +167,7 @@ client c1 {
 		expect goaway.laststream == 1
 	} -start
 	stream 1 {
-		txprio
+		txreq -nostrend
 		sendhex "000008 05 00 00000001 0001020304050607"
 	} -run
 	stream 0 -wait
@@ -200,7 +200,7 @@ client c1 {
 		expect goaway.laststream == 1
 	} -start
 	stream 1 {
-		txprio
+		txreq -nostrend
 		# RST wrong length
 		sendhex "000005 03 00 00000001 0000000800"
 	} -run


### PR DESCRIPTION
As described in #2775, Varnish doesn't allow PRIORITY frames on closed streams, but it should.

Since there's no priority handling at all and PRIORITY frames are essentially discarded I thought that preventing the whole [stream creation section](https://github.com/varnishcache/varnish-cache/blob/6fdc89c1fdd12bb83fadd8412faa1d7703761e36/bin/varnishd/http2/cache_http2_proto.c#L926-L941) to be run upon receiving PRIORITY frame could be a good way to solve the issue.

Reading the specifications carefully I also noticed that this solution fixes some PRIORITY frame related issues:
Currently when Varnish receives a PRIORITY frame it creates a new h2_req object, which increases the concurrent streams counter. So we can get a REFUSED_STREAM if enough PRIORITY frames are sent.
This is however a wrong behaviour: [the spec](https://tools.ietf.org/html/rfc7540#section-5.1.2) states that only streams in "open" or "half-closed" states count toward the concurrent limit.
Since the proposed fix doesn't create new h2_req objects on PRIORITY frames, this is resolved.
Another thing is highest_stream: it is now updated even on PRIORITY frames, but the [RFC only lists](https://tools.ietf.org/html/rfc7540#section-5.1.1) HEADERS and PUSH_PROMISE.
This is also solved.

These changes caused some test to fail, so two preparatory commits were needed.

I'm only unsure on what to do for https://github.com/varnishcache/varnish-cache/blob/6fdc89c1fdd12bb83fadd8412faa1d7703761e36/bin/varnishd/http2/cache_http2_proto.c#L1028-L1033: the current changes make that untrue and unneeded.
Maybe something like this?
```patch
@@ -990,7 +990,6 @@ static int
 h2_sweep(struct worker *wrk, struct h2_sess *h2)
 {
        int tmo = 0;
-       int nprio = 0;
        struct h2_req *r2, *r22;
 
        ASSERT_RXTHR(h2);
@@ -1022,20 +1021,18 @@ h2_sweep(struct worker *wrk, struct h2_sess *h2)
                        }
                        break;
                case H2_S_IDLE:
-                       /* This stream was created from receiving a
-                        * PRIORITY frame, and should not be counted
-                        * as an active stream keeping the connection
-                        * open. */
-                       AZ(r2->scheduled);
-                       nprio++;
-                       break;
+                       /* Current code make this unreachable: h2_new_req is
+                        * only called inside h2_rx_headers, which immediately
+                        * sets the new stream state to H2_S_OPEN */
+                       /* FALLTHROUGH */
                default:
+                       WRONG("Wrong h2 stream state");
                        break;
                }
        }
        if (tmo)
                return (0);
-       return ((h2->refcnt - nprio) > 1);
+       return (h2->refcnt > 1);
 }

```

Please let me know what you think.