### PR TITLE
"via" backends: dynamic backend connections via haproxy

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -35,15 +35,18 @@
 #include <stdlib.h>
 
 #include "cache_varnishd.h"
+#include "cache_director.h"
 
 #include "vtcp.h"
 #include "vtim.h"
+#include "vsa.h"
 
 #include "cache_backend.h"
 #include "cache_tcp_pool.h"
 #include "cache_transport.h"
 #include "cache_vcl.h"
 #include "http1/cache_http1.h"
+#include "proxy/cache_proxy.h"
 
 #include "VSC_vbe.h"
 
@@ -170,11 +173,16 @@ vbe_dir_getfd(struct worker *wrk, struct backend *bp, struct busyobj *bo,
 	Lck_Unlock(&bp->mtx);
 
 	err = 0;
-	if (bp->proxy_header != 0)
+	if (bp->preamble) {
+		VSLb(bo->vsl, SLT_Debug, "preamble %s", VSB_data(bp->preamble));
+		err = write(*fdp, VSB_data(bp->preamble),
+		    VSB_len(bp->preamble));
+	}
+	if (err >= 0 && bp->proxy_header != 0)
 		err += VPX_Send_Proxy(*fdp, bp->proxy_header, bo->sp);
 	if (err < 0) {
 		VSLb(bo->vsl, SLT_FetchError,
-		     "backend %s: proxy write errno %d (%s)",
+		     "backend %s: preamble/proxy write errno %d (%s)",
 		     VRT_BACKEND_string(bp->director),
 		     errno, vstrerror(errno));
 		// account as if connect failed - good idea?
@@ -422,6 +430,9 @@ vbe_destroy(const struct director *d)
 	if (be->probe != NULL)
 		VBP_Remove(be);
 
+	if (be->preamble)
+		VSB_destroy(&be->preamble);
+
 	VSC_vbe_Destroy(&be->vsc_seg);
 	Lck_Lock(&backends_mtx);
 	if (be->cooled > 0)
@@ -510,11 +521,13 @@ VRT_backend_vsm_need(VRT_CTX)
 
 VCL_BACKEND v_matchproto_()
 VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
-    const struct vrt_backend *vrt)
+    const struct vrt_backend *vrt, VCL_BACKEND via)
 {
 	struct backend *be;
 	struct vcl *vcl;
 	const struct vrt_backend_probe *vbp;
+	const struct backend *viabe = NULL;
+	const struct suckaddr *sa = NULL;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(vrt, VRT_BACKEND_MAGIC);
@@ -524,6 +537,37 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 	else
 		assert(vrt->ipv4_suckaddr == NULL &&
 		    vrt->ipv6_suckaddr == NULL);
+
+	/*
+	 * director resolution could be moved to the time we make the actual
+	 * connection
+	 */
+
+	if (via)
+		via = VRT_DirectorResolve(ctx, via);
+	if (via && via->vdir->methods == vbe_methods) {
+		CAST_OBJ_NOTNULL(viabe, via->priv, BACKEND_MAGIC);
+		via = NULL;
+		// XXX error handling if via is not a backend?
+	}
+	if (viabe) {
+		/* decide on the address for the proxy header -
+		 * could be moved to connection time
+		 */
+		if (cache_param->prefer_ipv6 && vrt->ipv6_suckaddr)
+			sa = vrt->ipv6_suckaddr;
+		if (sa == NULL)
+			sa = vrt->ipv4_suckaddr;
+		if (sa == NULL)
+			sa = vrt->ipv6_suckaddr;
+		if (sa == NULL) {
+			// XXX err handling? via not supported
+			// with UDS
+			return (NULL);
+		}
+		// XXX sa is not necessarily de-duped, so
+		// pool-sharing may be sub-optimal
+	}
 
 	vcl = ctx->vcl;
 	AN(vcl);
@@ -544,8 +588,17 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 	    "%s.%s", VCL_Name(ctx->vcl), vrt->vcl_name);
 	AN(be->vsc);
 
-	be->tcp_pool = VTP_Ref(vrt->ipv4_suckaddr, vrt->ipv6_suckaddr,
-	    vrt->path, vbe_proto_ident);
+	if (viabe) {
+		AN(viabe->tcp_pool);
+		be->tcp_pool = VTP_Clone(viabe->tcp_pool, sa);
+		// XXX proxy v2 - using 1 for easy vtc ?
+		be->preamble = VSB_new_auto();
+		VPX_Format_Proxy(be->preamble, 1, bogo_ip, sa);
+		AN(be->preamble);
+	} else {
+		be->tcp_pool = VTP_Ref(vrt->ipv4_suckaddr, vrt->ipv6_suckaddr,
+		    vrt->path, vbe_proto_ident);
+	}
 	AN(be->tcp_pool);
 
 	vbp = vrt->probe;
