### PR TITLE
Initialize ESIs from the correct header set

### DIFF
--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -141,7 +141,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 	req->top = preq->top;
 
 	HTTP_Setup(req->http, req->ws, req->vsl, SLT_ReqMethod);
-	HTTP_Copy(req->http, preq->http);
+	HTTP_Copy(req->http, preq->http0);
 
 	http_SetH(req->http, HTTP_HDR_URL, src);
 	if (host != NULL && *host != '\0')  {

--- a/bin/varnishtest/tests/e00003.vtc
+++ b/bin/varnishtest/tests/e00003.vtc
@@ -3,6 +3,7 @@ varnishtest "ESI include"
 
 server s1 {
 	rxreq
+	expect req.http.esi0 == "foo"
 	txresp -body {
 		<html>
 		Before include
@@ -12,6 +13,7 @@ server s1 {
 	}
 	rxreq
 	expect req.url == "/body1"
+	expect req.http.esi0 != "foo"
 	txresp -body {
 		Included file
 	}
@@ -21,6 +23,8 @@ varnish v1 -vcl+backend {
 	sub vcl_recv {
 		if (req.esi_level > 0) {
 			set req.url = req.url + req.esi_level;
+		} else {
+			set req.http.esi0 = "foo";
 		}
 	}
 	sub vcl_backend_response {


### PR DESCRIPTION
Ensure ESI children are set up from preq->http0.

This broke in 2c59afe22ba108c7f2ab5ff75b2e30baf4ef9ec7