### PR TITLE
EPROTO can happen on solar-ish OSes

### DIFF
--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -562,6 +562,10 @@ VTCP_Check(int a)
 		return (1);
 	if (errno == ECONNRESET || errno == ENOTCONN || errno == EPIPE)
 		return (1);
+#if (defined (__SVR4) && defined (__sun))
+	if (errno == EPROTO)
+		return (1);
+#endif
 #if (defined (__SVR4) && defined (__sun)) || defined (__NetBSD__)
 	/*
 	 * Solaris returns EINVAL if the other end unexpectedly reset the


### PR DESCRIPTION
I have checked the illumos source and there are some legit conditions when `EPROTO` is signalled for misbehaving tcp peers.

panic seen in production:

```
Assert error in VTCP_blocking(), vtcp.c line 225:
  Condition(VTCP_Check(j)) not true.
version = varnish-trunk revision 3457ded, vrt api = 6.1
ident = -jsolaris,-smalloc,-smalloc,-hcritbit,ports
now = 39647514.473957 (mono), 1564367221.322315 (real)
Backtrace:
  4630c2: /usr/local/sbin/varnishd'pan_backtrace+0x30 [0x4630c2]
  463535: /usr/local/sbin/varnishd'pan_ic+0x23a [0x463535]
  4cefcb: /usr/local/sbin/varnishd'VTCP_blocking+0x5e [0x4cefcb]
  48e789: /usr/local/sbin/varnishd'HTTP1_Session+0x150 [0x48e789]
  48d6bd: /usr/local/sbin/varnishd'http1_req+0x12a [0x48d6bd]
  482cbd: /usr/local/sbin/varnishd'Pool_Work_Thread+0x4e4 [0x482cbd]
  481d4c: /usr/local/sbin/varnishd'WRK_Thread+0x2bf [0x481d4c]
  482de4: /usr/local/sbin/varnishd'pool_thread+0x96 [0x482de4]
  fffffc7fef23e1ea: /lib/amd64/libc.so.1'_thrp_setup+0x8a [0xfffffc7fef23e1ea]
  fffffc7fef23e500: /lib/amd64/libc.so.1'_lwp_start+0x0 [0xfffffc7fef23e500]
errno = 71 (Protocol error)
```