### PR TITLE
Bigger stack for the curses thread in hist/top

### DIFF
--- a/bin/varnishhist/varnishhist.c
+++ b/bin/varnishhist/varnishhist.c
@@ -479,6 +479,7 @@ main(int argc, char **argv)
 	char *colon;
 	const char *ptag, *profile = "responsetime";
 	pthread_t thr;
+	pthread_attr_t attr;
 	int fnum;
 	struct profile cli_p = {0};
 
@@ -627,7 +628,9 @@ main(int argc, char **argv)
 		ident = VSM_Dup(vut->vsm, "Arg", "-i");
 	else
 		ident = strdup("");
-	AZ(pthread_create(&thr, NULL, do_curses, NULL));
+	AZ(pthread_attr_init(&attr));
+	pthread_attr_setstacksize(&attr, 2097152);
+	AZ(pthread_create(&thr, &attr, do_curses, NULL));
 	vut->dispatch_f = accumulate;
 	vut->dispatch_priv = NULL;
 	(void)VUT_Main(vut);

--- a/bin/varnishtop/varnishtop.c
+++ b/bin/varnishtop/varnishtop.c
@@ -312,6 +312,7 @@ main(int argc, char **argv)
 {
 	int o, once = 0;
 	pthread_t thr;
+	pthread_attr_t attr;
 	char *e = NULL;
 
 	vut = VUT_InitProg(argc, argv, &vopt_spec);
@@ -359,7 +360,9 @@ main(int argc, char **argv)
 		(void)VUT_Main(vut);
 		dump();
 	} else {
-		AZ(pthread_create(&thr, NULL, do_curses, NULL));
+		AZ(pthread_attr_init(&attr));
+		pthread_attr_setstacksize(&attr, 2097152);
+		AZ(pthread_create(&thr, &attr, do_curses, NULL));
 		(void)VUT_Main(vut);
 		end_of_file = 1;
 		AZ(pthread_join(thr, NULL));


### PR DESCRIPTION
musl libc has a considerably smaller stack size than glibc
(https://wiki.musl-libc.org/functional-differences-from-glibc.html#Thread-stack-size)
and curses will crash right in initscr().

I looked for recommendations but couldn't find any, so I used the 2MB
announced in the musl FAQ.