### PR TITLE
make VRT_fail() work with any initializier

### DIFF
--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -200,6 +200,7 @@ struct inifin {
 	unsigned		magic;
 #define INIFIN_MAGIC		0x583c274c
 	unsigned		n;
+	unsigned		ignore_errors;
 	struct vsb		*ini;
 	struct vsb		*fin;
 	struct vsb		*final;


### PR DESCRIPTION
Historically, all initializers called from VGC_Load() would handle
failures individually (return (1) from VGC_Load) or not fail at
all. Now that we got VRT_fail(), it makes sense to generalize.

The upcoming use case is to properly handle failures from
VRT_new_backend_clustered().