### PR TITLE
free array returned by backtrace_symbols(3)

### DIFF
--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -646,6 +646,7 @@ pan_backtrace(struct vsb *vsb)
 			VSB_printf(vsb, "%s", p);
 		}
 		VSB_printf (vsb, "\n");
+		free(strings);
 	}
 	VSB_indent(vsb, -2);
 }


### PR DESCRIPTION
I was trying to understand why `backtrace(3)` doesn't work on alpine and noticed that we are supposed to free whatever `backtrace_symbols(3)`. From the man page:

> This array is malloc(3)ed by backtrace_symbols(), and must be freed by the caller. (The strings pointed to by the array of pointers need not and should not be freed) 