### PR TITLE
centralize definition of backend.list fields width

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -465,7 +465,8 @@ vbe_list(VRT_CTX, const struct director *d, struct vsb *vsb, int vflag,
 	else if (vflag | pflag)
 		return;
 	else
-		VSB_printf(vsb, "%-10s", d->sick ? "sick" : "healthy");
+		VSB_printf(vsb, "%-*s", VDI_LIST_W_PROBE,
+		    d->sick ? "sick" : "healthy");
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -515,7 +515,7 @@ void
 VBP_Status(struct vsb *vsb, const struct backend *be, int details, int json)
 {
 	struct vbp_target *vt;
-	char buf[12];
+	char buf[VDI_LIST_W_PROBE + 2];
 
 	CHECK_OBJ_NOTNULL(be, BACKEND_MAGIC);
 	vt = be->probe;
@@ -527,7 +527,7 @@ VBP_Status(struct vsb *vsb, const struct backend *be, int details, int json)
 		if (json)
 			VSB_printf(vsb, "\"%s\"", buf);
 		else
-			VSB_printf(vsb, "%-10s", buf);
+			VSB_printf(vsb, "%-*s", VDI_LIST_W_PROBE, buf);
 		return;
 	}
 

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -301,12 +301,14 @@ do_list(struct cli *cli, struct director *d, void *priv)
 	ctx = VCL_Get_CliCtx(0,0);
 
 	// XXX admin health "probe" for the no-probe case is confusing
-	VCLI_Out(cli, "\n%-30s %-7s ", d->vdir->cli_name, VDI_Ahealth(d));
+	VCLI_Out(cli, "\n%-*s %-*s ",
+	     VDI_LIST_W_NAME, d->vdir->cli_name,
+	     VDI_LIST_W_ADMIN, VDI_Ahealth(d));
 
 	if (d->vdir->methods->list != NULL)
 		d->vdir->methods->list(ctx, d, cli->sb, 0, 0, 0);
 	else
-		VCLI_Out(cli, "%-10s", cli_health(ctx, d));
+		VCLI_Out(cli, "%-*s", VDI_LIST_W_PROBE, cli_health(ctx, d));
 
 	VTIM_format(d->vdir->health_changed, time_str);
 	VCLI_Out(cli, " %s", time_str);
@@ -402,8 +404,11 @@ cli_backend_list(struct cli *cli, const char * const *av, void *priv)
 		VCLI_Out(cli, "}");
 		VCLI_JSON_end(cli);
 	} else {
-		VCLI_Out(cli, "%-30s %-7s %-10s %s",
-		    "Backend name", "Admin", "Probe", "Last change");
+		VCLI_Out(cli, "%-*s %-*s %-*s %s",
+		    VDI_LIST_W_NAME, "Backend name",
+		    VDI_LIST_W_ADMIN, "Admin",
+		    VDI_LIST_W_PROBE, "Probe",
+		    "Last change");
 		(void)VCL_IterDirector(cli, av[i], do_list, la);
 	}
 }

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -496,6 +496,11 @@ struct vdi_methods {
 	vdi_list_f			*list;
 };
 
+/* width of fields in "backend.list" */
+#define VDI_LIST_W_NAME	30
+#define VDI_LIST_W_ADMIN	 7
+#define VDI_LIST_W_PROBE	10
+
 struct vcldir;
 
 struct director {


### PR DESCRIPTION
Yes, this is fugly, yet formatting of the backend.list output
is spread all over the place (including vmods via the vdi_list_f
callback), so until we decide it is worth spending time on separating
formatting from content, I see no other option than making the
field widths known to all vrt.