### PR TITLE
Add Debug to the default VSL mask

### DIFF
--- a/bin/varnishd/mgt/mgt_param_bits.c
+++ b/bin/varnishd/mgt/mgt_param_bits.c
@@ -135,6 +135,7 @@ tweak_vsl_mask(struct vsb *vsb, const struct parspec *par, const char *arg)
 			(void)bit(mgt_param.vsl_mask, SLT_ObjProtocol, BSET);
 			(void)bit(mgt_param.vsl_mask, SLT_ObjReason, BSET);
 			(void)bit(mgt_param.vsl_mask, SLT_ObjStatus, BSET);
+			(void)bit(mgt_param.vsl_mask, SLT_Debug, BSET);
 		} else {
 			return (bit_tweak(vsb, mgt_param.vsl_mask,
 			    SLT__Reserved, arg, VSL_tags,

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -424,6 +424,7 @@ varnish_launch(struct varnish *v)
 	VSB_printf(vsb, " -p sigsegv_handler=on");
 	VSB_printf(vsb, " -p thread_pool_min=10");
 	VSB_printf(vsb, " -p debug=+vtc_mode");
+	VSB_printf(vsb, " -p vsl_mask=+Debug");
 	if (!v->has_a_arg) {
 		VSB_printf(vsb, " -a '%s'", "127.0.0.1:0");
 		if (v->proto != NULL)


### PR DESCRIPTION
The name implies that this is not for production usage.