### PR TITLE
Reduce locking in HSH_Lookup

### DIFF
--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -1012,7 +1012,6 @@ HSH_DerefObjHead(struct worker *wrk, struct objhead **poh)
 		hsh_rush2(wrk, &rush);
 		Lck_Lock(&oh->mtx);
 	}
-	Lck_Unlock(&oh->mtx);
 
 	assert(oh->refcnt > 0);
 	return (hash->deref(wrk, oh));

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -983,7 +983,6 @@ HSH_DerefObjHead(struct worker *wrk, struct objhead **poh)
 {
 	struct objhead *oh;
 	struct rush rush;
-	int r;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	TAKE_OBJ_NOTNULL(oh, poh, OBJHEAD_MAGIC);
@@ -1016,10 +1015,7 @@ HSH_DerefObjHead(struct worker *wrk, struct objhead **poh)
 	Lck_Unlock(&oh->mtx);
 
 	assert(oh->refcnt > 0);
-	r = hash->deref(oh);
-	if (!r)
-		HSH_DeleteObjHead(wrk, oh);
-	return (r);
+	return (hash->deref(wrk, oh));
 }
 
 void

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -459,10 +459,11 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 					oc->hits++;
 				retval = HSH_HIT;
 			}
-			Lck_Unlock(&oh->mtx);
 			*ocp = oc;
 			if (*bocp == NULL)
-				assert(hsh_deref_objhead(wrk, &oh));
+				AN(hsh_deref_objhead_unlock(wrk, &oh));
+			else
+				Lck_Unlock(&oh->mtx);
 
 			switch (retval) {
 			case HSH_HITPASS:
@@ -539,12 +540,10 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 		assert(oh->refcnt > 1);
 		assert(exp_oc->objhead == oh);
 		exp_oc->refcnt++;
-		Lck_Unlock(&oh->mtx);
 		*ocp = exp_oc;
-
-		assert(hsh_deref_objhead(wrk, &oh));
 		if (exp_oc->hits < LONG_MAX)
 			exp_oc->hits++;
+		AN(hsh_deref_objhead_unlock(wrk, &oh));
 		return (HSH_GRACE);
 	}
 

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -76,7 +76,7 @@ static struct objhead *private_oh;
 static void hsh_rush1(const struct worker *, struct objhead *,
     struct rush *, int);
 static void hsh_rush2(struct worker *, struct rush *);
-static int HSH_DerefObjHead(struct worker *wrk, struct objhead **poh);
+static int hsh_deref_objhead(struct worker *wrk, struct objhead **poh);
 
 /*---------------------------------------------------------------------*/
 
@@ -461,7 +461,7 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 			Lck_Unlock(&oh->mtx);
 			*ocp = oc;
 			if (*bocp == NULL)
-				assert(HSH_DerefObjHead(wrk, &oh));
+				assert(hsh_deref_objhead(wrk, &oh));
 
 			switch (retval) {
 			case HSH_HITPASS:
@@ -541,7 +541,7 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp,
 		Lck_Unlock(&oh->mtx);
 		*ocp = exp_oc;
 
-		assert(HSH_DerefObjHead(wrk, &oh));
+		assert(hsh_deref_objhead(wrk, &oh));
 		if (exp_oc->hits < LONG_MAX)
 			exp_oc->hits++;
 		return (HSH_GRACE);
@@ -974,12 +974,12 @@ HSH_DerefObjCore(struct worker *wrk, struct objcore **ocp, int rushmax)
 
 	/* Drop our ref on the objhead */
 	assert(oh->refcnt > 0);
-	(void)HSH_DerefObjHead(wrk, &oh);
+	(void)hsh_deref_objhead(wrk, &oh);
 	return (0);
 }
 
 static int
-HSH_DerefObjHead(struct worker *wrk, struct objhead **poh)
+hsh_deref_objhead(struct worker *wrk, struct objhead **poh)
 {
 	struct objhead *oh;
 	struct rush rush;

--- a/bin/varnishd/hash/hash_classic.c
+++ b/bin/varnishd/hash/hash_classic.c
@@ -172,7 +172,7 @@ hcl_lookup(struct worker *wrk, const void *digest, struct objhead **noh)
  */
 
 static int v_matchproto_(hash_deref_f)
-hcl_deref(struct objhead *oh)
+hcl_deref(struct worker *wrk, struct objhead *oh)
 {
 	struct hcl_hd *hp;
 	int ret;
@@ -187,6 +187,8 @@ hcl_deref(struct objhead *oh)
 	} else
 		ret = 1;
 	Lck_Unlock(&hp->mtx);
+	if (!ret)
+		HSH_DeleteObjHead(wrk, oh);
 	return (ret);
 }
 

