### PR TITLE
2nd attempt at resolving the waitinglist rush HSH_Unbusy and boc->state race

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -809,6 +809,7 @@ vbf_stp_fail(struct worker *wrk, const struct busyobj *bo)
 
 	assert(bo->fetch_objcore->boc->state < BOS_FINISHED);
 	ObjSetState(wrk, bo->fetch_objcore, BOS_FAILED);
+	HSH_Fail(bo->fetch_objcore);
 	if (!(bo->fetch_objcore->flags & OC_F_BUSY))
 		HSH_Kill(bo->fetch_objcore);
 	return (F_STP_DONE);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -593,6 +593,7 @@ vbf_stp_fetchend(struct worker *wrk, struct busyobj *bo)
 		assert(bo->fetch_objcore->boc->state == BOS_STREAM);
 	else {
 		assert(bo->fetch_objcore->boc->state == BOS_REQ_DONE);
+		ObjSetState(wrk, bo->fetch_objcore, BOS_PREP_STREAM);
 		HSH_Unbusy(wrk, bo->fetch_objcore);
 	}
 
@@ -790,6 +791,7 @@ vbf_stp_error(struct worker *wrk, struct busyobj *bo)
 	}
 	AZ(ObjSetU64(wrk, bo->fetch_objcore, OA_LEN, o));
 	VSB_destroy(&synth_body);
+	ObjSetState(wrk, bo->fetch_objcore, BOS_PREP_STREAM);
 	HSH_Unbusy(wrk, bo->fetch_objcore);
 	if (stale != NULL && bo->fetch_objcore->ttl > 0)
 		HSH_Kill(stale);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -562,8 +562,9 @@ vbf_stp_fetch(struct worker *wrk, struct busyobj *bo)
 	assert(bo->fetch_objcore->boc->state == BOS_REQ_DONE);
 
 	if (bo->do_stream) {
-		ObjSetState(wrk, bo->fetch_objcore, BOS_STREAM);
+		ObjSetState(wrk, bo->fetch_objcore, BOS_PREP_STREAM);
 		HSH_Unbusy(wrk, bo->fetch_objcore);
+		ObjSetState(wrk, bo->fetch_objcore, BOS_STREAM);
 	}
 
 	VSLb(bo->vsl, SLT_Fetch_Body, "%u %s %s",
@@ -588,20 +589,18 @@ vbf_stp_fetchend(struct worker *wrk, struct busyobj *bo)
 	AZ(ObjSetU64(wrk, bo->fetch_objcore, OA_LEN,
 	    bo->fetch_objcore->boc->len_so_far));
 
+	if (bo->do_stream)
+		assert(bo->fetch_objcore->boc->state == BOS_STREAM);
+	else {
+		assert(bo->fetch_objcore->boc->state == BOS_REQ_DONE);
+		HSH_Unbusy(wrk, bo->fetch_objcore);
+	}
+
 	/* Recycle the backend connection before setting BOS_FINISHED to
 	   give predictable backend reuse behavior for varnishtest */
 	VDI_Finish(bo);
 
-	if (bo->do_stream)
-		assert(bo->fetch_objcore->boc->state == BOS_STREAM);
-	else
-		assert(bo->fetch_objcore->boc->state == BOS_REQ_DONE);
 	ObjSetState(wrk, bo->fetch_objcore, BOS_FINISHED);
-
-	if (!bo->do_stream)
-		HSH_Unbusy(wrk, bo->fetch_objcore);
-	AZ(bo->fetch_objcore->flags & OC_F_BUSY);
-
 	VSLb_ts_busyobj(bo, "BerespBody", W_TIM_real(wrk));
 	if (bo->stale_oc != NULL)
 		HSH_Kill(bo->stale_oc);
@@ -655,8 +654,9 @@ vbf_stp_condfetch(struct worker *wrk, struct busyobj *bo)
 	AZ(ObjCopyAttr(bo->wrk, bo->fetch_objcore, bo->stale_oc, OA_GZIPBITS));
 
 	if (bo->do_stream) {
-		ObjSetState(wrk, bo->fetch_objcore, BOS_STREAM);
+		ObjSetState(wrk, bo->fetch_objcore, BOS_PREP_STREAM);
 		HSH_Unbusy(wrk, bo->fetch_objcore);
+		ObjSetState(wrk, bo->fetch_objcore, BOS_STREAM);
 	}
 
 	if (ObjIterate(wrk, bo->stale_oc, bo, vbf_objiterator, 0))
@@ -790,10 +790,10 @@ vbf_stp_error(struct worker *wrk, struct busyobj *bo)
 	}
 	AZ(ObjSetU64(wrk, bo->fetch_objcore, OA_LEN, o));
 	VSB_destroy(&synth_body);
