### PR TITLE
Add public functions VCS_VersionStr() and VCS_RevisionStr()

### DIFF
--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -44,7 +44,7 @@
 #include "storage/storage.h"
 #include "vcli_serve.h"
 #include "vtim.h"
-#include "vcs.h"
+#include "vcs_int.h"
 
 /*
  * The panic string is constructed in memory, then copied to the

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -42,7 +42,7 @@
 
 #include "miniobj.h"
 #include "vas.h"
-#include "vcs.h"
+#include "vcs_int.h"
 #include "vqueue.h"
 #include "vsb.h"
 

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -60,6 +60,7 @@
 #include "vtim.h"
 #include "waiter/mgt_waiter.h"
 #include "vsa.h"
+#include "vcs.h"
 
 struct heritage		heritage;
 unsigned		d_flag = 0;

--- a/bin/varnishtest/tests/m00001.vtc
+++ b/bin/varnishtest/tests/m00001.vtc
@@ -15,6 +15,8 @@ varnish v1 -syntax 4.1 -vcl+backend {
 		set resp.http.vcl41 = std.syntax(4.1);
 		set resp.http.vcl42 = std.syntax(4.2);
 		std.set_ip_tos(32);
+		set resp.http.version = std.version();
+		set resp.http.revision = std.revision();
 	}
 } -start
 
@@ -30,6 +32,8 @@ client c1 {
 	expect resp.http.vcl40 == "true"
 	expect resp.http.vcl41 == "true"
 	expect resp.http.vcl42 == "false"
+	expect resp.http.version ~ ".+"
+	expect resp.http.revision ~ ".+"
 } -run
 
 varnish v1 -syntax 4.0 -vcl+backend {

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -88,6 +88,7 @@ nobase_noinst_HEADERS = \
 	libvcc.h \
 	vcli_serve.h \
 	vcs_version.h \
+	vcs_int.h \
 	vct.h \
 	vcurses.h \
 	vend.h \

--- a/include/vcs.h
+++ b/include/vcs.h
@@ -29,5 +29,6 @@
  */
 
 /* from libvarnish/version.c */
-extern const char *VCS_version;
 void VCS_Message(const char *);
+const char *VCS_VersionStr(void);
+const char *VCS_RevisionStr(void);

--- a/include/vcs_int.h
+++ b/include/vcs_int.h
@@ -1,5 +1,6 @@
 /*-
- * Copyright (c) 2010-2014 Varnish Software AS
+ * Copyright (c) 2006 Verdens Gang AS
+ * Copyright (c) 2006-2011 Varnish Software AS
  * All rights reserved.
  *
  * Author: Poul-Henning Kamp <phk@phk.freebsd.dk>
@@ -27,11 +28,5 @@
  *
  */
 
-#include <stdint.h>
-
-#include "vapi/vsm.h"
-#include "vapi/vsc.h"
-
-#include "vas.h"
-
-void do_curses(struct vsm *,  struct vsc *);
+/* from libvarnish/version.c */
+extern const char *VCS_version;

--- a/lib/libvarnish/version.c
+++ b/lib/libvarnish/version.c
@@ -34,10 +34,23 @@
 #include <stdio.h>
 
 #include "vcs.h"
+#include "vcs_int.h"
 #include "vcs_version.h"
 
 const char *VCS_version =
     PACKAGE_TARNAME "-" PACKAGE_VERSION " revision " VCS_Version;
+
+const char *
+VCS_VersionStr(void)
+{
+	return (PACKAGE_VERSION);
+}
+
+const char *
+VCS_RevisionStr(void)
+{
+	return (VCS_Version);
+}
 
 void
 VCS_Message(const char *progname)

--- a/lib/libvarnishapi/Makefile.am
+++ b/lib/libvarnishapi/Makefile.am
@@ -17,6 +17,7 @@ libvarnishapi_la_SOURCES = \
 	vxp_tokens.h \
 	../libvarnish/vas.c \
 	../libvarnish/vav.c \
+	../../include/vcs.h \
 	../../include/vcs_version.h \
 	../libvarnish/version.c \
 	../libvarnish/vcli_proto.c \

--- a/lib/libvarnishapi/libvarnishapi.map
+++ b/lib/libvarnishapi/libvarnishapi.map
@@ -167,3 +167,12 @@ LIBVARNISHAPI_2.2 {
     local:
 	*;
 };
+
+LIBVARNISHAPI_2.3 {
+    global:
+	# version.c
+	VCS_VersionStr;
+	VCS_RevisionStr;
+    local:
+	*;
+};

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -571,6 +571,13 @@ Examples::
 	# Matches /foo/ followed by a non-digit
 	if (std.fnmatch("/foo/[!0-9]", req.url)) { ... }
 
+$Function STRING version()
+
+Returns the Varnish version string.
+
+$Function STRING revision()
+
+Returns the Varnish revision string (the source repository commit ID).
 
 SEE ALSO
 ========

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -46,6 +46,7 @@
 #include "vsa.h"
 #include "vtim.h"
 #include "vcl.h"
+#include "vcs.h"
 
 #include "vcc_if.h"
 
@@ -327,4 +328,18 @@ vmod_fnmatch(VRT_CTX, VCL_STRING pattern, VCL_STRING subject,
 	if (period)
 		flags |= FNM_PERIOD;
 	return (fnmatch(pattern, subject, flags) != FNM_NOMATCH);
+}
+
+VCL_STRING
+vmod_version(VRT_CTX)
+{
+	(void)ctx;
+	return (VCS_VersionStr());
+}
+
+VCL_STRING
+vmod_revision(VRT_CTX)
+{
+	(void)ctx;
+	return (VCS_RevisionStr());
 }


### PR DESCRIPTION
``vcs.h`` is in the public include directory, but ``VCS_version`` is currently not a public symbol in ``libvarnishapi.so``.

``VCS_Message()`` prints the version and copyright messages to stderr. There is nothing else in the lib that external code can use to find out the version.

This snippet of Go code fails against the current Varnish API, because the symbol is not found:
```
package varnish

/*
#cgo pkg-config: varnishapi
#include <vcs.h>
*/
import "C"

func Version() string {
	return C.GoString(C.VCS_version)
}
```
```
$ go build
# code.uplex.de/uplex-varnish/varnishapi/pkg/varnish
/tmp/go-build413795692/b001/_cgo_main.o:(.data.rel+0x0): undefined reference to `VCS_version'
collect2: error: ld returned 1 exit status
```
With the change, this Go package builds:

```
package varnish

/*
#cgo pkg-config: varnishapi
#include <vcs.h>
*/
import "C"

func Version() string {
        return C.GoString(C.VCS_VersionStr())
}

func Revision() string {
        return C.GoString(C.VCS_RevisionStr())
}
```

Test for the Go package (with the change):
```
package varnish

import "testing"

func TestVersion(t *testing.T) {
	v := Version()
	r := Revision()
	if testing.Verbose() {
		t.Log("Version():", v)
		t.Log("Revision():", r)
	}
}
```
Test output:
```
$ go test -v
=== RUN   TestVersion
--- PASS: TestVersion (0.00s)
	version_test.go:37: Version(): trunk
	version_test.go:38: Revision(): 6f65045bd819e85c7244677b27e05d7e282fcb63
PASS
```

The change moves ``VCS_version`` to a private include header ``vsl_int.h``, since the public include evidently never could have worked.

The second commit also adds functions ``version()`` and ``revision()`` to VMOD std, which are thin wrappers to the two new functions, making the version info available in VCL.