### PR TITLE
Add bytes() and bytes2string() to vmod std

### DIFF
--- a/bin/varnishtest/tests/m00051.vtc
+++ b/bin/varnishtest/tests/m00051.vtc
@@ -1,0 +1,140 @@
+varnishtest "Test std.bytes"
+
+server s1 -repeat 30 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_deliver {
+		set resp.http.converted = std.bytes(req.http.bytes, 11B);
+	}
+
+} -start
+
+client c1 {
+
+	txreq
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: "
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: 1"
+	rxresp
+	expect resp.http.converted == "1.000"
+
+	txreq -hdr "bytes: 0MB"
+	rxresp
+	expect resp.http.converted == "0.000"
+
+	txreq -hdr "bytes: 0.MB"
+	rxresp
+	expect resp.http.converted == "0.000"
+
+	txreq -hdr "bytes: 0.0MB"
+	rxresp
+	expect resp.http.converted == "0.000"
+
+	txreq -hdr "bytes: 1MB"
+	rxresp
+	expect resp.http.converted == "1048576.000"
+
+	txreq -hdr "bytes: 123456"
+	rxresp
+	expect resp.http.converted == "123456.000"
+
+	txreq -hdr "bytes: 666B"
+	rxresp
+	expect resp.http.converted == "666.000"
+
+	txreq -hdr "bytes: TB"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: 1234"
+	rxresp
+	expect resp.http.converted == "1234.000"
+
+	txreq -hdr "bytes: abcd"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: 10.B"
+	rxresp
+	expect resp.http.converted == "10.000"
+
+	txreq -hdr "bytes: 10."
+	rxresp
+	expect resp.http.converted == "10.000"
+
+	txreq -hdr "bytes: .1GB"
+	rxresp
+	expect resp.http.converted == "107374182.000"
+
+	txreq -hdr "bytes: 0.1GB"
+	rxresp
+	expect resp.http.converted == "107374182.000"
+
+	txreq -hdr "bytes: 0.1GB0"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: 0.1GBB"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: 0.1gb"
+	rxresp
+	expect resp.http.converted == "107374182.000"
+
+	txreq -hdr "bytes: 0.1 GB"
+	rxresp
+	expect resp.http.converted == "107374182.000"
+
+	txreq -hdr "bytes: 0.1PB"
+	rxresp
+	expect resp.http.converted == "112589990684262.000"
+
+	txreq -hdr "bytes: 1.1111GB"
+	rxresp
+	expect resp.http.converted == "1193034541.000"
+
+	txreq -hdr "bytes: 1.1.1GB"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: .1GBa"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: .1GB1"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: a.1GB"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: 1E10B"
+	rxresp
+	expect resp.http.converted == "10000000000.000"
+
+	txreq -hdr "bytes: ##"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+	txreq -hdr "bytes: 00000001KB"
+	rxresp
+	expect resp.http.converted == "1024.000"
+
+	txreq -hdr "bytes: 100.00%"
+	rxresp
+	expect resp.http.converted == "11.000"
+
+} -run
+