-	ObjSetState(wrk, bo->fetch_objcore, BOS_FINISHED);
 	HSH_Unbusy(wrk, bo->fetch_objcore);
 	if (stale != NULL && bo->fetch_objcore->ttl > 0)
 		HSH_Kill(stale);
+	ObjSetState(wrk, bo->fetch_objcore, BOS_FINISHED);
 	return (F_STP_DONE);
 }
 
@@ -808,10 +808,10 @@ vbf_stp_fail(struct worker *wrk, const struct busyobj *bo)
 	CHECK_OBJ_NOTNULL(bo->fetch_objcore, OBJCORE_MAGIC);
 
 	assert(bo->fetch_objcore->boc->state < BOS_FINISHED);
-	ObjSetState(wrk, bo->fetch_objcore, BOS_FAILED);
 	HSH_Fail(bo->fetch_objcore);
 	if (!(bo->fetch_objcore->flags & OC_F_BUSY))
 		HSH_Kill(bo->fetch_objcore);
+	ObjSetState(wrk, bo->fetch_objcore, BOS_FAILED);
 	return (F_STP_DONE);
 }
 
@@ -982,6 +982,8 @@ VBF_Fetch(struct worker *wrk, struct req *req, struct objcore *oc,
 			ObjWaitState(oc, BOS_STREAM);
 			if (oc->boc->state == BOS_FAILED) {
 				AN((oc->flags & OC_F_FAILED));
+			} else {
+				AZ(oc->flags & OC_F_BUSY);
 			}
 		}
 	}

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -420,11 +420,11 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp)
 			continue;
 
 		CHECK_OBJ_ORNULL(oc->boc, BOC_MAGIC);
