### PR TITLE
Include vnum.h in public headers

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -67,6 +67,7 @@ nobase_pkginclude_HEADERS += \
 	vcs.h \
 	verrno.h \
 	vmod_abi.h \
+	vnum.h \
 	vqueue.h \
 	vre.h \
 	vdef.h \
@@ -97,7 +98,6 @@ nobase_noinst_HEADERS = \
 	vjsn.h \
 	vlu.h \
 	vmb.h \
-	vnum.h \
 	vpf.h \
 	vsc_priv.h \
 	vsl_priv.h \


### PR DESCRIPTION
I ran into a case with an out of tree VMOD where I wanted to convert a string to a number. I wound up including `vnum.h` by hand to convert the string but I thought including `vnum.h` in the public headers would be a useful addition.