### PR TITLE
Add a configure switch to skip backtrace() calls

### DIFF
--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -611,6 +611,7 @@ pan_sess(struct vsb *vsb, const struct sess *sp)
 
 #define BACKTRACE_LEVELS	10
 
+#ifdef HAVE_BACKTRACE
 static void
 pan_backtrace(struct vsb *vsb)
 {
@@ -649,6 +650,7 @@ pan_backtrace(struct vsb *vsb)
 	}
 	VSB_indent(vsb, -2);
 }
+#endif
 
 #ifdef HAVE_PTHREAD_GETATTR_NP
 static void
@@ -740,7 +742,11 @@ pan_ic(const char *func, const char *file, int line, const char *cond,
 	VSB_printf(pan_vsb, "now = %f (mono), %f (real)\n",
 	    VTIM_mono(), VTIM_real());
 
+#ifdef HAVE_BACKTRACE
 	pan_backtrace(pan_vsb);
+#else
+	VSB_printf(pan_vsb, "Backtrace support disabled at compile time");
+#endif
 
 	if (err)
 		VSB_printf(pan_vsb, "errno = %d (%s)\n", err, vstrerror(err));

--- a/configure.ac
+++ b/configure.ac
@@ -343,9 +343,18 @@ esac
 AC_SUBST(JEMALLOC_LDADD)
 
 AC_CHECK_FUNCS([setproctitle])
-AC_SEARCH_LIBS(backtrace, [execinfo], [], [
-   AC_MSG_ERROR([Could not find backtrace() support])
-])
+
+AC_ARG_WITH([backtrace],
+	    [AS_HELP_STRING([--without-backtrace], [Disable backtrace() ])])
+
+if test "$with_backtrace" != no; then
+	AC_SEARCH_LIBS(backtrace, [execinfo], [], [
+		AC_MSG_ERROR([Could not find backtrace() support])
+	])
+	AC_DEFINE([HAVE_BACKTRACE], [1],
+		[Define to 1 to enable backtraces iin panic reports])
+fi
+
 # white lie - we don't actually test it
 AC_MSG_CHECKING([whether daemon() works])
 case $target in

--- a/configure.ac
+++ b/configure.ac
@@ -345,14 +345,18 @@ AC_SUBST(JEMALLOC_LDADD)
 AC_CHECK_FUNCS([setproctitle])
 
 AC_ARG_WITH([backtrace],
-	    [AS_HELP_STRING([--without-backtrace], [Disable backtrace() ])])
+	[AS_HELP_STRING([--without-backtrace], [Disable backtrace() ])])
 
-if test "$with_backtrace" != no; then
-	AC_SEARCH_LIBS(backtrace, [execinfo], [], [
-		AC_MSG_ERROR([Could not find backtrace() support])
-	])
-	AC_DEFINE([HAVE_BACKTRACE], [1],
-		[Define to 1 to enable backtraces iin panic reports])
+if test "$with_backtrace" == no; then
+	AC_MSG_WARN([backtrace() support disabled])
+else
+	AC_RUN_IFELSE(
+		[AC_LANG_PROGRAM([[#include <execinfo.h>]],
+			[[void *buf[10];backtrace(buf, 10);]])],
+		[AC_DEFINE([HAVE_BACKTRACE], [1],
+			[Define to 1 to enable backtraces in panic reports])],
+		[AC_MSG_WARN([Could not find backtrace() support])]
+	)
 fi
 
 # white lie - we don't actually test it


### PR DESCRIPTION
musl libc doesn't doesn't support backtrace/backtrace_symbols, but there
are stubs for them, so varnish will compile/link/run, but will crash
once they are called.

There are solutions to keep the features but they all involve extra libraries,
so I went for the big hammer first: just not calling
backtrace/backtrace_symbols.

more context: https://redmine.alpinelinux.org/issues/5079