### PR TITLE
remaining backend.list cleanup & retire (struct director).sick

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -461,12 +461,11 @@ vbe_list(VRT_CTX, const struct director *d, struct vsb *vsb, int pflag,
 	else if (jflag && pflag)
 		VSB_printf(vsb, "{},\n");
 	else if (jflag)
-		VSB_printf(vsb, "\"%s\"", bp->sick ? "sick" : "healthy");
+		VSB_printf(vsb, "[0, 0, \"healthy\"]");
 	else if (pflag)
 		return;
 	else
-		VSB_printf(vsb, "%s",
-		    bp->sick ? "sick" : "healthy");
+		VSB_cat(vsb, "0/0\thealthy");
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -459,9 +459,9 @@ vbe_list(VRT_CTX, const struct director *d, struct vsb *vsb, int pflag,
 	if (bp->probe != NULL)
 		VBP_Status(vsb, bp, pflag, jflag);
 	else if (jflag && pflag)
-		VSB_printf(vsb, "{},\n");
+		VSB_cat(vsb, "{},\n");
 	else if (jflag)
-		VSB_printf(vsb, "[0, 0, \"healthy\"]");
+		VSB_cat(vsb, "[0, 0, \"healthy\"]");
 	else if (pflag)
 		return;
 	else

--- a/bin/varnishd/cache/cache_backend.h
+++ b/bin/varnishd/cache/cache_backend.h
@@ -57,6 +57,9 @@ struct backend {
 
 	VRT_BACKEND_FIELDS()
 
+	unsigned		sick;
+	vtim_real		changed;
+
 	struct vbp_target	*probe;
 
 	struct vsc_seg		*vsc_seg;

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -519,7 +519,7 @@ VBP_Status(struct vsb *vsb, const struct backend *be, int details, int json)
 			    vt->good, vt->window,
 			    vt->backend->sick ? "sick" : "healthy");
 		else
-			VSB_printf(vsb, "%u/%u %s", vt->good, vt->window,
+			VSB_printf(vsb, "%u/%u\t%s", vt->good, vt->window,
 			    vt->backend->sick ? "sick" : "healthy");
 		return;
 	}

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -229,21 +229,18 @@ VRT_Healthy(VRT_CTX, VCL_BACKEND d, VCL_TIME *changed)
 	if (d->vdir->methods->healthy == NULL) {
 		if (changed != NULL)
 			*changed = d->vdir->health_changed;
-		return (!d->sick);
+		return (1);
 	}
 
 	return (d->vdir->methods->healthy(ctx, d, changed));
 }
 
 /*--------------------------------------------------------------------
- * Update health_changed. This is for load balancing directors
- * to update their health_changed time based on their backends.
+ * Update health_changed.
  */
 VCL_VOID
-VRT_SetChanged(VRT_CTX, VCL_BACKEND d, VCL_TIME changed)
+VRT_SetChanged(VCL_BACKEND d, VCL_TIME changed)
 {
-	(void)ctx;
-
 	if (d == NULL)
 		return;
 
@@ -278,7 +275,6 @@ VDI_Panic(const struct director *d, struct vsb *vsb, const char *nm)
 	VSB_printf(vsb, "%s = %p {\n", nm, d);
 	VSB_indent(vsb, 2);
 	VSB_printf(vsb, "cli_name = %s,\n", d->vdir->cli_name);
-	VSB_printf(vsb, "health = %s,\n", d->sick ?  "sick" : "healthy");
 	VSB_printf(vsb, "admin_health = %s, changed = %f,\n",
 	    VDI_Ahealth(d), d->vdir->health_changed);
 	VSB_printf(vsb, "type = %s {\n", d->vdir->methods->type);
@@ -460,8 +456,6 @@ do_set_health(struct cli *cli, struct director *d, void *priv)
 	if (d->vdir->admin_health != sh->ah) {
 		d->vdir->health_changed = VTIM_real();
 		d->vdir->admin_health = sh->ah;
-		d->sick &= ~0x02;
-		d->sick |= sh->ah->health ? 0 : 0x02;
 	}
 	return (0);
 }

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -60,7 +60,6 @@ vdi_str2ahealth(const char *t)
 #define VBE_AHEALTH(l,u,h) if (!strcasecmp(t, #l)) return (VDI_AH_##u);
 VBE_AHEALTH_LIST
 #undef VBE_AHEALTH
-	if (!strcasecmp(t, "auto")) return (VDI_AH_PROBE);
 	return (NULL);
 }
 
