### PR TITLE
Blob nocopy: should we introduce struct vmod_blob ?

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -841,9 +841,18 @@ VRT_blob(VRT_CTX, const char *err, const void *src, size_t len)
 	struct vmod_priv *p;
 	void *d;
 
+	if (src == NULL)
+		assert (len == 0);
+
 	p = (void *)WS_Alloc(ctx->ws, sizeof *p);
-	d = WS_Copy(ctx->ws, src, len);
-	if (p == NULL || d == NULL) {
+
+	/* XXX struct vmod_blob with const priv pointer */
+	if (src == NULL || WS_Inside(ctx->ws, src, NULL))
+		d = TRUST_ME(src);
+	else
+		d = WS_Copy(ctx->ws, src, len);
+
+	if (p == NULL || (d == NULL && src != NULL)) {
 		VRT_fail(ctx, "Workspace overflow (%s)", err);
 		return (NULL);
 	}

--- a/lib/libvmod_blob/vmod_blob.c
+++ b/lib/libvmod_blob/vmod_blob.c
@@ -525,7 +525,6 @@ vmod_length(VRT_CTX, VCL_BLOB b)
 VCL_BLOB v_matchproto_(td_blob_sub)
 vmod_sub(VRT_CTX, VCL_BLOB b, VCL_BYTES n, VCL_BYTES off)
 {
-	uintptr_t snap;
 	struct vmod_priv *sub;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
@@ -547,17 +546,12 @@ vmod_sub(VRT_CTX, VCL_BLOB b, VCL_BYTES n, VCL_BYTES off)
 	if (n == 0)
 		return null_blob;
 
-	snap = WS_Snapshot(ctx->ws);
 	if ((sub = WS_Alloc(ctx->ws, sizeof(*sub))) == NULL) {
 		ERRNOMEM(ctx, "Allocating BLOB result in blob.sub()");
 		return NULL;
 	}
-	if ((sub->priv = WS_Alloc(ctx->ws, n)) == NULL) {
-		VERRNOMEM(ctx, "Allocating %jd bytes in blob.sub()", (intmax_t)n);
-		WS_Reset(ctx->ws, snap);
-		return NULL;
-	}
-	memcpy(sub->priv, (char *)b->priv + off, n);
+
+	sub->priv = (char *)b->priv + off;
 	sub->len = n;
 	return sub;
 }


### PR DESCRIPTION
TBD - opening a PR because of the unavoidable `TRUST_ME()` required with the current `struct vmod_priv`:

Should we rather introduce a separate struct for blobs as?

```
struct vrt_blob {
        unsigned                magic;
        int                     len; // or size_t ?
        const void              *blob;
        vmod_priv_free_f        *free;
};

```