### PR TITLE
Limit the number of concurrent pipe transactions

### DIFF
--- a/bin/varnishd/VSC_main.vsc
+++ b/bin/varnishd/VSC_main.vsc
@@ -394,6 +394,11 @@
 	:oneliner:	Total sessions seen
 
 
+.. varnish_vsc:: n_pipe
+	:type:	gauge
+	:oneliner:	Number of ongoing pipe sessions
+
+
 .. varnish_vsc:: s_pipe
 	:group: wrk
 	:oneliner:	Total pipe sessions seen

--- a/bin/varnishd/VSC_main.vsc
+++ b/bin/varnishd/VSC_main.vsc
@@ -399,6 +399,14 @@
 	:oneliner:	Number of ongoing pipe sessions
 
 
+.. varnish_vsc:: pipe_limited
+	:group: wrk
+	:oneliner:	Pipes hit pipe_sess_max
+
+	Number of times more pipes were needed, but the limit was reached. See
+	also parameter pipe_sess_max.
+
+
 .. varnish_vsc:: s_pipe
 	:group: wrk
 	:oneliner:	Total pipe sessions seen

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -710,6 +710,7 @@ cnt_pipe(struct worker *wrk, struct req *req)
 			V1P_Leave();
 			break;
 		}
+		wrk->stats->pipe_limited++;
 		/* fall through */
 	case VCL_RET_FAIL:
 		req->req_step = R_STP_VCLFAIL;

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -44,6 +44,7 @@
 #include "cache_transport.h"
 
 #include "hash/hash_slinger.h"
+#include "http1/cache_http1.h"
 #include "storage/storage.h"
 #include "common/heritage.h"
 #include "vcl.h"
@@ -704,11 +705,13 @@ cnt_pipe(struct worker *wrk, struct req *req)
 		nxt = REQ_FSM_MORE;
 		break;
 	case VCL_RET_PIPE:
+		XXXAZ(V1P_Enter());
 		AZ(bo->req);
 		bo->req = req;
 		bo->wrk = wrk;
 		SES_Close(req->sp, VDI_Http1Pipe(req, bo));
 		nxt = REQ_FSM_DONE;
+		V1P_Leave();
 		break;
 	default:
 		WRONG("Illegal return from vcl_pipe{}");

--- a/bin/varnishd/http1/cache_http1.h
+++ b/bin/varnishd/http1/cache_http1.h
@@ -50,6 +50,8 @@ struct v1p_acct {
 	uint64_t        out;
 };
 
+int V1P_Enter(void);
+void V1P_Leave(void);
 void V1P_Process(const struct req *, int fd, struct v1p_acct *);
 void V1P_Charge(struct req *, const struct v1p_acct *, struct VSC_vbe *);
 

--- a/bin/varnishd/http1/cache_http1_pipe.c
+++ b/bin/varnishd/http1/cache_http1_pipe.c
@@ -65,11 +65,16 @@ rdf(int fd0, int fd1, uint64_t *pcnt)
 int
 V1P_Enter(void)
 {
+	int retval = 0;
 
 	Lck_Lock(&pipestat_mtx);
-	VSC_C_main->n_pipe++;
+	if (cache_param->pipe_sess_max == 0 ||
+	    VSC_C_main->n_pipe < cache_param->pipe_sess_max)
+		VSC_C_main->n_pipe++;
+	else
+		retval = -1;
 	Lck_Unlock(&pipestat_mtx);
-	return (0);
+	return (retval);
 }
 
 void

--- a/bin/varnishd/http1/cache_http1_pipe.c
+++ b/bin/varnishd/http1/cache_http1_pipe.c
@@ -62,6 +62,26 @@ rdf(int fd0, int fd1, uint64_t *pcnt)
 	return (0);
 }
 