@@ -70,7 +69,11 @@ VDI_Ahealth(const struct director *d)
 
 	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
 	AN(d->vdir->admin_health);
-	return (d->vdir->admin_health->name);
+	if (d->vdir->admin_health != VDI_AH_AUTO)
+		return (d->vdir->admin_health->name);
+	if (d->vdir->methods->healthy != NULL)
+		return ("probe");
+	return ("healthy");
 }
 
 /* Resolve director --------------------------------------------------*/

--- a/bin/varnishd/cache/cache_director.h
+++ b/bin/varnishd/cache/cache_director.h
@@ -46,7 +46,7 @@ struct vcldir {
 #define VBE_AHEALTH_LIST					\
 	VBE_AHEALTH(healthy,	HEALTHY,	1)		\
 	VBE_AHEALTH(sick,	SICK,		0)		\
-	VBE_AHEALTH(probe,	PROBE,		-1)		\
+	VBE_AHEALTH(auto,	AUTO,		-1)		\
 	VBE_AHEALTH(deleted,	DELETED,	0)
 
 #define VBE_AHEALTH(l,u,h) extern const struct vdi_ahealth * const VDI_AH_##u;

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -186,7 +186,7 @@ VRT_AddDirector(VRT_CTX, const struct vdi_methods *m, void *priv,
 	d->vcl_name = vdir->cli_name + i;
 
 	vdir->vcl = vcl;
-	vdir->admin_health = VDI_AH_PROBE;
+	vdir->admin_health = VDI_AH_AUTO;
 	vdir->health_changed = VTIM_real();
 
 	Lck_Lock(&vcl_mtx);

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -186,7 +186,6 @@ VRT_AddDirector(VRT_CTX, const struct vdi_methods *m, void *priv,
 	d->vcl_name = vdir->cli_name + i;
 
 	vdir->vcl = vcl;
-	d->sick = 0;
 	vdir->admin_health = VDI_AH_PROBE;
 	vdir->health_changed = VTIM_real();
 
@@ -232,22 +231,6 @@ VRT_DelDirector(VCL_BACKEND *bp)
 }
 
 void
-VRT_SetHealth(VCL_BACKEND d, int health)
-{
-	struct vcldir *vdir;
-
-	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
-	vdir = d->vdir;
-	CHECK_OBJ_NOTNULL(vdir, VCLDIR_MAGIC);
-
-	if (health)
-		vdir->dir->sick &= ~0x01;
-	else
-		vdir->dir->sick |= 0x01;
-	vdir->health_changed = VTIM_real();
-}
-
-void
 VRT_DisableDirector(VCL_BACKEND d)
 {
 	struct vcldir *vdir;
@@ -257,7 +240,6 @@ VRT_DisableDirector(VCL_BACKEND d)
 	CHECK_OBJ_NOTNULL(vdir, VCLDIR_MAGIC);
 
 	vdir->admin_health = VDI_AH_DELETED;
-	vdir->dir->sick |= 0x04;
 	vdir->health_changed = VTIM_real();
 }
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -64,6 +64,7 @@
  *	struct vdi_methods .list callback signature changed
  *	VRT_LookupDirector() added
  *	VRT_SetChanged() added
+ *	VRT_SetHealth() removed
  * 8.0 (2018-09-15)
  *	VRT_Strands() added
  *	VRT_StrandsWS() added
@@ -518,17 +519,15 @@ struct vcldir;
 struct director {
 	unsigned			magic;
 #define DIRECTOR_MAGIC			0x3336351d
-	unsigned			sick;
 	void				*priv;
 	char				*vcl_name;
 	struct vcldir			*vdir;
 };
 
 VCL_BOOL VRT_Healthy(VRT_CTX, VCL_BACKEND, VCL_TIME *);
-VCL_VOID VRT_SetChanged(VRT_CTX, VCL_BACKEND, VCL_TIME);
+VCL_VOID VRT_SetChanged(VCL_BACKEND, VCL_TIME);
 VCL_BACKEND VRT_AddDirector(VRT_CTX, const struct vdi_methods *,
     void *, const char *, ...) v_printflike_(4, 5);
-void VRT_SetHealth(VCL_BACKEND d, int health);
 void VRT_DisableDirector(VCL_BACKEND);
 VCL_BACKEND VRT_LookupDirector(VRT_CTX, VCL_STRING);
 void VRT_DelDirector(VCL_BACKEND *);

--- a/lib/libvmod_directors/vdir.c
+++ b/lib/libvmod_directors/vdir.c
@@ -238,7 +238,7 @@ vdir_list(VRT_CTX, struct vdir *vd, struct vsb *vsb, int pflag, int jflag)
 	}
 	vdir_unlock(vd);
 
-	VRT_SetChanged(ctx, vd->dir, changed);
+	VRT_SetChanged(vd->dir, changed);
 
 	if (jflag && (pflag)) {
 		VSB_printf(vsb, "\n");

--- a/lib/libvmod_directors/vdir.c
+++ b/lib/libvmod_directors/vdir.c
@@ -207,10 +207,10 @@ vdir_list(VRT_CTX, struct vdir *vd, struct vsb *vsb, int pflag, int jflag)
 
 	if (pflag) {
 		if (jflag) {
-			VSB_printf(vsb, "{\n");
+			VSB_cat(vsb, "{\n");
 			VSB_indent(vsb, 2);
 		} else {
-			VSB_printf(vsb, "\n");
+			VSB_cat(vsb, "\n");
 		}
 	}
 
@@ -228,7 +228,7 @@ vdir_list(VRT_CTX, struct vdir *vd, struct vsb *vsb, int pflag, int jflag)
 			continue;
 		if (jflag) {
 			if (u)
-				VSB_printf(vsb, ",\n");
+				VSB_cat(vsb, ",\n");
 			VSB_printf(vsb, "\"%s\": \"%s\"",
 			    be->vcl_name, h ? "healthy" : "sick");
 		} else {
@@ -241,9 +241,9 @@ vdir_list(VRT_CTX, struct vdir *vd, struct vsb *vsb, int pflag, int jflag)
 	VRT_SetChanged(vd->dir, changed);
 
 	if (jflag && (pflag)) {
-		VSB_printf(vsb, "\n");
+		VSB_cat(vsb, "\n");
 		VSB_indent(vsb, -2);
-		VSB_printf(vsb, "},\n");
+		VSB_cat(vsb, "},\n");
 	}
 
 	if (pflag)

--- a/lib/libvmod_directors/vdir.c
+++ b/lib/libvmod_directors/vdir.c
@@ -259,7 +259,7 @@ vdir_list(VRT_CTX, struct vdir *vd, struct vsb *vsb, int pflag, int jflag)
 		VSB_printf(vsb, "[%u, %u, \"%s\"]", nh, u,
 		    nh ? "healthy" : "sick");
 	else
-		VSB_printf(vsb, "%u/%u %s", nh, u, nh ? "healthy" : "sick");
+		VSB_printf(vsb, "%u/%u\t%s", nh, u, nh ? "healthy" : "sick");
 }
 
 static unsigned


### PR DESCRIPTION
This implements the remaining bits from #2896, please see individual commit messages

* To fix the admin health "probe" column, we basically got two options: Either we need to include this column in the list callback, for which we would need to give up the admin health isolation, or we need to give the generic director code a way to tell if a backend has a probe. At this point I think that the most straightforward way is the latter by using the presence of a _healthy_ callback to indicate if there is a probe.

I had also tried adding a flag to the director to indicate presence of a probe, but that lead to more duplication, IMHO.

* To indicate via the healthy callback the presence of a probe, we restructure VBE and move the extra `sick` bitfield at the VDIR layer to VBE. This also cleans the code I believe because the `sick` bitfield and the healthy callback are similar things viewed from opposite sides.

* With these patches in place, the output for the sample VCL from #2896 changes as follows (for the case that a4 went sick some time after starting varnish)

h3. backend.list
```
Backend name   Admin      Probe          Last change
boot.a1        healthy    0/0 healthy    Mon, 04 Mar 2019 17:40:54 GMT
boot.a2        healthy    0/0 healthy    Mon, 04 Mar 2019 17:40:54 GMT
boot.a3        healthy    0/0 healthy    Mon, 04 Mar 2019 17:40:54 GMT
boot.a4        probe      1/8 sick       Mon, 04 Mar 2019 17:43:35 GMT
boot.rr1       probe      3/4 healthy    Mon, 04 Mar 2019 17:43:35 GMT
boot.rr2       probe      2/2 healthy    Mon, 04 Mar 2019 17:40:54 GMT
boot.rr3       probe      0/1 sick       Mon, 04 Mar 2019 17:43:35 GMT
```

h3. backend.list -j
```
[ 3, ["backend.list", "-j"], 1551721439.480,
  {
    "boot.a1": {
      "type": "backend",
      "admin_health": "healthy",
      "probe_message": [0, 0, "healthy"],
      "last_change": 1551721254.908
    },
    "boot.a2": {
      "type": "backend",
      "admin_health": "healthy",
      "probe_message": [0, 0, "healthy"],
      "last_change": 1551721254.908
    },
    "boot.a3": {
      "type": "backend",
      "admin_health": "healthy",
      "probe_message": [0, 0, "healthy"],
      "last_change": 1551721254.908
    },
    "boot.a4": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": [0, 8, "sick"],
      "last_change": 1551721415.018
    },
    "boot.rr1": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": [3, 4, "healthy"],
      "last_change": 1551721415.018
    },
    "boot.rr2": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": [2, 2, "healthy"],
      "last_change": 1551721254.908
    },
    "boot.rr3": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": [0, 1, "sick"],
      "last_change": 1551721415.018
    }
  }
]
```

h3. backend.list -p
```
Backend name   Admin          Probe          Last change
boot.a1        healthy        0/0 healthy    Mon, 04 Mar 2019 17:40:54 GMT
boot.a2        healthy        0/0 healthy    Mon, 04 Mar 2019 17:40:54 GMT
boot.a3        healthy        0/0 healthy    Mon, 04 Mar 2019 17:40:54 GMT
boot.a4        probe          0/8 sick       Mon, 04 Mar 2019 17:43:35 GMT
 Current states  good:  0 threshold:  3 window:  8
  Average response time of good probes: 0.000357
  Oldest ================================================== Newest
  -----------------------44444444444444444444444444444444444444444 Good IPv4
  -----------------------XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Good Xmit
  -----------------------RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR Good Recv
  ---------------------HHHHHHHHHHHHHHHHHHHHHHHHHHHHH-------------- Happy

boot.rr1       probe          3/4 healthy    Mon, 04 Mar 2019 17:43:35 GMT
               a1: healthy
               a2: healthy
               a3: healthy
               a4: sick

boot.rr2       probe          2/2 healthy    Mon, 04 Mar 2019 17:40:54 GMT
               a1: healthy
               a2: healthy

boot.rr3       probe          0/1 sick       Mon, 04 Mar 2019 17:43:35 GMT
               a4: sick
```

h3. backend.list -pj
```
[ 3, ["backend.list", "-pj"], 1551721473.440,
  {
    "boot.a1": {
      "type": "backend",
      "admin_health": "healthy",
      "probe_message": [0, 0, "healthy"],
      "probe_details": {},
      "last_change": 1551721254.908
    },
    "boot.a2": {
      "type": "backend",
      "admin_health": "healthy",
      "probe_message": [0, 0, "healthy"],
      "probe_details": {},
      "last_change": 1551721254.908
    },
    "boot.a3": {
      "type": "backend",
      "admin_health": "healthy",
      "probe_message": [0, 0, "healthy"],
      "probe_details": {},
      "last_change": 1551721254.908
    },
    "boot.a4": {
      "type": "backend",
      "admin_health": "probe",
      "probe_message": [0, 8, "sick"],
      "probe_details": {
        "bits_4": 17592186044415,
        "bits_6": 0,
        "bits_U": 0,
        "bits_x": 0,
        "bits_X": 17592186044415,
        "bits_r": 0,
        "bits_R": 17592186044415,
        "bits_H": 70368744046592,
        "good": 0,
        "threshold": 3,
        "window": 8
      },
      "last_change": 1551721415.018
    },
    "boot.rr1": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": [3, 4, "healthy"],
      "probe_details": {
        "a1": "healthy",
        "a2": "healthy",
        "a3": "healthy",
        "a4": "sick"
      },
      "last_change": 1551721415.018
    },
    "boot.rr2": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": [2, 2, "healthy"],
      "probe_details": {
        "a1": "healthy",
        "a2": "healthy"
      },
      "last_change": 1551721254.908
    },
    "boot.rr3": {
      "type": "round-robin",
      "admin_health": "probe",
      "probe_message": [0, 1, "sick"],
      "probe_details": {
        "a4": "sick"
      },
      "last_change": 1551721415.018
    }
  }
]
```