### PR TITLE
make proxy protocol header formatting available in VRT

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -172,8 +172,27 @@ vbe_dir_getfd(struct worker *wrk, struct backend *bp, struct busyobj *bo,
 	bp->vsc->req++;
 	Lck_Unlock(&bp->mtx);
 
+	err = 0;
 	if (bp->proxy_header != 0)
-		VPX_Send_Proxy(*fdp, bp->proxy_header, bo->sp);
+		err += VPX_Send_Proxy(*fdp, bp->proxy_header, bo->sp);
+	if (err < 0) {
+		VSLb(bo->vsl, SLT_FetchError,
+		     "backend %s: proxy write errno %d (%s)",
+		     VRT_BACKEND_string(bp->director),
+		     errno, vstrerror(errno));
+		// account as if connect failed - good idea?
+		VSC_C_main->backend_fail++;
+		bo->htc = NULL;
+		VTP_Close(&pfd);
+		AZ(pfd);
+		Lck_Lock(&bp->mtx);
+		bp->n_conn--;
+		bp->vsc->conn--;
+		bp->vsc->req--;
+		Lck_Unlock(&bp->mtx);
+		return (NULL);
+	}
+	bo->acct.bereq_hdrbytes += err;
 
 	PFD_LocalName(pfd, abuf1, sizeof abuf1, pbuf1, sizeof pbuf1);
 	PFD_RemoteName(pfd, abuf2, sizeof abuf2, pbuf2, sizeof pbuf2);

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -75,7 +75,7 @@ void H2_PU_Sess(struct worker *, struct sess *, struct req *);
 void H2_OU_Sess(struct worker *, struct sess *, struct req *);
 
 const struct transport *XPORT_ByNumber(uint16_t no);
-void VPX_Send_Proxy(int fd, int version, const struct sess *);
+int VPX_Send_Proxy(int fd, int version, const struct sess *);
 
 /* cache_session.c */
 struct sess *SES_New(struct pool *);

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -989,7 +989,8 @@ VRT_VSA_GetPtr(VRT_CTX, const struct suckaddr *sua, const unsigned char ** dst)
 }
 
 void
-VRT_Format_Proxy(struct vsb *vsb, VCL_INT version, VCL_IP sac, VCL_IP sas)
+VRT_Format_Proxy(struct vsb *vsb, VCL_INT version, VCL_IP sac, VCL_IP sas,
+    VCL_STRING auth)
 {
-	VPX_Format_Proxy(vsb, (int)version, sac, sas);
+	VPX_Format_Proxy(vsb, (int)version, sac, sas, auth);
 }

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -47,6 +47,7 @@
 
 #include "common/heritage.h"
 #include "common/vsmw.h"
+#include "proxy/cache_proxy.h"
 
 const void * const vrt_magic_string_end = &vrt_magic_string_end;
 const void * const vrt_magic_string_unset = &vrt_magic_string_unset;
@@ -985,4 +986,10 @@ VRT_VSA_GetPtr(VRT_CTX, const struct suckaddr *sua, const unsigned char ** dst)
 		return (-1);
 	}
 	return (VSA_GetPtr(sua, dst));
+}
+
+void
+VRT_Format_Proxy(struct vsb *vsb, VCL_INT version, VCL_IP sac, VCL_IP sas)
+{
+	VPX_Format_Proxy(vsb, (int)version, sac, sas);
 }

--- a/bin/varnishd/proxy/cache_proxy.h
+++ b/bin/varnishd/proxy/cache_proxy.h
@@ -39,3 +39,5 @@
 #define PP2_SUBTYPE_SSL_MAX     0x25
 
 int VPX_tlv(const struct req *req, int tlv, void **dst, int *len);
+void VPX_Format_Proxy(struct vsb *, int, const struct suckaddr *,
+    const struct suckaddr *);

--- a/bin/varnishd/proxy/cache_proxy.h
+++ b/bin/varnishd/proxy/cache_proxy.h
@@ -40,4 +40,4 @@
 
 int VPX_tlv(const struct req *req, int tlv, void **dst, int *len);
 void VPX_Format_Proxy(struct vsb *, int, const struct suckaddr *,
-    const struct suckaddr *);
+    const struct suckaddr *, const char *);

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -632,6 +632,34 @@ vpx_format_proxy_v1(struct vsb *vsb, int proto,
 	AZ(VSB_finish(vsb));
 }
 
