### PR TITLE
Work around old and new getaddrinfo quirks

### DIFF
--- a/bin/varnishtest/tests/m00011.vtc
+++ b/bin/varnishtest/tests/m00011.vtc
@@ -7,25 +7,76 @@ server s1 {
 
 varnish v1 -vcl+backend {
 	import std;
+	import debug;
 
 	sub vcl_deliver {
 		std.timestamp("t0");
-		set resp.http.foo0 = std.ip("8.8.8.*", client.ip);
+
+		debug.store_ip(std.ip("8.8.8.*", client.ip));
+		set resp.http.ip0 = debug.get_ip();
+		set resp.http.port0 = std.port(debug.get_ip());
 		std.timestamp("8.8.8.*, client.ip");
-		set resp.http.foo1 = std.ip("9.9.9.*", server.ip);
+
+		debug.store_ip(std.ip("9.9.9.*", server.ip));
+		set resp.http.ip1 = debug.get_ip();
+		set resp.http.port1 = std.port(debug.get_ip());
 		std.timestamp("9.9.9.*, server.ip");
-		set resp.http.foo2 = std.ip("1.2.3.*", "127.0.0.2");
+
+		debug.store_ip(std.ip("1.2.3.*", "127.0.0.2"));
+		set resp.http.ip2 = debug.get_ip();
+		set resp.http.port2 = std.port(debug.get_ip());
 		std.timestamp("1.2.3.*");
-		set resp.http.foo3 = std.ip("1.2.3.5", "127.0.0.3");
+
+		debug.store_ip(std.ip("1.2.3.5", "127.0.0.3"));
+		set resp.http.ip3 = debug.get_ip();
+		set resp.http.port3 = std.port(debug.get_ip());
 		std.timestamp("1.2.3.5");
-		set resp.http.foo4 = std.ip("2001:db8::", "[::1]");
+
+		debug.store_ip(std.ip("2001:db8::", "[::1]"));
+		set resp.http.ip4 = debug.get_ip();
+		set resp.http.port4 = std.port(debug.get_ip());
 		std.timestamp("2001:db8::");
-		set resp.http.foo5 = std.ip("2001::db8::", "[::1]");
+
+		debug.store_ip(std.ip("2001::db8::", "[::1]"));
+		set resp.http.ip5 = debug.get_ip();
+		set resp.http.port5 = std.port(debug.get_ip());
 		std.timestamp("2001::db8::");
-		set resp.http.foo6 = std.ip("localhost", "0.0.0.0", resolve = false);
+
+		debug.store_ip(std.ip("localhost", "0.0.0.0", resolve = false));
+		set resp.http.ip6 = debug.get_ip();
+		set resp.http.port6 = std.port(debug.get_ip());
 		std.timestamp("localhost, resolve = false");
-		set resp.http.foo7 = std.ip("1.2.3.4", "0.0.0.0", resolve = false);
+
+		debug.store_ip(std.ip("1.2.3.4", "0.0.0.0", resolve = false));
+		set resp.http.ip7 = debug.get_ip();
+		set resp.http.port7 = std.port(debug.get_ip());
 		std.timestamp("1.2.3.4, resolve = false");
+
+		debug.store_ip(std.ip("1.2.3.4 8080", "0.0.0.0"));
+		set resp.http.ip8 = debug.get_ip();
+		set resp.http.port8 = std.port(debug.get_ip());
+		std.timestamp("1.2.3.4 8080");
+
+		debug.store_ip(std.ip("1.2.3.4:443", "0.0.0.0"));
+		set resp.http.ip9 = debug.get_ip();
+		set resp.http.port9 = std.port(debug.get_ip());
+		std.timestamp("1.2.3.4:443");
+
+		debug.store_ip(std.ip("1.2.3.4", "0.0.0.0", resolve = false));
+		set resp.http.ip10 = debug.get_ip();
+		set resp.http.port10 = std.port(debug.get_ip());
+		std.timestamp("1.2.3.4, resolve = false");
+
+		debug.store_ip(std.ip("9.9.9.*", "${s1_sock}"));
+		set resp.http.ip10 = debug.get_ip();
+		set resp.http.port10 = std.port(debug.get_ip());
+		std.timestamp("9.9.9.*, ${s1_sock}");
+
+		debug.store_ip(std.ip("1.2.3.4 80", "0.0.0.0", p = "443"));
+		set resp.http.ip11 = debug.get_ip();
+		set resp.http.port11 = std.port(debug.get_ip());
+		std.timestamp("1.2.3.4 80, p = 443");
+
 	}
 } -start
 
@@ -34,12 +85,29 @@ client c1 {
 	timeout 60
 	txreq
 	rxresp
-	expect resp.http.foo0 == "${localhost}"
-	expect resp.http.foo1 == "${localhost}"
-	expect resp.http.foo2 == "127.0.0.2"
-	expect resp.http.foo3 == "1.2.3.5"
-	expect resp.http.foo4 == "2001:db8::"
-	expect resp.http.foo5 == "::1"
-	expect resp.http.foo6 == "0.0.0.0"
-	expect resp.http.foo7 == "1.2.3.4"
+	expect resp.http.ip0 == ${localhost}
+	expect resp.http.port0 != 0
+	expect resp.http.port0 != 80
+	expect resp.http.ip1 == ${v1_addr}
+	expect resp.http.port1 == ${v1_port}
+	expect resp.http.ip2 == 127.0.0.2
+	expect resp.http.port2 == 80
+	expect resp.http.ip3 == 1.2.3.5
+	expect resp.http.port3 == 80
+	expect resp.http.ip4 == 2001:db8::
+	expect resp.http.port4 == 80
+	expect resp.http.ip5 == ::1
+	expect resp.http.port5 == 80
+	expect resp.http.ip6 == 0.0.0.0
+	expect resp.http.port6 == 80
+	expect resp.http.ip7 == 1.2.3.4
+	expect resp.http.port7 == 80
+	expect resp.http.ip8 == 1.2.3.4
+	expect resp.http.port8 == 8080
+	expect resp.http.ip9 == 1.2.3.4
+	expect resp.http.port9 == 443
+	expect resp.http.ip10 == ${s1_addr}
+	expect resp.http.port10 == ${s1_port}
+	expect resp.http.ip11 == 1.2.3.4
+	expect resp.http.port11 == 80
 } -run

--- a/bin/varnishtest/vtc_client.c
+++ b/bin/varnishtest/vtc_client.c
@@ -110,6 +110,8 @@ client_tcp_connect(struct vtclog *vl, const char *addr, double tmo,
 	int fd;
 	char mabuf[32], mpbuf[32];
 
+	AN(addr);
+	AN(errp);
 	fd = VTCP_open(addr, NULL, tmo, errp);
 	if (fd < 0)
 		return (fd);

--- a/bin/varnishtest/vtc_haproxy.c
+++ b/bin/varnishtest/vtc_haproxy.c
@@ -167,6 +167,8 @@ haproxy_cli_tcp_connect(struct vtclog *vl, const char *addr, double tmo,
 	int fd;
 	char mabuf[32], mpbuf[32];
 
+	AN(addr);
+	AN(errp);
 	fd = VTCP_open(addr, NULL, tmo, errp);
 	if (fd < 0)
 		return (fd);

--- a/include/vss.h
+++ b/include/vss.h
@@ -37,3 +37,6 @@ int VSS_resolver_socktype(const char *addr, const char *def_port,
 struct suckaddr *VSS_ResolveOne(void *dst,
     const char *addr, const char *port,
     int family, int socktype, int flags);
+struct suckaddr *VSS_ResolveFirst(void *dst,
+    const char *addr, const char *port,
+    int family, int socktype, int flags);

--- a/lib/libvarnish/vsa.c
+++ b/lib/libvarnish/vsa.c
@@ -252,6 +252,10 @@ VSA_Malloc(const void *s, unsigned  sal)
 	}
 	if (l != 0) {
 		ALLOC_OBJ(sua, SUCKADDR_MAGIC);
+		/* XXX: shouldn't we AN(sua) instead of mixing up failed
+		 * allocations with unsupported address family or bogus
+		 * sockaddr?
+		 */
 		if (sua != NULL)
 			memcpy(&sua->sa, s, l);
 	}

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -381,20 +381,12 @@ int
 VTCP_open(const char *addr, const char *def_port, vtim_dur timeout,
     const char **errp)
 {
-	int error;
-	const char *err;
 
-	if (errp != NULL)
-		*errp = NULL;
+	AN(errp);
 	assert(timeout >= 0);
-	error = VSS_resolver(addr, def_port, vtcp_open_callback,
-	    &timeout, &err);
-	if (err != NULL) {
-		if (errp != NULL)
-			*errp = err;
-		return (-1);
-	}
-	return (error);
+
+	return (VSS_resolver(addr, def_port, vtcp_open_callback,
+	    &timeout, errp));
 }
 
 /*--------------------------------------------------------------------
@@ -513,6 +505,7 @@ VTCP_listen_on(const char *addr, const char *def_port, int depth,
 	struct helper h;
 	int sock;
 
+	AN(errp);
 	h.depth = depth;
 	h.errp = errp;
 

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -258,3 +258,13 @@ $Function VOID sndbuf(BYTES sndbuf)
 Set the client socket' send buffer size to *sndbuf*. The previous, desired
 and actual values appear in the logs. Not currently implemented for backend
 transactions.
+
+$Function VOID store_ip(PRIV_TASK, IP)
+
+Store an IP address to be later found by ``debug.get_ip()`` in the same
+transaction.
+
+$Function IP get_ip(PRIV_TASK)
+
+Get the IP address previously stored by ``debug.store_ip()`` in the same
+transaction.

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -254,3 +254,7 @@ $Function VOID vcl_allow_cold(PRIV_VCL)
 Allow VCL to go cold
 
 $Function VOID sndbuf(BYTES sndbuf)
+
+Set the client socket' send buffer size to *sndbuf*. The previous, desired
+and actual values appear in the logs. Not currently implemented for backend
+transactions.

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -854,3 +854,30 @@ xyzzy_sndbuf(VRT_CTX, VCL_BYTES arg)
 	VSLb(ctx->vsl, SLT_Debug, "SO_SNDBUF fd=%d old=%d new=%d actual=%d",
 	    fd, oldbuf, buflen, newbuf);
 }
+
+VCL_VOID
+xyzzy_store_ip(VRT_CTX, struct vmod_priv *priv, VCL_IP ip)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(priv);
+	AZ(priv->free);
+	assert(VSA_Sane(ip));
+
+	priv->priv = TRUST_ME(ip);
+}
+
+VCL_IP
+xyzzy_get_ip(VRT_CTX, struct vmod_priv *priv)
+{
+	VCL_IP ip;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(priv);
+	AZ(priv->free);
+
+	ip = priv->priv;
+	assert(VSA_Sane(ip));
+
+	return (ip);
+}

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -341,7 +341,8 @@ and a port number or service name.
 When *s* contains both, the syntax is either ``address:port`` or
 ``address port``. If the address is a numerical IPv6 address it must be
 enclosed between brackets, for example ``[::1] 80`` or ``[::1]:http``.
-The *fallback* may also contain both an address and a port.
+The *fallback* may also contain both an address and a port, but its default
+port is always 80.
 
 If *resolve* is false, `getaddrinfo(3)` is called using ``AI_NUMERICHOST``
 and ``AI_NUMERICSERV`` to avoid network lookups depending on the system's

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -222,8 +222,7 @@ Returns ``true`` if the backend *be* is healthy.
 $Function INT port(IP ip)
 
 Returns the port number of the IP address *ip*. Always returns ``0``
-for a ``*.ip`` variable whose value is ``0.0.0.0`` because the listen
-address is a Unix domain socket.
+for a ``*.ip`` variable when the address is a Unix domain socket.
 
 Type Conversion functions
 =========================
@@ -328,15 +327,26 @@ Examples::
 	set resp.http.answer = std.integer(real=126.42/3);
 
 
-$Function IP ip(STRING s, [IP fallback], BOOL resolve = 1)
+$Function IP ip(STRING s, [IP fallback], BOOL resolve = 1, [STRING p])
 
-Converts the string *s* to the first IP number returned by
-the system library function `getaddrinfo(3)`. If conversion
-fails, *fallback* will be returned or VCL failure will happen.
+Converts the string *s* to the first IP number returned by the system
+library function `getaddrinfo(3)`. If conversion fails, *fallback* will
+be returned or VCL failure will happen.
+
+The IP address includes a port number that can be found with ``std.port()``
+that defaults to 80. The default port can be set to a different value with
+the *p* argument. It will be overriden if *s* contains both an IP address
+and a port number or service name.
+
+When *s* contains both, the syntax is either ``address:port`` or
+``address port``. If the address is a numerical IPv6 address it must be
+enclosed between brackets, for example ``[::1] 80`` or ``[::1]:http``.
+The *fallback* may also contain both an address and a port.
 
 If *resolve* is false, `getaddrinfo(3)` is called using ``AI_NUMERICHOST``
-to avoid network lookups. This makes "numerical" IP strings cheaper
-to convert.
+and ``AI_NUMERICSERV`` to avoid network lookups depending on the system's
+`getaddrinfo(3)` or nsswitch configuration. This makes "numerical" IP
+strings and services cheaper to convert.
 
 Example::
 

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -202,8 +202,7 @@ vmod_ip(VRT_CTX, struct VARGS(ip) *a)
 
 	p = WS_Alloc(ctx->ws, vsa_suckaddr_len);
 	if (p == NULL) {
-		VSLb(ctx->vsl, SLT_VCL_Error,
-		    "vmod std.ip(): insufficient workspace");
+		VRT_fail(ctx, "std.ip: insufficient workspace");
 		return (NULL);
 	}
 
@@ -217,7 +216,7 @@ vmod_ip(VRT_CTX, struct VARGS(ip) *a)
 	if (a->valid_fallback)
 		return (a->fallback);
 
-	VRT_fail(ctx, "std.integer: conversion failed");
+	VRT_fail(ctx, "std.ip: conversion failed");
 	return (NULL);
 }
 

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -206,7 +206,7 @@ vmod_ip(VRT_CTX, struct VARGS(ip) *a)
 		return (NULL);
 	}
 
-	retval = VSS_ResolveOne(p, a->s, "80", PF_UNSPEC, SOCK_STREAM,
+	retval = VSS_ResolveFirst(p, a->s, "80", PF_UNSPEC, SOCK_STREAM,
 	    a->resolve ? 0 : AI_NUMERICHOST);
 	if (retval != NULL)
 		return (retval);

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -206,8 +206,11 @@ vmod_ip(VRT_CTX, struct VARGS(ip) *a)
 		return (NULL);
 	}
 
-	retval = VSS_ResolveFirst(p, a->s, "80", AF_UNSPEC, SOCK_STREAM,
-	    a->resolve ? 0 : AI_NUMERICHOST);
+	retval = VSS_ResolveFirst(
+	    p, a->s, a->valid_p ? a->p : "80",
+	    AF_UNSPEC, SOCK_STREAM,
+	    a->resolve ? 0 : AI_NUMERICHOST|AI_NUMERICSERV);
+
 	if (retval != NULL)
 		return (retval);
 

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -206,7 +206,7 @@ vmod_ip(VRT_CTX, struct VARGS(ip) *a)
 		return (NULL);
 	}
 
-	retval = VSS_ResolveFirst(p, a->s, "80", PF_UNSPEC, SOCK_STREAM,
+	retval = VSS_ResolveFirst(p, a->s, "80", AF_UNSPEC, SOCK_STREAM,
 	    a->resolve ? 0 : AI_NUMERICHOST);
 	if (retval != NULL)
 		return (retval);


### PR DESCRIPTION
Starting with glibc 2.29 I lost the behavior we consistently rely upon when it comes to resolving names and services. A `VSS_ResolveOne` function was introduced as the blessed wrapper around `getaddrinfo`, but is not consistent with the expected behavior.

This patch introduces a `vss_resolve` function shared by both old and new interfaces, and aligns `VSS_ResolveOne` with the established behavior, treating its port as a default port overriden if one is present in the address.

<details>
<summary>Previous pull request description</summary>
Its first purpose is to deduplicate results as it may happen at least
with glibc depending on your nsswitch configuration. In particular if
one has more than one source for name and service lookup the exact same
entry may show up more than once, especially with special names like
localhost.

That lead us to choose that binding for -a types of parameters should be
"at least one" to be considered successful. We could now reconsider to
make "all results" the condition to succeed. That would move the error
for ports already bound to the user if multiple -a parameters create an
overlap, or something is bound by another process.

The second problem is that since glibc 2.29 our ability to pass both
name and service as the node parameter and ignore the service parameter
was geopardized and is no longer reliable. We rely on it implicitly in
several places so the wrapper decomposes service and name when it runs
into such occurrence.

I ran into this trying to build the 6.0 branch where d00007.vtc would
fail inconditionally. This was not apparent in trunk because of a patch
that had been back-ported slightly differently:

- ead72749b78d99f941649e879deadbb683891d10 (master)
- b302a2cf4d4f3863d4ebe9d8c0d6092e5b401079 (6.0)

As this is mostly used in the test suite, this could explain why we
haven't heard of the second problem yet. But as of today glibc 2.29 is
fairly young so maybe few systems are using it and running Varnish.

For this reason d00007.vtc was changed to exhibit the usage of a
"name service" node with and without a service name to show that we
definitively get the implicit behavior we were reyling on so far.
I also found that debug.dyn() failed if at least one of name or service
was omitted and changed that since getaddrinfo doesn't require both,
especially if we pass them via the node argument.

Finally, to make this change throughout the tree I wrote a Coccinelle
patch. If we decide to expose this facility via libvarnishapi it may
become useful out of tree too.
</details>