### PR TITLE
Make backends optional and unset-able

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -792,7 +792,6 @@ cnt_recv_prep(struct req *req, const char *ci)
 
 		/* By default we use the first backend */
 		req->director_hint = VCL_DefaultDirector(req->vcl);
-		AN(req->director_hint);
 
 		req->d_ttl = -1;
 		req->d_grace = -1;

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -459,8 +459,19 @@ VRT_r_req_##nm(VRT_CTX)							\
 	return (ctx->req->elem);					\
 }
 
+#define REQ_VAR_U(nm, elem)						\
+									\
+VCL_VOID								\
+VRT_u_req_##nm(VRT_CTX)							\
+{									\
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);				\
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);				\
+	ctx->req->elem = NULL;						\
+}
+
 REQ_VAR_L(backend_hint, director_hint, VCL_BACKEND,)
 REQ_VAR_R(backend_hint, director_hint, VCL_BACKEND)
+REQ_VAR_U(backend_hint, director_hint)
 REQ_VAR_L(ttl, d_ttl, VCL_DURATION, if (!(arg>0.0)) arg = 0;)
 REQ_VAR_R(ttl, d_ttl, VCL_DURATION)
 REQ_VAR_L(grace, d_grace, VCL_DURATION, if (!(arg>0.0)) arg = 0;)
@@ -484,6 +495,15 @@ VRT_r_bereq_backend(VRT_CTX)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
 	return (ctx->bo->director_req);
+}
+
+VCL_VOID
+VRT_u_bereq_backend(VRT_CTX)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+	ctx->bo->director_req = NULL;
 }
 
 VCL_BACKEND

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -221,6 +221,7 @@ extern const char *mgt_vcl_path;
 extern const char *mgt_vmod_path;
 extern unsigned mgt_vcc_err_unref;
 extern unsigned mgt_vcc_allow_inline_c;
+extern unsigned mgt_vcc_no_backend;
 extern unsigned mgt_vcc_unsafe_path;
 
 #if defined(PTHREAD_CANCELED) || defined(PTHREAD_MUTEX_DEFAULT)

--- a/bin/varnishd/mgt/mgt_param_tbl.c
+++ b/bin/varnishd/mgt/mgt_param_tbl.c
@@ -84,6 +84,11 @@ struct parspec mgt_parspec[] = {
 		"Allow inline C code in VCL.",
 		0,
 		"off", "bool" },
