### PR TITLE
Expose max connection failure in v_b_e

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -133,6 +133,7 @@ vbe_dir_getfd(struct worker *wrk, struct backend *bp, struct busyobj *bo,
 	if (bp->max_connections > 0 && bp->n_conn >= bp->max_connections) {
 		VSLb(bo->vsl, SLT_FetchError,
 		     "backend %s: busy", VRT_BACKEND_string(bp->director));
+		bo->was_max_conn = 1;
 		bp->vsc->busy++;
 		VSC_C_main->backend_busy++;
 		return (NULL);

--- a/bin/varnishtest/tests/b00069.vtc
+++ b/bin/varnishtest/tests/b00069.vtc
@@ -1,0 +1,56 @@
+varnishtest "Check backend connection limit (beresp.was_max_conn)"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+server s1 {
+	rxreq
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -vcl {
+
+ 	backend default {
+		.host = "${s1_addr}";
+		.port = "${s1_port}";
+		.max_connections = 1;
+		.first_byte_timeout = 1s;
+	}
+
+ 	sub vcl_recv {
+		return(pass);
+	}
+
+	sub vcl_backend_error {
+		set beresp.http.max_conn = beresp.was_max_conn;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.max_conn == <undef>
+} -start
+
+client c2 {
+	barrier b1 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	expect resp.http.max_conn == true
+} -run
+
+barrier b2 sync
+client c1 -wait
+
+varnish v1 -expect backend_busy == 1
+
+client c3 {
+	txreq
+	rxresp
+	expect resp.status == 503
+	expect resp.http.max_conn == false
+} -run

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -808,6 +808,16 @@ beresp.was_304
 	to our conditional fetch from the backend and turned
 	that into `beresp.status = 200`
 
+beresp.was_max_conn
+
+ 	Type: BOOL
+
+ 	Readable from: vcl_backend_error
+
+
+ 	When `true` this indicates that we got a 503 response
+	due to the backend not having enough available connections.
+
 beresp.uncacheable
 
 	Type: BOOL

--- a/include/tbl/bo_flags.h
+++ b/include/tbl/bo_flags.h
@@ -37,6 +37,7 @@ BO_FLAG(do_stream,	1, 1, "")
 BO_FLAG(do_pass,	0, 0, "")
 BO_FLAG(uncacheable,	0, 0, "")
 BO_FLAG(was_304,	1, 0, "")
+BO_FLAG(was_max_conn,	1, 0, "")
 BO_FLAG(is_bgfetch,	0, 0, "")
 #undef BO_FLAG
 


### PR DESCRIPTION
This adds a new read-only flag that is accessible in the ```backend_error``` subroutine called ```beresp.was_max_conn``` that describes whether the backend request had failed because of the max connections threshold for the backend having been reached. This is useful information for possibly sleeping then retrying the request or for returning a more detailed error message to the client. The reason we went with a flag rather than a string to describe the general reason why it failed was because it is much easier to mess up writing a VCL check comparing a string than it is to check a flag. This only adds 1 bit to the struct and also the lifetime of the struct is only for the backend request.