### PR TITLE
fix PRIV_TOP for real

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -452,6 +452,7 @@ struct reqtop {
 #define REQTOP_MAGIC		0x57fbda52
 	struct req		*topreq;
 	struct vcl		*vcl0;
+	struct vrt_privs	privs[1];
 };
 
 struct req {

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -447,6 +447,11 @@ struct busyobj {
 
 /*--------------------------------------------------------------------*/
 
+struct reqtop {
+	unsigned		magic;
+#define REQTOP_MAGIC		0x57fbda52
+	struct req		*topreq;
+};
 
 struct req {
 	unsigned		magic;
@@ -456,8 +461,8 @@ struct req {
 	volatile enum req_body_state_e	req_body_status;
 	enum sess_close		doclose;
 	int			restarts;
-	unsigned		esi_level;
-	struct req		*topreq;	/* esi_level == 0 request */
+	int			esi_level;
+	struct reqtop		*top;	/* esi_level == 0 request */
 	struct vcl		*vcl0;
 
 #define REQ_FLAG(l, r, w, d) unsigned	l:1;
@@ -538,7 +543,7 @@ struct req {
 	struct vcf		*vcf;
 };
 
-#define IS_TOPREQ(req) ((req)->topreq == (req))
+#define IS_TOPREQ(req) ((req)->top == NULL || (req)->top->topreq == (req))
 
 /*--------------------------------------------------------------------
  * Struct sess is a high memory-load structure because sessions typically

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -451,6 +451,7 @@ struct reqtop {
 	unsigned		magic;
 #define REQTOP_MAGIC		0x57fbda52
 	struct req		*topreq;
+	struct vcl		*vcl0;
 };
 
 struct req {
@@ -463,7 +464,6 @@ struct req {
 	int			restarts;
 	int			esi_level;
 	struct reqtop		*top;	/* esi_level == 0 request */
-	struct vcl		*vcl0;
 
 #define REQ_FLAG(l, r, w, d) unsigned	l:1;
 #include "tbl/req_flags.h"

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -263,15 +263,8 @@ ved_vdp_esi_init(struct req *req, void **priv)
 	*priv = ecx;
 	RFC2616_Weaken_Etag(req->resp);
 
-	if (IS_TOPREQ(req)) {
-		Req_MakeTop(req);
-		if (req->top == NULL) {
-			VSLb(req->vsl, SLT_Error,
-			    "(top)request workspace overflow");
-			Req_Fail(req, SC_OVERLOAD);
-			return (-1);
-		}
-	}
+	if (IS_TOPREQ(req) && Req_MakeTop(req))
+		return (-1);
 
 	req->res_mode |= RES_ESI;
 	if (req->resp_len != 0)

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -170,8 +170,9 @@ ved_include(struct req *preq, const char *src, const char *host,
 	req->req_body_status = REQ_BODY_NONE;
 
 	AZ(req->vcl);
-	if (req->vcl0)
-		req->vcl = req->vcl0;
+	AN(req->top);
+	if (req->top->vcl0)
+		req->vcl = req->top->vcl0;
 	else
 		req->vcl = preq->vcl;
 	VCL_Ref(req->vcl);

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -113,7 +113,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 	enum req_fsm_nxt s;
 
 	CHECK_OBJ_NOTNULL(preq, REQ_MAGIC);
-	CHECK_OBJ_NOTNULL(preq->topreq, REQ_MAGIC);
+	CHECK_OBJ_NOTNULL(preq->top, REQTOP_MAGIC);
 	sp = preq->sp;
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 	CHECK_OBJ_NOTNULL(ecx, ECX_MAGIC);
@@ -139,7 +139,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 
 	req->esi_level = preq->esi_level + 1;
 
-	req->topreq = preq->topreq;
+	req->top = preq->top;
 
 	HTTP_Setup(req->http, req->ws, req->vsl, SLT_ReqMethod);
 	HTTP_Dup(req->http, preq->http0);
@@ -170,8 +170,8 @@ ved_include(struct req *preq, const char *src, const char *host,
 	req->req_body_status = REQ_BODY_NONE;
 
 	AZ(req->vcl);
-	if (req->topreq->vcl0)
-		req->vcl = req->topreq->vcl0;
+	if (req->vcl0)
+		req->vcl = req->vcl0;
 	else
 		req->vcl = preq->vcl;
 	VCL_Ref(req->vcl);
@@ -262,6 +262,16 @@ ved_vdp_esi_init(struct req *req, void **priv)
 	ecx->preq = req;
 	*priv = ecx;
 	RFC2616_Weaken_Etag(req->resp);
+
+	if (IS_TOPREQ(req)) {
+		Req_MakeTop(req);
+		if (req->top == NULL) {
+			VSLb(req->vsl, SLT_Error,
+			    "(top)request workspace overflow");
+			Req_Fail(req, SC_OVERLOAD);
+			return (-1);
+		}
+	}
 
 	req->res_mode |= RES_ESI;
 	if (req->resp_len != 0)

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -485,6 +485,20 @@ pan_busyobj(struct vsb *vsb, const struct busyobj *bo)
 /*--------------------------------------------------------------------*/
 
 static void
+pan_top(struct vsb *vsb, const struct reqtop *top)
+{
+	VSB_printf(vsb, "top = %p {\n", top);
+	if (PAN_already(vsb, top))
+		return;
+	VSB_indent(vsb, 2);
+	pan_req(vsb, top->topreq);
+	VSB_indent(vsb, -2);
+	VSB_printf(vsb, "},\n");
+}
+
+/*--------------------------------------------------------------------*/
+
+static void
 pan_req(struct vsb *vsb, const struct req *req)
 {
 	const char *stp;
@@ -560,11 +574,8 @@ pan_req(struct vsb *vsb, const struct req *req)
 
 	pan_privs(vsb, req->privs);
 
-	VSB_printf(vsb, "topreq = {\n");
-	VSB_indent(vsb, 2);
-	pan_req(vsb, req->topreq);
-	VSB_indent(vsb, -2);
-	VSB_printf(vsb, "},\n");
+	if (req->top != NULL)
+		pan_top(vsb, req->top);
 
 	VSB_indent(vsb, -2);
 	VSB_printf(vsb, "},\n");

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -492,6 +492,7 @@ pan_top(struct vsb *vsb, const struct reqtop *top)
 		return;
 	VSB_indent(vsb, 2);
 	pan_req(vsb, top->topreq);
+	VCL_Panic(vsb, "vcl0", top->vcl0);
 	VSB_indent(vsb, -2);
 	VSB_printf(vsb, "},\n");
 }
@@ -558,7 +559,6 @@ pan_req(struct vsb *vsb, const struct req *req)
 		pan_vdp(vsb, req->vdc);
 
 	VCL_Panic(vsb, "vcl", req->vcl);
-	VCL_Panic(vsb, "vcl0", req->vcl0);
 
 	if (req->body_oc != NULL)
 		pan_objcore(vsb, "BODY", req->body_oc);

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -492,6 +492,7 @@ pan_top(struct vsb *vsb, const struct reqtop *top)
 		return;
 	VSB_indent(vsb, 2);
 	pan_req(vsb, top->topreq);
+	pan_privs(vsb, top->privs);
 	VCL_Panic(vsb, "vcl0", top->vcl0);
 	VSB_indent(vsb, -2);
 	VSB_printf(vsb, "},\n");

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -260,16 +260,22 @@ Req_Fail(struct req *req, enum sess_close reason)
 /*----------------------------------------------------------------------
  */
 
-void
+int
 Req_MakeTop(struct req *req)
 {
 
 	CHECK_OBJ_ORNULL(req->top, REQTOP_MAGIC);
 	if (req->top != NULL)
-		return;
+		return (0);
 	req->top = WS_Alloc(req->ws, sizeof *req->top);
-	if (req->top != NULL) {
-		INIT_OBJ(req->top, REQTOP_MAGIC);
-		req->top->topreq = req;
+	if (req->top == NULL) {
+		VSLb(req->vsl, SLT_Error,
+		     "(top)request workspace overflow");
+		Req_Fail(req, SC_OVERLOAD);
+		return (-1);
 	}
+	INIT_OBJ(req->top, REQTOP_MAGIC);
+	req->top->topreq = req;
+
+	return (0);
 }

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -270,10 +270,10 @@ Req_Fail(struct req *req, enum sess_close reason)
 int
 Req_MakeTop(struct req *req)
 {
-
 	CHECK_OBJ_ORNULL(req->top, REQTOP_MAGIC);
 	if (req->top != NULL)
 		return (0);
+	assert(req->esi_level == 0);
 	req->top = WS_Alloc(req->ws, sizeof *req->top);
 	if (req->top == NULL) {
 		VSLb(req->vsl, SLT_Error,
@@ -287,6 +287,7 @@ Req_MakeTop(struct req *req)
 	return (0);
 }
 
+/* to be called after WS_Reset() and VCL_TaskLeve (empty privs) */
 void
 Req_MoveTop(struct req *req)
 {
@@ -295,8 +296,10 @@ Req_MoveTop(struct req *req)
 	if (top == NULL)
 		return;
 
+	assert(req->esi_level == 0);
 	CHECK_OBJ_NOTNULL(top, REQTOP_MAGIC);
+	AZ(top->privs->magic);
 	req->top = WS_Alloc(req->ws, sizeof *req->top);
-	AN(req->top);	// MoveTop to be called after WS_Reset
+	AN(req->top);
 	memmove(req->top, top, sizeof *req->top);
 }

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -189,7 +189,6 @@ Req_Rollback(struct req *req)
 	if (WS_Overflowed(req->ws))
 		req->wrk->stats->ws_client_overflow++;
 	WS_Reset(req->ws, req->ws_req);
-	req->top = NULL;
 }
 
 /*----------------------------------------------------------------------
@@ -204,7 +203,8 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	assert(sp == req->sp);
-	AZ(req->vcl0);
+	if (req->top != NULL && IS_TOPREQ(req))
+		AZ(req->top->vcl0);
 
 	req->director_hint = NULL;
 	req->restarts = 0;
@@ -237,7 +237,7 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 	req->hash_ignore_busy = 0;
 	req->esi_level = 0;
 	req->is_hit = 0;
-	req->top = 0;
+	req->top = NULL;
 
 	if (WS_Overflowed(req->ws))
 		wrk->stats->ws_client_overflow++;

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -1025,7 +1025,6 @@ CNT_Embark(struct worker *wrk, struct req *req)
 		VSLb(req->vsl, SLT_VCL_use, "%s", VCL_Name(req->vcl));
 	}
 
-	AZ(req->vcl0);
 	AN(req->vcl);
 }
 
@@ -1036,7 +1035,7 @@ CNT_Request(struct req *req)
 	enum req_fsm_nxt nxt;
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-	assert(IS_TOPREQ(req) || req->vcl0 == NULL);
+	assert(IS_TOPREQ(req) || req->top != NULL);
 
 	wrk = req->wrk;
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
@@ -1080,8 +1079,10 @@ CNT_Request(struct req *req)
 	}
 	wrk->vsl = NULL;
 	if (nxt == REQ_FSM_DONE) {
-		if (IS_TOPREQ(req) && req->vcl0 != NULL)
-			VCL_Rel(&req->vcl0);
+		if (IS_TOPREQ(req) && req->top != NULL) {
+			if (req->top->vcl0 != NULL)
+				VCL_Rel(&req->top->vcl0);
+		}
 		VCL_TaskLeave(req->vcl, req->privs);
 		AN(req->vsl->wid);
 		VRB_Free(req);

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -1014,7 +1014,6 @@ CNT_Embark(struct worker *wrk, struct req *req)
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-	CHECK_OBJ_NOTNULL(req->topreq, REQ_MAGIC);
 
 	/* wrk can have changed for restarts */
 	req->vfc->wrk = req->wrk = wrk;

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -1080,6 +1080,7 @@ CNT_Request(struct req *req)
 	wrk->vsl = NULL;
 	if (nxt == REQ_FSM_DONE) {
 		if (IS_TOPREQ(req) && req->top != NULL) {
+			VCL_TaskLeave(req->vcl, req->top->privs);
 			if (req->top->vcl0 != NULL)
 				VCL_Rel(&req->top->vcl0);
 		}

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -351,6 +351,7 @@ void Req_Rollback(struct req *req);
 void Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req);
 void Req_Fail(struct req *req, enum sess_close reason);
 void Req_AcctLogCharge(struct VSC_main_wrk *, struct req *);
+void Req_MakeTop(struct req *req);
 
 /* cache_req_body.c */
 int VRB_Ignore(struct req *);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -352,6 +352,7 @@ void Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req);
 void Req_Fail(struct req *req, enum sess_close reason);
 void Req_AcctLogCharge(struct VSC_main_wrk *, struct req *);
 int Req_MakeTop(struct req *req);
+void Req_MoveTop(struct req *req);
 
 /* cache_req_body.c */
 int VRB_Ignore(struct req *);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -351,7 +351,7 @@ void Req_Rollback(struct req *req);
 void Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req);
 void Req_Fail(struct req *req, enum sess_close reason);
 void Req_AcctLogCharge(struct VSC_main_wrk *, struct req *);
-void Req_MakeTop(struct req *req);
+int Req_MakeTop(struct req *req);
 
 /* cache_req_body.c */
 int VRB_Ignore(struct req *);

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -93,12 +93,15 @@ VCL_Req2Ctx(struct vrt_ctx *ctx, struct req *req)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-	CHECK_OBJ_ORNULL(req->topreq, REQ_MAGIC);
 
 	ctx->vcl = req->vcl;
 	ctx->vsl = req->vsl;
 	ctx->http_req = req->http;
-	ctx->http_req_top = req->topreq->http;
+	CHECK_OBJ_ORNULL(req->top, REQTOP_MAGIC);
+	if (req->top != NULL)
+		ctx->http_req_top = req->top->topreq->http;
+	else
+		ctx->http_req_top = req->http;
 	ctx->http_resp = req->resp;
 	ctx->req = req;
 	ctx->sp = req->sp;

--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -91,12 +91,19 @@ VPI_vcl_select(VRT_CTX, VCL_VCL vcl)
 
 	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
 
-	if (IS_TOPREQ(req) && req->vcl0 != NULL)
+	if (IS_TOPREQ(req) && req->top && req->top->vcl0 != NULL)
 		return;		// Illegal, req-FSM will fail this later.
+
+	if (IS_TOPREQ(req) && Req_MakeTop(req)) {
+		VRT_fail(ctx, "(top)request workspace overflow");
+		return;
+	}
 
 	VCL_TaskLeave(req->vcl, req->privs);
 	if (IS_TOPREQ(req)) {
-		req->vcl0 = req->vcl;
+		AN(req->top);
+		AZ(req->top->vcl0);
+		req->top->vcl0 = req->vcl;
 		req->vcl = NULL;
 	} else {
 		VCL_Rel(&req->vcl);

--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -99,6 +99,12 @@ VPI_vcl_select(VRT_CTX, VCL_VCL vcl)
 		return;
 	}
 
+	/* XXX VCL_Task* are somewhat duplicated to those in Req_Rollback called
+	 * from FSM for VCL_RET_VCL. Keeping them here to ensure there are no
+	 * tasks during calls to VCL_Rel / vcl_get
+	 */
+	if (req->top != NULL)
+		VCL_TaskLeave(req->vcl, req->top->privs);
 	VCL_TaskLeave(req->vcl, req->privs);
 	if (IS_TOPREQ(req)) {
 		AN(req->top);
@@ -112,4 +118,6 @@ VPI_vcl_select(VRT_CTX, VCL_VCL vcl)
 	VSLb(ctx->req->vsl, SLT_VCL_use, "%s via %s",
 	    req->vcl->loaded_name, vcl->loaded_name);
 	VCL_TaskEnter(req->vcl, req->privs);
+	if (req->top != NULL)
+		VCL_TaskEnter(req->vcl, req->top->privs);
 }

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -165,15 +165,10 @@ VRT_priv_top(VRT_CTX, const void *vmod_id)
 		WRONG("PRIV_TOP is only accessible in client VCL context");
 		NEEDLESS(return (NULL));
 	}
-	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
-	if (ctx->req->top != NULL) {
-		CHECK_OBJ_NOTNULL(ctx->req->top, REQTOP_MAGIC);
-		CHECK_OBJ_NOTNULL(ctx->req->top->topreq, REQ_MAGIC);
-		req = ctx->req->top->topreq;
-	} else {
-		req = ctx->req;
-	}
-	CAST_OBJ_NOTNULL(vps, req->privs, VRT_PRIVS_MAGIC);
+	req = ctx->req;
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	Req_MakeTop(req);
+	CAST_OBJ_NOTNULL(vps, req->top->privs, VRT_PRIVS_MAGIC);
 	return (vrt_priv_dynamic(req->ws, vps, (uintptr_t)vmod_id));
 }
 

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -42,7 +42,6 @@ struct vrt_priv {
 #define VRT_PRIV_MAGIC			0x24157a52
 	VRBT_ENTRY(vrt_priv)		entry;
 	struct vmod_priv		priv[1];
-	uintptr_t			id;
 	uintptr_t			vmod_id;
 };
 
@@ -96,9 +95,9 @@ VRTPRIV_init(struct vrt_privs *privs)
 static inline int
 vrt_priv_dyncmp(const struct vrt_priv *vp1, const struct vrt_priv *vp2)
 {
-	if (vp1->vmod_id < vp2->vmod_id || vp1->id < vp2->id)
+	if (vp1->vmod_id < vp2->vmod_id)
 		return (-1);
-	if (vp1->vmod_id > vp2->vmod_id || vp1->id > vp2->id)
+	if (vp1->vmod_id > vp2->vmod_id)
 		return (1);
 	return (0);
 }
@@ -106,23 +105,17 @@ vrt_priv_dyncmp(const struct vrt_priv *vp1, const struct vrt_priv *vp2)
 VRBT_GENERATE_STATIC(vrt_priv_tree, vrt_priv, entry, vrt_priv_dyncmp)
 
 static struct vmod_priv *
-vrt_priv_dynamic(struct ws *ws, struct vrt_privs *vps, uintptr_t id,
-    uintptr_t vmod_id)
+vrt_priv_dynamic(struct ws *ws, struct vrt_privs *vps, uintptr_t vmod_id)
 {
 	struct vrt_priv *vp;
-	const struct vrt_priv needle = {
-		.id = id,
-		.vmod_id = vmod_id,
-	};
+	const struct vrt_priv needle = {.vmod_id = vmod_id};
 
 	CHECK_OBJ_NOTNULL(vps, VRT_PRIVS_MAGIC);
-	AN(id);
 	AN(vmod_id);
 
 	vp = VRBT_FIND(vrt_priv_tree, &vps->privs, &needle);
 	if (vp) {
 		CHECK_OBJ(vp, VRT_PRIV_MAGIC);
-		assert(vp->id == id);
 		assert(vp->vmod_id == vmod_id);
 		return (vp->priv);
 	}
@@ -131,7 +124,6 @@ vrt_priv_dynamic(struct ws *ws, struct vrt_privs *vps, uintptr_t id,
 	if (vp == NULL)
 		return (NULL);
 	INIT_OBJ(vp, VRT_PRIV_MAGIC);
-	vp->id = id;
 	vp->vmod_id = vmod_id;
 	VRBT_INSERT(vrt_priv_tree, &vps->privs, vp);
 	return (vp->priv);
@@ -140,7 +132,6 @@ vrt_priv_dynamic(struct ws *ws, struct vrt_privs *vps, uintptr_t id,
 struct vmod_priv *
 VRT_priv_task(VRT_CTX, const void *vmod_id)
 {
-	uintptr_t id;
 	struct vrt_privs *vps;
 	struct vmod_priv *vp;
 
@@ -150,40 +141,34 @@ VRT_priv_task(VRT_CTX, const void *vmod_id)
 
 	if (ctx->req) {
 		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
-		id = (uintptr_t)ctx->req;
 		CAST_OBJ_NOTNULL(vps, ctx->req->privs, VRT_PRIVS_MAGIC);
 	} else if (ctx->bo) {
 		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
-		id = (uintptr_t)ctx->bo;
 		CAST_OBJ_NOTNULL(vps, ctx->bo->privs, VRT_PRIVS_MAGIC);
 	} else {
 		ASSERT_CLI();
-		id = (uintptr_t)cli_task_privs;
 		CAST_OBJ_NOTNULL(vps, cli_task_privs, VRT_PRIVS_MAGIC);
 	}
 
-	vp = vrt_priv_dynamic(ctx->ws, vps, id, (uintptr_t)vmod_id);
+	vp = vrt_priv_dynamic(ctx->ws, vps, (uintptr_t)vmod_id);
 	return (vp);
 }
 
 struct vmod_priv *
 VRT_priv_top(VRT_CTX, const void *vmod_id)
 {
-	uintptr_t id;
 	struct vrt_privs *vps;
 	struct req *req;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (ctx->req == NULL) {
-		/* XXX: should we VRT_fail here instead? */
 		WRONG("PRIV_TOP is only accessible in client VCL context");
 		NEEDLESS(return (NULL));
 	}
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
 	req = ctx->req->topreq;
-	id = (uintptr_t)&req->topreq;
 	CAST_OBJ_NOTNULL(vps, req->privs, VRT_PRIVS_MAGIC);
-	return (vrt_priv_dynamic(req->ws, vps, id, (uintptr_t)vmod_id));
+	return (vrt_priv_dynamic(req->ws, vps, (uintptr_t)vmod_id));
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -166,7 +166,13 @@ VRT_priv_top(VRT_CTX, const void *vmod_id)
 		NEEDLESS(return (NULL));
 	}
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
-	req = ctx->req->topreq;
+	if (ctx->req->top != NULL) {
+		CHECK_OBJ_NOTNULL(ctx->req->top, REQTOP_MAGIC);
+		CHECK_OBJ_NOTNULL(ctx->req->top->topreq, REQ_MAGIC);
+		req = ctx->req->top->topreq;
+	} else {
+		req = ctx->req;
+	}
 	CAST_OBJ_NOTNULL(vps, req->privs, VRT_PRIVS_MAGIC);
 	return (vrt_priv_dynamic(req->ws, vps, (uintptr_t)vmod_id));
 }

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -428,6 +428,7 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 		CHECK_OBJ(req, REQ_MAGIC);
 		CHECK_OBJ_NOTNULL(req->sp, SESS_MAGIC);
 		CHECK_OBJ_NOTNULL(req->vcl, VCL_MAGIC);
+		CHECK_OBJ_ORNULL(req->top, REQTOP_MAGIC);
 		VCL_Req2Ctx(&ctx, req);
 	}
 	if (bo != NULL) {

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -415,7 +415,7 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 				VCL_TaskEnter(req->vcl, req->privs);
 			if (CNT_Request(req) == REQ_FSM_DISEMBARK)
 				return;
-			AZ(req->vcl0);
+			assert(req->top == NULL || req->top->vcl0 == NULL);
 			req->task.func = NULL;
 			req->task.priv = NULL;
 			AZ(req->ws->r);

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -529,7 +529,7 @@ h2_do_req(struct worker *wrk, void *priv)
 	wrk->stats->client_req++;
 	if (CNT_Request(req) != REQ_FSM_DISEMBARK) {
 		AZ(req->ws->r);
-		AZ(req->vcl0);
+		assert(req->top == NULL || req->top->vcl0 == NULL);
 		h2 = r2->h2sess;
 		CHECK_OBJ_NOTNULL(h2, H2_SESS_MAGIC);
 		Lck_Lock(&h2->sess->mtx);

--- a/bin/varnishtest/tests/r03019.vtc
+++ b/bin/varnishtest/tests/r03019.vtc
@@ -1,0 +1,35 @@
+varnishtest "return(vcl) then reembark"
+
+barrier b1 cond 2
+
+server s1 {
+	rxreq
+	barrier b1 sync
+	txresp
+} -start
+
+varnish v1 -vcl+backend ""
+varnish v1 -cliok "vcl.label lbl vcl1"
+varnish v1 -vcl {
+	backend be { .host = "${bad_backend}"; }
+
+	sub vcl_recv {
+		return (vcl(lbl));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -start
+
+client c2 {
+	barrier b1 sync
+	txreq
+	rxresp
+	expect resp.status == 200
+} -start
+
+client c1 -wait
+client c2 -wait


### PR DESCRIPTION
#3003 exposed a bug which I introduced when I removed the additional id from `struct vrt_priv`, unfortunately.
This series of patches ultimately implements an own head for `PRIV_TOP` which only exists once per top request.
As also the `vcl0` pointer is once per top request, we now reintroduce `struct topreq` (which was added and removed again recently) to contain the pointer to the top request, `vcl0` and the `PRIV_TOP` head.
One particular complication regarding `struct topreq` is that we want to allocate it only on demand, yet it needs to persist a rollback. `Req_MoveTop()` moves it to the beginning of the workspace after a `WS_Reset()`
