### PR TITLE
Save writev() calls for high numbers of http headers

### DIFF
--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -226,6 +226,7 @@ htc_complete_f HTTP1_Complete;
 uint16_t HTTP1_DissectRequest(struct http_conn *, struct http *);
 uint16_t HTTP1_DissectResponse(struct http_conn *, struct http *resp,
     const struct http *req);
+unsigned HTTP1_Estimate(const struct http *hp);
 unsigned HTTP1_Write(const struct worker *w, const struct http *hp, const int*);
 
 /* cache_main.c */

--- a/bin/varnishd/http1/cache_http1.h
+++ b/bin/varnishd/http1/cache_http1.h
@@ -60,4 +60,5 @@ void V1L_Open(struct worker *, struct ws *, int *fd, struct vsl_log *,
     double t0, unsigned niov);
 unsigned V1L_Flush(const struct worker *w);
 unsigned V1L_Close(struct worker *w, uint64_t *cnt);
+unsigned V1L_Reopen(struct worker *wrk, uint64_t *cnt, unsigned niov);
 size_t V1L_Write(const struct worker *w, const void *ptr, ssize_t len);

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -85,8 +85,8 @@ void v_matchproto_(vtr_deliver_f)
 V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 {
 	int err = 0, chunked = 0;
-	unsigned u;
-	uint64_t hdrbytes, bytes;
+	unsigned u, niov;
+	uint64_t hdrbytes, bytes = 0;
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	CHECK_OBJ_ORNULL(boc, BOC_MAGIC);
@@ -129,9 +129,15 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 		return;
 	}
 
+	if (HTTP1_Estimate(req->resp) > cache_param->http1_iovs)
+		niov = 0;
+	else
+		niov = cache_param->http1_iovs;
+
+	u = 0;
 	AZ(req->wrk->v1l);
 	V1L_Open(req->wrk, req->wrk->aws,
-		 &req->sp->fd, req->vsl, req->t_prev, cache_param->http1_iovs);
+		 &req->sp->fd, req->vsl, req->t_prev, niov);
 
 	if (WS_Overflowed(req->wrk->aws)) {
 		v1d_error(req, "workspace_thread overflow");
@@ -141,7 +147,21 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 
 	hdrbytes = HTTP1_Write(req->wrk, req->resp, HTTP1_Resp);
 
-	if (sendbody) {
+	while (sendbody) {
+		if (niov == 0) {
+			u = V1L_Reopen(req->wrk, &bytes,
+			    cache_param->http1_iovs);
+
+			if (WS_Overflowed(req->wrk->aws)) {
+				v1d_error(req, "workspace_thread overflow");
+				AZ(req->wrk->v1l);
+				return;
+			}
+		}
+
+		if (u)
+			break;
+
 		if (DO_DEBUG(DBG_FLUSH_HEAD))
 			(void)V1L_Flush(req->wrk);
 		if (chunked)
@@ -149,9 +169,11 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 		err = VDP_DeliverObj(req);
 		if (!err && chunked)
 			V1L_EndChunk(req->wrk);
+		break;
 	}
 
-	u = V1L_Close(req->wrk, &bytes);
+	if (u == 0)
+		u = V1L_Close(req->wrk, &bytes);
 	AZ(req->wrk->v1l);
 
 	/* Bytes accounting */

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -74,7 +74,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	struct http *hp;
 	int j;
 	ssize_t i;
-	uint64_t bytes, hdrbytes;
+	uint64_t bytes = 0, hdrbytes;
 	struct http_conn *htc;
 	int do_chunked = 0;
 

--- a/bin/varnishd/http1/cache_http1_line.c
+++ b/bin/varnishd/http1/cache_http1_line.c
@@ -134,12 +134,39 @@ V1L_Close(struct worker *wrk, uint64_t *cnt)
 	v1l = wrk->v1l;
 	wrk->v1l = NULL;
 	CHECK_OBJ_NOTNULL(v1l, V1L_MAGIC);
-	*cnt = v1l->cnt;
+	*cnt += v1l->cnt;
 	if (v1l->ws->r)
 		WS_Release(v1l->ws, 0);
 	WS_Reset(v1l->ws, v1l->res);
 	return (u);
 }
+
+/* change the number of iovs */
+unsigned
+V1L_Reopen(struct worker *wrk, uint64_t *cnt, unsigned niov)
+{
+	struct v1l *v1l = wrk->v1l;
+
+	unsigned u;
+	struct ws *ws;
+	int *fd;
+	struct vsl_log *vsl;
+	double t0;
+
+	ws = v1l->ws;
+	fd = v1l->wfd;
+	vsl = v1l->vsl;
+	t0 = v1l->t0;
+	v1l = NULL;
+
+	u = V1L_Close(wrk, cnt);
+	if (u)
+		return (u);
+
+	V1L_Open(wrk, ws, fd, vsl, t0, niov);
+	return (0);
+}
+
 
 static void
 v1l_prune(struct v1l *v1l, ssize_t bytes)

--- a/bin/varnishd/http1/cache_http1_proto.c
+++ b/bin/varnishd/http1/cache_http1_proto.c
@@ -481,6 +481,13 @@ http1_WrTxt(const struct worker *wrk, const txt *hh, const char *suf)
 	return (u);
 }
 
+/* estimate the number of IOVs required by HTTP1_Write */
+unsigned
+HTTP1_Estimate(const struct http *hp)
+{
+	return (2 * hp->nhd + 1);
+}
+
 unsigned
 HTTP1_Write(const struct worker *w, const struct http *hp, const int *hf)
 {

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -67,6 +67,11 @@ Varnish Cache trunk (ongoing)
 * Changed ``ExpKill`` log tags to emit microsecond-precision
   timestamps instead of nanoseconds (2792_)
 
+* Changed ``V1L_Close()`` to add written bytes to the ``cnt`` argument
+  (instead of assigning)
+
+* Added ``V1L_Reopen()``
+
 .. _2792: https://github.com/varnishcache/varnish-cache/pull/2792
 .. _2783: https://github.com/varnishcache/varnish-cache/pull/2783
 .. _2780: https://github.com/varnishcache/varnish-cache/issues/2780


### PR DESCRIPTION
Since 7bf932f3a674fa934c1bfd586686686003eec550 we might exceed the
number of iovs for many http headers (>31 with default parameters), so
we would issue more than one writev() for the http headers.

While sending http headers, we can use all of the thread workspace for
IOVs, so if we know that we would need a seond writev call anyway, we
re-open V1L to ensure we send as many headers at once as possible.