### PR TITLE
add vrt & vmod support to look up a director by name

### DIFF
--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -261,6 +261,35 @@ VRT_DisableDirector(VCL_BACKEND d)
 	vdir->health_changed = VTIM_real();
 }
 
+VCL_BACKEND
+VRT_LookupDirector(VRT_CTX, VCL_STRING name)
+{
+	struct vcl *vcl;
+	struct vcldir *vdir;
+	VCL_BACKEND dd, d = NULL;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(name);
+
+	assert(ctx->method & VCL_MET_TASK_H);
+	ASSERT_CLI();
+
+	vcl = ctx->vcl;
+	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
+
+	Lck_Lock(&vcl_mtx);
+	VTAILQ_FOREACH(vdir, &vcl->director_list, list) {
+		dd = vdir->dir;
+		if (strcmp(dd->vcl_name, name))
+			continue;
+		d = dd;
+		break;
+	}
+	Lck_Unlock(&vcl_mtx);
+
+	return (d);
+}
+
 /*--------------------------------------------------------------------*/
 
 VCL_BACKEND

--- a/bin/varnishtest/tests/b00016.vtc
+++ b/bin/varnishtest/tests/b00016.vtc
@@ -6,7 +6,12 @@ server s1 -repeat 2 -keepalive {
 } -start
 
 varnish v1 -vcl+backend {
+	import directors;
+
 	sub vcl_recv {
+		if (req.url == "/lookup") {
+			set req.http.foo = directors.lookup("s1");
+		}
 		return (pass);
 	}
 
@@ -19,6 +24,10 @@ client c1 {
 	txreq -url "/"
 	rxresp
 	expect resp.http.X-Backend-Name == "s1"
+	txreq -url "/lookup"
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
 } -run
 
 varnish v1 -vcl+backend {
@@ -26,7 +35,7 @@ varnish v1 -vcl+backend {
 
 	sub vcl_init {
 		new bar = directors.random();
-		bar.add_backend(s1, 1);
+		bar.add_backend(directors.lookup("s1"), 1);
 	}
 
 	sub vcl_recv {

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -104,6 +104,11 @@ VCL
 * Added ``req.is_hitmiss`` and ``req.is_hitpass`` (2743_)
 
 
+bundled vmods
+-------------
+
+* Added ``directors.lookup()``
+
 bundled tools
 -------------
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -62,6 +62,7 @@
  *	req->req_bodybytes removed
  *	    use: AZ(ObjGetU64(req->wrk, req->body_oc, OA_LEN, &u));
  *	struct vdi_methods .list callback signature changed
+ *	VRT_LookupDirector() added
  * 8.0 (2018-09-15)
  *	VRT_Strands() added
  *	VRT_StrandsWS() added
@@ -512,6 +513,7 @@ VCL_BACKEND VRT_AddDirector(VRT_CTX, const struct vdi_methods *,
     void *, const char *, ...) v_printflike_(4, 5);
 void VRT_SetHealth(VCL_BACKEND d, int health);
 void VRT_DisableDirector(VCL_BACKEND);
+VCL_BACKEND VRT_LookupDirector(VRT_CTX, VCL_STRING);
 void VRT_DelDirector(VCL_BACKEND *);
 
 /* Suckaddr related */

--- a/lib/libvmod_directors/Makefile.am
+++ b/lib/libvmod_directors/Makefile.am
@@ -5,6 +5,7 @@ libvmod_directors_la_SOURCES = \
 	vdir.h \
 	fall_back.c \
 	hash.c \
+	misc.c \
 	random.c \
 	round_robin.c \
 	vmod_shard.c \

--- a/lib/libvmod_directors/misc.c
+++ b/lib/libvmod_directors/misc.c
@@ -1,0 +1,47 @@
+/*-
+ * Copyright 2019 UPLEX - Nils Goroll Systemoptimierung
+ * All rights reserved.
+ *
+ * Author: Nils Goroll <nils.goroll@uplex.de>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "vdef.h"
+#include "vrt.h"
+#include "vcl.h"
+
+#include "vcc_if.h"
+
+VCL_BACKEND
+VPFX(lookup)(VRT_CTX, VCL_STRING name)
+{
+	if ((ctx->method & VCL_MET_TASK_H) == 0) {
+		VRT_fail(ctx,
+		    "lookup() may only be called from vcl_init / vcl_fini");
+		return (NULL);
+	}
+
+	return (VRT_LookupDirector(ctx, name));
+}

--- a/lib/libvmod_directors/vmod.vcc
+++ b/lib/libvmod_directors/vmod.vcc
@@ -687,6 +687,12 @@ This method may only be used in backend context.
 For use with the `param` argument of `vmod_directors.shard.backend`_ to associate
 this shard parameter set with a shard director.
 
+$Function BACKEND lookup(STRING)
+
+Lookup a backend by its name.
+
+This function can only be used from ``vcl_init{}`` and  ``vcl_fini{}``.
+
 ACKNOWLEDGEMENTS
 ================
 


### PR DESCRIPTION
This allows for relevant simplification of vcl with varying backend / director names, as when identical VCL is deployed to several nodes.
Toy example:
```
vcl_init {
    new myself = directors.round-robin();
    myself.add_backend(directors.lookup(server.identity));
}
```