@@ -588,9 +641,9 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 }
 
 VCL_BACKEND v_matchproto_()
-VRT_new_backend(VRT_CTX, const struct vrt_backend *vrt)
+VRT_new_backend(VRT_CTX, const struct vrt_backend *vrt, VCL_BACKEND via)
 {
-	return (VRT_new_backend_clustered(ctx, NULL, vrt));
+	return (VRT_new_backend_clustered(ctx, NULL, vrt, via));
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_backend.h
+++ b/bin/varnishd/cache/cache_backend.h
@@ -41,6 +41,7 @@ struct vbp_target;
 struct vrt_ctx;
 struct vrt_backend_probe;
 struct tcp_pool;
+struct vsb;
 
 /*--------------------------------------------------------------------
  * An instance of a backend from a VCL program.
@@ -67,6 +68,8 @@ struct backend {
 	VCL_BACKEND		director;
 
 	vtim_real		cooled;
+
+	struct vsb		*preamble;
 };
 
 /*---------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -276,12 +276,13 @@ vbp_write_proxy_v1(struct vbp_target *vt, int *sock)
 static void
 vbp_poke(struct vbp_target *vt)
 {
-	int s, tmo, i, proxy_header, err;
+	int s, tmo, i, err, proxy_header = -1;
 	vtim_real t_start, t_now, t_end;
 	unsigned rlen, resp;
 	char buf[8192], *p;
 	struct pollfd pfda[1], *pfd = pfda;
 	const struct suckaddr *sa;
+	const struct vsb *preamble = NULL;
 
 	t_start = t_now = VTIM_real();
 	t_end = t_start + vt->timeout;
@@ -317,10 +318,10 @@ vbp_poke(struct vbp_target *vt)
 	}
 
 	Lck_Lock(&vbp_mtx);
-	if (vt->backend != NULL)
+	if (vt->backend != NULL) {
 		proxy_header = vt->backend->proxy_header;
-	else
-		proxy_header = -1;
+		preamble = vt->backend->preamble;
+	}
 	Lck_Unlock(&vbp_mtx);
 
 	if (proxy_header < 0) {
@@ -328,6 +329,10 @@ vbp_poke(struct vbp_target *vt)
 		VTCP_close(&s);
 		return;
 	}
+
+	if (preamble && vbp_write(vt, &s, VSB_data(preamble),
+	    VSB_len(preamble)) != 0)
+		return;
 
 	/* Send the PROXY header */
 	assert(proxy_header <= 2);

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -78,28 +78,25 @@ VDI_Ahealth(const struct director *d)
 static VCL_BACKEND
 VDI_Resolve(VRT_CTX)
 {
-	const struct director *d;
-	const struct director *d2;
+	VCL_BACKEND d;
 	struct busyobj *bo;
 
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	bo = ctx->bo;
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
-	CHECK_OBJ_ORNULL(bo->director_req, DIRECTOR_MAGIC);
 
-	for (d = bo->director_req; d != NULL &&
-	    d->vdir->methods->resolve != NULL; d = d2) {
-		CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
-		AN(d->vdir);
-		d2 = d->vdir->methods->resolve(ctx, d);
-		if (d2 == NULL)
-			VSLb(bo->vsl, SLT_FetchError,
-			    "Director %s returned no backend", d->vcl_name);
-	}
-	CHECK_OBJ_ORNULL(d, DIRECTOR_MAGIC);
-	if (d == NULL)
+	if (bo->director_req == NULL) {
 		VSLb(bo->vsl, SLT_FetchError, "No backend");
-	else
-		AN(d->vdir);
+		return (NULL);
+	}
+
+	d = VRT_DirectorResolve(ctx, bo->director_req);
+	if (d == NULL) {
+		VSLb(bo->vsl, SLT_FetchError,
+		     "Director %s returned no backend",
+		     bo->director_req->vcl_name);
+		return (NULL);
+	}
 	return (d);
 }
 

--- a/bin/varnishd/cache/cache_tcp_pool.c
+++ b/bin/varnishd/cache/cache_tcp_pool.c
@@ -722,6 +722,17 @@ static const struct cp_methods vus_methods = {
 };
 
 /*--------------------------------------------------------------------
+ * Reference a (potentially new) clone of a pool with a different id
+ */
+struct tcp_pool *
+VTP_Clone(struct tcp_pool *tp, const void *id)
+{
+	AN(tp);
+	return (VTP_Ref(tp->ip4, tp->ip6, tp->uds, id));
+}
+
+
+/*--------------------------------------------------------------------
  * Reference a TCP pool given by {ip4, ip6} pair or a UDS.  Create if
  * it doesn't exist already.
  */

--- a/bin/varnishd/cache/cache_tcp_pool.h
+++ b/bin/varnishd/cache/cache_tcp_pool.h
@@ -52,6 +52,8 @@ void PFD_RemoteName(const struct pfd *, char *, unsigned, char *, unsigned);
 
 struct VSC_vbe;
 
+struct tcp_pool *VTP_Clone(struct tcp_pool *tp, const void *id);
+
 struct tcp_pool *VTP_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6,
     const char *uds, const void *id);
 	/*

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -75,7 +75,7 @@ void H2_PU_Sess(struct worker *, struct sess *, struct req *);
 void H2_OU_Sess(struct worker *, struct sess *, struct req *);
 
 const struct transport *XPORT_ByNumber(uint16_t no);
-void VPX_Send_Proxy(int fd, int version, const struct sess *);
+int VPX_Send_Proxy(int fd, int version, const struct sess *);
 
 /* cache_session.c */
 struct sess *SES_New(struct pool *);

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -43,6 +43,7 @@
 
 #include "common/heritage.h"
 #include "common/vsmw.h"
