### PR TITLE
Fix VRT_fail for 'if'/'elseif' conditional expressions

### DIFF
--- a/bin/varnishtest/tests/v00051.vtc
+++ b/bin/varnishtest/tests/v00051.vtc
@@ -425,3 +425,32 @@ varnish v1 -expect sc_vcl_failure == 10
 
 logexpect l1 -wait
 
+#######################################################################
+# Fail in vmod call used in an if test
+
+varnish v1 -vcl+backend {
+	import debug;
+	sub vcl_recv {
+		if (debug.fail2()) {
+			return (hash);
+		}
+	}
+}
+
+logexpect l1 -v v1 -g raw {
+	expect * 1033	VCL_call	"RECV"
+	expect 0 1033	VCL_Error	"Forced failure"
+	expect 0 1033	VCL_return	"fail"
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
+} -run
+
+varnish v1 -expect vcl_fail == 14
+varnish v1 -expect sc_vcl_failure == 11
+
+logexpect l1 -wait

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -149,6 +149,7 @@ vcc_Compound(struct vcc *tl)
 	Fb(tl, 1, "{\n");
 	tl->indent += INDENT;
 	C(tl, ";");
+	Fb(tl, 1, "if (*ctx->handling) return;\n");
 	while (1) {
 		ERRCHK(tl);
 		t = tl->t;

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -130,6 +130,10 @@ $Function VOID fail()
 
 Function to fail vcl code.  (See also: RFC748)
 
+$Function BOOL fail2()
+
+Function to fail vcl code. Always returns true.
+
 $Object dyn(STRING addr, STRING port, PROBE probe=0)
 
 Dynamically create a single-backend director, addr and port must not be empty.

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -252,6 +252,14 @@ xyzzy_fail(VRT_CTX)
 	VRT_fail(ctx, "Forced failure");
 }
 
+VCL_BOOL v_matchproto_(td_debug_fail2)
+xyzzy_fail2(VRT_CTX)
+{
+
+	VRT_fail(ctx, "Forced failure");
+	return (1);
+}
+
 static void v_matchproto_(vmod_priv_free_f)
 priv_vcl_free(void *priv)
 {


### PR DESCRIPTION
This adds a ``ctx->handling`` test at the beginning of any compound statement, to catch the cases where VRT_fail was invoked as part of an if test condition.

A side-effect of this approach is that we will end up with one extra ``ctx->handling`` test at the start of any ``sub``. Ideally we could restrict adding this to the cases where the compound statement was an if/elseif block. From the look of things, that would require us to either redo how/where we insert the curly brackets, or carry state that tells us "this is an if block". Having the extra ``ctx->handling`` test seems like the lesser evil. 

Fixes: #2840