+int
+V1P_Enter(void)
+{
+
+	Lck_Lock(&pipestat_mtx);
+	VSC_C_main->n_pipe++;
+	Lck_Unlock(&pipestat_mtx);
+	return (0);
+}
+
+void
+V1P_Leave(void)
+{
+
+	Lck_Lock(&pipestat_mtx);
+	assert(VSC_C_main->n_pipe > 0);
+	VSC_C_main->n_pipe--;
+	Lck_Unlock(&pipestat_mtx);
+}
+
 void
 V1P_Charge(struct req *req, const struct v1p_acct *a, struct VSC_vbe *b)
 {

--- a/bin/varnishtest/tests/v00059.vtc
+++ b/bin/varnishtest/tests/v00059.vtc
@@ -1,4 +1,4 @@
-varnishtest "n_pipe gauge"
+varnishtest "concurrent pipe limit"
 
 barrier b1 cond 2
 barrier b2 cond 2
@@ -36,6 +36,7 @@ varnish v1 -expect MAIN.n_pipe == 0
 client c1 {
 	txreq -url "/c1"
 	rxresp
+	expect resp.status == 200
 } -start
 
 barrier b1 sync
@@ -45,10 +46,20 @@ varnish v1 -expect MAIN.n_pipe == 1
 client c2 {
 	txreq -url "/c2"
 	rxresp
+	expect resp.status == 200
 } -start
 
 barrier b3 sync
 varnish v1 -expect MAIN.n_pipe == 2
+
+varnish v1 -cliok "param.set pipe_sess_max 2"
+
+client c3 {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
 barrier b2 sync
 varnish v1 -expect MAIN.n_pipe == 1
 barrier b4 sync

--- a/bin/varnishtest/tests/v00059.vtc
+++ b/bin/varnishtest/tests/v00059.vtc
@@ -64,3 +64,4 @@ barrier b2 sync
 varnish v1 -expect MAIN.n_pipe == 1
 barrier b4 sync
 varnish v1 -expect MAIN.n_pipe == 0
+varnish v1 -expect MAIN.pipe_limited == 1

--- a/bin/varnishtest/tests/v00059.vtc
+++ b/bin/varnishtest/tests/v00059.vtc
@@ -1,0 +1,55 @@
+varnishtest "n_pipe gauge"
+
+barrier b1 cond 2
+barrier b2 cond 2
+barrier b3 cond 2
+barrier b4 cond 2
+
+server s1 {
+	rxreq
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+server s2 {
+	rxreq
+	barrier b3 sync
+	barrier b4 sync
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.url == "/c1") {
+			set req.backend_hint = s1;
+		}
+		elsif (req.url == "/c2") {
+			set req.backend_hint = s2;
+		}
+		return (pipe);
+	}
+} -start
+
+varnish v1 -expect MAIN.n_pipe == 0
+
+client c1 {
+	txreq -url "/c1"
+	rxresp
+} -start
+
+barrier b1 sync
+
+varnish v1 -expect MAIN.n_pipe == 1
+
+client c2 {
+	txreq -url "/c2"
+	rxresp
+} -start
+
+barrier b3 sync
+varnish v1 -expect MAIN.n_pipe == 2
+barrier b2 sync
+varnish v1 -expect MAIN.n_pipe == 1
+barrier b4 sync
+varnish v1 -expect MAIN.n_pipe == 0

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -915,6 +915,20 @@ PARAM(
 )
 
 PARAM(
+	/* name */	pipe_sess_max,
+	/* typ */	uint,
+	/* min */	"0",
+	/* max */	NULL,
+	/* default */	"0",
+	/* units */	"connections",
+	/* flags */	0,
+	/* s-text */
+	"Maximum number of sessions dedicated to pipe transactions.",
+	/* l-text */	"",
+	/* func */	NULL
+)
+
+PARAM(
 	/* name */	pipe_timeout,
 	/* typ */	timeout,
 	/* min */	"0.000",


### PR DESCRIPTION
This is a first of hopefully three patch series in the pipe vicinity.

This is pretty straightforward, count and limit ongoing pipe transactions only if we `return (pipe)` from `vcl_pipe`.