### PR TITLE
Add a -j switch to varnishlog to output JSON

### DIFF
--- a/bin/varnishlog/varnishlog.c
+++ b/bin/varnishlog/varnishlog.c
@@ -58,6 +58,7 @@ static struct log {
 	/* Options */
 	int		a_opt;
 	int		A_opt;
+	int		j_opt;
 	char		*w_arg;
 
 	/* State */
@@ -125,6 +126,10 @@ main(int argc, char * const *argv)
 		case 'h':
 			/* Usage help */
 			VUT_Usage(vut, &vopt_spec, 0);
+		case 'j':
+			/* JSON output */
+			LOG.j_opt = 1;
+			break;
 		case 'w':
 			/* Write to file */
 			REPLACE(LOG.w_arg, optarg);
@@ -142,7 +147,9 @@ main(int argc, char * const *argv)
 		VUT_Error(vut, 1, "Missing -w option");
 
 	/* Setup output */
-	if (LOG.A_opt || !LOG.w_arg)
+	if (LOG.j_opt)
+		vut->dispatch_f = VSL_PrintJSONTransactions;
+	else if (LOG.A_opt || !LOG.w_arg)
 		vut->dispatch_f = VSL_PrintTransactions;
 	else
 		vut->dispatch_f = VSL_WriteTransactions;

--- a/bin/varnishlog/varnishlog_options.h
+++ b/bin/varnishlog/varnishlog_options.h
@@ -42,6 +42,11 @@
 	    " data in ascii format."					\
 	)
 
+#define LOG_OPT_j							\
+	VOPT("j", "[-j]", "LDJSON output",				\
+	    "Print each record block as a JSON object"			\
+	)
+
 #define LOG_OPT_w							\
 	VOPT("w:", "[-w <filename>]", "Output filename",		\
 	    "Redirect output to file. The file will be overwritten"	\
@@ -63,6 +68,7 @@ VUT_GLOBAL_OPT_D
 VUT_OPT_g
 VUT_OPT_h
 VSL_OPT_i
+LOG_OPT_j
 VSL_OPT_I
 VUT_OPT_k
 VSL_OPT_L

--- a/include/vapi/vsl.h
+++ b/include/vapi/vsl.h
@@ -439,6 +439,19 @@ VSLQ_dispatch_f VSL_PrintTransactions;
 	 *    !=0:	Return value from either VSL_Next or VSL_Print
 	 */
 
+VSLQ_dispatch_f VSL_PrintJSONTransactions;
+	/* Prints the array ptrans as one JSON object, on one line.
+	 *
+	 * Arguments:
+	 *   vsl: The VSL_data context
+	 *    cp: A NULL-terminated array of VSL_cursor pointers
+	 *    fo: A FILE* pointer, stdout if NULL
+	 *
+	 * Return values:
+	 *	0:	OK
+	 *    !=0:	Return value from either VSL_Next or VSL_Print
+	 */
+
 FILE *VSL_WriteOpen(struct VSL_data *vsl, const char *name, int append,
 		    int unbuffered);
 	/*

--- a/lib/libvarnishapi/libvarnishapi.map
+++ b/lib/libvarnishapi/libvarnishapi.map
@@ -89,6 +89,7 @@ LIBVARNISHAPI_2.0 {
 		VSL_Next;
 		VSL_Print;
 		VSL_PrintAll;
+		VSL_PrintJSONTransactions;
 		VSL_PrintTerse;
 		VSL_PrintTransactions;
 		VSL_ResetCursor;


### PR DESCRIPTION
This presents each record block as line-delimited JSON, placing a `links` array at the end of the object to store the linked transactions.

Here's a relatively complete session example:
- unformatted: https://pastebin.varnish-software.com/550d9de7ceb6d1eeced3ac2404191da70cab12148c623ab0f052ae68d366471c
- prettified: https://pastebin.varnish-software.com/1729e7e8c02554f204b1116af9d4dafb18d85144632869b2b0abb5d47542b834

And here's a raw record:

```
{ "id": 6774245, "type": "Record", "records": [ { "tag": "Begin", "value": "req 6386031 rxreq" } ] }
```

```
{
  "id": 6774245,
  "type": "Record",
  "records": [
    {
      "tag": "Begin",
      "value": "req 6386031 rxreq"
    }
  ]
}
```

Two main questions here:
- ~~should `-j` be used as it's technically not JSON but LDJSON (even though, in a streaming context, pure JSON doesn't really make sense)?~~
- we could push the data into a VSB for a performance boost, should we?