### PR TITLE
Delay bereq WS_Reset() when using std.rollback()

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -404,6 +404,7 @@ struct busyobj {
 
 	struct ws		ws[1];
 	uintptr_t		ws_bo;
+	uintptr_t		ws_bo_rst;
 	struct http		*bereq0;
 	struct http		*bereq;
 	struct http		*beresp;

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -497,6 +497,7 @@ struct req {
 	struct vcl		*vcl;
 
 	uintptr_t		ws_req;		/* WS above request data */
+	uintptr_t		ws_req_rst;
 
 	/* Timestamps */
 	vtim_real		t_first;	/* First timestamp logged */

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -185,14 +185,17 @@ Req_Release(struct req *req)
  */
 
 void
-Req_Rollback(struct req *req)
+Req_Rollback(struct req *req, int delay)
 {
 	VCL_TaskLeave(req->vcl, req->privs);
 	VCL_TaskEnter(req->vcl, req->privs);
 	HTTP_Clone(req->http, req->http0);
 	if (WS_Overflowed(req->ws))
 		req->wrk->stats->ws_client_overflow++;
-	WS_Reset(req->ws, req->ws_req);
+	if (delay)
+		req->ws_req_rst = WS_Snapshot(req->ws);
+	else
+		WS_Reset(req->ws, req->ws_req);
 }
 
 /*----------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -346,7 +346,7 @@ int Pool_Task_Any(struct pool_task *task, enum task_prio prio);
 /* cache_req.c */
 struct req *Req_New(const struct worker *, struct sess *);
 void Req_Release(struct req *);
-void Req_Rollback(struct req *req);
+void Req_Rollback(struct req *req, int delay);
 void Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req);
 void Req_Fail(struct req *req, enum sess_close reason);
 

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -659,7 +659,7 @@ VRT_Rollback(VRT_CTX, VCL_HTTP hp)
 	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
 	if (hp == ctx->http_req) {
 		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
-		Req_Rollback(ctx->req);
+		Req_Rollback(ctx->req, 1);
 	} else if (hp == ctx->http_bereq) {
 		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
 		// -> VBO_Rollback ?

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -666,8 +666,7 @@ VRT_Rollback(VRT_CTX, VCL_HTTP hp)
 		VCL_TaskLeave(ctx->bo->vcl, ctx->bo->privs);
 		VCL_TaskEnter(ctx->bo->vcl, ctx->bo->privs);
 		HTTP_Clone(ctx->bo->bereq, ctx->bo->bereq0);
-		WS_Reset(ctx->bo->bereq->ws, ctx->bo->ws_bo);
-		WS_Reset(ctx->bo->ws, ctx->bo->ws_bo);
+		ctx->bo->ws_bo_rst = WS_Snapshot(ctx->bo->ws);
 	} else
 		WRONG("VRT_Rollback 'hp' invalid");
 }

--- a/bin/varnishtest/tests/c00100.vtc
+++ b/bin/varnishtest/tests/c00100.vtc
@@ -1,12 +1,12 @@
 varnishtest "Dont overwrite workspace when using std.rollback()"
 
