### PR TITLE
Docfix: varnishlog and varnishncsa exits from SIGHUP in the foreground

### DIFF
--- a/doc/sphinx/reference/varnishlog.rst
+++ b/doc/sphinx/reference/varnishlog.rst
@@ -30,7 +30,8 @@ SIGNALS
 
 * SIGHUP
 
-  Rotate the log file (see -w option)
+  Rotate the log file (see -w option) in daemon mode,
+  abort the loop and die gracefully when running in the foreground.
 
 * SIGUSR1
 

--- a/doc/sphinx/reference/varnishncsa.rst
+++ b/doc/sphinx/reference/varnishncsa.rst
@@ -196,10 +196,13 @@ Supported formatters are:
 SIGNALS
 =======
 
-SIGHUP
-  Rotate the log file (see -w option).
+* SIGHUP
 
-SIGUSR1
+  Rotate the log file (see -w option) in daemon mode,
+  abort the loop and die gracefully when running in the foreground.
+
+* SIGUSR1
+
   Flush any outstanding transactions.
 
 NOTES


### PR DESCRIPTION
Be a bit more elaborate on the expected behaviour