### PR TITLE
backend synth vs. stale oc take 2

### DIFF
--- a/bin/varnishtest/tests/r01395.vtc
+++ b/bin/varnishtest/tests/r01395.vtc
@@ -1,4 +1,4 @@
-varnishtest "Test vcl_synth is called even if vcl_backend_fetch failed"
+varnishtest "Test vcl_backend_error is called if vcl_backend_fetch fails"
 
 varnish v1 -vcl {
 	backend default { .host = "${bad_backend}"; }

--- a/bin/varnishtest/tests/r02946.vtc
+++ b/bin/varnishtest/tests/r02946.vtc
@@ -1,0 +1,45 @@
+varnishtest "#2946 - objcore leak for backend_synth"
+
+varnish v1 -vcl {
+	backend bad { .host = "${bad_backend}"; }
+
+	sub vcl_backend_error {
+		if (bereq.http.abandon) {
+			return (abandon);
+		}
+		if (bereq.http.ttl0) {
+			set beresp.ttl = 0s;
+			return (deliver);
+		}
+		set beresp.status = 200;
+		set beresp.ttl = 0.0001s;
+		set beresp.grace = 1h;
+		return (deliver);
+	}
+} -start
+
+client c1 -repeat 20 -keepalive {
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	delay 0.001
+} -run
+
+delay 2
+
+client c1 {
+	txreq -hdr "abandon: true"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.age > 1
+} -run
+
+client c1 {
+	txreq -hdr "ttl0: true"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.age > 1
+} -run
+
+varnish v1 -expect n_objectcore == 1

--- a/doc/sphinx/users-guide/vcl-built-in-subs.rst
+++ b/doc/sphinx/users-guide/vcl-built-in-subs.rst
@@ -495,8 +495,12 @@ vcl_backend_error
 This subroutine is called if we fail the backend fetch or if
 *max_retries* has been exceeded.
 
-A synthetic object is generated in VCL, whose body may be constructed
-using the ``synthetic()`` function.
+Returning with `abandon`_ does not leave a cache object.
+
+If returning with ``deliver`` and a ``beresp.ttl > 0s``, a synthetic
+cache object is generated in VCL, whose body may be constructed using
+the ``synthetic()`` function. This may be useful to increase the
+efficiency of failing backend requests.
 
 The `vcl_backend_error` subroutine may terminate with calling ``return()``
 with one of the following keywords:


### PR DESCRIPTION
includes #2950 as a prerequisite

I have now made up my mind about #2946 and would fix/clarify as follows:

Fixes #2946 in the sense that we want to treat a cacheable backend synth like any other object and kill the stale object it replaces.
  
We do not replace the stale oc when
* abandoning the bereq
* leaving vcl_backend_error with return (deliver) and beresp.ttl == 0s
* there is a waitinglist on this object because in this case the default ttl would be 1s, so we might be looking at the same case as the previous