### PR TITLE
Ensure that we always log h2 idle_send_timeout

### DIFF
--- a/bin/varnishtest/tests/t02016.vtc
+++ b/bin/varnishtest/tests/t02016.vtc
@@ -8,6 +8,8 @@ server s1 {
 varnish v1 -cliok "param.set feature +http2"
 varnish v1 -vcl+backend "" -start
 
+# coverage for send_timeout with c1
+
 varnish v1 -cliok "param.set send_timeout 1"
 
 logexpect l1 -v v1 {
@@ -42,6 +44,8 @@ client c1 {
 
 logexpect l1 -wait
 
+# coverage for idle_send_timeout with c2
+
 varnish v1 -cliok "param.set idle_send_timeout 1"
 varnish v1 -cliok "param.reset send_timeout"
 
@@ -74,3 +78,42 @@ client c2 {
 } -run
 
 logexpect l2 -wait
+
+# coverage for idle_send_timeout change with c3
+
+barrier b3 cond 2
+
+logexpect l3 -v v1 {
+	expect * * Debug "Hit idle_send_timeout"
+} -start
+
+client c3 {
+	txpri
+
+	stream 0 {
+		rxsettings
+		expect settings.ack == false
+		txsettings -ack
+		txsettings -winsize 1000
+		rxsettings
+		expect settings.ack == true
+	} -run
+
+	stream 1 {
+		txreq
+		rxhdrs
+		rxdata
+		# keep the stream idle for 2 seconds
+		barrier b3 sync
+		delay 2
+		rxrst
+		expect rst.err == CANCEL
+	} -run
+
+} -start
+
+barrier b3 sync
+varnish v1 -cliok "param.reset idle_send_timeout"
+
+client c3 -wait
+logexpect l3 -wait


### PR DESCRIPTION
Revisiting #2980 recently compelled me to fix this.