+#include "proxy/cache_proxy.h"
 
 const void * const vrt_magic_string_end = &vrt_magic_string_end;
 const void * const vrt_magic_string_unset = &vrt_magic_string_unset;
@@ -864,4 +865,10 @@ int
 VRT_VSA_GetPtr(const struct suckaddr *sua, const unsigned char ** dst)
 {
 	return (VSA_GetPtr(sua, dst));
+}
+
+void
+VRT_Format_Proxy(struct vsb *vsb, VCL_INT version, VCL_IP sac, VCL_IP sas)
+{
+	VPX_Format_Proxy(vsb, (int)version, sac, sas);
 }

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -264,6 +264,24 @@ VRT_DisableDirector(VCL_BACKEND d)
 /*--------------------------------------------------------------------*/
 
 VCL_BACKEND
+VRT_DirectorResolve(VRT_CTX, VCL_BACKEND d)
+{
+	VCL_BACKEND d2;
+
+	for (; d != NULL && d->vdir->methods->resolve != NULL; d = d2) {
+		CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+		AN(d->vdir);
+		d2 = d->vdir->methods->resolve(ctx, d);
+	}
+	CHECK_OBJ_ORNULL(d, DIRECTOR_MAGIC);
+	if (d != NULL)
+		AN(d->vdir);
+	return (d);
+}
+
+/*--------------------------------------------------------------------*/
+
+VCL_BACKEND
 VCL_DefaultDirector(const struct vcl *vcl)
 {
 

--- a/bin/varnishd/proxy/cache_proxy.h
+++ b/bin/varnishd/proxy/cache_proxy.h
@@ -39,3 +39,5 @@
 #define PP2_SUBTYPE_SSL_MAX     0x25
 
 int VPX_tlv(const struct req *req, int tlv, void **dst, int *len);
+void VPX_Format_Proxy(struct vsb *, int, const struct suckaddr *,
+    const struct suckaddr *);

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -614,15 +614,97 @@ vpx_enc_port(struct vsb *vsb, const struct suckaddr *s)
 	VSB_bcat(vsb, b, sizeof(b));
 }
 
+/* short path for stringified addresses from session attributes */
+static void
+vpx_format_proxy_v1(struct vsb *vsb, int proto,
+    const char *cip,  const char *cport,
+    const char *sip,  const char *sport)
+{
+	AN(vsb);
+	AN(cip);
+	AN(cport);
+	AN(sip);
+	AN(sport);
+
+	VSB_bcat(vsb, vpx1_sig, sizeof(vpx1_sig));
+
+	if (proto == PF_INET6)
+		VSB_printf(vsb, " TCP6 ");
+	else if (proto == PF_INET)
+		VSB_printf(vsb, " TCP4 ");
+	else
+		WRONG("Wrong proxy v1 proto");
+
+	VSB_printf(vsb, "%s %s %s %s\r\n", cip, sip, cport, sport);
+
+	AZ(VSB_finish(vsb));
+}
+
+static void
+vpx_format_proxy_v2(struct vsb *vsb, int proto,
+    const struct suckaddr *sac, const struct suckaddr *sas)
+{
+	AN(vsb);
+	AN(sac);
+	AN(sas);
+
+	VSB_bcat(vsb, vpx2_sig, sizeof(vpx2_sig));
+	VSB_putc(vsb, 0x21);
+	if (proto == PF_INET6) {
+		VSB_putc(vsb, 0x21);
+		VSB_putc(vsb, 0x00);
+		VSB_putc(vsb, 0x24);
+	} else if (proto == PF_INET) {
+		VSB_putc(vsb, 0x11);
+		VSB_putc(vsb, 0x00);
+		VSB_putc(vsb, 0x0c);
+	} else {
+		WRONG("Wrong proxy v2 proto");
+	}
+	vpx_enc_addr(vsb, proto, sac);
+	vpx_enc_addr(vsb, proto, sas);
+	vpx_enc_port(vsb, sac);
+	vpx_enc_port(vsb, sas);
+	AZ(VSB_finish(vsb));
+}
+
 void
