### PR TITLE
include sys/time.h for struct timeval

### DIFF
--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -30,6 +30,7 @@
 #include "config.h"
 
 #include <sys/types.h>
+#include <sys/time.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #ifdef HAVE_SYS_FILIO_H


### PR DESCRIPTION
This PR fixes ...

vtcp.c:352:27: error: calling 'VTIM_timeval' with incomplete return type 'struct timeval'
        struct timeval timeout = VTIM_timeval(seconds);

... when building on NetBSD HEAD-llvm.