-server s1 -repeat 7 {
+server s1 -repeat 20 {
 	rxreq
 	txresp
 } -start
 
 # Dont panic
-varnish v1 -arg "-p workspace_backend=12000" -vcl+backend {
+varnish v1 -arg "-p workspace_client=12000" -arg "-p workspace_backend=12000" -vcl+backend {
 	import std;
 	import vtc;
 
@@ -72,6 +72,9 @@ varnish v1 -vcl+backend {
 			set bereq.http.response2 = "Another response";
 			if (bereq.url == "/4") {
 				vtc.workspace_alloc(backend, -10);
+			} else if (bereq.url == "/5") {
+				vtc.workspace_alloc(backend, -10);
+				std.rollback(bereq);
 			}
 			return (retry);
 		}
@@ -92,4 +95,109 @@ client c3 {
 	txreq -url /4
 	rxresp
 	expect resp.status == 503
+
+	txreq -url /5
+	rxresp
+	expect resp.status == 200
+	expect resp.http.fetch == "Fetch value 1"
+	expect resp.http.response == ""
+	expect resp.http.response2 == ""
 } -run
+
+# CLIENT
+
+# Dont panic
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_recv {
+		unset req.http.test;
+	}
+
+	sub vcl_deliver {
+		std.rollback(req);
+		set resp.http.test = req.http.test;
+		vtc.workspace_alloc(client, -200);
+	}
+}
+
+client c4 {
+	txreq -url /6 -hdr "test: 1"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.test == "1"
+} -run
+
+# Dont run out of workspace
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_recv {
+		vtc.workspace_alloc(client, 1000);
+	}
+
+	sub vcl_deliver {
+		if (req.restarts == 0) {
+			vtc.workspace_alloc(client, -10);
+			std.rollback(req);
+			return (restart);
+		}
+	}
+}
+
+client c5 {
+	txreq -url /7
+	rxresp
+	expect resp.status == 200
+} -run
+
+# Keep workspace intact (and possibly overflow)
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_recv {
+		set req.http.fetch = "Fetch value " + req.restarts;
+	}
+
+	sub vcl_deliver {
+		if (req.restarts == 0) {
+			std.rollback(req);
+			set req.http.response = "123";
+			set req.http.response2 = "Another response";
+			if (req.url == "/4") {
+				vtc.workspace_alloc(client, -200);
+			} else if (req.url == "/5") {
+				vtc.workspace_alloc(client, -10);
+				std.rollback(req);
+			}
+			return (restart);
+		}
+		set resp.http.fetch = req.http.fetch;
+		set resp.http.response = req.http.response;
+		set resp.http.response2 = req.http.response2;
+	}
+}
+
+client c6 {
+	txreq -url /8
+	rxresp
+	expect resp.status == 200
+	expect resp.http.fetch == "Fetch value 1"
+	expect resp.http.response == "123"
+	expect resp.http.response2 == "Another response"
+
+	txreq -url /9
+	rxresp
+	expect resp.status == 500
+}
+
+client c7 {
+	txreq -url /10
+	rxresp
+	expect resp.status == 200
+	expect resp.http.fetch == "Fetch value 1"
+	expect resp.http.response == ""
+}

--- a/bin/varnishtest/tests/c00100.vtc
+++ b/bin/varnishtest/tests/c00100.vtc
@@ -1,0 +1,95 @@
+varnishtest "Dont overwrite workspace when using std.rollback()"
+
+server s1 -repeat 7 {
+	rxreq
+	txresp
+} -start
+
+# Dont panic
+varnish v1 -arg "-p workspace_backend=12000" -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_recv {
+		set req.http.test = "1";
+	}
+
+	sub vcl_backend_fetch {
+		unset bereq.http.test;
+	}
+
+	sub vcl_backend_response {
+		std.rollback(bereq);
+		set beresp.http.test = bereq.http.test;
+		vtc.workspace_alloc(backend, -10);
+	}
+} -start
+
+client c1 {
+	txreq -url /1
+	rxresp
+	expect resp.status == 200
+	expect resp.http.test == "1"
+} -run
+
+# Dont run out of workspace
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_backend_fetch {
+		vtc.workspace_alloc(backend, 1000);
+	}
+
+	sub vcl_backend_response {
+		if (bereq.retries == 0) {
+			vtc.workspace_alloc(backend, -10);
+			std.rollback(bereq);
+			return (retry);
+		}
+	}
+}
+
+client c2 {
+	txreq -url /2
+	rxresp
+	expect resp.status == 200
+} -run
+
+# Keep workspace intact (and possibly overflow)
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_backend_fetch {
+		set bereq.http.fetch = "Fetch value " + bereq.retries;
+	}
+
+	sub vcl_backend_response {
+		if (bereq.retries == 0) {
+			std.rollback(bereq);
+			set bereq.http.response = "123";
+			set bereq.http.response2 = "Another response";
+			if (bereq.url == "/4") {
+				vtc.workspace_alloc(backend, -10);
+			}
+			return (retry);
+		}
+		set beresp.http.fetch = bereq.http.fetch;
+		set beresp.http.response = bereq.http.response;
+		set beresp.http.response2 = bereq.http.response2;
+	}
+}
+
+client c3 {
+	txreq -url /3
+	rxresp
+	expect resp.status == 200
+	expect resp.http.fetch == "Fetch value 1"
+	expect resp.http.response == "123"
+	expect resp.http.response2 == "Another response"
+
+	txreq -url /4
+	rxresp
+	expect resp.status == 503
+} -run


### PR DESCRIPTION
Resetting the workspace during the actual call exposes workspace structures to VCL writes. This delays the reset until a retry is performed.

Fixes #3009

Doing a rollback in req also has a similar problem. Can fix that once we settle on a fix for bereq.