### PR TITLE
Kill all still running varnishtest tasks when the parent varnishtest …

### DIFF
--- a/bin/varnishtest/vtc_main.c
+++ b/bin/varnishtest/vtc_main.c
@@ -40,8 +40,6 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include <fcntl.h>
-
 #include "vtc.h"
 
 #include "vev.h"
@@ -679,7 +677,7 @@ static void sig_handler(int signo)
 	
 	VTAILQ_FOREACH(jp, &job_head, list) {
 		CHECK_OBJ_NOTNULL(jp, JOB_MAGIC);
-		if (jp->child > 0) {
+		if (jp->child > 0 && !jp->killed) {
 			AZ(kill(jp->child, signo));
 		}
 	}


### PR DESCRIPTION
By adding a list of running varnishtest jobs and catching the kill message we can make sure that all varnishtest tasks are exited when the main varnishtest is killed.

Fixes: varnishcache#2952