### PR TITLE
Allow now to be used in vcl_init

### DIFF
--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -43,6 +43,7 @@
 #include "cache_director.h"
 #include "cache_vcl.h"
 #include "vcli_serve.h"
+#include "vtim.h"
 
 const char * const VCL_TEMP_INIT = "init";
 const char * const VCL_TEMP_COLD = "cold";
@@ -118,6 +119,7 @@ vcl_get_ctx(unsigned method, int msg)
 	handling_cli = 0;
 	ctx_cli.handling = &handling_cli;
 	ctx_cli.method = method;
+	ctx_cli.now = VTIM_real();
 	if (msg) {
 		ctx_cli.msg = VSB_new_auto();
 		AN(ctx_cli.msg);


### PR DESCRIPTION
So I noticed that the following VCL:

```vcl
sub vcl_init {
	std.log("NOW: " + now);
}
```

Produces: `NOW: Thu, 01 Jan 1970 00:00:00 GMT`

This is due to `ctx->now` not being initialized. This PR initializes it.

Now you get: `NOW: Fri, 07 Dec 2018 01:57:06 GMT`

I didn't bother with a VTC, seems pretty straight forward.