### PR TITLE
Document 1 second TTL on (synthetic) error objects

### DIFF
--- a/doc/sphinx/users-guide/vcl-built-in-subs.rst
+++ b/doc/sphinx/users-guide/vcl-built-in-subs.rst
@@ -509,8 +509,17 @@ Returning with `abandon`_ does not leave a cache object.
 
 If returning with ``deliver`` and a ``beresp.ttl > 0s``, a synthetic
 cache object is generated in VCL, whose body may be constructed using
-the ``synthetic()`` function. This may be useful to increase the
-efficiency of failing backend requests.
+the ``synthetic()`` function.
+
+When there is a waiting list on the object, the default ``ttl`` will
+be positive (currently one second), set before entering
+``vcl_backend_error``. This is to avoid request serialization and
+hammering on a potentially failing backend.
+
+Since these synthetic objects are cached in these special
+circumstances, be cautious with putting private information there. If
+you really must, then you need to explicitly set ``beresp.ttl`` to
+zero in ``vcl_backend_error``.
 
 The `vcl_backend_error` subroutine may terminate with calling ``return()``
 with one of the following keywords:


### PR DESCRIPTION
The behavior described here is old (see cache_fetch.c), but has not been cleanly documented in the docs.

I am making this pull request (instead of committing directly) so that @carlosabalde can have a look first.