### PR TITLE
Improve VDI_Resolve() FetchErrors

### DIFF
--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -94,9 +94,11 @@ VDI_Resolve(VRT_CTX)
 		CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
 		AN(d->vdir);
 		d2 = d->vdir->methods->resolve(ctx, d);
-		if (d2 == NULL)
-			VSLb(bo->vsl, SLT_FetchError,
-			    "Director %s returned no backend", d->vcl_name);
+		if (d2 != NULL)
+			continue;
+		VSLb(bo->vsl, SLT_FetchError,
+		     "Director %s returned no backend", d->vcl_name);
+		return (NULL);
 	}
 
 	CHECK_OBJ_ORNULL(d, DIRECTOR_MAGIC);

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -101,14 +101,17 @@ VDI_Resolve(VRT_CTX)
 		return (NULL);
 	}
 
-	CHECK_OBJ_ORNULL(d, DIRECTOR_MAGIC);
 	if (d == NULL) {
 		VSLb(bo->vsl, SLT_FetchError, "No backend");
-	} else {
-		AN(d->vdir);
+		return (NULL);
+	}
 
-		if (d->vdir->admin_health->health == 0)
-			d = NULL;
+	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+	AN(d->vdir);
+	if (d->vdir->admin_health->health == 0) {
+		VSLb(bo->vsl, SLT_FetchError,
+		     "Director %s is administratively unhealthy", d->vcl_name);
+		return (NULL);
 	}
 
 	return (d);


### PR DESCRIPTION
for after release. Minor issues, except for the fact that we do not emit a FetchError for "administratively unhealthy". Do we want this in the release?