### PR TITLE
Show ESI request in varnishncsa

### DIFF
--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -140,6 +140,7 @@ static struct ctx {
 	int			a_opt;
 	int			b_opt;
 	int			c_opt;
+	int			e_opt;
 	char			*w_arg;
 
 	FILE			*fo;
@@ -891,7 +892,7 @@ dispatch_f(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 			be_mark = BACKEND_MARKER;
 		} else
 			continue;
-		if (t->reason == VSL_r_esi)
+		if (t->reason == VSL_r_esi && !CTX.e_opt)
 			/* Skip ESI requests */
 			continue;
 		CTX.hitmiss = "-";
@@ -1110,6 +1111,10 @@ main(int argc, char * const *argv)
 		case 'c':
 			/* client mode */
 			CTX.c_opt = 1;
+			break;
+		case 'e':
+			/* show ESI */
+			CTX.e_opt = 1;
 			break;
 		case 'F':
 			if (format != NULL)

--- a/bin/varnishncsa/varnishncsa_options.h
+++ b/bin/varnishncsa/varnishncsa_options.h
@@ -72,10 +72,15 @@
 	    "Log client requests. This is the default. If -b is"	\
 	    " specified, then -c is needed to also log client requests"	\
 	)
+#define NCSA_OPT_e							\
+	VOPT("e", "[-e]", "Show ESI request",				\
+	    "Show ESI request."	\
+	)
 
 NCSA_OPT_a
 NCSA_OPT_b
 NCSA_OPT_c
+NCSA_OPT_e
 VSL_OPT_C
 VUT_OPT_d
 VUT_GLOBAL_OPT_D

--- a/bin/varnishtest/tests/e00033.vtc
+++ b/bin/varnishtest/tests/e00033.vtc
@@ -1,0 +1,32 @@
+varnishtest "varnishncsa show ESI request"
+
+server s1 {
+	rxreq
+	txresp -body {
+		<html>
+		Before include
+		<esi:include src="/esi"/>
+		After include
+		</html>
+	}
+	rxreq
+	txresp -body {
+		Included file
+	}
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.do_esi = true;
+	}
+} -start
+
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+shell -match "^0$" "varnishncsa -n ${v1_name}  -d  -q \"requrl ~ '/esi'\"    | wc -l"
+shell -match "^1$" "varnishncsa -n ${v1_name}  -d  -q \"requrl ~ '/esi'\" -e | wc -l"
+


### PR DESCRIPTION
varnishncsa skip ESI subrequests.
https://github.com/varnishcache/varnish-cache/blob/master/bin/varnishncsa/varnishncsa.c#L894-L895

I think useful for ESI debugging, if show ESI subrequests.