### PR TITLE
Directors can fail with a specific status

### DIFF
--- a/bin/varnishtest/tests/d00040.vtc
+++ b/bin/varnishtest/tests/d00040.vtc
@@ -1,0 +1,23 @@
+varnishtest "Director internal error"
+
+varnish v1 -vcl {
+	import debug;
+
+	backend be { .host = "${bad_backend}"; }
+
+	sub vcl_backend_fetch {
+		set bereq.backend = debug.fail_backend();
+	}
+
+	sub vcl_backend_error {
+		set beresp.http.visited = "true";
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 500
+	expect resp.reason == "Internal Server Error"
+	expect resp.http.visited == true
+} -run

--- a/doc/sphinx/whats-new/changes-trunk.rst
+++ b/doc/sphinx/whats-new/changes-trunk.rst
@@ -143,4 +143,6 @@ Changes for developers and VMOD authors
 **XXX changes concerning VRT, the public APIs, source code organization,
 builds etc.**
 
+**TODO: directors can fail with an arbitrary beresp.status**
+
 *eof*

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -268,3 +268,7 @@ $Function IP get_ip(PRIV_TASK)
 
 Get the IP address previously stored by ``debug.store_ip()`` in the same
 transaction.
+
+$Function BACKEND fail_backend()
+
+Return a backend that always fails with an internal error.

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -883,6 +883,38 @@ xyzzy_get_ip(VRT_CTX, struct vmod_priv *priv)
 }
 
 /**********************************************************************
+ * The backend that always fails a fetch
+ */
+
+static int v_matchproto_(vdi_gethdrs_f)
+fbe_dir_gethdrs(VRT_CTX, VCL_BACKEND d)
+{
+	struct busyobj *bo;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
+	bo = ctx->bo;
+
+	bo->err_code = 500;
+	bo->err_reason = NULL;
+	return (-1);
+}
+
+static const struct vdi_methods fbe_methods[1] = {{
+	.magic =		VDI_METHODS_MAGIC,
+	.type =			"fail-backend",
+	.gethdrs =		fbe_dir_gethdrs,
+}};
+
+VCL_BACKEND
+xyzzy_fail_backend(VRT_CTX)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	return (VRT_AddDirector(ctx, fbe_methods, NULL, "%s", "fail-backend"));
+}
+
+/**********************************************************************
  * For testing import code on bad vmod files (m00003.vtc)
  */
 


### PR DESCRIPTION
This merely adds test coverage and shows that since #3014 it became possible as a side effect.

I think that complex directors could benefit from going to `vcl_backend_error` with a 500 "Internal Server Error" status, this isn't meant for vmod-directors. Therefore, we should rather have coverage and not decide that core code should prevent this behavior.

Initially submitted as part of #3016.