### PR TITLE
Guard against OA_GZIPBITS streaming race

### DIFF
--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -294,7 +294,6 @@ vdp_gunzip_init(struct req *req, void **priv)
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
-	CHECK_OBJ_ORNULL(req->objcore->boc, BOC_MAGIC);
 
 	vg = VGZ_NewGunzip(req->vsl, "U D -");
 	AN(vg);

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -292,6 +292,10 @@ vdp_gunzip_init(struct req *req, void **priv)
 	ssize_t dl;
 	uint64_t u;
 
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
+	CHECK_OBJ_ORNULL(req->objcore->boc, BOC_MAGIC);
+
 	vg = VGZ_NewGunzip(req->vsl, "U D -");
 	AN(vg);
 	if (vgz_getmbuf(vg)) {
@@ -305,6 +309,10 @@ vdp_gunzip_init(struct req *req, void **priv)
 	http_Unset(req->resp, H_Content_Encoding);
 
 	req->resp_len = -1;
+
+	/* OA_GZIPBITS is not stable yet */
+	if (req->objcore->boc)
+		return (0);
 
 	p = ObjGetAttr(req->wrk, req->objcore, OA_GZIPBITS, &dl);
 	if (p != NULL && dl == 32) {


### PR DESCRIPTION
Ran into an issue where Varnish reports an incorrect Content-Length when streaming a backend response (gzip) and running that thru a gunzip VDP. Turns out that `OA_GZIPBITS` is being unsafely used. The patch simply forces Varnish to do a chunked response when streaming.

Reproducer VTC is [here](https://gist.github.com/rezan/015b181d0fa14392f14f9cf05060d6c3).

Just to explain, when we write the gunzip length of `3167` here:

https://github.com/varnishcache/varnish-cache/blob/4709fae3a703b5904a799b8aa1df2872e803219f/bin/varnishd/cache/cache_gzip.c#L402

We end up here:

https://github.com/varnishcache/varnish-cache/blob/4709fae3a703b5904a799b8aa1df2872e803219f/include/vend.h#L103-L106

And because we are writing single bytes, the delivery thread can incorrectly read `3167` as `3072` or `95`, which would be the good value missing 8 of its bits.

I talked this over with @mbgrydeland and we ran into a few issues. First, there is no good VTC for this. This is because the VTC will either pass with the race in place or it can possibly fail with the patch in place due to the way a `boc` is grabbed late in the client delivery. Basically, the VTC checks that a gunzip streamed response has no Content-Length, but there are cases where this is both true and false before and after the patch. So no VTC unless everyone is ok with a racy VTC.

The other possibly bigger issue is that when we cache miss, get a `boc`, but its cleared by the time we grab it in `transmit`, we could have stale memory in cache, which could in theory give us a partial read. I believe this is due to not hitting a memory barrier anywhere in this code path. I left this issue for Martin to explain (and fix) as this represents a much bigger issue than this patch can handle.