+	{ "vcc_no_backend", tweak_bool, &mgt_vcc_no_backend,
+		NULL, NULL,
+		"Allow VCL to not include a minimum of one backend.",
+		0,
+		"off", "bool" },
 	{ "vcc_unsafe_path", tweak_bool, &mgt_vcc_unsafe_path,
 		NULL, NULL,
 		"Allow '/' in vmod & include paths.\n"

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -65,6 +65,7 @@ const char *mgt_vcl_path;
 const char *mgt_vmod_path;
 unsigned mgt_vcc_err_unref;
 unsigned mgt_vcc_allow_inline_c;
+unsigned mgt_vcc_no_backend;
 unsigned mgt_vcc_unsafe_path;
 
 
@@ -106,6 +107,7 @@ run_vcc(void *priv)
 	VCC_VMOD_path(vcc, mgt_vmod_path);
 	VCC_Err_Unref(vcc, mgt_vcc_err_unref);
 	VCC_Allow_InlineC(vcc, mgt_vcc_allow_inline_c);
+	VCC_No_Backend(vcc, mgt_vcc_no_backend);
 	VCC_Unsafe_Path(vcc, mgt_vcc_unsafe_path);
 	STV_Foreach(stv)
 		VCC_Predef(vcc, "VCL_STEVEDORE", stv->ident);

--- a/bin/varnishtest/tests/v00060.vtc
+++ b/bin/varnishtest/tests/v00060.vtc
@@ -1,0 +1,22 @@
+varnishtest "No backend needed"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-pvcc_no_backend=on" -vcl {
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+# if the flag is off an error should be thrown
+
+varnish v1 -cliok "param.set vcc_no_backend false"
+
+varnish v1 -errvcl {No backends or directors found} {
+}

--- a/bin/varnishtest/tests/v00061.vtc
+++ b/bin/varnishtest/tests/v00061.vtc
@@ -1,0 +1,114 @@
+varnishtest "Allow backend and backend_hint unset"
+
+server s1 -repeat 10 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-p vcc_no_backend=true" -vcl+backend {
+	sub vcl_recv {
+		return (pass);
+	}
+
+	sub vcl_backend_fetch {
+		if (bereq.url == "/no-backend") {
+			unset bereq.backend;
+		}
+
+		if (bereq.url == "/unset-set") {
+			unset bereq.backend;
+			set bereq.backend = s1;
+		}
+	}
+} -start
+
+client c1 {
+	txreq -url "/no-backend"
+	rxresp
+	expect resp.status == 503
+
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/unset-set"
+	rxresp
+	expect resp.status == 200
+} -run
+
+# Unset with no backend
+
+varnish v1 -vcl {
+	sub vcl_recv {
+		return (pass);
+	}
+
+	sub vcl_backend_fetch {
+		if (bereq.url == "/no-backend") {
+			unset bereq.backend;
+		}
+	}
+}
+
+client c1 {
+	txreq -url "/no-backend"
+	rxresp
+	expect resp.status == 503
+
+	txreq -url "/"
+	rxresp
+	expect resp.status == 503
+} -run
+
+# Unset backend_hint
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.url == "/no-backend") {
+			unset req.backend_hint;
+		}
+
+		if (req.url == "/unset-set") {
+			unset req.backend_hint;
+			set req.backend_hint = s1;
+		}
+
+		return (pass);
+	}
+}
+
+client c1 {
+	txreq -url "/no-backend"
+	rxresp
+	expect resp.status == 503
+
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/unset-set"
+	rxresp
+	expect resp.status == 200
+} -run
+
+
+# Unset backend_hint with no default backend
+
+varnish v1 -vcl {
+	sub vcl_recv {
+		if (req.url == "/no-backend") {
+			unset req.backend_hint;
+		}
+		return (pass);
+	}
+}
+
+client c1 {
+	txreq -url "/no-backend"
+	rxresp
+	expect resp.status == 503
+
+	txreq -url "/"
+	rxresp
+	expect resp.status == 503
+} -run

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -351,6 +351,8 @@ req.backend_hint
 
 	Writable from: client
 
+	Unsetable from: client
+
 	Set bereq.backend to this if we attempt to fetch.
 	When set to a director, reading this variable returns
 	an actual backend if the director has resolved immediately,
@@ -495,6 +497,8 @@ bereq.backend
 	Readable from: vcl_pipe, backend
 
 	Writable from: vcl_pipe, backend
+
+	Unsetable from: vcl_pipe, backend
 
 	This is the backend or director we attempt to fetch from.
 	When set to a director, reading this variable returns

--- a/include/libvcc.h
+++ b/include/libvcc.h
@@ -32,6 +32,7 @@ struct vcc;
 
 struct vcc *VCC_New(void);
 void VCC_Allow_InlineC(struct vcc *, unsigned);
+void VCC_No_Backend(struct vcc *, unsigned);
 void VCC_Builtin_VCL(struct vcc *, const char *);
 void VCC_Err_Unref(struct vcc *, unsigned);
 void VCC_Unsafe_Path(struct vcc *, unsigned);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -219,6 +219,7 @@ struct vcc {
 	struct vfil_path	*vmod_path;
 	unsigned		err_unref;
 	unsigned		allow_inline_c;
+	unsigned		no_backend;
 	unsigned		unsafe_path;
 
 	struct symtab		*syms;


### PR DESCRIPTION
Allow backends to be optional and unset-able. The optional backends feature has been put behind a parameter called "vcc_no_backend" that defaults to false to prevent breaking the previous behavior that users might rely on.