### PR TITLE
engage tighter master file descriptor checks

### DIFF
--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -188,9 +188,7 @@ mch_cli_panic_clear(struct cli *cli, const char * const *av, void *priv)
 
 static int		mgt_max_fd;
 
-#define CLOSE_FD_UP_TO	(mgt_max_fd + 100)
-// XXX should work now - engage?
-//#define CLOSE_FD_UP_TO	mgt_max_fd
+#define CLOSE_FD_UP_TO	mgt_max_fd
 #define CHECK_FD_UP_TO	(CLOSE_FD_UP_TO + 100)
 
 void


### PR DESCRIPTION
In the master process, we record file descriptors to be inherited to the worker child and a maximum file descriptor ever used.
Previously, there was a tolerance margin of 100 file descriptors which we close on the suspicion that they could be used. 6bead571da6a2027a518af81e14d87a247f38156 hopefully has fixed an issue where we failed to track the max fd, so I presume that we now got accurate knowledge.
This simple change removes the margin and thus more tightly engages the assertions from 1be6ad1d5a807038adcaa39168ce69a5a76bc8e1