### PR TITLE
change semantics of the vcl 'auto' state and centralize vcl mgt

### DIFF
--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -923,13 +923,6 @@ mcf_vcl_label(struct cli *cli, const char * const *av, void *priv)
 			VCLI_Out(cli, "%s is not a label", vpl->name);
 			return;
 		}
-		if (!VTAILQ_EMPTY(&vpl->dfrom) &&
-		    VTAILQ_FIRST(&vpl->dfrom)->to == vpt) {
-			VCLI_SetResult(cli, CLIS_PARAM);
-			VCLI_Out(cli, "VCL '%s' already has label '%s'",
-			    vpt->name, vpl->name);
-			return;
-		}
 		if (!VTAILQ_EMPTY(&vpt->dfrom) &&
 		    !VTAILQ_EMPTY(&vpl->dto)) {
 			VCLI_SetResult(cli, CLIS_PARAM);

--- a/bin/varnishtest/tests/c00077.vtc
+++ b/bin/varnishtest/tests/c00077.vtc
@@ -13,6 +13,8 @@ varnish v1 -vcl+backend {
 
 varnish v1 -clierr 106 "vcl.label vcl.A vcl1"
 varnish v1 -cliok "vcl.label vclA vcl1"
+# labeling twice #2834
+varnish v1 -cliok "vcl.label vclA vcl1"
 
 varnish v1 -vcl+backend {
 	sub vcl_recv {

--- a/bin/varnishtest/tests/c00077.vtc
+++ b/bin/varnishtest/tests/c00077.vtc
@@ -13,10 +13,6 @@ varnish v1 -vcl+backend {
 
 varnish v1 -clierr 106 "vcl.label vcl.A vcl1"
 varnish v1 -cliok "vcl.label vclA vcl1"
-varnish v1 -clierr 106 "vcl.label vclA vcl1"
-varnish v1 -cliexpect {VCL 'vcl1' already has label 'vclA'} {
-	vcl.label vclA vcl1
-}
 
 varnish v1 -vcl+backend {
 	sub vcl_recv {

--- a/bin/varnishtest/tests/r02432.vtc
+++ b/bin/varnishtest/tests/r02432.vtc
@@ -11,6 +11,7 @@ varnish v1 -vcl+backend {
 } -start
 
 varnish v1 -cliok "vcl.label label1 vcl1"
+varnish v1 -cliok "vcl.list"
 
 varnish v1 -vcl+backend {
 	sub vcl_recv {

--- a/bin/varnishtest/tests/r02471.vtc
+++ b/bin/varnishtest/tests/r02471.vtc
@@ -27,6 +27,7 @@ varnish v1 -cliexpect "cold    cold         0    vcl1" "vcl.list"
 
 
 # Grab hold of vcl1
+varnish v1 -cliok "vcl.state vcl1 auto"
 varnish v1 -cliok "vcl.use vcl1"
 client c1 {
 	txreq -url "/hold"
@@ -45,6 +46,7 @@ varnish v1 -cliok "vcl.state vcl1 cold"
 varnish v1 -cliexpect "cold    busy         [12]    vcl1" "vcl.list"
 
 # Release hold on vcl1
+varnish v1 -cliok "vcl.state vcl1 auto"
 varnish v1 -cliok "vcl.use vcl1"
 client c1 {
 	txreq -url "/release"

--- a/bin/varnishtest/tests/v00003.vtc
+++ b/bin/varnishtest/tests/v00003.vtc
@@ -48,7 +48,10 @@ varnish v1 -cliexpect "available *cold *cold *[0-9]+ *vcl1\\s+active *auto *warm
 delay .4
 varnish v1 -expect !VBE.vcl1.default.happy
 
-# Use it, and it should come warm (but not auto)
+# Manual temperature control needs to be explicit before use
+varnish v1 -clierr 300 "vcl.use vcl1"
+
+varnish v1 -cliok "vcl.state vcl1 warm"
 varnish v1 -cliok "vcl.use vcl1"
 varnish v1 -cliexpect "active *warm *warm *[0-9]+ *vcl1\\s+available *auto *warm *[0-9]+ *vcl2" "vcl.list"
 delay .4

--- a/bin/varnishtest/tests/v00003.vtc
+++ b/bin/varnishtest/tests/v00003.vtc
@@ -4,7 +4,6 @@ server s1 -repeat 20 {
 	rxreq
 	txresp
 	delay .2
-	close
 } -start
 
 # The debug vmod logs temperature vcl events
@@ -12,7 +11,8 @@ varnish v1 -arg "-p vcl_cooldown=1" -vcl {
 	import debug;
 	backend default {
 		.host = "${s1_addr}";
-		.probe = { .interval = 1s; .initial = 1;}
+		.port = "${s1_port}";
+		.probe = { .interval = 1s; }
 	}
 } -start
 
@@ -24,7 +24,8 @@ varnish v1 -cliok "backend.list -p *.*"
 varnish v1 -vcl {
 	backend default {
 		.host = "${s1_addr}";
-		.probe = { .interval = 1s; .initial = 1;}
+		.port = "${s1_port}";
+		.probe = { .interval = 1s; }
 	}
 }
 
@@ -33,64 +34,64 @@ delay .4
 varnish v1 -expect VBE.vcl1.default.happy >= 0
 varnish v1 -expect VBE.vcl2.default.happy >= 0
 
-# Freeze the first VCL
+# We are about to freeze vcl, then implicitly thaw it via use.
+# check that we see the events
+
+logexpect l1 -v v1 -g raw {
+	expect * 0 Debug "vcl1: VCL_EVENT_COLD"
+	expect * 0 Debug "vcl1: VCL_EVENT_WARM"
+} -start
+
+# Freeze vcl1
 varnish v1 -cliok "vcl.state vcl1 cold"
+varnish v1 -cliexpect "available *cold *cold *[0-9]+ *vcl1\\s+active *auto *warm *[0-9]+ *vcl2" "vcl.list"
 delay .4
 varnish v1 -expect !VBE.vcl1.default.happy
 
-# Set it auto should be a no-op
-varnish v1 -cliok "vcl.state vcl1 auto"
-delay .4
-varnish v1 -expect !VBE.vcl1.default.happy
-
-# Use it, and it should come alive
+# Use it, and it should come warm (but not auto)
 varnish v1 -cliok "vcl.use vcl1"
+varnish v1 -cliexpect "active *warm *warm *[0-9]+ *vcl1\\s+available *auto *warm *[0-9]+ *vcl2" "vcl.list"
 delay .4
 varnish v1 -expect VBE.vcl1.default.happy >= 0
 varnish v1 -expect VBE.vcl2.default.happy >= 0
 
+logexpect l1 -wait
+
 # and the unused one should go cold
 delay 4
+varnish v1 -cliexpect "active *warm *warm *[0-9]+ *vcl1\\s+available *auto *cold *[0-9]+ *vcl2" "vcl.list"
 varnish v1 -expect !VBE.vcl2.default.happy
 
-# Mark the used warm and use the other
-varnish v1 -cliok "vcl.state vcl1 warm"
+# use the other
 varnish v1 -cliok "vcl.use vcl2"
+varnish v1 -cliexpect "available *warm *warm *[0-9]+ *vcl1\\s+active *auto *warm *[0-9]+ *vcl2" "vcl.list"
 
-# It will stay warm even after the cooldown period
+# the non-auto vcl will stay warm even after the cooldown period
 delay 4
+varnish v1 -cliexpect "available *warm *warm *[0-9]+ *vcl1\\s+active *auto *warm *[0-9]+ *vcl2" "vcl.list"
 varnish v1 -expect VBE.vcl1.default.happy >= 0
 varnish v1 -expect VBE.vcl2.default.happy >= 0
 
 # You can't freeze the active VCL
 varnish v1 -clierr 300 "vcl.state vcl2 cold"
 
-# However a warm event is guaranteed...
-logexpect l1 -v v1 -g raw {
-	expect * 0 Debug "vcl1: VCL_EVENT_COLD"
-	expect * 0 Debug "vcl1: VCL_EVENT_WARM"
-} -start
-
-# ...when you use a cold VCL
-varnish v1 -cliok "vcl.state vcl1 cold"
-varnish v1 -cliok "vcl.use vcl1"
-
-logexpect l1 -wait
-
-# It will apply the cooldown period once inactive
-varnish v1 -cliok "vcl.use vcl2"
+# the non-auto vcl will apply the cooldown again once changed back to auto
+varnish v1 -cliok "vcl.state vcl1 auto"
+varnish v1 -cliexpect "available *auto *warm *[0-9]+ *vcl1\\s+active *auto *warm *[0-9]+ *vcl2" "vcl.list"
 delay .4
 varnish v1 -expect VBE.vcl1.default.happy >= 0
 delay 4
+varnish v1 -cliexpect "available *auto *cold *[0-9]+ *vcl1\\s+active *auto *warm *[0-9]+ *vcl2" "vcl.list"
 varnish v1 -expect !VBE.vcl1.default.happy
 
 # A VMOD's warm-up can fail
 varnish v1 -cliok "param.set max_esi_depth 42"
 varnish v1 -clierr 300 "vcl.state vcl1 warm"
 
-varnish v1 -cliexpect "available *cold *cold *[0-9]+ *vcl1\\s+active *warm *warm *[0-9]+ *vcl2" "vcl.list"
+varnish v1 -cliexpect "available *auto *cold *[0-9]+ *vcl1\\s+active *auto *warm *[0-9]+ *vcl2" "vcl.list"
 
 # A warm-up failure can also fail a child start
 varnish v1 -cliok stop
 varnish v1 -cliok "vcl.state vcl1 warm"
+varnish v1 -cliok "vcl.list"
 varnish v1 -clierr 300 start


### PR DESCRIPTION
Conceptually, the auto state was a variant of the warm state which
would automatically cool the vcl. Yet, cooling did not only transition
the temperature, but also the state, so 'auto' only worked one way -
except that vcl.use or moving a label (by labeling another vcl) would
also set 'auto', so a manual warm/cold setting would get lost.

Now the auto-state will remain no matter the actual temperature or
labeling, so when a vcl needs to implicitly change temperature (due to
being used or being labeled), an auto vcl will remain auto, and a
cold/warm vcl will change state, but never become 'auto' implicitly.

The vcl state/temperature test v00003.vtc, besides testing the new
auto semantics, now also checks for the right vcl.list output and has
been reduced by a duplicate check (warm event check has been
integrated into an existing warm event).

On other code changes:

* mgt_vcl_setstate

  is now only concerned with the state, the temperature will be
  changed implicitly if so required. The state will either end up
  changed or restored, depending on success.

  owner of changes to the (struct vclprog).state member

* mgt_vcl_settemp

  responsible for the right action to change the temperature. For auto,
  it will only change the temperature, for non-auto, also the state.

  owner of changes to the (struct vclprog).warm member

* mgt_vcl_tellchild

  Inform the child about a change and/or temperature change

* mgt_vcl_set_cooldown

  Update the cooldown (go_cold) appropriately, should be called after
  a change/temperature change.

Fixes #2834
Closes #2801