--- a/bin/varnishd/hash/hash_classic.c
+++ b/bin/varnishd/hash/hash_classic.c
@@ -178,6 +178,9 @@ hcl_deref(struct worker *wrk, struct objhead *oh)
 	int ret;
 
 	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
+	Lck_AssertHeld(&oh->mtx);
+	Lck_Unlock(&oh->mtx);
+
 	CAST_OBJ_NOTNULL(hp, oh->hoh_head, HCL_HEAD_MAGIC);
 	assert(oh->refcnt > 0);
 	Lck_Lock(&hp->mtx);

--- a/bin/varnishd/hash/hash_critbit.c
+++ b/bin/varnishd/hash/hash_critbit.c
@@ -347,13 +347,15 @@ hcb_start(void)
 }
 
 static int v_matchproto_(hash_deref_f)
-hcb_deref(struct objhead *oh)
+hcb_deref(struct worker *wrk, struct objhead *oh)
 {
+	int r;
 
+	(void)wrk;
 	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
 	Lck_Lock(&oh->mtx);
 	assert(oh->refcnt > 0);
-	oh->refcnt--;
+	r = --oh->refcnt;
 	if (oh->refcnt == 0) {
 		Lck_Lock(&hcb_mtx);
 		hcb_delete(&hcb_root, oh);
@@ -364,7 +366,7 @@ hcb_deref(struct objhead *oh)
 #ifdef PHK
 	fprintf(stderr, "hcb_defef %d %d <%s>\n", __LINE__, r, oh->hash);
 #endif
-	return (1);
+	return (r);
 }
 
 static struct objhead * v_matchproto_(hash_lookup_f)

--- a/bin/varnishd/hash/hash_critbit.c
+++ b/bin/varnishd/hash/hash_critbit.c
@@ -353,7 +353,7 @@ hcb_deref(struct worker *wrk, struct objhead *oh)
 
 	(void)wrk;
 	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
-	Lck_Lock(&oh->mtx);
+	Lck_AssertHeld(&oh->mtx);
 	assert(oh->refcnt > 0);
 	r = --oh->refcnt;
 	if (oh->refcnt == 0) {

--- a/bin/varnishd/hash/hash_simple_list.c
+++ b/bin/varnishd/hash/hash_simple_list.c
@@ -112,6 +112,10 @@ hsl_deref(struct worker *wrk, struct objhead *oh)
 {
 	int ret;
 
+	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
+	Lck_AssertHeld(&oh->mtx);
+	Lck_Unlock(&oh->mtx);
+
 	Lck_Lock(&hsl_mtx);
 	if (--oh->refcnt == 0) {
 		VTAILQ_REMOVE(&hsl_head, oh, hoh_list);

--- a/bin/varnishd/hash/hash_simple_list.c
+++ b/bin/varnishd/hash/hash_simple_list.c
@@ -108,7 +108,7 @@ hsl_lookup(struct worker *wrk, const void *digest, struct objhead **noh)
  */
 
 static int v_matchproto_(hash_deref_f)
-hsl_deref(struct objhead *oh)
+hsl_deref(struct worker *wrk, struct objhead *oh)
 {
 	int ret;
 
@@ -119,6 +119,8 @@ hsl_deref(struct objhead *oh)
 	} else
 		ret = 1;
 	Lck_Unlock(&hsl_mtx);
+	if (!ret)
+		HSH_DeleteObjHead(wrk, oh);
 	return (ret);
 }
 

--- a/bin/varnishd/hash/hash_slinger.h
+++ b/bin/varnishd/hash/hash_slinger.h
@@ -36,7 +36,7 @@ typedef void hash_start_f(void);
 typedef void hash_prep_f(struct worker *);
 typedef struct objhead *hash_lookup_f(struct worker *, const void *digest,
     struct objhead **);
-typedef int hash_deref_f(struct objhead *);
+typedef int hash_deref_f(struct worker *, struct objhead *);
 
 struct hash_slinger {
 	unsigned		magic;


### PR DESCRIPTION
This patch set reduces the number of times the objhead mutex needs to be acquired for many types of passes through HSH_Lookup(), including the simple cache hit. It does this by changing the functions to deref objhead to take an already locked objhead as input, and then unlocking it as part of the operation. This saves the need to take the lock again during deref.

This change will likely give a measurable performance increase for caches seeing a large number of hits to the same object.