+VPX_Format_Proxy(struct vsb *vsb, int version,
+    const struct suckaddr *sac, const struct suckaddr *sas)
+{
+	int proto;
+	char hac[VTCP_ADDRBUFSIZE];
+	char pac[VTCP_PORTBUFSIZE];
+	char has[VTCP_ADDRBUFSIZE];
+	char pas[VTCP_PORTBUFSIZE];
+
+	AN(vsb);
+	AN(sac);
+	AN(sas);
+
+	assert(version == 1 || version == 2);
+
+	proto = VSA_Get_Proto(sas);
+	assert(proto == VSA_Get_Proto(sac));
+
+	if (version == 1) {
+		VTCP_name(sac, hac, sizeof hac, pac, sizeof pac);
+		VTCP_name(sas, has, sizeof has, pas, sizeof pas);
+		vpx_format_proxy_v1(vsb, proto, hac, pac, has, pas);
+	} else if (version == 2) {
+		vpx_format_proxy_v2(vsb, proto, sac, sas);
+	} else
+		WRONG("Wrong proxy version");
+}
+
+int
 VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 {
 	struct vsb *vsb, *vsb2;
-	const char *p1, *p2;
 	struct suckaddr *sac, *sas;
 	char ha[VTCP_ADDRBUFSIZE];
 	char pa[VTCP_PORTBUFSIZE];
-	int proto;
+	int proto, r;
 
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 	assert(version == 1 || version == 2);
@@ -632,47 +714,24 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	AZ(SES_Get_server_addr(sp, &sas));
 	AN(sas);
 	proto = VSA_Get_Proto(sas);
-	assert(proto == PF_INET6 || proto == PF_INET);
 
 	if (version == 1) {
-		VSB_bcat(vsb, vpx1_sig, sizeof(vpx1_sig));
-		p1 = SES_Get_String_Attr(sp, SA_CLIENT_IP);
-		AN(p1);
-		p2 = SES_Get_String_Attr(sp, SA_CLIENT_PORT);
-		AN(p2);
 		VTCP_name(sas, ha, sizeof ha, pa, sizeof pa);
-		if (proto == PF_INET6)
-			VSB_printf(vsb, " TCP6 ");
-		else if (proto == PF_INET)
-			VSB_printf(vsb, " TCP4 ");
-		VSB_printf(vsb, "%s %s %s %s\r\n", p1, ha, p2, pa);
+		vpx_format_proxy_v1(vsb, proto,
+		    SES_Get_String_Attr(sp, SA_CLIENT_IP),
+		    SES_Get_String_Attr(sp, SA_CLIENT_PORT),
+		    ha, pa);
 	} else if (version == 2) {
 		AZ(SES_Get_client_addr(sp, &sac));
 		AN(sac);
-
-		VSB_bcat(vsb, vpx2_sig, sizeof(vpx2_sig));
-		VSB_putc(vsb, 0x21);
-		if (proto == PF_INET6) {
-			VSB_putc(vsb, 0x21);
-			VSB_putc(vsb, 0x00);
-			VSB_putc(vsb, 0x24);
-		} else if (proto == PF_INET) {
-			VSB_putc(vsb, 0x11);
-			VSB_putc(vsb, 0x00);
-			VSB_putc(vsb, 0x0c);
-		}
-		vpx_enc_addr(vsb, proto, sac);
-		vpx_enc_addr(vsb, proto, sas);
-		vpx_enc_port(vsb, sac);
-		vpx_enc_port(vsb, sas);
+		vpx_format_proxy_v2(vsb, proto, sac, sas);
 	} else
 		WRONG("Wrong proxy version");
 
-	AZ(VSB_finish(vsb));
-	(void)write(fd, VSB_data(vsb), VSB_len(vsb));
+	r = write(fd, VSB_data(vsb), VSB_len(vsb));
 	if (!DO_DEBUG(DBG_PROTOCOL)) {
 		VSB_delete(vsb);
-		return;
+		return (r);
 	}
 
 	vsb2 = VSB_new_auto();
@@ -683,4 +742,5 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	VSL(SLT_Debug, 999, "PROXY_HDR %s", VSB_data(vsb2));
 	VSB_delete(vsb);
 	VSB_delete(vsb2);
+	return (r);
 }

