### PR TITLE
Relaxed UDS backend restrictions

### DIFF
--- a/bin/varnishtest/tests/c00086.vtc
+++ b/bin/varnishtest/tests/c00086.vtc
@@ -1,4 +1,4 @@
-varnishtest "-a sub-args user, group and mode"
+varnishtest "-a sub-args user, group and mode; and warn if stat(EACCES) fails for UDS"
 
 feature user_vcache
 feature group_varnish
@@ -51,3 +51,14 @@ shell -match "vcache" { ls -l ${tmpdir}/v6.sock }
 varnish v7 -arg "-a ${tmpdir}/v7.sock,group=varnish" -vcl+backend {}
 
 shell -match "root.+varnish" { ls -l ${tmpdir}/v7.sock }
+
+# VCC warns, but does not fail, if stat(UDS) fails with EACCES.
+shell { mkdir ${tmpdir}/dir }
+server s2 -listen ${tmpdir}/dir/s1.sock {} -start
+
+shell { chmod go-rx ${tmpdir}/dir }
+
+varnish v8 -arg "-j unix,user=vcache" -vcl { backend b {.host="${bad_ip}";} }
+
+varnish v8 -cliexpect "(?s)Cannot stat:.+That was just a warning" \
+	{vcl.inline test "vcl 4.1; backend b {.path=\"${tmpdir}/dir/s1.sock\";}"}

--- a/bin/varnishtest/tests/v00038.vtc
+++ b/bin/varnishtest/tests/v00038.vtc
@@ -123,16 +123,39 @@ varnish v1 -errvcl "Must be an absolute path:" {
 	}
 }
 
-shell { rm -f ${tmpdir}/foo }
-
-varnish v1 -errvcl "Cannot stat:" {
-	backend b1 {
-		.path = "${tmpdir}/foo";
-	}
-}
-
 varnish v1 -errvcl "Not a socket:" {
 	backend b1 {
 		.path = "${tmpdir}";
 	}
 }
+
+# VCC warns, but does not fail, if stat(UDS) fails with ENOENT.
+shell { rm -f ${tmpdir}/foo }
+
+varnish v1 -vcl { backend b {.host="${bad_ip}";} }
+
+varnish v1 -cliexpect "(?s)Cannot stat:.+That was just a warning" \
+	{vcl.inline test "vcl 4.1; backend b {.path=\"${tmpdir}/foo\";}"}
+
+# VCC also warns but doesn't fail for EACCES. Tested in c00086.vtc.
+
+# The following test verifies that Varnish continues connecting to a
+# socket file, even if the listener at that location changes.
+
+server s1 -listen "${tmpdir}/server.sock" {
+	rxreq
+	txresp -hdr "Connection: close" -hdr "Cache-Control: max-age=0"
+} -start
+
+varnish v1 -vcl {
+	backend b {.path = "${s1_sock}"; }
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+server s1 -start
+
+client c1 -run

--- a/doc/sphinx/reference/vcl.rst
+++ b/doc/sphinx/reference/vcl.rst
@@ -233,9 +233,17 @@ parameters. The following attributes are available:
     is declared.
 
   ``.path``	(``VCL >= 4.1``)
+
     The absolute path of a Unix domain socket at which a backend is
-    listening. The file at that path must exist and must be accessible
-    to Varnish at VCL load time, and it must be a socket. One of
+    listening. If the file at that path does not exist or is not
+    accessible to Varnish at VCL load time, then the VCL compiler
+    issues a warning, but does not fail. This makes it possible to
+    start the UDS-listening peer, or set the socket file's
+    permissions, after starting Varnish or loading VCL with a UDS
+    backend.  But the socket file must exist and have necessary
+    permissions before the first connection is attempted, otherwise
+    fetches will fail. If the file does exist and is accessible, then
+    it must be a socket; otherwise the VCL load fails. One of
     ``.path`` or ``.host`` must be declared (but not both). ``.path``
     may only be used in VCL since version 4.1.
 

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -276,12 +276,16 @@ Emit_UDS_Path(struct vcc *tl, const struct token *t_path, const char *errid)
 	}
 	errno = 0;
 	if (stat(t_path->dec, &st) != 0) {
+		int err = errno;
 		VSB_printf(tl->sb, "%s: Cannot stat: %s\n", errid,
 			   strerror(errno));
 		vcc_ErrWhere(tl, t_path);
-		return;
-	}
-	if (!S_ISSOCK(st.st_mode)) {
+		if (err == ENOENT || err == EACCES) {
+			VSB_printf(tl->sb, "(That was just a warning)\n");
+			tl->err = 0;
+		} else
+			return;
+	} else if (!S_ISSOCK(st.st_mode)) {
 		VSB_printf(tl->sb, "%s: Not a socket:\n", errid);
 		vcc_ErrWhere(tl, t_path);
 		return;


### PR DESCRIPTION
VCC issues a warning, but does not fail, if stat(UDS backend) fails with ENOENT or EACCES.

This makes it possible to start the UDS-listening peer, or set the socket file's permissions, after starting Varnish or loading VCL with a UDS backend.

If the file at the specified path does exist and is accessible, then it must be a socket, otherwise the VCL load fails.

Closes #2884 