### PR TITLE
Tolerate null IP addresses for ACL matches

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -82,6 +82,10 @@ VRT_acl_match(VRT_CTX, VCL_ACL acl, VCL_IP ip)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(acl, VRT_ACL_MAGIC);
+	if (ip == NULL) {
+		VRT_fail(ctx, "Cannot match a null IP address");
+		return (0);
+	}
 	assert(VSA_Sane(ip));
 	return (acl->match(ctx, ip));
 }

--- a/bin/varnishtest/tests/r01504.vtc
+++ b/bin/varnishtest/tests/r01504.vtc
@@ -1,10 +1,26 @@
-varnishtest "unreferenced acls"
+varnishtest "unreferenced or null acls"
 
 varnish v1 -arg "-p vcc_err_unref=off" -vcl {
+	import vtc;
 	backend s1 {
-		.host = "127.0.0.1";
+		.host = "${bad_backend}";
 	}
 	acl foo {
 		"127.0.0.1";
 	}
-}
+	acl bar {
+		"127.0.0.1";
+	}
+	sub vcl_recv {
+		if (vtc.no_ip() ~ bar) {
+			return (synth(200));
+		}
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+	expect resp.body ~ "VCL failed"
+} -run

--- a/lib/libvmod_vtc/vmod.vcc
+++ b/lib/libvmod_vtc/vmod.vcc
@@ -66,6 +66,10 @@ $Function STEVEDORE no_stevedore()
 
 Fails at storage selection.
 
+$Function IP no_ip()
+
+Returns a null IP address, not even a bogo_ip.
+
 $Function VOID panic(STRING_LIST)
 
 It can be useful to crash the child process in order to test the robustness

--- a/lib/libvmod_vtc/vmod_vtc.c
+++ b/lib/libvmod_vtc/vmod_vtc.c
@@ -88,6 +88,14 @@ vmod_no_stevedore(VRT_CTX)
 	return (NULL);
 }
 
+VCL_IP v_matchproto_(td_vtc_no_ip)
+vmod_no_ip(VRT_CTX)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	return (NULL);
+}
+
 /*--------------------------------------------------------------------*/
 
 VCL_VOID v_matchproto_(td_vtc_panic)


### PR DESCRIPTION
A vmod may return a null IP. This relaxes the check in `VRT_acl_match` to
fail the transaction instead of crashing.

Refs #2842