### PR TITLE
cache_lck: pthread_cond_timedwait can also returns EINVAL

### DIFF
--- a/bin/varnishd/cache/cache_lck.c
+++ b/bin/varnishd/cache/cache_lck.c
@@ -216,6 +216,7 @@ Lck_CondWait(pthread_cond_t *cond, struct lock *lck, vtim_real when)
 		errno = pthread_cond_timedwait(cond, &ilck->mtx, &ts);
 		assert(errno == 0 ||
 		    errno == ETIMEDOUT ||
+		    errno == EINVAL ||
 		    errno == EINTR);
 	}
 	AZ(ilck->held);


### PR DESCRIPTION
Much more so than EINTR, at least on FreeBSD/macOS, but keeping as it is harmless.