+static void
+vpx_format_proxy_v2(struct vsb *vsb, int proto,
+    const struct suckaddr *sac, const struct suckaddr *sas)
+{
+	AN(vsb);
+	AN(sac);
+	AN(sas);
+
+	VSB_bcat(vsb, vpx2_sig, sizeof(vpx2_sig));
+	VSB_putc(vsb, 0x21);
+	if (proto == PF_INET6) {
+		VSB_putc(vsb, 0x21);
+		VSB_putc(vsb, 0x00);
+		VSB_putc(vsb, 0x24);
+	} else if (proto == PF_INET) {
+		VSB_putc(vsb, 0x11);
+		VSB_putc(vsb, 0x00);
+		VSB_putc(vsb, 0x0c);
+	} else {
+		WRONG("Wrong proxy v2 proto");
+	}
+	vpx_enc_addr(vsb, proto, sac);
+	vpx_enc_addr(vsb, proto, sas);
+	vpx_enc_port(vsb, sac);
+	vpx_enc_port(vsb, sas);
+	AZ(VSB_finish(vsb));
+}
+
 void
 VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 {
@@ -649,7 +677,6 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	AZ(SES_Get_server_addr(sp, &sas));
 	AN(sas);
 	proto = VSA_Get_Proto(sas);
-	assert(proto == PF_INET6 || proto == PF_INET);
 
 	if (version == 1) {
 		VTCP_name(sas, ha, sizeof ha, pa, sizeof pa);
@@ -660,23 +687,7 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	} else if (version == 2) {
 		AZ(SES_Get_client_addr(sp, &sac));
 		AN(sac);
-
-		VSB_bcat(vsb, vpx2_sig, sizeof(vpx2_sig));
-		VSB_putc(vsb, 0x21);
-		if (proto == PF_INET6) {
-			VSB_putc(vsb, 0x21);
-			VSB_putc(vsb, 0x00);
-			VSB_putc(vsb, 0x24);
-		} else if (proto == PF_INET) {
-			VSB_putc(vsb, 0x11);
-			VSB_putc(vsb, 0x00);
-			VSB_putc(vsb, 0x0c);
-		}
-		vpx_enc_addr(vsb, proto, sac);
-		vpx_enc_addr(vsb, proto, sas);
-		vpx_enc_port(vsb, sac);
-		vpx_enc_port(vsb, sas);
-		AZ(VSB_finish(vsb));
+		vpx_format_proxy_v2(vsb, proto, sac, sas);
 	} else
 		WRONG("Wrong proxy version");
 

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -689,14 +689,14 @@ VPX_Format_Proxy(struct vsb *vsb, int version,
 		WRONG("Wrong proxy version");
 }
 
-void
+int
 VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 {
 	struct vsb *vsb, *vsb2;
 	struct suckaddr *sac, *sas;
 	char ha[VTCP_ADDRBUFSIZE];
 	char pa[VTCP_PORTBUFSIZE];
-	int proto;
+	int proto, r;
 
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 	assert(version == 1 || version == 2);
@@ -720,11 +720,11 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	} else
 		WRONG("Wrong proxy version");
 
-	(void)write(fd, VSB_data(vsb), VSB_len(vsb));
+	r = write(fd, VSB_data(vsb), VSB_len(vsb));
 
 	if (!DO_DEBUG(DBG_PROTOCOL)) {
 		VSB_delete(vsb);
-		return;
+		return (r);
 	}
 
 	vsb2 = VSB_new_auto();
@@ -735,4 +735,5 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	VSL(SLT_Debug, 999, "PROXY_HDR %s", VSB_data(vsb2));
 	VSB_delete(vsb);
 	VSB_delete(vsb2);
+	return (r);
 }

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -661,6 +661,35 @@ vpx_format_proxy_v2(struct vsb *vsb, int proto,
 }
 
 void
