### PR TITLE
Stop shell scripts on autotools errors.

### DIFF
--- a/autogen.des
+++ b/autogen.des
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Use this when doing code development
+set -e	# Stop on errors.
 
 SRCDIR=${SRCDIR:-.}
 
@@ -23,7 +24,11 @@ else
 fi
 
 rm -f configure
-(cd $SRCDIR && . ./autogen.sh 2>&1 | egrep -v "(subdir-objects|is in a subdirectory)")
+TREEDIR=`pwd`
+cd $SRCDIR
+. ./autogen.sh
+cd $TREEDIR
+unset TREEDIR
 
 # autoconf prior to 2.62 has issues with zsh 4.2 and newer
 export CONFIG_SHELL=/bin/sh

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+set -e   # Stop on errors.
 
 warn() {
 	echo "WARNING: $@" 1>&2
@@ -47,5 +48,9 @@ set -ex
 $LIBTOOLIZE --copy --force
 aclocal -I m4 -I .
 autoheader
-automake --add-missing --copy --foreign
+AM_OUTPUT=$(automake --add-missing --copy --foreign 2>&1 | egrep -v "(subdir-objects|is in a subdirectory)")
+if [ -n "$AM_OUTPUT" ]; then
+	printf "$AM_OUTPUT";
+	exit 1;
+fi
 autoconf


### PR DESCRIPTION
When configure is still around, it looks like your automake.am changes
were used, but in fact nothing happened on disk.