### PR TITLE
Add a mechanism to interrupt VSM_Attach

### DIFF
--- a/bin/varnishadm/varnishadm.c
+++ b/bin/varnishadm/varnishadm.c
@@ -73,6 +73,7 @@
 
 
 static double timeout = 5;
+static struct vsm *vsm;
 
 static void
 cli_write(int sock, const char *s)
@@ -388,17 +389,24 @@ usage(int status)
 	exit(status);
 }
 
+static void
+vsm_sighandler(int sig)
+{
+	if (vsm != NULL)
+		VSM_Signaled(vsm, sig);
+}
+
 static int
 n_arg_sock(const char *n_arg, const char *t_arg)
 {
 	char *T_arg = NULL, *T_start = NULL;
 	char *S_arg = NULL;
-	struct vsm *vsm;
 	char *p;
 	int sock;
 
 	vsm = VSM_New();
 	AN(vsm);
+	VSM_Signal(vsm_sighandler);
 	if (VSM_Arg(vsm, 'n', n_arg) < 0 ||
 	    VSM_Arg(vsm, 't', t_arg) < 0 ||
 	    VSM_Attach(vsm, STDERR_FILENO) < 0) {

--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -52,6 +52,7 @@
 #include "varnishstat.h"
 
 static struct VUT *vut;
+static struct vsm *vd;
 
 /*--------------------------------------------------------------------*/
 
@@ -245,6 +246,15 @@ list_fields(struct vsm *vsm, struct vsc *vsc)
 
 /*--------------------------------------------------------------------*/
 
+static void
+vsm_sighandler(int sig)
+{
+	if (vd != NULL)
+		VSM_Signaled(vd, sig);
+}
+
+/*--------------------------------------------------------------------*/
+
 static void v_noreturn_
 usage(int status)
 {
@@ -260,7 +270,6 @@ usage(int status)
 int
 main(int argc, char * const *argv)
 {
-	struct vsm *vd;
 	int once = 0, xml = 0, json = 0, f_list = 0, curses = 0;
 	signed char opt;
 	int i;
@@ -314,6 +323,7 @@ main(int argc, char * const *argv)
 	if (!(xml || json || once || f_list))
 		curses = 1;
 
+	VSM_Signal(vsm_sighandler);
 	if (VSM_Attach(vd, STDERR_FILENO))
 		VUT_Error(vut, 1, "%s", VSM_Error(vd));
 

--- a/include/vapi/vsm.h
+++ b/include/vapi/vsm.h
@@ -38,6 +38,8 @@
 
 struct vsm;
 
+typedef void VSM_sighandler_f(int);
+
 /*
  * This structure is used to reference a VSM chunk
  */
@@ -185,6 +187,16 @@ char *VSM_Dup(struct vsm*, const char *class, const char *ident);
 	 * Return:
 	 *   NULL = Failure
 	 *   !NULL = malloc'ed pointer
+	 */
+
+void VSM_Signal(VSM_sighandler_f);
+	/*
+	 *
+	 */
+
+void VSM_Signaled(struct vsm *, int);
+	/*
+	 *
 	 */
 
 #endif /* VAPI_VSM_H_INCLUDED */

--- a/lib/libvarnishapi/vut.c
+++ b/lib/libvarnishapi/vut.c
@@ -247,6 +247,8 @@ VUT_Signaled(struct VUT *vut, int sig)
 	vut->sighup |= (int)(sig == SIGHUP);
 	vut->sigint |= (int)(sig == SIGINT || sig == SIGTERM);
 	vut->sigusr1 |= (int)(sig == SIGUSR1);
+	if (vut->vsm)
+		VSM_Signaled(vut->vsm, sig);
 }
 
 void


### PR DESCRIPTION
Call it from the VUT code so tools using it can be interrupted.
Fixes #2657.