### PR TITLE
Start honoring [idle_]send_timeout of h2 streams

### DIFF
--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -232,6 +232,7 @@ void H2_Send(struct worker *, struct h2_req *, h2_frame type, uint8_t flags,
 /* cache_http2_proto.c */
 struct h2_req * h2_new_req(const struct worker *, struct h2_sess *,
     unsigned stream, struct req *);
+int h2_stream_tmo(struct h2_sess *, const struct h2_req *, vtim_real);
 void h2_del_req(struct worker *, const struct h2_req *);
 void h2_kill_req(struct worker *, struct h2_sess *, struct h2_req *, h2_error);
 int h2_rxframe(struct worker *, struct h2_sess *);

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -87,6 +87,10 @@ h2_fini(struct req *req, void **priv)
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	TAKE_OBJ_NOTNULL(r2, priv, H2_REQ_MAGIC);
+
+	if (r2->error)
+		return (0);
+
 	H2_Send_Get(req->wrk, r2->h2sess, r2);
 	H2_Send(req->wrk, r2, H2_F_DATA, H2FF_DATA_END_STREAM, 0, "", NULL);
 	H2_Send_Rel(r2->h2sess, r2);

--- a/bin/varnishtest/tests/t02016.vtc
+++ b/bin/varnishtest/tests/t02016.vtc
@@ -1,0 +1,76 @@
+varnishtest "client h2 send timeouts"
+
+server s1 {
+	rxreq
+	txresp -bodylen 12345
+} -start
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -vcl+backend "" -start
+
+varnish v1 -cliok "param.set send_timeout 1"
+
+logexpect l1 -v v1 {
+	expect * * Debug "Hit send_timeout"
+} -start
+
+client c1 {
+	txpri
+
+	stream 0 {
+		rxsettings
+		expect settings.ack == false
+		txsettings -ack
+		txsettings -winsize 1000
+		rxsettings
+		expect settings.ack == true
+	} -run
+
+	stream 1 {
+		txreq
+		rxhdrs
+		rxdata
+		# keep the stream idle for 2 seconds
+		delay 2
+		txwinup -size 256
+		# too late
+		rxrst
+		expect rst.err == CANCEL
+	} -run
+
+} -run
+
+logexpect l1 -wait
+
+varnish v1 -cliok "param.set idle_send_timeout 1"
+varnish v1 -cliok "param.reset send_timeout"
+
+logexpect l2 -v v1 {
+	expect * * Debug "Hit idle_send_timeout"
+} -start
+
+client c2 {
+	txpri
+
+	stream 0 {
+		rxsettings
+		expect settings.ack == false
+		txsettings -ack
+		txsettings -winsize 1000
+		rxsettings
+		expect settings.ack == true
+	} -run
+
+	stream 1 {
+		txreq
+		rxhdrs
+		rxdata
+		# keep the stream idle for 2 seconds
+		delay 2
+		rxrst
+		expect rst.err == CANCEL
+	} -run
+
+} -run
+
+logexpect l2 -wait


### PR DESCRIPTION
I entered my garage to work on something two days ago and found my pet blocking the way. It wouldn't budge until after a good shaving.

There is a lot to review here and I tried to break it down to be as granular as possible. When I first wrote my patch I found bugs I thought I had caused but no, they were already there so instead of just fixing them I tried to reorder them in a more coherent way, and tried to also add h1 coverage.

The first problem is the use of `SO_{RCV,SND}BUF` to cover the h1 timeouts. It works on my machine (obviously) but I don't know how portable this is:

- does it work on all systems in general?
- how may each system round up buffer size?
- may the rounding up lead to test failures?

I decided to leave this to the review because I won't be available next week, and don't have time today to test the various systems we care about.

There is not really a second problem, but rather open questions that may appear in individual commit messages.

And finally, I used the modest hardware from my garage to run all the h2 test cases under load (`-j32 -n1000`) a few times without finding any problem, but this hasn't seen production traffic. I also inspected passing test results as closely as I could and this is partly how I found the bugs I fixed along the way.

Summoning @xcir and @simonvik in case they could give it a try with real traffic.

Did I mention my pet is a yak?