### PR TITLE
use our knowledge about master file descriptors also for VSUBs

### DIFF
--- a/bin/varnishd/common/heritage.h
+++ b/bin/varnishd/common/heritage.h
@@ -95,6 +95,7 @@ extern struct heritage heritage;
 
 /* Really belongs in mgt.h, but storage_file chokes on both */
 void MCH_Fd_Inherit(int fd, const char *what);
+void MCH_Fd_closefrom(int);
 
 #define ARGV_ERR(...)						\
 	do {							\

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -237,7 +237,7 @@ mgt_vcc_compile(struct vcc_priv *vp, struct vsb *sb, int C_flag)
 	if (mgt_vcc_touchfile(vp->libfile, sb))
 		return (2);
 
-	subs = VSUB_run(sb, run_vcc, vp, "VCC-compiler", -1);
+	subs = VSUB_run(sb, run_vcc, vp, "VCC-compiler", -1, MCH_Fd_closefrom);
 	if (subs)
 		return (subs);
 
@@ -248,11 +248,11 @@ mgt_vcc_compile(struct vcc_priv *vp, struct vsb *sb, int C_flag)
 		free(csrc);
 	}
 
-	subs = VSUB_run(sb, run_cc, vp, "C-compiler", 10);
+	subs = VSUB_run(sb, run_cc, vp, "C-compiler", 10, MCH_Fd_closefrom);
 	if (subs)
 		return (subs);
 
-	subs = VSUB_run(sb, run_dlopen, vp, "dlopen", 10);
+	subs = VSUB_run(sb, run_dlopen, vp, "dlopen", 10, MCH_Fd_closefrom);
 	return (subs);
 }
 

--- a/include/vsub.h
+++ b/include/vsub.h
@@ -28,10 +28,11 @@
  *
  */
 
-/* from libvarnish/subproc.c */
+/* from lib/libvarnish/vsub.c */
 typedef void vsub_func_f(void*);
+typedef void vsub_closefrom_f(int);
 
-unsigned VSUB_run(struct vsb *, vsub_func_f *, void *priv, const char *name,
-    int maxlines);
+unsigned VSUB_run(struct vsb *, vsub_func_f *, void *, const char *, int,
+    vsub_closefrom_f);
 
 void VSUB_closefrom(int fd);


### PR DESCRIPTION
In the master process, we record file descriptors to be inherited to the worker child and a maximum file descriptor ever used. We long used this knowledge when starting a worker child to selectively not close file descriptors required by the child and to limit the maximum file descriptor number to close.

This patch makes the same knowledge available to `VSUB_run()` which is used by the master process to start the VCC- and C-Compilers and the .so test-load while executing `vcl.load`. The benefit is to avoid long `vcl.load` times on systems which do not have an efficient `closefrom()` implementation. In addition, the issue addressed in #1841 should, in principle, also apply to processes started via `VSUB_run()` and this change should fix those as well.

Regarding the information leakage argument made in #2730, we would have the same issue for the varnish worker child, so I do not think that we are taking on additional risks. Also, since 1be6ad1d5a807038adcaa39168ce69a5a76bc8e1 we can now be more confident not to be missing to close any file descriptors which should be closed.

Fixes #2730