### PR TITLE
manage dynamic privs as a red/black tree

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -49,6 +49,7 @@
 #include "miniobj.h"
 #include "vas.h"
 #include "vqueue.h"
+#include "vtree.h"
 
 #include "vapi/vsl_int.h"
 
@@ -198,10 +199,12 @@ struct vxid_pool {
 
 /*--------------------------------------------------------------------*/
 
+VRBT_HEAD(vrt_priv_tree,vrt_priv);
+
 struct vrt_privs {
 	unsigned		magic;
-#define VRT_PRIVS_MAGIC		0x03ba7501
-	VTAILQ_HEAD(,vrt_priv)	privs;
+#define VRT_PRIVS_MAGIC		0x03ba7502
+	struct vrt_priv_tree	privs;
 };
 
 /* Worker pool stuff -------------------------------------------------*/

--- a/bin/varnishtest/tests/v00041.vtc
+++ b/bin/varnishtest/tests/v00041.vtc
@@ -49,12 +49,11 @@ varnish v1 -arg "-p debug=+vclrel -p workspace_client=1m" -vcl+backend {
 	}
 
 	sub vcl_synth {
-		std.log("discard 100 " + debug.priv_perf(100));
+		std.log("discard 1000 " + debug.priv_perf(1000));
 		std.log("perf    1 " + debug.priv_perf(1));
 		std.log("perf   10 " + debug.priv_perf(10));
 		std.log("perf  100 " + debug.priv_perf(100));
-		## unbearable with the list implementation - ok with rb tree
-		# std.log("perf 1000 " + debug.priv_perf(1000));
+		std.log("perf 1000 " + debug.priv_perf(1000));
 		return (deliver);
 	}
 


### PR DESCRIPTION
O(n) does not scale for a high number of dynamic privs, so trade some
workspace for O(lg n)