+VPX_Format_Proxy(struct vsb *vsb, int version,
+    const struct suckaddr *sac, const struct suckaddr *sas)
+{
+	int proto;
+	char hac[VTCP_ADDRBUFSIZE];
+	char pac[VTCP_PORTBUFSIZE];
+	char has[VTCP_ADDRBUFSIZE];
+	char pas[VTCP_PORTBUFSIZE];
+
+	AN(vsb);
+	AN(sac);
+	AN(sas);
+
+	assert(version == 1 || version == 2);
+
+	proto = VSA_Get_Proto(sas);
+	assert(proto == VSA_Get_Proto(sac));
+
+	if (version == 1) {
+		VTCP_name(sac, hac, sizeof hac, pac, sizeof pac);
+		VTCP_name(sas, has, sizeof has, pas, sizeof pas);
+		vpx_format_proxy_v1(vsb, proto, hac, pac, has, pas);
+	} else if (version == 2) {
+		vpx_format_proxy_v2(vsb, proto, sac, sas);
+	} else
+		WRONG("Wrong proxy version");
+}
+
+void
 VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 {
 	struct vsb *vsb, *vsb2;

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -689,19 +689,24 @@ VPX_Format_Proxy(struct vsb *vsb, int version,
 		WRONG("Wrong proxy version");
 }
 
+#define PXY_BUFSZ						\
+	sizeof(vpx1_sig) + 4 /* TCPx */ +			\
+	2 * VTCP_ADDRBUFSIZE + 2 * VTCP_PORTBUFSIZE +		\
+	6 /* spaces, CRLF */ + 16 /* safety */
+
 int
 VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 {
-	struct vsb *vsb, *vsb2;
+	struct vsb vsb[1], *vsb2;
 	struct suckaddr *sac, *sas;
 	char ha[VTCP_ADDRBUFSIZE];
 	char pa[VTCP_PORTBUFSIZE];
+	char buf[PXY_BUFSZ];
 	int proto, r;
 
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 	assert(version == 1 || version == 2);
-	vsb = VSB_new_auto();
-	AN(vsb);
+	AN(VSB_new(vsb, buf, sizeof buf, VSB_FIXEDLEN));
 
 	AZ(SES_Get_server_addr(sp, &sas));
 	AN(sas);
@@ -737,3 +742,5 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	VSB_delete(vsb2);
 	return (r);
 }
+
+#undef PXY_BUFSZ

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -606,11 +606,36 @@ vpx_enc_port(struct vsb *vsb, const struct suckaddr *s)
 	VSB_bcat(vsb, b, sizeof(b));
 }
 
