### PR TITLE
Ban lurker dying objcores

### DIFF
--- a/bin/varnishd/cache/cache_ban_lurker.c
+++ b/bin/varnishd/cache/cache_ban_lurker.c
@@ -365,7 +365,7 @@ ban_lurker_work(struct worker *wrk, struct vsl_log *vsl)
 
 	/*
 	 * conceptually, all obans are now completed. Remove the tail. If it
-	 * containted the first oban, all obans were on the tail and we're
+	 * contained the first oban, all obans were on the tail and we're
 	 * done.
 	 */
 	if (ban_cleantail(VTAILQ_FIRST(&obans)))


### PR DESCRIPTION
Not evaluating dying objects against bans seems like a good idea, and I propose a way of fixing that here.

The *holdoff* behavior change in the last commit is there to sleep less (for example) when a lone object between the markers dies while the ban lurker is *holdoff* sleeping. When it removes the dying object on the next run, we do not want it to sleep again before returning `NULL`.

It could be that we should also do something smarter with *busy* objects, maybe move them past the end marker instead of consider them "contested", but that is not clear to me.

This is code very hard to test in a VTC. Perhaps a debugging VDP which sleeps a lot, can allow us to have dying objects in the ban lists without too much fuzz, and make this commit testable.