### PR TITLE
Add timeout_idle customization per session

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -572,8 +572,11 @@ struct sess {
 
 	vtim_real		t_open;		/* fd accepted */
 	vtim_real		t_idle;		/* fd accepted or resp sent */
-
+	vtim_dur		timeout_idle;
 };
+
+#define SESS_TMO(sp, tmo)					\
+	(isnan((sp)->tmo) ? cache_param->tmo : (sp)->tmo)
 
 /* Prototypes etc ----------------------------------------------------*/
 

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -378,6 +378,7 @@ SES_New(struct pool *pp)
 
 	sp->t_open = NAN;
 	sp->t_idle = NAN;
+	sp->timeout_idle = NAN;
 	Lck_New(&sp->mtx, lck_sess);
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 	return (sp);
@@ -465,7 +466,7 @@ SES_Wait(struct sess *sp, const struct transport *xp)
 	wp->priv2 = (uintptr_t)xp;
 	wp->idle = sp->t_idle;
 	wp->func = ses_handle;
-	wp->tmo = cache_param->timeout_idle;
+	wp->tmo = SESS_TMO(sp, timeout_idle);
 	if (Wait_Enter(pp->waiter, wp))
 		SES_Delete(sp, SC_PIPE_OVERFLOW, NAN);
 }

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -939,3 +939,27 @@ HTTP_VAR(req)
 HTTP_VAR(resp)
 HTTP_VAR(bereq)
 HTTP_VAR(beresp)
+
+/*--------------------------------------------------------------------*/
+
+VCL_VOID
+VRT_l_sess_timeout_idle(VRT_CTX, VCL_DURATION d)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->sp, SESS_MAGIC);
+	ctx->sp->timeout_idle = d > 0.0 ? d : 0.0;
+}
+
+VCL_DURATION
+VRT_r_sess_timeout_idle(VRT_CTX)
+{
+	VCL_DURATION d;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->sp, SESS_MAGIC);
+
+	d = ctx->sp->timeout_idle;
+	if (isnan(d))
+		return (cache_param->timeout_idle);
+	return (d);
+}

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -331,7 +331,7 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 			hs = HTC_RxStuff(req->htc, HTTP1_Complete,
 			    &req->t_first, &req->t_req,
 			    sp->t_idle + cache_param->timeout_linger,
-			    sp->t_idle + cache_param->timeout_idle,
+			    sp->t_idle + SESS_TMO(sp, timeout_idle),
 			    NAN,
 			    cache_param->http_req_size);
 			AZ(req->htc->ws->r);

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -1097,8 +1097,8 @@ h2_rxframe(struct worker *wrk, struct h2_sess *h2)
 	h2->sess->t_idle = VTIM_real();
 	hs = HTC_RxStuff(h2->htc, h2_frame_complete,
 	    NULL, NULL, NAN,
-	    h2->sess->t_idle + cache_param->timeout_idle, NAN,
-	    h2->local_settings.max_frame_size + 9);
+	    h2->sess->t_idle + SESS_TMO(h2->sess, timeout_idle),
+	    NAN, h2->local_settings.max_frame_size + 9);
 	switch (hs) {
 	case HTC_S_COMPLETE:
 		break;

--- a/bin/varnishtest/tests/b00067.vtc
+++ b/bin/varnishtest/tests/b00067.vtc
@@ -3,6 +3,11 @@ varnishtest "Check timeout_idle"
 varnish v1 -arg "-p timeout_idle=1" -vcl {
 	backend dummy { .host = "${bad_ip}"; }
 
+	sub vcl_deliver {
+		if (req.url == "/sess") {
+			set sess.timeout_idle = 2s;
+		}
+	}
 	sub vcl_backend_error {
 		set beresp.status = 200;
 		set beresp.ttl = 1h;
@@ -12,9 +17,19 @@ varnish v1 -arg "-p timeout_idle=1" -vcl {
 client c1 {
 	txreq
 	rxresp
-	delay .2
+	delay 0.2
 	txreq
 	rxresp
-	delay 2
+	delay 1.2
+	expect_close
+} -run
+
+client c1 {
+	txreq -url "/sess"
+	rxresp
+	delay 1.2
+	txreq
+	rxresp
+	delay 2.2
 	expect_close
 } -run

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1250,6 +1250,17 @@ sess.xid	``VCL >= 4.1``
 
 	Unique ID of this session.
 
+sess.timeout_idle
+
+	Type: DURATION
+
+	Readable from: client
+
+	Writable from: client
+
+	Idle timeout for this session, defaults to the
+	``timeout_idle`` parameter, see :ref:`varnishd(1)`
+
 storage
 ~~~~~~~
 


### PR DESCRIPTION
Purposes:

* Allow to optimize keepalive for trusted client connections (e.g. CDN, authenticated clients)

* Prepare for an optimization to time out connections on inactive VCLs earlier (see #2764)

A VTC and the other client timeouts will be added when accepted.