### PR TITLE
Keep error messages from additional VRT_fail() invocations

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -508,9 +508,7 @@ VRT_fail(VRT_CTX, const char *fmt, ...)
 
 	assert(ctx->vsl != NULL || ctx->msg != NULL);
 	AN(ctx->handling);
-	if (*ctx->handling == VCL_RET_FAIL)
-		return;
-	AZ(*ctx->handling);
+	assert(*ctx->handling == 0 || *ctx->handling == VCL_RET_FAIL);
 	AN(fmt);
 	AZ(strchr(fmt, '\n'));
 	va_start(ap, fmt);


### PR DESCRIPTION
this is particularly important for testing failure conditions as in

	vmod.test_error_handling(vmod.failing())

where `vmod.failing()` fails and `vmod.test_error_handling()` is expected to produce an error message for the case that `vmod.failing()` returns a invalid value (such as `NULL`).

Real life example: https://code.uplex.de/uplex-varnish/libvmod-blobdigest/commit/5a057fb51a5a2ea99490293fae3e92c4b015c9a4

fixes regression from 5735a543c720655c484ef11c70b6cde7f201d5ca