--- a/bin/varnishtest/tests/d00007.vtc
+++ b/bin/varnishtest/tests/d00007.vtc
@@ -7,29 +7,80 @@ server s1 {
 	accept
 	rxreq
 	txresp
+	close
+	accept
+	rxreq
+	txresp
+	close
+	accept
+	rxreq
+	txresp
 } -start
 
-varnish v1 -vcl {
+# the use case for via-proxy is to have a(n ha)proxy make a(n ssl)
+# connection on our behalf. For the purpose of testing, we use another
+# varnish in place - but we are behaving realistically in that we do
+# not use any prior information for the actual backend connection -
+# just the information from the proxy protocol
+
+varnish v2 -proto PROXY -vcl {
 	import debug;
+	import std;
 
 	backend dummy { .host = "${bad_backend}"; }
-
-	probe pr {}
 
 	sub vcl_init {
 		new s1 = debug.dyn("0.0.0.0", "0");
 	}
 
 	sub vcl_recv {
-		s1.refresh("${s1_addr}", "${s1_port}", pr);
+		s1.refresh(server.ip, std.port(server.ip));
+		set req.backend_hint = s1.backend();
+		return (pass);
+	}
+} -start
+
+#
+# we vtc.sleep to make sure that the health check is done and server
+# s1 has accepted again. We would rather want to use barriers, but
+# there is a (yet not understood) bug in varnishtest which prevents
+# the bX_sock marcros from being available in the second varnish
+# instance
+
+varnish v1 -vcl {
+	import debug;
+	import vtc;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	backend v2 { .host = "${v2_addr}"; .port = "${v2_port}"; }
+
+	probe pr { .interval = 1m; }
+
+	sub vcl_init {
+		new s1 = debug.dyn("0.0.0.0", "0");
+	}
+
+	sub vcl_recv {
+		if (req.url == "/1") {
+			s1.refresh("${s1_addr}", "${s1_port}", pr);
+			vtc.sleep(1s);
+		} else if (req.url == "/2") {
+			s1.refresh("${s1_addr}", "${s1_port}", pr,
+			    via=v2);
+			vtc.sleep(1s);
+		}
 		set req.backend_hint = s1.backend();
 	}
 } -start
 
-varnish v1 -expect MAIN.n_backend == 2
+varnish v1 -expect MAIN.n_backend == 3
 
 client c1 {
-	txreq
+	txreq -url /1
+	rxresp
+	expect resp.status == 200
+	txreq -url /2
 	rxresp
 	expect resp.status == 200
 } -run

--- a/bin/varnishtest/tests/o00003.vtc
+++ b/bin/varnishtest/tests/o00003.vtc
@@ -1,4 +1,4 @@
-varnishtest "VCL backend side access to IP#s"
+varnishtest "VCL backend side access to IP#s and proxy.header"
 
 server s1 {
 	rxreq
@@ -6,11 +6,17 @@ server s1 {
 } -start
 
 varnish v1 -proto PROXY -vcl+backend {
+	import proxy;
+	import blob;
+
 	sub vcl_backend_response {
 		set beresp.http.li = local.ip;
 		set beresp.http.ri = remote.ip;
 		set beresp.http.ci = client.ip;
 		set beresp.http.si = server.ip;
+
+		set beresp.http.proxy1 = blob.encode(blob=blob.sub(proxy.header(1, client.ip, server.ip), 36B));
+		set beresp.http.proxy2 = blob.encode(encoding=HEX, blob=proxy.header(2, client.ip, server.ip));
 	}
 } -start
 
@@ -20,4 +26,6 @@ client c1 -proxy1 "1.2.3.4:1111 5.6.7.8:5678" {
 	expect resp.http.li == ${v1_addr}
 	expect resp.http.ci == 1.2.3.4
 	expect resp.http.si == 5.6.7.8
+	expect resp.http.proxy1 == "PROXY TCP4 1.2.3.4 5.6.7.8 1111 5678"
+	expect resp.http.proxy2 == "0d0a0d0a000d0a515549540a2111000c01020304050607080457162e"
 } -run

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -508,6 +508,7 @@ VCL_BACKEND VRT_AddDirector(VRT_CTX, const struct vdi_methods *,
 void VRT_SetHealth(VCL_BACKEND d, int health);
 void VRT_DisableDirector(VCL_BACKEND);
 void VRT_DelDirector(VCL_BACKEND *);
+VCL_BACKEND VRT_DirectorResolve(VRT_CTX, VCL_BACKEND);
 
 /* Suckaddr related */
 int VRT_VSA_GetPtr(VCL_IP sua, const unsigned char ** dst);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -51,13 +51,13 @@
  * Whenever something is deleted or changed in a way which is not
  * binary/load-time compatible, increment MAJOR version
  *
- *
  * 9.0 (scheduled for 2019-03-15)
  *	HTTP_Copy() removed
  *	HTTP_Dup() added
  *	HTTP_Clone() added
  *	changed type of VCL_BLOB to newly introduced struct vrt_blob *
  *	changed VRT_blob()
+ *	VRT_Fortmat_Proxy() added
  * 8.0 (2018-09-15)
  *	VRT_Strands() added
  *	VRT_StrandsWS() added
@@ -512,6 +512,7 @@ VCL_BACKEND VRT_DirectorResolve(VRT_CTX, VCL_BACKEND);
 
 /* Suckaddr related */
 int VRT_VSA_GetPtr(VCL_IP sua, const unsigned char ** dst);
+void VRT_Format_Proxy(struct vsb *, VCL_INT, VCL_IP, VCL_IP);
 
 /* VMOD/Modules related */
 int VRT_Vmod_Init(VRT_CTX, struct vmod **hdl, unsigned nbr, void *ptr, int len,

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -453,9 +453,9 @@ VCL_VOID VRT_Rollback(VRT_CTX, VCL_HTTP);
 VCL_VOID VRT_synth_page(VRT_CTX, const char *, ...);
 
 /* Backend related */
-VCL_BACKEND VRT_new_backend(VRT_CTX, const struct vrt_backend *);
+VCL_BACKEND VRT_new_backend(VRT_CTX, const struct vrt_backend *, VCL_BACKEND);
 VCL_BACKEND VRT_new_backend_clustered(VRT_CTX,
-    struct vsmw_cluster *, const struct vrt_backend *);
+    struct vsmw_cluster *, const struct vrt_backend *, VCL_BACKEND);
 size_t VRT_backend_vsm_need(VRT_CTX);
 void VRT_delete_backend(VRT_CTX, VCL_BACKEND *);
 

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -498,7 +498,7 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	ifp = New_IniFin(tl);
 	VSB_printf(ifp->ini,
 	    "\t%s =\n\t    VRT_new_backend_clustered(ctx, vsc_cluster,\n"
-	    "\t\t&vgc_dir_priv_%s);",
+	    "\t\t&vgc_dir_priv_%s, NULL);",
 	    vgcname, vgcname);
 	VSB_printf(ifp->fin, "\t\tVRT_delete_backend(ctx, &%s);", vgcname);
 }

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -135,7 +135,7 @@ $Function BOOL fail2()
 
 Function to fail vcl code. Always returns true.
 
-$Object dyn(STRING addr, STRING port, PROBE probe=0)
+$Object dyn(STRING addr, STRING port, PROBE probe=0, BACKEND via=0)
 
 Dynamically create a single-backend director, addr and port must not be empty.
 
@@ -143,7 +143,7 @@ $Method BACKEND .backend()
 
 Return the dynamic backend.
 
-$Method VOID .refresh(STRING addr, STRING port, PROBE probe=0)
+$Method VOID .refresh(STRING addr, STRING port, PROBE probe=0, BACKEND via=0)
 
 Dynamically refresh & (always!) replace the backend by a new one.
 

--- a/lib/libvmod_debug/vmod_debug_dyn.c
+++ b/lib/libvmod_debug/vmod_debug_dyn.c
@@ -59,7 +59,7 @@ struct xyzzy_debug_dyn_uds {
 
 static void
 dyn_dir_init(VRT_CTX, struct xyzzy_debug_dyn *dyn,
-     VCL_STRING addr, VCL_STRING port, VCL_PROBE probe)
+    VCL_STRING addr, VCL_STRING port, VCL_PROBE probe, VCL_BACKEND via)
 {
 	struct addrinfo hints, *res = NULL;
 	struct suckaddr *sa;
@@ -69,6 +69,7 @@ dyn_dir_init(VRT_CTX, struct xyzzy_debug_dyn *dyn,
 	CHECK_OBJ_NOTNULL(dyn, VMOD_DEBUG_DYN_MAGIC);
 	XXXAN(addr);
 	XXXAN(port);
+	CHECK_OBJ_ORNULL(via, DIRECTOR_MAGIC);
 
 	INIT_OBJ(&vrt, VRT_BACKEND_MAGIC);
 	vrt.port = port;
@@ -95,7 +96,7 @@ dyn_dir_init(VRT_CTX, struct xyzzy_debug_dyn *dyn,
 
 	freeaddrinfo(res);
 
-	dir = VRT_new_backend(ctx, &vrt);
+	dir = VRT_new_backend(ctx, &vrt, via);
 	AN(dir);
 
 	/*
@@ -116,7 +117,8 @@ dyn_dir_init(VRT_CTX, struct xyzzy_debug_dyn *dyn,
 
 VCL_VOID
 xyzzy_dyn__init(VRT_CTX, struct xyzzy_debug_dyn **dynp,
-    const char *vcl_name, VCL_STRING addr, VCL_STRING port, VCL_PROBE probe)
+    const char *vcl_name, VCL_STRING addr, VCL_STRING port, VCL_PROBE probe,
+    VCL_BACKEND via)
 {
 	struct xyzzy_debug_dyn *dyn;
 
@@ -139,7 +141,7 @@ xyzzy_dyn__init(VRT_CTX, struct xyzzy_debug_dyn **dynp,
 
 	AZ(pthread_mutex_init(&dyn->mtx, NULL));
 
-	dyn_dir_init(ctx, dyn, addr, port, probe);
+	dyn_dir_init(ctx, dyn, addr, port, probe, via);
 	XXXAN(dyn->dir);
 	*dynp = dyn;
 }
@@ -172,11 +174,11 @@ xyzzy_dyn_backend(VRT_CTX, struct xyzzy_debug_dyn *dyn)
 
 VCL_VOID
 xyzzy_dyn_refresh(VRT_CTX, struct xyzzy_debug_dyn *dyn,
-    VCL_STRING addr, VCL_STRING port, VCL_PROBE probe)
+    VCL_STRING addr, VCL_STRING port, VCL_PROBE probe, VCL_BACKEND via)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(dyn, VMOD_DEBUG_DYN_MAGIC);
-	dyn_dir_init(ctx, dyn, addr, port, probe);
+	dyn_dir_init(ctx, dyn, addr, port, probe, via);
 }
 
 static int
@@ -211,7 +213,8 @@ dyn_uds_init(VRT_CTX, struct xyzzy_debug_dyn_uds *uds, VCL_STRING path)
 	vrt.ipv4_suckaddr = NULL;
 	vrt.ipv6_suckaddr = NULL;
 
-	if ((dir = VRT_new_backend(ctx, &vrt)) == NULL)
+	// we support via: uds -> ip, but not via: ip -> uds
+	if ((dir = VRT_new_backend(ctx, &vrt, NULL)) == NULL)
 		return (-1);
 
 	AZ(pthread_mutex_lock(&uds->mtx));

--- a/lib/libvmod_proxy/vmod.vcc
+++ b/lib/libvmod_proxy/vmod.vcc
@@ -1,8 +1,10 @@
 #-
 # Copyright (c) 2018 GANDI SAS
+# Copyright 2018 UPLEX - Nils Goroll Systemoptimierung
 # All rights reserved.
 #
-# Author: Emmanuel Hocdet <manu@gandi.net>
+# Authors: Emmanuel Hocdet <manu@gandi.net>
+#	   Nils Goroll <nils.goroll@uplex.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,6 +36,8 @@ DESCRIPTION
 `vmod_proxy` contains functions to extract proxy-protocol-v2 TLV attributes
 as described in https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt.
 
+It also allows for generating a proxy header (without the option to
+add TLV attributes for the time being).
 
 $Function STRING alpn()
 
@@ -117,6 +121,12 @@ Description
 	Extract the certificate key algorithm attribute.
 Example
 	set req.http.cert-key = proxy.cert_key();
+
+$Function BLOB header(INT version, IP client, IP server)
+
+Format a proxy header of the given version (must be 1 or 2) and
+addresses (The VCL IP type also conatins the port number).
+
 
 SEE ALSO
 ========

--- a/lib/libvmod_proxy/vmod_proxy.c
+++ b/lib/libvmod_proxy/vmod_proxy.c
@@ -1,8 +1,10 @@
 /*-
  * Copyright (c) 2018 GANDI SAS
+ * Copyright 2018 UPLEX - Nils Goroll Systemoptimierung
  * All rights reserved.
  *
- * Author: Emmanuel Hocdet <manu@gandi.net>
+ * Authors: Emmanuel Hocdet <manu@gandi.net>
+ *	    Nils Goroll <nils.goroll@uplex.de>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +37,7 @@
 #include "cache/cache.h"
 
 #include "vend.h"
+#include "vsb.h"
 
 #include "proxy/cache_proxy.h"
 
@@ -154,4 +157,38 @@ VCL_STRING v_matchproto_(td_proxy_client_cert_cn)
 vmod_client_cert_cn(VRT_CTX)
 {
 	return tlv_string(ctx, PP2_SUBTYPE_SSL_CN);
+}
+
+/*--------------------------------------------------------------------*/
+
+#define BLOB_VMOD_PROXY_HEADER_TYPE	0xc8f34f78
+
+VCL_BLOB v_matchproto_(td_proxy_header)
+vmod_header(VRT_CTX, VCL_INT version, VCL_IP client, VCL_IP server)
+{
+	struct vsb *vsb;
+	const void *h;
+	size_t l;
+
+	CHECK_OBJ_ORNULL(ctx, VRT_CTX_MAGIC);
+
+	if (version != 1 && version != 2) {
+		VRT_fail(ctx, "proxy.header: invalid version %ld", version);
+		return (NULL);
+	}
+
+	vsb = VSB_new_auto();
+	AN(vsb);
+	VRT_Format_Proxy(vsb, version, client, server);
+	l = VSB_len(vsb);
+	h = WS_Copy(ctx->ws, VSB_data(vsb), l);
+	VSB_delete(vsb);
+
+	if (h == NULL) {
+		VRT_fail(ctx, "proxy.header: out of workspace");
+		return (NULL);
+	}
+
+	return (VRT_blob(ctx, "proxy.header", h, l,
+	    BLOB_VMOD_PROXY_HEADER_TYPE));
 }


### PR DESCRIPTION
In varnish-cache, the deliberate decision has been made to not support TLS from the same address space as varnish itself, see https://github.com/varnishcache/varnish-cache/blob/master/doc/sphinx/phk/ssl_again.rst

So the obvious way to connect to TLS backends is to use a TLS"onloader" (a term coined by @slimhazard as in the opposite of "offloader"), which turns a clear connection into a TLS connection to some other fixed config address.
    
This requires additional configuration in two places: An address/port or UDS path needs to be uniquely allocated for the onloader, the specific onloader configuration has to be put in place and a varnish backend needs to be added to the onloader. All of this for each individual backend. Also, this requirement prevents any use of dynamic backends with a TLS onloader.
    
haproxy, however, offers a convenient and elegant way to avoid this configuration overhead: The PROXY protocol can also be used to transport the destination address which haproxy is to connect to if a server's address is unspecified (IN_ADDR_ANY / 0.0.0.0). The configuration template for this use case looks like this (huge thank you to @wtarreau for pointing out this great option in haproxy):

```
    listen clear-to-ssl
            bind /my/path/to/ssl_onloader accept-proxy
            balance roundrobin
            stick-table type ip size 100
            stick on dst
            server s0 0.0.0.0:443 ssl ca-file /etc/ssl/certs/ca-bundle.crt
            server s1 0.0.0.0:443 ssl ca-file /etc/ssl/certs/ca-bundle.crt
            server s2 0.0.0.0:443 ssl ca-file /etc/ssl/certs/ca-bundle.crt
            # .. approximately as many servers as expected peers
            # for improved tls session caching
```

With this setup, by connecting to `/my/path/to/ssl_onloader` and sending the address to make a TLS connection to in a PROXY header (as the server address / port), we can reduce the configuration overhead outside varnish substantially. In particular, we do not require a path / port per destination and get back the option to use dynamic backends.
    
This patch, which has yet to undergo final polishing if reviewed positively, implements the basis for simple means of configuring such an ssl onloader:
    
backends can be created with an additional "via" director, which has to resolve to a simple backend. The connection is then made to that address and the actual endpoint address is sent in an additional PROXY header.  Notice that sending yet another proxy header to the actual backend is unaffected. Despite using the same format, the two proxy headers are semantically different: The first, here coined the "preamble", is the address to make the connection to while the (optional) second proxy header continues to contain the addresses of the connection to varnish.
    
This patch is based upon two other PRs:
    
* #2845 for generic proxy header formatting
* #2680 for resolving a director
    
Again, I do not consider this PR final. There are lots of other options to implement the same functionality, but this one is the most direct one I could come up with so far.
    
Reviews and comments are highly appreciated.
