### PR TITLE
Move backend error state reason and code struct field to end of busyobj struct

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -412,9 +412,6 @@ struct busyobj {
 
 	struct http_conn	*htc;
 
-	uint16_t		err_code;
-	const char		*err_reason;
-
 	struct pool_task	fetch_task;
 
 #define BO_FLAG(l, r, w, d) unsigned	l:1;
@@ -442,6 +439,9 @@ struct busyobj {
 
 	uint8_t			digest[DIGEST_LEN];
 	struct vrt_privs	privs[1];
+
+	uint16_t		err_code;
+	const char		*err_reason;
 };
 
 


### PR DESCRIPTION
This moves the error code and reason fields to the end of the struct where they should have been when these fields were added to maintain VRT compatibility (putting them in the middle would require anyone who is using the struct to recompile their VMODs apparently).