### PR TITLE
bring "more nuance" (quote phk) to backend.list output for directors

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -524,10 +524,10 @@ VBP_Status(struct vsb *vsb, const struct backend *be, int details, int json)
 		if (json)
 			VSB_printf(vsb, "[%u, %u, \"%s\"]",
 			    vt->good, vt->window,
-			    vt->backend->director->sick ? "bad" : "good");
+			    vt->backend->director->sick ? "sick" : "healthy");
 		else
 			VSB_printf(vsb, "%u/%u %s", vt->good, vt->window,
-			    vt->backend->director->sick ? "bad" : "good");
+			    vt->backend->director->sick ? "sick" : "healthy");
 		return;
 	}
 

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -229,6 +229,26 @@ VRT_Healthy(VRT_CTX, VCL_BACKEND d, VCL_TIME *changed)
 	return (d->vdir->methods->healthy(ctx, d, changed));
 }
 
+/*--------------------------------------------------------------------
+ * Update health_changed. This is for load balancing directors
+ * to update their health_changed time based on their backends.
+ */
+VCL_VOID
+VRT_SetChanged(VRT_CTX, VCL_BACKEND d, VCL_TIME changed)
+{
+	(void)ctx;
+
+	if (d == NULL)
+		return;
+
+	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+
+	if (changed <= d->vdir->health_changed)
+		return;
+
+	d->vdir->health_changed = changed;
+}
+
 /* Send Event ----------------------------------------------------------
  */
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -63,6 +63,7 @@
  *	    use: AZ(ObjGetU64(req->wrk, req->body_oc, OA_LEN, &u));
  *	struct vdi_methods .list callback signature changed
  *	VRT_LookupDirector() added
+ *	VRT_SetChanged() added
  * 8.0 (2018-09-15)
  *	VRT_Strands() added
  *	VRT_StrandsWS() added
@@ -524,6 +525,7 @@ struct director {
 };
 
 VCL_BOOL VRT_Healthy(VRT_CTX, VCL_BACKEND, VCL_TIME *);
+VCL_VOID VRT_SetChanged(VRT_CTX, VCL_BACKEND, VCL_TIME);
 VCL_BACKEND VRT_AddDirector(VRT_CTX, const struct vdi_methods *,
     void *, const char *, ...) v_printflike_(4, 5);
 void VRT_SetHealth(VCL_BACKEND d, int health);

--- a/lib/libvmod_directors/round_robin.c
+++ b/lib/libvmod_directors/round_robin.c
@@ -44,7 +44,7 @@ struct vmod_directors_round_robin {
 	unsigned				nxt;
 };
 
-static VCL_BOOL v_matchproto_(vdi_healthy)
+static VCL_BOOL v_matchproto_(vdi_healthy_f)
 vmod_rr_healthy(VRT_CTX, VCL_BACKEND dir, VCL_TIME *changed)
 {
 	struct vmod_directors_round_robin *rr;
@@ -53,6 +53,17 @@ vmod_rr_healthy(VRT_CTX, VCL_BACKEND dir, VCL_TIME *changed)
 	CHECK_OBJ_NOTNULL(dir, DIRECTOR_MAGIC);
 	CAST_OBJ_NOTNULL(rr, dir->priv, VMOD_DIRECTORS_ROUND_ROBIN_MAGIC);
 	return (vdir_any_healthy(ctx, rr->vd, changed));
+}
+
+static void v_matchproto_(vdi_list_f)
+vmod_rr_list(VRT_CTX, VCL_BACKEND dir, struct vsb *vsb, int pflag, int jflag)
+{
+	struct vmod_directors_round_robin *rr;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(dir, DIRECTOR_MAGIC);
+	CAST_OBJ_NOTNULL(rr, dir->priv, VMOD_DIRECTORS_ROUND_ROBIN_MAGIC);
+	return (vdir_list(ctx, rr->vd, vsb, pflag, jflag));
 }
 
 static VCL_BACKEND v_matchproto_(vdi_resolve_f)
@@ -96,7 +107,8 @@ static const struct vdi_methods vmod_rr_methods[1] = {{
 	.type =			"round-robin",
 	.healthy =		vmod_rr_healthy,
 	.resolve =		vmod_rr_resolve,
-	.destroy =		vmod_rr_destroy
+	.destroy =		vmod_rr_destroy,
+	.list =			vmod_rr_list
 }};
 
 VCL_VOID v_matchproto_()

--- a/lib/libvmod_directors/vdir.h
+++ b/lib/libvmod_directors/vdir.h
@@ -50,4 +50,5 @@ void vdir_unlock(struct vdir *vd);
 void vdir_add_backend(VRT_CTX, struct vdir *, VCL_BACKEND, double weight);
 void vdir_remove_backend(VRT_CTX, struct vdir *, VCL_BACKEND, unsigned *cur);
 VCL_BOOL vdir_any_healthy(VRT_CTX, struct vdir *, VCL_TIME *);
+void vdir_list(VRT_CTX, struct vdir *, struct vsb *, int, int);
 VCL_BACKEND vdir_pick_be(VRT_CTX, struct vdir *, double w);


### PR DESCRIPTION
... by example of the round-robin director. Should this suggestion get accepted, the next step would be to adopt the code for the other bundled directors.

This adds:
* basic stats on the number of healthy backends for directors as
  * `x/y healthy` if only _x_ out of _y_ backends are healthy.
  * `healthy` for all healthy  as before
  * `sick` for all sick as before
