### PR TITLE
Ban lurker optimalization: Remove from ban list when possible

### DIFF
--- a/bin/varnishd/cache/cache_ban.c
+++ b/bin/varnishd/cache/cache_ban.c
@@ -266,6 +266,8 @@ BAN_DestroyObj(struct objcore *oc)
 {
 
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+	if (oc->ban == NULL)
+		return;
 	Lck_Lock(&ban_mtx);
 	CHECK_OBJ_ORNULL(oc->ban, BAN_MAGIC);
 	if (oc->ban != NULL) {

--- a/bin/varnishd/cache/cache_ban_lurker.c
+++ b/bin/varnishd/cache/cache_ban_lurker.c
@@ -365,7 +365,7 @@ ban_lurker_work(struct worker *wrk, struct vsl_log *vsl)
 
 	/*
 	 * conceptually, all obans are now completed. Remove the tail. If it
-	 * containted the first oban, all obans were on the tail and we're
+	 * contained the first oban, all obans were on the tail and we're
 	 * done.
 	 */
 	if (ban_cleantail(VTAILQ_FIRST(&obans)))

--- a/bin/varnishd/cache/cache_ban_lurker.c
+++ b/bin/varnishd/cache/cache_ban_lurker.c
@@ -167,8 +167,23 @@ ban_lurker_getfirst(struct vsl_log *vsl, struct ban *bt)
 		oh = oc->objhead;
 		CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
 		if (!Lck_Trylock(&oh->mtx)) {
-			if (oc->refcnt == 0 || oc->flags & OC_F_BUSY) {
+			if (oc->flags & OC_F_BUSY) {
 				Lck_Unlock(&oh->mtx);
+			} else if (oc->refcnt == 0 ||
+			    oc->flags & (OC_F_DYING | OC_F_FAILED)) {
+				/*
+				 * We seize the opportunity to remove
+				 * the object completely off the ban
+				 * list, now that we have both the oh
+				 * and ban mutexes.
+				 */
+				noc = VTAILQ_NEXT(oc, ban_list);
+				VTAILQ_REMOVE(&bt->objcore, oc, ban_list);
+				oc->ban = NULL;
+				bt->refcount--;
+				Lck_Unlock(&oh->mtx);
+				oc = noc;
+				continue;
 			} else {
 				/*
 				 * We got the lock, and the oc is not being


### PR DESCRIPTION
This is an improvement of #2925 (which I will close). The the difference is that this PR is even more eager to remove objects from the ban list.

The goal of this PR is to not hold off when dying objects are encountered, and it turned out that we can remove `oc`s in other cases as well.

I am not sure how much effect the last commit has, but I think there are corner cases where the speedup would be significant.