-		if (oc->flags & OC_F_BUSY) {
+		if (oc->boc != NULL && oc->boc->state < BOS_STREAM) {
 			if (req->hash_ignore_busy)
 				continue;
 
-			if (oc->boc != NULL && oc->boc->vary != NULL &&
+			if (oc->boc->vary != NULL &&
 			    !VRY_Match(req, oc->boc->vary))
 				continue;
 

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -420,11 +420,11 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp)
 			continue;
 
 		CHECK_OBJ_ORNULL(oc->boc, BOC_MAGIC);
-		if (oc->boc != NULL && oc->boc->state < BOS_STREAM) {
+		if (oc->flags & OC_F_BUSY) {
 			if (req->hash_ignore_busy)
 				continue;
 
-			if (oc->boc->vary != NULL &&
+			if (oc->boc && oc->boc->vary != NULL &&
 			    !VRY_Match(req, oc->boc->vary))
 				continue;
 

--- a/bin/varnishd/cache/cache_obj.c
+++ b/bin/varnishd/cache/cache_obj.c
@@ -267,6 +267,7 @@ ObjSetState(struct worker *wrk, const struct objcore *oc,
 	assert(next > oc->boc->state);
 
 	CHECK_OBJ_ORNULL(oc->stobj->stevedore, STEVEDORE_MAGIC);
+	assert(next != BOS_STREAM || oc->boc->state == BOS_PREP_STREAM);
 	assert(next != BOS_FINISHED || (oc->oa_present & (1 << OA_LEN)));
 
 	if (oc->stobj->stevedore != NULL) {

--- a/bin/varnishd/cache/cache_obj.c
+++ b/bin/varnishd/cache/cache_obj.c
@@ -84,7 +84,6 @@
 #include <stdlib.h>
 
 #include "cache_varnishd.h"
-#include "cache_objhead.h"
 #include "cache_obj.h"
 #include "vend.h"
 #include "storage/storage.h"
@@ -258,7 +257,8 @@ ObjWaitExtend(const struct worker *wrk, const struct objcore *oc, uint64_t l)
  */
 
 void
-ObjSetState(struct worker *wrk, struct objcore *oc, enum boc_state_e next)
+ObjSetState(struct worker *wrk, const struct objcore *oc,
+    enum boc_state_e next)
 {
 	const struct obj_methods *om;
 
@@ -273,13 +273,6 @@ ObjSetState(struct worker *wrk, struct objcore *oc, enum boc_state_e next)
 		om = oc->stobj->stevedore->methods;
 		if (om->objsetstate != NULL)
 			om->objsetstate(wrk, oc, next);
-	}
-
-	if (next == BOS_FAILED) {
-		/* Signal to cache_hash.c that this object is failed. This
-		 * needs to happen before we signal the boc so that code
-		 * will see the OC_F_FAILED flag after ObjWaitState() */
-		HSH_Fail(oc);
 	}
 
 	Lck_Lock(&oc->boc->mtx);

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -353,6 +353,8 @@ cnt_transmit(struct worker *wrk, struct req *req)
 
 	/* Grab a ref to the bo if there is one (=streaming) */
 	boc = HSH_RefBoc(req->objcore);
+	if (boc && boc->state < BOS_STREAM)
+		ObjWaitState(req->objcore, BOS_STREAM);
 	clval = http_GetContentLength(req->resp);
 	/* RFC 7230, 3.3.3 */
 	status = http_GetStatus(req->resp);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -293,7 +293,8 @@ int ObjGetSpace(struct worker *, struct objcore *, ssize_t *sz, uint8_t **ptr);
 void ObjExtend(struct worker *, struct objcore *, ssize_t l);
 uint64_t ObjWaitExtend(const struct worker *, const struct objcore *,
     uint64_t l);
-void ObjSetState(struct worker *, struct objcore *, enum boc_state_e next);
+void ObjSetState(struct worker *, const struct objcore *,
+    enum boc_state_e next);
 void ObjWaitState(const struct objcore *, enum boc_state_e want);
 void ObjTrimStore(struct worker *, struct objcore *);
 void ObjTouch(struct worker *, struct objcore *, vtim_real now);

--- a/include/tbl/boc_state.h
+++ b/include/tbl/boc_state.h
@@ -30,6 +30,7 @@
 
 BOC_STATE(INVALID,	invalid)	/* don't touch (yet) */
 BOC_STATE(REQ_DONE,	req_done)	/* bereq.* can be examined */
+BOC_STATE(PREP_STREAM,	prep_stream)	/* Prepare for streaming */
 BOC_STATE(STREAM,	stream)		/* beresp.* can be examined */
 BOC_STATE(FINISHED,	finished)	/* object is complete */
 BOC_STATE(FAILED,	failed)		/* something went wrong */


### PR DESCRIPTION
The previous attempt at fixing this was less than ideal. By signalling the delivery threads BOS_STREAM state before HSH_Unbusy, several test cases became fragile, and would fail under high load conditions. What would happen was that the fetch initiating request was allowed to continue (seeing BOS_STREAM) even though HSH_Unbusy had not been run yet, allowing the handling of that request to finish completely, and the test case to continue running. If the test case next step e.g.. was to purge the same URL, it would fail to purge the object (still OC_F_BUSY).

This PR reverts commits 501246e and 4130055. The third patch adds a new approach to fix the initial race.