* Details on the backends configured in the director for `-p`

Example output for this vcl:

```
vcl 4.1;

import directors;
import std;

probe p {.url = "/foo"; }
backend a1 {.host = "127.0.0.1";}
backend a2 {.host = "127.0.0.1";}
backend a3 {.host = "127.0.0.1";}
backend a4 {.host = "127.0.0.1"; .port = "8080"; .probe = p;}

sub vcl_init {
	new rr1 = directors.round_robin();
	rr1.add_backend(a1);
	rr1.add_backend(a2);
	rr1.add_backend(a3);
	rr1.add_backend(a4);
	new rr2 = directors.round_robin();
	rr2.add_backend(a1);
	rr2.add_backend(a2);
	new rr3 = directors.round_robin();
	rr3.add_backend(a4);
}

sub vcl_recv {
	if (std.file_exists("/tmp/ok")) {
		return(synth(200));
	}
	return(synth(404));
}
```

## examples

### backend.list

```
$ /tmp/bin/varnishadm backend.list 
Backend name                   Admin   Probe          Last change
boot.a1                        probe   healthy        Tue, 05 Feb 2019 11:15:24 GMT
boot.a2                        probe   healthy        Tue, 05 Feb 2019 11:15:24 GMT
boot.a3                        probe   healthy        Tue, 05 Feb 2019 11:15:24 GMT
boot.a4                        probe   0/8 bad        Tue, 05 Feb 2019 11:15:24 GMT
boot.rr1                       probe   3/4 healthy    Tue, 05 Feb 2019 11:15:24 GMT
boot.rr2                       probe   healthy        Tue, 05 Feb 2019 11:15:24 GMT
boot.rr3                       probe   sick           Tue, 05 Feb 2019 11:15:24 GMT
```

### backend.list  -p

```
$ /tmp/bin/varnishadm backend.list -p
Backend name                   Admin   Probe          Last change
boot.a1                        probe   healthy        Tue, 05 Feb 2019 11:15:24 GMT
boot.a2                        probe   healthy        Tue, 05 Feb 2019 11:15:24 GMT
boot.a3                        probe   healthy        Tue, 05 Feb 2019 11:15:24 GMT
boot.a4                        probe   0/8 bad        Tue, 05 Feb 2019 11:15:24 GMT
Current states  good:  0 threshold:  3 window:  8
  Average response time of good probes: 0.000000
  Oldest ================================================== Newest
  -----------------------------44444444444444444444444444444444444 Good IPv4
  -----------------------------XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Good Xmit
  -----------------------------RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR Good Recv
  --------------------------HH------------------------------------ Happy

boot.rr1                       probe   3/4 healthy    Tue, 05 Feb 2019 11:15:24 GMT
	a1: healthy
	a2: healthy
	a3: healthy
	a4: sick

boot.rr2                       probe   healthy        Tue, 05 Feb 2019 11:15:24 GMT
	a1: healthy
	a2: healthy

boot.rr3                       probe   sick           Tue, 05 Feb 2019 11:15:24 GMT
	a4: sick
```

### backend.list -j
```
$ /tmp/bin/varnishadm backend.list -j
[ 2, ["backend.list", "-j"], 1549365503.728,
  {
    "boot.a1": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": "healthy",
      "last_change": 1549365324.218
    },
    "boot.a2": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": "healthy",
      "last_change": 1549365324.218
    },
    "boot.a3": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": "healthy",
      "last_change": 1549365324.218
    },
    "boot.a4": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": "0/8 bad",
      "last_change": 1549365324.218
    },
    "boot.rr1": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": "3/4 healthy",
      "last_change": 1549365324.218
    },
    "boot.rr2": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": "healthy",
      "last_change": 1549365324.218
    },
    "boot.rr3": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": "sick",
      "last_change": 1549365324.218
    }
  }
]
```
### backend.list -pj
```
$ /tmp/bin/varnishadm backend.list -pj
[ 2, ["backend.list", "-pj"], 1549365507.112,
  {
    "boot.a1": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": "healthy",
      "probe_details": {},
      "last_change": 1549365324.218
    },
    "boot.a2": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": "healthy",
      "probe_details": {},
      "last_change": 1549365324.218
    },
    "boot.a3": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": "healthy",
      "probe_details": {},
      "last_change": 1549365324.218
    },
    "boot.a4": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": "0/8 bad",
      "probe_details": {
        "bits_4": 68719476735,
        "bits_6": 0,
        "bits_U": 0,
        "bits_x": 0,
        "bits_X": 68719476735,
        "bits_r": 0,
        "bits_R": 68719476735,
        "bits_H": 412316860416,
        "good": 0,
        "threshold": 3,
        "window": 8
      },
      "last_change": 1549365324.218
    },
    "boot.rr1": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": "3/4 healthy",
      "probe_details": {
        "a1": "healthy",
        "a2": "healthy",
        "a3": "healthy",
        "a4": "sick"
      },
      "last_change": 1549365324.218
    },
    "boot.rr2": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": "healthy",
      "probe_details": {
        "a1": "healthy",
        "a2": "healthy"
      },
      "last_change": 1549365324.218
    },
    "boot.rr3": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": "sick",
      "probe_details": {
        "a4": "sick"
      },
      "last_change": 1549365324.218
    }
  }
]
```