### PR TITLE
 Make Backend_health fields work in VSL queries

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -508,7 +508,7 @@ vca_accept_task(struct worker *wrk, void *arg)
 				    lport, VTCP_PORTBUFSIZE);
 			}
 
-			VSL(SLT_SessError, 0, "%s %s %s %d %d %s",
+			VSL(SLT_SessError, 0, "%s %s %s %d %d \"%s\"",
 			    wa.acceptlsock->name, laddr, lport,
 			    ls->sock, i, vstrerror(i));
 			(void)Pool_TrySumstat(wrk);

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -181,7 +181,7 @@ VBP_Update_Backend(struct vbp_target *vt)
 	vt->backend->sick = i;
 
 	AN(dir->vcl_name);
-	VSL(SLT_Backend_health, 0, "%s %s %s %s %u %u %u %.6f %.6f %s",
+	VSL(SLT_Backend_health, 0, "%s %s %s %s %u %u %u %.6f %.6f \"%s\"",
 	    dir->vcl_name, chg ? "Went" : "Still",
 	    i ? "sick" : "healthy", bits,
 	    vt->good, vt->threshold, vt->window,

--- a/bin/varnishtest/tests/r02872.vtc
+++ b/bin/varnishtest/tests/r02872.vtc
@@ -1,8 +1,16 @@
 varnishtest "VSL quoted fields"
 
+server s1 {
+        rxreq
+        txresp
+} -start
+
 varnish v1 -vcl {
 	import std;
-        backend be none;
+        backend be {
+                .host = "${s1_sock}";
+                .probe = { .interval = 1m; }
+        }
 	sub vcl_recv {
 		# a series of 3-fields log records
 		std.log({"  custom   log     "ok" "});
@@ -23,4 +31,11 @@ client c1 {
 # records with malformed fields don't show up
 shell -expect "2" {
         varnishlog -d -n ${v1_name} -g raw -q 'VCL_Log[3]' | wc -l
+}
+
+server s1 -wait
+
+shell -expect "Went healthy" {
+        varnishlog -d -n ${v1_name} -g raw \
+		-q 'Backend_health[10] eq "HTTP/1.1 200 OK"'
 }

--- a/bin/varnishtest/tests/r02872.vtc
+++ b/bin/varnishtest/tests/r02872.vtc
@@ -39,3 +39,8 @@ shell -expect "Went healthy" {
         varnishlog -d -n ${v1_name} -g raw \
 		-q 'Backend_health[10] eq "HTTP/1.1 200 OK"'
 }
+
+# s1 starts sick before the first probe request is made
+shell -expect "Went sick" {
+        varnishlog -d -n ${v1_name} -g raw -q 'Backend_health[10] eq ""'
+}

--- a/bin/varnishtest/tests/r02872.vtc
+++ b/bin/varnishtest/tests/r02872.vtc
@@ -1,0 +1,26 @@
+varnishtest "VSL quoted fields"
+
+varnish v1 -vcl {
+	import std;
+        backend be none;
+	sub vcl_recv {
+		# a series of 3-fields log records
+		std.log({"  custom   log     "ok" "});
+		std.log({" "valid"  "fields"  ok "});
+		std.log({" "missing""blank"   ko "});
+		std.log({"  missing  dquote  "ko "});
+		# "
+		return (synth(200));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+# records with malformed fields don't show up
+shell -expect "2" {
+        varnishlog -d -n ${v1_name} -g raw -q 'VCL_Log[3]' | wc -l
+}

--- a/include/tbl/vsl_tags.h
+++ b/include/tbl/vsl_tags.h
@@ -191,7 +191,7 @@ SLTM(Length, 0, "Size of object body",
 
 SLTM(FetchError, 0, "Error while fetching object",
 	"Logs the error message of a failed fetch operation.\n\n"
-	"Error messages should be self-explanatory, yet the http connection"
+	"Error messages should be self-explanatory, yet the http connection\n"
 	"(HTC) class of errors is reported with these symbols:\n\n"
 	"\t* junk (-5): Received unexpected data\n"
 	"\t* close (-4): Connection closed\n"
@@ -272,11 +272,11 @@ SLTM(TTL, 0, "TTL set on object",
 SLTM(Fetch_Body, 0, "Body fetched from backend",
 	"Ready to fetch body from backend.\n\n"
 	"The format is::\n\n"
-	"\t%d (%s) %s\n"
-	"\t|   |    |\n"
-	"\t|   |    +---- 'stream' or '-'\n"
-	"\t|   +--------- Text description of body fetch mode\n"
-	"\t+------------- Body fetch mode\n"
+	"\t%d %s %s\n"
+	"\t|  |  |\n"
+	"\t|  |  +---- 'stream' or '-'\n"
+	"\t|  +------- Text description of body fetch mode\n"
+	"\t+---------- Body fetch mode\n"
 	"\n"
 )
 

--- a/include/tbl/vsl_tags.h
+++ b/include/tbl/vsl_tags.h
@@ -51,9 +51,9 @@
  * kept for now for VSL binary compatibility
  */
 #define NOSUP_NOTICE \
-    "\tNOTE: This tag is currently not in use in the Varnish log.\n" \
-    "\tIt is mentioned here to document legacy versions of the log,\n" \
-    "\tor reserved for possible use in future versions.\n\n"
+    "NOTE: This tag is currently not in use in the Varnish log.\n" \
+    "It is mentioned here to document legacy versions of the log,\n" \
+    "or reserved for possible use in future versions.\n\n"
 
 SLTM(Debug, SLT_F_UNSAFE, "Debug messages",
 	"Debug messages can normally be ignored, but are sometimes"

--- a/include/tbl/vsl_tags_http.h
+++ b/include/tbl/vsl_tags_http.h
@@ -43,6 +43,11 @@
  *
  */
 
+#define HEADER_NOTICE \
+    "NOTE: HTTP header fields are free form records and not strictly\n" \
+    "made of 2 fields. Accessing a specific header with the prefix\n" \
+    "notation helps treating the header value as a single string.\n\n"
+
 /*lint -save -e525 -e539 -e835 */
 
 SLTH(Method,	HTTP_HDR_METHOD,	1, 0, "method",
@@ -73,6 +78,7 @@ SLTH(Header,	HTTP_HDR_FIRST,		1, 1, "header",
 	"\t|   +- Header value\n"
 	"\t+----- Header name\n"
 	"\n"
+	HEADER_NOTICE
 )
 
 SLTH(Unset,	HTTP_HDR_UNSET,		0, 0, "unset header",
@@ -83,12 +89,14 @@ SLTH(Unset,	HTTP_HDR_UNSET,		0, 0, "unset header",
 	"\t|   +- Header value\n"
 	"\t+----- Header name\n"
 	"\n"
+	HEADER_NOTICE
 )
 
 SLTH(Lost,	HTTP_HDR_LOST,		0, 0, "lost header",
 	""
 )
 
+#undef HEADER_NOTICE
 #undef SLTH
 
 /*lint -restore */


### PR DESCRIPTION
This is just a quick proof of concept. The VSL query code relies too much on asserts and maybe we should add a negative return value to `vslq_test_rec` to gracefully recover from malformed fields and print an error when we encounter one.

I ran into this use case:

```
varnishtest "Backend_health fields"

server s1 {
        rxreq
        txresp
} -start

varnish v1 -vcl {
        backend s1 {
                .host = "${s1_sock}";
                .probe = {
                        .interval = 1m;
                }
        }
} -start

server s1 -wait

shell -expect "HTTP/1.1 200 OK" {
        varnishlog -d -n ${v1_name} -g raw -q 'Backend_health[2] ~ healthy'
}
```

I will update this change based on review feedback.