### PR TITLE
take2: use our knowledge about master file descriptors also for VSUBs

### DIFF
--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -71,11 +71,13 @@ void MAC_Arg(const char *);
 int MAC_reopen_sockets(void);
 
 /* mgt_child.c */
+struct vbitmap;
 void MCH_Init(void);
 int MCH_Running(void);
 void MCH_Stop_Child(void);
 int MCH_Start_Child(void);
 void MCH_TrackHighFd(int fd);
+void MCH_FdInfo(int *, int *, const struct vbitmap **);
 void MCH_Cli_Fail(void);
 
 /* mgt_cli.c */

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -50,6 +50,7 @@
 #include "vfil.h"
 #include "vlu.h"
 #include "vtim.h"
+#include "vsub.h"
 
 #include "common/heritage.h"
 #include "common/vsmw.h"
@@ -201,6 +202,14 @@ MCH_TrackHighFd(int fd)
 	assert(fd > 0);
 	if (fd > mgt_max_fd)
 		mgt_max_fd = fd;
+}
+
+void
+MCH_FdInfo(int *nullto, int *closeto, const struct vbitmap **map)
+{
+	*nullto = CLOSE_FD_UP_TO;
+	*closeto = CLOSE_FD_UP_TO;
+	*map = fd_map;
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -542,7 +542,7 @@ main(int argc, char * const *argv)
 	 * Start out by closing all unwanted file descriptors we might
 	 * have inherited from sloppy process control daemons.
 	 */
-	VSUB_closefrom(STDERR_FILENO + 1);
+	VSUB_closefrom(STDERR_FILENO + 1, -1, NULL, -1);
 	MCH_TrackHighFd(STDERR_FILENO);
 
 	/*

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -231,13 +231,19 @@ mgt_vcc_compile(struct vcc_priv *vp, struct vsb *sb, int C_flag)
 {
 	char *csrc;
 	unsigned subs;
+	int nullto, closeto;
+	const struct vbitmap *fd_map;
 
 	if (mgt_vcc_touchfile(vp->csrcfile, sb))
 		return (2);
 	if (mgt_vcc_touchfile(vp->libfile, sb))
 		return (2);
 
-	subs = VSUB_run(sb, run_vcc, vp, "VCC-compiler", -1);
+	MCH_FdInfo(&nullto, &closeto, &fd_map);
+
+	subs = VSUB_run(sb, run_vcc, vp, "VCC-compiler", -1,
+	    closeto, fd_map, -1);
+
 	if (subs)
 		return (subs);
 
@@ -248,11 +254,13 @@ mgt_vcc_compile(struct vcc_priv *vp, struct vsb *sb, int C_flag)
 		free(csrc);
 	}
 
-	subs = VSUB_run(sb, run_cc, vp, "C-compiler", 10);
+	subs = VSUB_run(sb, run_cc, vp, "C-compiler", 10,
+	    closeto, fd_map, -1);
 	if (subs)
 		return (subs);
 
-	subs = VSUB_run(sb, run_dlopen, vp, "dlopen", 10);
+	subs = VSUB_run(sb, run_dlopen, vp, "dlopen", 10,
+	    closeto, fd_map, -1);
 	return (subs);
 }
 

--- a/bin/varnishtest/vtc_main.c
+++ b/bin/varnishtest/vtc_main.c
@@ -421,7 +421,8 @@ start_test(void)
 		VFIL_null_fd(STDIN_FILENO);
 		assert(dup2(p[1], STDOUT_FILENO) == STDOUT_FILENO);
 		assert(dup2(p[1], STDERR_FILENO) == STDERR_FILENO);
-		VSUB_closefrom(STDERR_FILENO + 1);
+		// XXX high fd tracking would be nice
+		VSUB_closefrom(STDERR_FILENO + 1, -1, NULL, -1);
 		retval = exec_file(jp->tst->filename, jp->tst->script,
 		    jp->tmpdir, jp->bp->buf, jp->bp->bufsiz);
 		exit(retval);

--- a/bin/varnishtest/vtc_process.c
+++ b/bin/varnishtest/vtc_process.c
@@ -677,7 +677,8 @@ process_start(struct process *p)
 #endif
 		AZ(close(STDOUT_FILENO));
 		assert(dup2(slave, STDOUT_FILENO) == STDOUT_FILENO);
-		VSUB_closefrom(STDERR_FILENO + 1);
+		// XXX high fd tracking would be nice
+		VSUB_closefrom(STDERR_FILENO + 1, -1, NULL, -1);
 		process_init_term(p, slave);
 
 		AZ(setenv("TERM", "xterm", 1));

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -453,7 +453,9 @@ varnish_launch(struct varnish *v)
 		closefd(&v->fds[1]);
 		closefd(&v->fds[2]);
 		closefd(&v->fds[3]);
-		VSUB_closefrom(STDERR_FILENO + 1);
+		// + 100 is just a guesstimate, varnishd will close again
+		VSUB_closefrom(STDERR_FILENO + 1,
+		    STDERR_FILENO + 100, NULL, -1);
 		AZ(execl("/bin/sh", "/bin/sh", "-c", VSB_data(vsb), (char*)0));
 		exit(1);
 	} else {

--- a/include/vsub.h
+++ b/include/vsub.h
@@ -28,10 +28,11 @@
  *
  */
 
-/* from libvarnish/subproc.c */
+struct vbitmap;
+
+/* from lib/libvarnish/vsub.c */
 typedef void vsub_func_f(void*);
 
-unsigned VSUB_run(struct vsb *, vsub_func_f *, void *priv, const char *name,
-    int maxlines);
-
-void VSUB_closefrom(int fd);
+unsigned VSUB_run(struct vsb *, vsub_func_f *, void *, const char *, int,
+    int, const struct vbitmap *, int);
+void VSUB_closefrom(int, int, const struct vbitmap *, int);


### PR DESCRIPTION
Follow up on #2843: @bsdphk is this like what you had in mind?

Regarding the information leakage argument, we would have the same issue
for the varnish worker child, so I do not think that we are taking on
additional risks.

Fixes #2730