### PR TITLE
Master unbusy race

### DIFF
--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -420,11 +420,11 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp)
 			continue;
 
 		CHECK_OBJ_ORNULL(oc->boc, BOC_MAGIC);
-		if (oc->boc != NULL && oc->boc->state < BOS_STREAM) {
+		if (oc->flags & OC_F_BUSY) {
 			if (req->hash_ignore_busy)
 				continue;
 
-			if (oc->boc->vary != NULL &&
+			if (oc->boc != NULL && oc->boc->vary != NULL &&
 			    !VRY_Match(req, oc->boc->vary))
 				continue;
 

--- a/bin/varnishd/cache/cache_obj.c
+++ b/bin/varnishd/cache/cache_obj.c
@@ -267,7 +267,6 @@ ObjSetState(struct worker *wrk, const struct objcore *oc,
 	assert(next > oc->boc->state);
 
 	CHECK_OBJ_ORNULL(oc->stobj->stevedore, STEVEDORE_MAGIC);
-	assert(next != BOS_STREAM || oc->boc->state == BOS_PREP_STREAM);
 	assert(next != BOS_FINISHED || (oc->oa_present & (1 << OA_LEN)));
 
 	if (oc->stobj->stevedore != NULL) {

--- a/bin/varnishtest/tests/c00097.vtc
+++ b/bin/varnishtest/tests/c00097.vtc
@@ -1,48 +1,63 @@
 varnishtest "Streaming delivery and waitinglist rushing"
 
-barrier b1 sock 4
-barrier b2 sock 4
+# Barrier to make sure that c1 connects to s1
+barrier b1 cond 2
+
+# Barrier to make sure that all requests are on waitinglist before
+# HSH_Unbusy is called
+barrier b2 cond 2
+
+# Barrier to control that all requests start streaming before the object
+# finishes. This tests that waitinglists are rushed before
+# HSH_DerefObjCore().
+barrier b3 sock 4
 
 server s1 {
 	rxreq
+	barrier b1 sync
+	barrier b2 sync
 	txresp -nolen -hdr "Transfer-Encoding: chunked"
 	chunkedlen 10
-	barrier b1 sync
+	barrier b3 sync
 	chunkedlen 10
 	chunkedlen 0
 } -start
 
-varnish v1 -arg "-p rush_exponent=2" -arg "-p debug=+syncvsl" -vcl+backend {
+varnish v1 -arg "-p thread_pools=1" -arg "-p thread_pool_min=20" -arg "-p rush_exponent=2" -arg "-p debug=+syncvsl" -arg "-p debug=+waitinglist" -vcl+backend {
 	import vtc;
 	sub vcl_hit {
-		vtc.barrier_sync("${b1_sock}");
+		vtc.barrier_sync("${b3_sock}");
 	}
 } -start
 
 client c1 {
 	txreq
-	rxresp -no_obj
-	barrier b2 sync
-	rxrespbody
+	rxresp
 } -start
 
+barrier b1 sync
+
 client c2 {
-	barrier b2 sync
 	txreq
 	rxresp
 } -start
 
 client c3 {
-	barrier b2 sync
 	txreq
 	rxresp
 } -start
 
 client c4 {
-	barrier b2 sync
 	txreq
 	rxresp
 } -start
+
+# Wait until c2-c4 are on the waitinglist
+delay 1
+varnish v1 -expect busy_sleep == 3
+
+# Open up the response headers from s1, and as a result HSH_Unbusy
+barrier b2 sync
 
 client c1 -wait
 client c2 -wait

--- a/bin/varnishtest/tests/c00098.vtc
+++ b/bin/varnishtest/tests/c00098.vtc
@@ -1,13 +1,24 @@
 varnishtest "Hit-for-pass and waitinglist rushing"
 
-barrier b2 cond 6
+# Barrier to make sure that s1 is run first
+barrier b1 cond 2
+
+# Barrier to make sure that all requests are on waitinglist before
+# HSH_Unbusy is called
+barrier b2 cond 2
+
+# Barrier to control that all backends are reached before any request
+# finishes. This tests that waitinglists are rushed before
+# HSH_DerefObjCore().
 barrier b3 cond 6
 
 server s1 {
 	rxreq
+	barrier b1 sync
+	barrier b2 sync
 	txresp -nolen -hdr "Transfer-Encoding: chunked"
 	chunkedlen 10
-	barrier b2 sync
+	barrier b3 sync
 	chunkedlen 10
 	chunkedlen 0
 } -start
@@ -16,7 +27,7 @@ server s2 {
 	rxreq
 	txresp -nolen -hdr "Transfer-Encoding: chunked"
 	chunkedlen 10
-	barrier b2 sync
+	barrier b3 sync
 	chunkedlen 10
 	chunkedlen 0
 } -start
@@ -25,7 +36,7 @@ server s3 {
 	rxreq
 	txresp -nolen -hdr "Transfer-Encoding: chunked"
 	chunkedlen 10
-	barrier b2 sync
+	barrier b3 sync
 	chunkedlen 10
 	chunkedlen 0
 } -start
@@ -34,7 +45,7 @@ server s4 {
 	rxreq
 	txresp -nolen -hdr "Transfer-Encoding: chunked"
 	chunkedlen 10
-	barrier b2 sync
+	barrier b3 sync
 	chunkedlen 10
 	chunkedlen 0
 } -start
@@ -43,7 +54,7 @@ server s5 {
 	rxreq
 	txresp -nolen -hdr "Transfer-Encoding: chunked"
 	chunkedlen 10
-	barrier b2 sync
+	barrier b3 sync
 	chunkedlen 10
 	chunkedlen 0
 } -start
@@ -52,13 +63,12 @@ server s6 {
 	rxreq
 	txresp -nolen -hdr "Transfer-Encoding: chunked"
 	chunkedlen 10
-	barrier b2 sync
+	barrier b3 sync
 	chunkedlen 10
 	chunkedlen 0
 } -start
 
-varnish v1 -arg "-p thread_pool_min=20" -arg "-p rush_exponent=2" -arg "-p debug=+syncvsl" -vcl+backend {
-	import vtc;
+varnish v1 -arg "-p thread_pools=1" -arg "-p thread_pool_min=30" -arg "-p rush_exponent=2" -arg "-p debug=+syncvsl" -arg "-p debug=+waitinglist" -vcl+backend {
 	sub vcl_backend_fetch {
 		if (bereq.http.client == "1") {
 			set bereq.backend = s1;
@@ -81,39 +91,43 @@ varnish v1 -arg "-p thread_pool_min=20" -arg "-p rush_exponent=2" -arg "-p debug
 
 client c1 {
 	txreq -url /hfp -hdr "Client: 1"
-	rxresp -no_obj
-	barrier b3 sync
+	rxresp
 } -start
 
+# This makes sure that c1->s1 is done first
+barrier b1 sync
+
 client c2 {
-	barrier b3 sync
 	txreq -url /hfp -hdr "Client: 2"
 	rxresp
 } -start
 
 client c3 {
-	barrier b3 sync
 	txreq -url /hfp -hdr "Client: 3"
 	rxresp
 } -start
 
 client c4 {
-	barrier b3 sync
 	txreq -url /hfp -hdr "Client: 4"
 	rxresp
 } -start
 
 client c5 {
-	barrier b3 sync
 	txreq -url /hfp -hdr "Client: 5"
 	rxresp
 } -start
 
 client c6 {
-	barrier b3 sync
 	txreq -url /hfp -hdr "Client: 6"
 	rxresp
 } -start
+
+# Wait until c2-c6 are on the waitinglist
+delay 1
+varnish v1 -expect busy_sleep == 5
+
+# Open up the response headers from s1, and as a result HSH_Unbusy
+barrier b2 sync
 
 client c1 -wait
 client c2 -wait
@@ -121,10 +135,3 @@ client c3 -wait
 client c4 -wait
 client c5 -wait
 client c6 -wait
-
-server s1 -wait
-server s2 -wait
-server s3 -wait
-server s4 -wait
-server s5 -wait
-server s6 -wait

--- a/bin/varnishtest/tests/c00099.vtc
+++ b/bin/varnishtest/tests/c00099.vtc
@@ -1,10 +1,21 @@
 varnishtest "Hit-for-miss and waitinglist rushing"
 
+# Barrier to make sure that s1 is run first
+barrier b1 cond 2
+
+# Barrier to make sure that all requests are on waitinglist before
+# HSH_Unbusy is called
+barrier b2 cond 2
+
+# Barrier to control that all backends are reached before any request
+# finishes. This tests that waitinglists are rushed before
+# HSH_DerefObjCore().
 barrier b3 cond 6
-barrier b4 cond 6
 
 server s1 {
 	rxreq
+	barrier b1 sync
+	barrier b2 sync
 	txresp -nolen -hdr "Transfer-Encoding: chunked"
 	chunkedlen 10
 	barrier b3 sync
@@ -57,8 +68,7 @@ server s6 {
 	chunkedlen 0
 } -start
 
-varnish v1 -arg "-p thread_pool_min=20" -arg "-p rush_exponent=2" -arg "-p debug=+syncvsl" -vcl+backend {
-	import vtc;
+varnish v1 -arg "-p thread_pools=1" -arg "-p thread_pool_min=30" -arg "-p rush_exponent=2" -arg "-p debug=+syncvsl" -arg "-p debug=+waitinglist" -vcl+backend {
 	sub vcl_backend_fetch {
 		if (bereq.http.client == "1") {
 			set bereq.backend = s1;
@@ -81,39 +91,43 @@ varnish v1 -arg "-p thread_pool_min=20" -arg "-p rush_exponent=2" -arg "-p debug
 
 client c1 {
 	txreq -url /hfm -hdr "Client: 1"
-	rxresp -no_obj
-	barrier b4 sync
+	rxresp
 } -start
 
+# This makes sure that c1->s1 is done first
+barrier b1 sync
+
 client c2 {
-	barrier b4 sync
 	txreq -url /hfm -hdr "Client: 2"
 	rxresp
 } -start
 
 client c3 {
-	barrier b4 sync
 	txreq -url /hfm -hdr "Client: 3"
 	rxresp
 } -start
 
 client c4 {
-	barrier b4 sync
 	txreq -url /hfm -hdr "Client: 4"
 	rxresp
 } -start
 
 client c5 {
-	barrier b4 sync
 	txreq -url /hfm -hdr "Client: 5"
 	rxresp
 } -start
 
 client c6 {
-	barrier b4 sync
 	txreq -url /hfm -hdr "Client: 6"
 	rxresp
 } -start
+
+# Wait until c2-c6 are on the waitinglist
+delay 1
+varnish v1 -expect busy_sleep == 5
+
+# Open up the response headers from s1, and as a result HSH_Unbusy
+barrier b2 sync
 
 client c1 -wait
 client c2 -wait
@@ -121,10 +135,3 @@ client c3 -wait
 client c4 -wait
 client c5 -wait
 client c6 -wait
-
-server s1 -wait
-server s2 -wait
-server s3 -wait
-server s4 -wait
-server s5 -wait
-server s6 -wait

--- a/include/tbl/boc_state.h
+++ b/include/tbl/boc_state.h
@@ -30,7 +30,6 @@
 
 BOC_STATE(INVALID,	invalid)	/* don't touch (yet) */
 BOC_STATE(REQ_DONE,	req_done)	/* bereq.* can be examined */
-BOC_STATE(PREP_STREAM,	prep_stream)	/* Prepare for streaming */
 BOC_STATE(STREAM,	stream)		/* beresp.* can be examined */
 BOC_STATE(FINISHED,	finished)	/* object is complete */
 BOC_STATE(FAILED,	failed)		/* something went wrong */


### PR DESCRIPTION
Resolve race on waitinglist rushing between OC_F_BUSY and boc->state  …
When an object is ready for delivery, HSH_Unbusy was called before calling
ObjSetState([BOS_STREAM|BOS_FINISHED]). The HSH_Unbusy() call does the
waitinglist rushing, but HSH_Lookup() wanted to look at the boc->state and
if BOS_STREAM had been reached. This could cause requests woken to find
that the stream state still hadn't been reached (ObjSetState still hadn't
executed), and go back on the waitinglist.

To fix this, this patch reverts commit 0375791, and goes back to considering
OC_F_BUSY as the gate keeper for HSH_Lookup. This eliminates the race,
because HSH_Unbusy and HSH_Lookup then uses the same mutex.

That change opens up the possiblity that req code after HSH_Lookup() sees
an object that has not yet reached BOS_STREAM. In order to not have to add
new ObjWaitState() calls (with the additional locking cost that would
bring) to wait for BOS_STREAM, the order of events is changed throughout,
and calls ObjSetState([BOS_STREAM|BOS_FINISHED]) before HSH_Unbusy(). That
way, an object returned from HSH_Lookup() is guaranteed to be at least
BOS_STREAM.