+/* short path for stringified addresses from session attributes */
+static void
+vpx_format_proxy_v1(struct vsb *vsb, int proto,
+    const char *cip,  const char *cport,
+    const char *sip,  const char *sport)
+{
+	AN(vsb);
+	AN(cip);
+	AN(cport);
+	AN(sip);
+	AN(sport);
+
+	VSB_bcat(vsb, vpx1_sig, sizeof(vpx1_sig));
+
+	if (proto == PF_INET6)
+		VSB_cat(vsb, " TCP6 ");
+	else if (proto == PF_INET)
+		VSB_cat(vsb, " TCP4 ");
+	else
+		WRONG("Wrong proxy v1 proto");
+
+	VSB_printf(vsb, "%s %s %s %s\r\n", cip, sip, cport, sport);
+
+	AZ(VSB_finish(vsb));
+}
+
 void
 VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 {
 	struct vsb *vsb, *vsb2;
-	const char *p1, *p2;
 	struct suckaddr *sac, *sas;
 	char ha[VTCP_ADDRBUFSIZE];
 	char pa[VTCP_PORTBUFSIZE];
@@ -627,17 +652,11 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	assert(proto == PF_INET6 || proto == PF_INET);
 
 	if (version == 1) {
-		VSB_bcat(vsb, vpx1_sig, sizeof(vpx1_sig));
-		p1 = SES_Get_String_Attr(sp, SA_CLIENT_IP);
-		AN(p1);
-		p2 = SES_Get_String_Attr(sp, SA_CLIENT_PORT);
-		AN(p2);
 		VTCP_name(sas, ha, sizeof ha, pa, sizeof pa);
-		if (proto == PF_INET6)
-			VSB_cat(vsb, " TCP6 ");
-		else if (proto == PF_INET)
-			VSB_cat(vsb, " TCP4 ");
-		VSB_printf(vsb, "%s %s %s %s\r\n", p1, ha, p2, pa);
+		vpx_format_proxy_v1(vsb, proto,
+		    SES_Get_String_Attr(sp, SA_CLIENT_IP),
+		    SES_Get_String_Attr(sp, SA_CLIENT_PORT),
+		    ha, pa);
 	} else if (version == 2) {
 		AZ(SES_Get_client_addr(sp, &sac));
 		AN(sac);
@@ -657,11 +676,12 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 		vpx_enc_addr(vsb, proto, sas);
 		vpx_enc_port(vsb, sac);
 		vpx_enc_port(vsb, sas);
+		AZ(VSB_finish(vsb));
 	} else
 		WRONG("Wrong proxy version");
 
-	AZ(VSB_finish(vsb));
-	(void)VSB_tofile(fd, vsb);	// XXX: Error handling ?
+	(void)write(fd, VSB_data(vsb), VSB_len(vsb));
+
 	if (!DO_DEBUG(DBG_PROTOCOL)) {
 		VSB_delete(vsb);
 		return;

--- a/bin/varnishtest/tests/o00003.vtc
+++ b/bin/varnishtest/tests/o00003.vtc
@@ -1,4 +1,4 @@
-varnishtest "VCL backend side access to IP#s"
+varnishtest "VCL backend side access to IP#s and debug.proxy_header"
 
 server s1 {
 	rxreq
@@ -6,11 +6,20 @@ server s1 {
 } -start
 
 varnish v1 -proto PROXY -vcl+backend {
+	import vtc;
+	import blob;
+
 	sub vcl_backend_response {
 		set beresp.http.li = local.ip;
 		set beresp.http.ri = remote.ip;
 		set beresp.http.ci = client.ip;
 		set beresp.http.si = server.ip;
+
+		set beresp.http.proxy1 = blob.encode(blob=blob.sub(
+		    vtc.proxy_header(v1, client.ip, server.ip), 36B));
+		set beresp.http.proxy2 = blob.encode(encoding=HEX,
+		    blob=vtc.proxy_header(v2, client.ip, server.ip,
+			"vtc.varnish-cache.org"));
 	}
 } -start
 
@@ -20,4 +29,6 @@ client c1 -proxy1 "1.2.3.4:1111 5.6.7.8:5678" {
 	expect resp.http.li == ${v1_addr}
 	expect resp.http.ci == 1.2.3.4
 	expect resp.http.si == 5.6.7.8
+	expect resp.http.proxy1 == "PROXY TCP4 1.2.3.4 5.6.7.8 1111 5678"
+	expect resp.http.proxy2 == "0d0a0d0a000d0a515549540a2111002401020304050607080457162e0200157674632e7661726e6973682d63616368652e6f7267"
 } -run

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -57,6 +57,7 @@
  *	VRT_HashStrands32() added
  *	VRT_l_resp_body() changed
  *	VRT_l_beresp_body() changed
+ *	VRT_Format_Proxy() added	// transitional interface
  * 10.0 (2019-09-15)
  *	VRT_UpperLowerStrands added.
  *	VRT_synth_page now takes STRANDS argument
@@ -76,7 +77,6 @@
  *	VRT_Stv_*() functions renamed to VRT_stevedore_*()
  *	[cache.h] WS_ReserveAll() added
  *	[cache.h] WS_Reserve(ws, 0) deprecated
- *	VRT_Fortmat_Proxy() added
  * 9.0 (2019-03-15)
  *	Make 'len' in vmod_priv 'long'
  *	HTTP_Copy() removed
@@ -550,7 +550,8 @@ void VRT_DelDirector(VCL_BACKEND *);
 
 /* Suckaddr related */
 int VRT_VSA_GetPtr(VRT_CTX, VCL_IP sua, const unsigned char ** dst);
-void VRT_Format_Proxy(struct vsb *, VCL_INT, VCL_IP, VCL_IP);
+/* transitional interface */
+void VRT_Format_Proxy(struct vsb *, VCL_INT, VCL_IP, VCL_IP, VCL_STRING);
 
 typedef int vmod_event_f(VRT_CTX, struct vmod_priv *, enum vcl_event_e);
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -76,6 +76,7 @@
  *	VRT_Stv_*() functions renamed to VRT_stevedore_*()
  *	[cache.h] WS_ReserveAll() added
  *	[cache.h] WS_Reserve(ws, 0) deprecated
+ *	VRT_Fortmat_Proxy() added
  * 9.0 (2019-03-15)
  *	Make 'len' in vmod_priv 'long'
  *	HTTP_Copy() removed
@@ -549,6 +550,7 @@ void VRT_DelDirector(VCL_BACKEND *);
 
 /* Suckaddr related */
 int VRT_VSA_GetPtr(VRT_CTX, VCL_IP sua, const unsigned char ** dst);
+void VRT_Format_Proxy(struct vsb *, VCL_INT, VCL_IP, VCL_IP);
 
 typedef int vmod_event_f(VRT_CTX, struct vmod_priv *, enum vcl_event_e);
 

--- a/lib/libvmod_vtc/vmod.vcc
+++ b/lib/libvmod_vtc/vmod.vcc
@@ -155,6 +155,18 @@ Returns the size in bytes of a collection of C-datatypes:
 
 This can be useful for VMOD authors in conjunction with workspace operations.
 
+$Function BLOB proxy_header(ENUM {v1,v2} version,
+    IP client, IP server, STRING authority=0)
+
+Format a proxy header of the given version ``v1`` or ``v2`` and
+addresses (The VCL IP type also conatins the port number).
+
+Optionally also send an authority TLV with version ``v2`` (ignored for
+version ``v1``).
+
+Candidate for moving into vmod_proxy, but there were concerns about
+the interface design
+
 SEE ALSO
 ========
 


### PR DESCRIPTION
the use case is to send proxy headers from backend vmod code