### PR TITLE
Add a catflap to control HSH_Lookup from within the object iteration

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -286,7 +286,7 @@ struct worker {
  * the init setter
  *
  * multiple flaps need to be handled by the flaps: Any flap allowing additional
- * flap must leave the callbacks and cat as if the next flap was the only one.
+ * flap must prepare the cat for the next flap and call it
  */
 
 union cat {

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -272,6 +272,25 @@ struct worker {
 	unsigned		handling;
 };
 
+/*--------------------------------------------------------------------
+ * catflap: control over HSH_Lookup
+ */
+
+enum catflap_e {
+	FLP_CONTINUE,
+	FLP_DEFAULT,
+	FLP_MISS,
+	FLP_HIT
+};
+
+typedef enum catflap_e catflap_f(const struct req *req,
+    struct objcore *oc, void **privp);
+
+typedef struct objcore * catflap_fini_f(struct objcore *oc, void **privp);
+
+typedef void catflap_init_f(struct req *req,
+    catflap_f **flap, catflap_fini_f **fini, void **privp);
+
 /* Stored object -----------------------------------------------------
  * This is just to encapsulate the fields owned by the stevedore
  */
@@ -530,6 +549,7 @@ struct req {
 	struct acct_req		acct;
 
 	struct vrt_privs	privs[1];
+	catflap_init_f		*catflap_init;
 };
 
 #define IS_TOPREQ(req) ((req)->topreq == (req))

--- a/bin/varnishd/hash/hash_slinger.h
+++ b/bin/varnishd/hash/hash_slinger.h
@@ -51,6 +51,8 @@ struct hash_slinger {
 
 enum lookup_e {
 	HSH_CONTINUE,
+	HSH_DEFAULT,
+	// ^^ catflap only
 	HSH_MISS,
 	HSH_BUSY,
 	HSH_HIT,

--- a/bin/varnishtest/tests/m00051.vtc
+++ b/bin/varnishtest/tests/m00051.vtc
@@ -1,0 +1,54 @@
+varnishtest "catflap"
+
+varnish v1 -vcl {
+	import debug;
+
+	backend dummy { .host = "${bad_backend}"; }
+
+	sub vcl_recv {
+		if (req.http.id) {
+			debug.catflap(miss);
+		} else if (req.http.get == "first") {
+			debug.catflap(first);
+		} else if (req.http.get == "last") {
+			debug.catflap(last);
+		} else {
+			return (fail);
+		}
+		return (hash);
+	}
+
+	sub vcl_backend_error {
+		if (! bereq.http.id) {
+			return (deliver);
+		}
+		set beresp.status = 200;
+		set beresp.ttl = 1s;
+		set beresp.grace = 1m;
+		set beresp.http.id = bereq.http.id;
+	}
+} -start
+
+client c1 {
+	txreq -hdr "id: 1"
+	rxresp
+	expect resp.status == 200
+	txreq -hdr "id: 2"
+	rxresp
+	expect resp.status == 200
+	txreq -hdr "id: 3"
+	rxresp
+	expect resp.status == 200
+
+	# the first object is the one which went into cache last
+
+	txreq -hdr "get: first"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.id == "3"
+
+	txreq -hdr "get: last"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.id == "1"
+} -run

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -229,3 +229,14 @@ $Method STRING .meth_opt(PRIV_CALL, PRIV_VCL, PRIV_TASK,
 Test object method with all the fancy stuff.
 
 $Function STRANDS return_strands(STRANDS strand)
+
+$Function VOID catflap(ENUM {miss, first, last} type)
+
+Test the hash lookup catflap:
+
+* miss = provoke a miss (just like hash_always_miss, but in the
+  catflap
+
+* first = return the first object as a hit (if any), irrespective of the ttl
+
+* last = return the last object as a hit (if any)

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -636,98 +636,104 @@ xyzzy_return_strands(VRT_CTX, VCL_STRANDS strand)
  */
 
 static enum catflap_e v_matchproto_(catflap_f)
-catflap_miss(const struct req *req, struct objcore *oc, void **catp)
+catflap_miss(const struct req *req, struct objcore *oc,
+    struct objcore **exp_oc, union cat *cat)
 {
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
-	AN(catp);
-	AZ(*catp);
+	(void) exp_oc;
+	AN(cat);
+	AZ(cat->ptr);
 
 	return (FLP_MISS);
 }
 
 static enum catflap_e v_matchproto_(catflap_f)
-catflap_hit(const struct req *req, struct objcore *oc, void **catp)
+catflap_hit(const struct req *req, struct objcore *oc,
+    struct objcore **exp_oc, union cat *cat)
 {
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
-	AN(catp);
-	AZ(*catp);
+	(void) exp_oc;
+	AN(cat);
+	AZ(cat->ptr);
 
 	return (FLP_HIT);
 }
 
 static enum catflap_e v_matchproto_(catflap_f)
-catflap_save(const struct req *req, struct objcore *oc, void **catp)
+catflap_save(const struct req *req, struct objcore *oc,
+    struct objcore **exp_oc, union cat *cat)
 {
-	struct objcore **cat;
+	struct objcore **ocp;
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
-	AN(catp);
-	AN(*catp);
-	cat = *catp;
-	*cat = oc;
+	(void) exp_oc;
+	AN(cat);
+	AN(cat->ptr);
+	ocp = cat->ptr;
+	*ocp = oc;
 
 	return (FLP_CONTINUE);
 }
 
 static struct objcore * v_matchproto_(catflap_fini_f)
-catflap_recall(struct objcore *oc, void **catp)
+catflap_recall(struct objcore *oc, struct objcore **exp_oc, union cat *cat)
 {
-	struct objcore **cat;
+	struct objcore **ocp;
 
 	AZ(oc);
-	AN(catp);
-	AN(*catp);
+	(void) exp_oc;
+	AN(cat);
+	AN(cat->ptr);
 
-	cat = *catp;
-	CAST_OBJ(oc, *cat, OBJCORE_MAGIC);
-	*catp = NULL;
+	ocp = cat->ptr;
+	CAST_OBJ(oc, *ocp, OBJCORE_MAGIC);
 	return (oc);
 }
 
 static void v_matchproto_(catflap_init_f)
 catflap_init_miss(struct req *req,
-    catflap_f **flap, catflap_fini_f **fini, void **catp)
+    catflap_f **flap, catflap_fini_f **fini, union cat *cat)
 {
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	AN(flap);
 	AN(fini);
-	AN(catp);
+	AN(cat);
 
 	*flap = catflap_miss;
 	AZ(*fini);
-	AZ(*catp);
+	AZ(cat->ptr);
 }
 
 static void v_matchproto_(catflap_init_f)
 catflap_init_first(struct req *req,
-    catflap_f **flap, catflap_fini_f **fini, void **catp)
+    catflap_f **flap, catflap_fini_f **fini, union cat *cat)
 {
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	AN(flap);
 	AN(fini);
-	AN(catp);
+	AN(cat);
 
 	*flap = catflap_hit;
 	AZ(*fini);
-	AZ(*catp);
+	AZ(cat->ptr);
 }
 
 static void v_matchproto_(catflap_init_f)
 catflap_init_last(struct req *req,
-    catflap_f **flap, catflap_fini_f **fini, void **catp)
+    catflap_f **flap, catflap_fini_f **fini, union cat *cat)
 {
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	AN(flap);
 	AN(fini);
-	AN(catp);
+	AN(cat);
 
 	// intentionally overly complicated to demo ws alloc
 	// XXX in the real world, this might be reserve + release
-	*catp = WS_Alloc(req->wrk->aws, sizeof(struct objcore *));
-	AN(*catp);
+	cat->ptr = WS_Alloc(req->wrk->aws, sizeof(struct objcore *));
+	AN(cat->ptr);
 	*flap = catflap_save;
 	*fini = catflap_recall;
 }


### PR DESCRIPTION
If non-`NULL`, `req->catflap_init` is called before the cache lookup. It may set a `catflap_f` callback to be called for objcores and a `catflap_fini_f` to be called after the objcore iterator loop finishes.

A `catflap_f` may return any of `enum catflap_e`: `FLP_CONTINUE` to continue the loop (and get to look at the next object, if any), `FLP_DEFAULT` to fall through to the built-in default handling, `FLP_MISS` to force a miss or `FLP_HIT` to consider the objcore a hit.

A `catflap_fini_f`, if present, gets a final say on the object beauty contest. For example, a `catflap_f` may have saved the most beautiful object in the private pointer, but the decision is only final after all objects were considered. The return value of `catflap_fini_f` is either the object to be hit, or `NULL` to force a cache miss. The remaining decision on the details (e.g. if it was a `HITMISS` or `HITPASS`) happens as before.

An `oc == NULL` argument to `catflap_fini_f` signals that the catflap had been called on all objects, otherwise the iteration was terminated early.

Catflap chaining has deliberately been left out of the core implementation. vmods wishing to chain catflaps can still do so (by calling `req->catflap_init` and deploying a custom cat which knows how to
operate additional catflaps).