--- a/bin/varnishtest/tests/m00052.vtc
+++ b/bin/varnishtest/tests/m00052.vtc
@@ -1,0 +1,84 @@
+varnishtest "Test std.bytes2string"
+
+server s1 -repeat 13 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+	
+	sub vcl_deliver {
+		if (req.http.unit == "PB") {
+			set resp.http.out = std.bytes2string(std.bytes(req.http.in, 0B), unit = PB);
+		} else if (req.http.unit == "TB") {
+			set resp.http.out = std.bytes2string(std.bytes(req.http.in, 0B), unit = TB);
+		} else if (req.http.unit == "GB") {
+			set resp.http.out = std.bytes2string(std.bytes(req.http.in, 0B), unit = GB);
+		} else if (req.http.unit == "MB") {
+			set resp.http.out = std.bytes2string(std.bytes(req.http.in, 0B), unit = MB);
+		} else if (req.http.unit == "KB") {
+			set resp.http.out = std.bytes2string(std.bytes(req.http.in, 0B), unit = KB);
+		} else {
+			set resp.http.out = std.bytes2string(std.bytes(req.http.in, 0B), unit = B);
+		}
+	}
+
+} -start
+
+client c1 {
+
+	txreq -hdr "in: 1B" -hdr "unit: PB"
+	rxresp
+	expect resp.http.out == "0.0000000000000008881784197001PB"
+
+	txreq -hdr "in: 0.0000000000000008881784197001PB" -hdr "unit: B"
+	rxresp
+	expect resp.http.out == "1B"
+
+	txreq -hdr "in: 1B" -hdr "unit: TB"
+	rxresp
+	expect resp.http.out == "0.0000000000009094947017729282TB"
+
+	txreq -hdr "in: 0.0000000000009094947017729282TB" -hdr "unit: B"
+	rxresp
+	expect resp.http.out == "1B"
+
+	txreq -hdr "in: 1B" -hdr "unit: GB"
+	rxresp
+	expect resp.http.out == "0.0000000009313225746154785156GB"
+
+	txreq -hdr "in: 0.0000000009313225746154785156GB" -hdr "unit: B"
+	rxresp
+	expect resp.http.out == "1B"
+
+	txreq -hdr "in: 1KB" -hdr "unit: B"
+	rxresp
+	expect resp.http.out == "1024B"
+
+	txreq -hdr "in: 1024B" -hdr "unit: KB"
+	rxresp
+	expect resp.http.out == "1KB"
+
+	txreq -hdr "in: 5KB" -hdr "unit: GB"
+	rxresp
+	expect resp.http.out == "0.00000476837158203125GB"
+
+	txreq -hdr "in: 0.00000476837158203125GB" -hdr "unit: KB"
+	rxresp
+	expect resp.http.out == "5KB"
+
+	txreq -hdr "in: 4000GB" -hdr "unit: TB"
+	rxresp
+	expect resp.http.out == "3.90625TB" 
+
+	txreq -hdr "in: 3.90625TB" -hdr "unit: KB"
+	rxresp
+	expect resp.http.out == "4194304000KB"
+
+	txreq -hdr "in: 12345678910B" -hdr "unit: KB"
+	rxresp
+	expect resp.http.out == "12056327.060546875KB"
+
+} -run
+

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -144,6 +144,24 @@ Examples
 	| std.collect(req.http.accept);
 	| std.collect(req.http.cookie, "; ");
 
+$Function BYTES bytes(STRING b, BYTES fallback)
+
+	Description
+		Converts the string *b* to bytes. *b* must be quantified
+		with B (bytes), MB (megabytes), KB (kilobytes), GB (gigabytes) or
+		TB (terabytes), PB (petabytes) units. If conversion fails, *fallback*
+		will be returned.
+	Example
+		| std.cache_req_body(std.bytes(req.http.stored_size, 1MB));
+
+$Function STRING bytes2string(BYTES b, ENUM {B, KB, MB, GB, TB, PB} unit = "B")
+
+	Description
+		Converts the bytes *b* to string. *unit* determines the unit the
+		converted string should be.
+	Example
+		| set req.http.size = std.bytes2string(10000KB, GB);
+
 $Function DURATION duration(STRING s, DURATION fallback)
 
 Description


### PR DESCRIPTION
I ran into a use case where I needed to store bytes in a string (i.e `3MB`) to convert to `BYTES` and pass it to `cache_req_body()` later on in the VCL. This was needed because `std.integer()` would throw an error when passing to `cache_req_body()` about using the wrong data type. For consistency's sake, I added the inverse function `bytes2string()`.

The API is as follows:
```
BYTES bytes(STRING b, BYTES fallback)
bytes2string(BYTES b, ENUM {B, KB, MB, GB, TB, PB} unit = "B")
```
`bytes()` utilizes `VNUM_2bytes()` to parse the string and return the converted string in bytes.

While `bytes2string()` takes in a BYTES and a type. The ENUM of types is taken from the possible values that can be parsed in `VNUM_2bytes()`. This function cannot fail without a hard failure in the bytes conversion, so no fallback is needed. The goal of this function is to be the inverse of `bytes()`.

I thought these functions were useful and might be worth adding to VMOD std.