### PR TITLE
Prepare for 6.1.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.59)
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
 Copyright (c) 2006-2018 Varnish Software])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [6.1.0], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [6.1.1], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -4,16 +4,14 @@ About this document
 
 .. keep this section at the top!
 
-This document contains notes from the Varnish developers about ongoing
-development and past versions:
+This document contains notes from the Varnish developers about
+the 6.1 branch of Varnish Cache.
 
 * Developers will note here changes which they consider particularly
   relevant or otherwise noteworthy
 
-* This document is not necessarily up-to-date with the code
-
-* It serves as a basis for release managers and others involved in
-  release documentation
+* This document is updated before releases and partly during
+  develoment. Between releases the document can be out of sync.
 
 * It is not rendered as part of the official documentation and thus
   only available in ReStructuredText (rst) format in the source
@@ -27,7 +25,7 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
-Varnish Cache 6.1.1 (unreleased)
+Varnish Cache 6.1.1 (2018-10-26)
 ================================
 
 * fixed ``varnishhist`` display error (2780_)


### PR DESCRIPTION
This is the first step towards releasing 6.1.1. The pull request is mostly for internal use, but do feel free to comment on the changes I did to the top of `doc/changes.rst`.