### PR TITLE
name vmod function / constructor / method RST xref like VCL

### DIFF
--- a/doc/sphinx/reference/directors.rst
+++ b/doc/sphinx/reference/directors.rst
@@ -162,7 +162,7 @@ Health Probes
 =============
 
 It is possible in a VCL program to query the health of a director (see
-:ref:`vmod_std.healthy`). A director can report its health if it implements the
+:ref:`std.healthy()`). A director can report its health if it implements the
 ``healthy`` function, it is otherwise always considered healthy.
 
 Unless you are making a dynamic backend, you need to take care of the

--- a/doc/sphinx/whats-new/changes-6.2.rst
+++ b/doc/sphinx/whats-new/changes-6.2.rst
@@ -117,7 +117,7 @@ to make them more flexible and easier to use. The ``std.``\ *x2y*
 conversion functions are now deprecated. See
 :ref:`whatsnew_upgrading_std_conversion_2019_03`.
 
-The function :ref:`vmod_directors.lookup` has been added to
+The function :ref:`directors.lookup()` has been added to
 :ref:`vmod_directors(3)`, only for use in ``vcl_init`` or
 ``vcl_fini``.
 

--- a/doc/sphinx/whats-new/upgrading-5.1.rst
+++ b/doc/sphinx/whats-new/upgrading-5.1.rst
@@ -197,7 +197,7 @@ vcl_recv
 
 * Added ``req.storage``, which tells Varnish which storage backend to
   use if you choose to save the request body (see
-  :ref:`vmod_std.cache_req_body`).
+  :ref:`std.cache_req_body()`).
 
 * ``return(vcl(LABEL))`` may not be called after a restart. It can
   only be called from the active VCL instance.
@@ -232,9 +232,9 @@ nuke limit is used in all cases.
 vmod_std
 ~~~~~~~~
 
-* Added ``std.getenv()``, see :ref:`vmod_std.getenv`.
+* Added :ref:`std.getenv()`.
 
-* Added ``std.late_100_continue()``, see :ref:`vmod_std.late_100_continue`.
+* Added :ref:`std.late_100_continue()`.
 
 Other changes
 =============

--- a/doc/sphinx/whats-new/upgrading-5.2.rst
+++ b/doc/sphinx/whats-new/upgrading-5.2.rst
@@ -121,7 +121,7 @@ situation.
 vmod_std
 ~~~~~~~~
 
-Added :ref:`vmod_std.file_exists`.
+Added :ref:`std.file_exists()`.
 
 New VMODs in the standard distribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx/whats-new/upgrading-6.0.rst
+++ b/doc/sphinx/whats-new/upgrading-6.0.rst
@@ -461,9 +461,9 @@ backend, or set a value for the Host header in VCL.
 VMOD std
 --------
 
-:ref:`std.port(IP) <vmod_std.port>` always returns 0 when applied to a
+:ref:`std.port()` always returns 0 when applied to a
 ``*.ip`` variable whose value is set to ``0.0.0.0`` because the
-listener is UDS.  :ref:`std.set_ip_tos(INT) <vmod_std.set_ip_tos>` is
+listener is UDS.  :ref:`std.set_ip_tos()` is
 silently ignored when the listener is UDS.
 
 The ``shard`` director
@@ -519,7 +519,7 @@ except for ``req.restarts`` and ``req.xid``, which change by design.
 
 If you need to reset the client request headers to their original
 state (before changes in VCL), call
-:ref:`std.rollback(req) <vmod_std.rollback>`.
+:ref:`std.rollback()`.
 
 ``return(restart)`` can now be called from ``vcl_recv{}``.
 

--- a/doc/sphinx/whats-new/upgrading-6.1.rst
+++ b/doc/sphinx/whats-new/upgrading-6.1.rst
@@ -138,7 +138,7 @@ Other changes to VCL
 VMODs
 =====
 
-Added the :ref:`vmod_std.fnmatch` function to :ref:`vmod_std(3)`, which
+Added the :ref:`std.fnmatch()` function to :ref:`vmod_std(3)`, which
 you can use for shell-style wildcard matching. Wildcard patterns may
 be a good fit for matching URLs, to match against a pattern like
 ``/foo/*/bar/*``. The patterns can be built at runtime, if you need to

--- a/doc/sphinx/whats-new/upgrading-6.2.rst
+++ b/doc/sphinx/whats-new/upgrading-6.2.rst
@@ -58,11 +58,11 @@ The existing type-conversion functions in :ref:`vmod_std(3)` have been
 reworked to make them more flexible and easier to use. These functions
 now also accept suitable numeral or quantitative arguments.
 
-* :ref:`vmod_std.duration`
-* :ref:`vmod_std.bytes`
-* :ref:`vmod_std.integer`
-* :ref:`vmod_std.real`
-* :ref:`vmod_std.time`
+* :ref:`std.duration()`
+* :ref:`std.bytes()`
+* :ref:`std.integer()`
+* :ref:`std.real()`
+* :ref:`std.time()`
 
 These type-conversion functions should be fully backwards compatible,
 but the following differences should be noted:
@@ -76,15 +76,15 @@ but the following differences should be noted:
 * Conversion functions now only ever truncate if necessary (instead of
   rounding).
 
-* :ref:`vmod_std.round` has been added for explicit rounding.
+* :ref:`std.round()` has been added for explicit rounding.
 
 The following functions are deprecated and should be replaced by the
 new conversion functions:
 
-* :ref:`vmod_std.real2integer`
-* :ref:`vmod_std.real2time`
-* :ref:`vmod_std.time2integer`
-* :ref:`vmod_std.time2real`
+* :ref:`std.real2integer()`
+* :ref:`std.real2time()`
+* :ref:`std.time2integer()`
+* :ref:`std.time2real()`
 
 They will be removed in a future version of Varnish.
 

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -715,7 +715,7 @@ class FunctionStanza(Stanza):
 
     def parse(self):
         self.proto = ProtoType(self)
-        self.rstlbl = 'vmod_%s.%s' % (self.vcc.modname, self.proto.name)
+        self.rstlbl = '%s.%s()' % (self.vcc.modname, self.proto.name)
         self.vcc.contents.append(self)
 
     def cstuff(self, fo, where):
@@ -748,7 +748,7 @@ class ObjectStanza(Stanza):
         self.fini.argstruct = False
         self.fini.args = []
 
-        self.rstlbl = 'vmod_%s.%s' % (self.vcc.modname, self.proto.name)
+        self.rstlbl = '%s.%s()' % (self.vcc.modname, self.proto.name)
         self.vcc.contents.append(self)
         self.methods = []
 
@@ -831,7 +831,7 @@ class MethodStanza(Stanza):
             err("$Method %s: Method names need to start with . (dot)"
                 % self.proto.bname, warn=False)
         self.proto.obj = "x" + self.pfx
-        self.rstlbl = 'vmod_%s.%s' % ( self.vcc.modname, self.proto.name)
+        self.rstlbl = 'x%s()' % self.proto.name
         p.methods.append(self)
 
     def cstruct(self, fo, define):

--- a/lib/libvmod_blob/vmod.vcc
+++ b/lib/libvmod_blob/vmod.vcc
@@ -240,7 +240,7 @@ the encoding of the resulting blob according to the scheme
 *encoding*. *case* determines the case of hex digits for the
 ``HEX`` and ``URL`` encodings, and is ignored for other encodings.
 
-As with `vmod_blob.decode`_: If *length* > 0, only decode the first
+As with `blob.decode()`_: If *length* > 0, only decode the first
 *length* characters of the encoded string, otherwise decode the
 entire string. The default value of *length* is 0.
 
@@ -274,8 +274,8 @@ object, i.e. they specify exactly the same region of memory, or both
 are empty.
 
 If the BLOBs are both empty (length is 0 and/or the internal pointer
-is ``NULL``), then `vmod_blob.same`_ returns ``true``. If any
-non-empty BLOB is compared to an empty BLOB, then `vmod_blob.same`_
+is ``NULL``), then `blob.same()`_ returns ``true``. If any
+non-empty BLOB is compared to an empty BLOB, then `blob.same()`_
 returns ``false``.
 
 $Function BOOL equal(BLOB, BLOB)
@@ -283,9 +283,9 @@ $Function BOOL equal(BLOB, BLOB)
 Returns true if and only if the two BLOB arguments have equal contents
 (possibly in different memory regions).
 
-As with `vmod_blob.same`_: If the BLOBs are both empty, then `vmod_blob.equal`_
+As with `blob.same()`_: If the BLOBs are both empty, then `blob.equal()`_
 returns ``true``. If any non-empty BLOB is compared to an empty BLOB,
-then `vmod_blob.equal`_ returns ``false``.
+then `blob.equal()`_ returns ``false``.
 
 $Function INT length(BLOB)
 
@@ -297,7 +297,7 @@ Returns a new BLOB formed from *length* bytes of the BLOB argument
 starting at *offset* bytes from the start of its memory region. The
 default value of *offset* is ``0B``.
 
-`vmod_blob.sub`_ fails and returns NULL if the BLOB argument is empty, or if
+`blob.sub()`_ fails and returns NULL if the BLOB argument is empty, or if
 ``offset + length`` requires more bytes than are available in the
 BLOB.
 
@@ -350,28 +350,28 @@ Example::
 	# blob as base64
 	set resp.http.The-Blob-b64 = theblob1.encode(BASE64);
 
-For any `vmod_blob.blob`_ object, `encoding` and `case`, encodings via
-the `vmod_blob.blob.encode`_ method and the `vmod_blob.encode`_
+For any `blob.blob()`_ object, `encoding` and `case`, encodings via
+the `xblob.encode()`_ method and the `blob.encode()`_
 function are equal::
 
   # Always true:
   blob.encode(ENC, CASE, blob.get()) == blob.encode(ENC, CASE)
 
-But the `vmod_blob.blob.encode`_ object method is more efficient --
+But the `xblob.encode()`_ object method is more efficient --
 the encoding is computed once and cached (with allocation in heap
 memory), and the cached encoding is retrieved on every subsequent
-call. The `vmod_blob.encode`_ function computes the encoding on every
+call. The `blob.encode()`_ function computes the encoding on every
 call, allocating space for the string in Varnish workspaces.
 
 So if the data in a BLOB are fixed at VCL initialization time, so that
 its encodings will always be the same, it is better to create a
-`vmod_blob.blob`_ object. The VMOD's functions should be used for data that are
+`blob.blob()`_ object. The VMOD's functions should be used for data that are
 not known until runtime.
 
 ERRORS
 ======
 
-The encoders, decoders and `vmod_blob.sub`_ may fail if there is
+The encoders, decoders and `blob.sub()`_ may fail if there is
 insufficient space to create the new blob or string. Decoders may also
 fail if the encoded string is an illegal format for the decoding
 scheme. Encoders will fail for the ``IDENTITY`` and ``BASE64*``
@@ -381,7 +381,7 @@ If any of the VMOD's methods, functions or constructor fail, then VCL
 failure is invoked, just as if ``return(fail)`` had been called in the
 VCL source. This means that:
 
-* If the ``vmod_blob.blob`_ object constructor fails, or if any methods or
+* If the ``blob.blob()`_ object constructor fails, or if any methods or
   functions fail during ``vcl_init{}``, then the VCL program will fail
   to load, and the VCC compiler will emit an error message.
 
@@ -399,18 +399,18 @@ LIMITATIONS
 ===========
 
 The VMOD allocates memory in various ways for new blobs and
-strings. The `vmod_blob.blob`_ object and its methods allocate memory
+strings. The `blob.blob()`_ object and its methods allocate memory
 from the heap, and hence they are only limited by available virtual
 memory.
 
-The `vmod_blob.encode`_, `vmod_blob.decode`_ and
-`vmod_blob.transcode`_ functions allocate Varnish workspace, as does
-`vmod_blob.sub`_ for the newly created BLOB.  If these functions are
+The `blob.encode()`_, `blob.decode()`_ and
+`blob.transcode()`_ functions allocate Varnish workspace, as does
+`blob.sub()`_ for the newly created BLOB.  If these functions are
 failing, as indicated by "out of space" messages in the Varnish log
 (with the ``VCL_Error`` tag), then you will need to increase the
 varnishd parameters ``workspace_client`` and/or ``workspace_backend``.
 
-The `vmod_blob.transcode`_ function also allocates space on the stack
+The `blob.transcode()`_ function also allocates space on the stack
 for a temporary BLOB. If this function causes stack overflow, you may
 need to increase the varnishd parameter ``thread_pool_stack``.
 

--- a/lib/libvmod_directors/vmod.vcc
+++ b/lib/libvmod_directors/vmod.vcc
@@ -190,7 +190,7 @@ $Object hash()
 Create a hashing backend director.
 
 The director chooses the backend server by computing a hash/digest of
-the string given to `vmod_directors.hash.backend`_.
+the string given to `xhash.backend()`_.
 
 Commonly used with ``client.ip`` or a session cookie to get sticky
 sessions.
@@ -232,8 +232,8 @@ $Object shard()
 Create a shard director.
 
 Note that the shard director needs to be configured using at least one
-`vmod_directors.shard.add_backend`_ call(s) **followed by a**
-`vmod_directors.shard.reconfigure`_ **call** before it can hand out
+`xshard.add_backend()`_ call(s) **followed by a**
+`xshard.reconfigure()`_ **call** before it can hand out
 backends.
 
 _Note_ that due to various restrictions (documented below), it is
@@ -312,14 +312,14 @@ The drawbacks are:
 Method
 ``````
 
-When `vmod_directors.shard.reconfigure`_ is called, a consistent
+When `xshard.reconfigure()`_ is called, a consistent
 hashing circular data structure gets built from the last 32 bits of
 SHA256 hash values of *<ident>*\ *<n>* (default *ident* being the
 backend name) for each backend and for a running number *n* from 1 to
 *replicas*. Hashing creates the seemingly random order for placement
 of backends on the consistent hashing ring.
 
-When `vmod_directors.shard.backend`_ is called, a load balancing key
+When `xshard.backend()`_ is called, a load balancing key
 gets generated unless provided. The smallest hash value in the circle
 is looked up that is larger than the key (searching clockwise and
 wrapping around as necessary). The backend for this hash value is the
@@ -349,26 +349,26 @@ when configuring the shard director, you are advised to check::
 $Method VOID .set_warmup(REAL probability=0.0)
 
 Set the default warmup probability. See the *warmup* parameter of
-`vmod_directors.shard.backend`_. If *probability* is 0.0 (default),
+`xshard.backend()`_. If *probability* is 0.0 (default),
 warmup is disabled.
 
 $Method VOID .set_rampup(DURATION duration=0)
 
 Set the default rampup duration. See *rampup* parameter of
-`vmod_directors.shard.backend`_. If *duration* is 0 (default), rampup
+`xshard.backend()`_. If *duration* is 0 (default), rampup
 is disabled.
 
 $Method VOID .associate(BLOB param=0)
 
-Associate a default `vmod_directors.shard_param`_ object or clear an
+Associate a default `directors.shard_param()`_ object or clear an
 association.
 
 The value of the *param* argument must be a call to the
-`vmod_directors.shard_param.use`_ method. No argument clears the
+`xshard_param.use()`_ method. No argument clears the
 association.
 
 The association can be changed per backend request using the *param*
-argument of `vmod_directors.shard.backend`_.
+argument of `xshard.backend()`_.
 
 $Method BOOL .add_backend(PRIV_TASK, BACKEND backend,
 	[STRING ident], [DURATION rampup])
@@ -376,7 +376,7 @@ $Method BOOL .add_backend(PRIV_TASK, BACKEND backend,
 Add a backend *backend* to the director.
 
 *ident*: Optionally specify an identification string for this backend,
-which will be hashed by `vmod_directors.shard.reconfigure`_ to
+which will be hashed by `xshard.reconfigure()`_ to
 construct the consistent hashing ring. The identification string
 defaults to the backend name.
 
@@ -384,10 +384,10 @@ defaults to the backend name.
 
 *rampup*: Optionally specify a specific rampup time for this
 backend. Otherwise, the per-director rampup time is used (see
-`vmod_directors.shard.set_rampup`_).
+`xshard.set_rampup()`_).
 
 NOTE: Backend changes need to be finalized with
-`vmod_directors.shard.reconfigure`_ and are only supported on one
+`xshard.reconfigure()`_ and are only supported on one
 shard director at a time.
 
 $Method BOOL .remove_backend(PRIV_TASK, [BACKEND backend=0], [STRING ident=0])
@@ -397,7 +397,7 @@ be specified. *ident* removes a specific instance. If *backend* is
 given without *ident*, all instances of this backend are removed.
 
 NOTE: Backend changes need to be finalized with
-`vmod_directors.shard.reconfigure`_ and are only supported on one
+`xshard.reconfigure()`_ and are only supported on one
 shard director at a time.
 
 $Method BOOL .clear(PRIV_TASK)
@@ -405,7 +405,7 @@ $Method BOOL .clear(PRIV_TASK)
 Remove all backends from the director.
 
 NOTE: Backend changes need to be finalized with
-`vmod_directors.shard.reconfigure`_ and are only supported on one
+`xshard.reconfigure()`_ and are only supported on one
 shard director at a time.
 
 $Method BOOL .reconfigure(PRIV_TASK, INT replicas=67)
@@ -418,12 +418,12 @@ used.
 $Method INT .key(STRANDS)
 
 Convenience method to generate a sharding key for use with the *key*
-argument to the `vmod_directors.shard.backend`_ method by hashing the
+argument to the `xshard.backend()`_ method by hashing the
 given string with SHA256.
 
 To generate sharding keys using other hashes, use a custom vmod like
 `vmod blobdigest`_ with the *key_blob* argument of the
-`vmod_directors.shard.backend`_ method.
+`xshard.backend()`_ method.
 
 .. _vmod blobdigest: https://code.uplex.de/uplex-varnish/libvmod-blobdigest/blob/master/README.rst
 
@@ -464,7 +464,7 @@ is _not_ the order given when backends are added.
 
 * *key* lookup key with ``by=KEY``
 
-  the `vmod_directors.shard.key`_ method may come handy to generate a
+  the `xshard.key()`_ method may come handy to generate a
   sharding key from custom strings.
 
 * *key_blob* lookup key with ``by=BLOB``
@@ -491,8 +491,8 @@ is _not_ the order given when backends are added.
   backend, unless this is also in its rampup period.
 
   The default rampup interval can be set per shard director using the
-  `vmod_directors.shard.set_rampup`_ method or specifically per
-  backend with the `vmod_directors.shard.add_backend`_ method.
+  `xshard.set_rampup()`_ method or specifically per
+  backend with the `xshard.add_backend()`_ method.
 
 * *warmup* probabilistic alternative server selection
 
@@ -552,14 +552,14 @@ is _not_ the order given when backends are added.
 * *param*
 
   Use or associate a parameter set. The value of the *param* argument
-  must be a call to the `vmod_directors.shard_param.use`_ method.
+  must be a call to the `xshard_param.use()`_ method.
 
-  default: as set by `vmod_directors.shard.associate`_ or unset.
+  default: as set by `xshard.associate()`_ or unset.
 
   * for ``resolve=NOW`` take parameter defaults from the
-    `vmod_directors.shard_param`_ parameter set
+    `directors.shard_param()`_ parameter set
 
-  * for ``resolve=LAZY`` associate the `vmod_directors.shard_param`_
+  * for ``resolve=LAZY`` associate the `directors.shard_param()`_
     parameter set for this backend request
 
     Implementation notes for use of parameter sets with
@@ -574,7 +574,7 @@ is _not_ the order given when backends are added.
       *param* argument is subsequently changed within the same backend
       request.
 
-    * Each call to `vmod_directors.shard.backend`_ overrides any
+    * Each call to `xshard.backend()`_ overrides any
       previous call.
 
 $Method VOID .debug(INT)
@@ -585,7 +585,7 @@ $Object shard_param()
 
 Create a shard parameter set.
 
-A parameter set allows for re-use of `vmod_directors.shard.backend`_
+A parameter set allows for re-use of `xshard.backend()`_
 arguments across many shard director instances and simplifies advanced
 use cases (e.g. shard director with custom parameters layered below
 other directors).
@@ -636,7 +636,7 @@ implement retries on alternative backends::
 $Method VOID .clear()
 
 Reset the parameter set to default values as documented for
-`vmod_directors.shard.backend`_.
+`xshard.backend()`_.
 
 * in ``vcl_init{}``, resets the parameter set default for this VCL
 * in backend context, resets the parameter set for this backend
@@ -654,7 +654,7 @@ $Method VOID .set(
 	[ ENUM {CHOSEN, IGNORE, ALL} healthy ])
 
 Change the given parameters of a parameter set as documented for
-`vmod_directors.shard.backend`_.
+`xshard.backend()`_.
 
 * in ``vcl_init{}``, changes the parameter set default for this VCL
 
@@ -668,39 +668,39 @@ $Method STRING .get_by()
 
 Get a string representation of the *by* enum argument which denotes
 how a shard director using this parameter object would derive the
-shard key. See `vmod_directors.shard.backend`_.
+shard key. See `xshard.backend()`_.
 
 $Method INT .get_key()
 
 Get the key which a shard director using this parameter object would
-use. See `vmod_directors.shard.backend`_.
+use. See `xshard.backend()`_.
 
 $Method INT .get_alt()
 
 Get the *alt* parameter which a shard director using this parameter
-object would use. See `vmod_directors.shard.backend`_.
+object would use. See `xshard.backend()`_.
 
 $Method REAL .get_warmup()
 
 Get the *warmup* parameter which a shard director using this parameter
-object would use. See `vmod_directors.shard.backend`_.
+object would use. See `xshard.backend()`_.
 
 $Method BOOL .get_rampup()
 
 Get the *rampup* parameter which a shard director using this parameter
-object would use. See `vmod_directors.shard.backend`_.
+object would use. See `xshard.backend()`_.
 
 $Method STRING .get_healthy()
 
 Get a string representation of the *healthy* enum argument which a
 shard director using this parameter object would use. See
-`vmod_directors.shard.backend`_.
+`xshard.backend()`_.
 
 $Method BLOB .use()
 
 This method may only be used in backend context.
 
-For use with the *param* argument of `vmod_directors.shard.backend`_
+For use with the *param* argument of `xshard.backend()`_
 to associate this shard parameter set with a shard director.
 
 $Function BACKEND lookup(STRING)

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -155,7 +155,7 @@ expression. A period is leading if it is the first character in
 immediately follows a ``/`` is also leading (as in ``/.``).  By
 default, *period* is ``false``.
 
-`vmod_std.fnmatch`_ invokes VCL failure and returns ``false`` if
+`std.fnmatch()`_ invokes VCL failure and returns ``false`` if
 either of *pattern* or *subject* is ``NULL`` -- for example, if an
 unset header is specified.
 
@@ -194,7 +194,7 @@ Example::
 
 Consider that the entire contents of the file appear in the string
 that is returned, including newlines that may result in invalid
-headers if `vmod_std.fileread`_ is used to form a header. In that
+headers if `std.fileread()`_ is used to form a header. In that
 case, you may need to modify the string, for example with
 ``regsub()`` (see :ref:`vcl(7)`)::
 
@@ -436,7 +436,7 @@ formed by ORing the facility and level values. See your system's
 
 Notice: Unlike VCL and other functions in the std vmod, this function
 will not fail VCL processing for workspace overflows: For an out of
-workspace condition, the `vmod_std.syslog`_ function has no effect.
+workspace condition, the `std.syslog()`_ function has no effect.
 
 Example::
 
@@ -551,8 +551,8 @@ DEPRECATED functions
 $Function INT real2integer(REAL r, INT fallback)
 
 **DEPRECATED**: This function will be removed in a future version of
-varnish, use `vmod_std.integer`_ with a *real* argument and the
-`vmod_std.round`_ function instead, for example::
+varnish, use `std.integer()`_ with a *real* argument and the
+`std.round()`_ function instead, for example::
 
 	std.integer(real=std.round(...), fallback=...)
 
@@ -569,13 +569,13 @@ Examples::
 $Function TIME real2time(REAL r, TIME fallback)
 
 **DEPRECATED**: This function will be removed in a future version of
-varnish, use `vmod_std.time`_ with a *real* argument and the
-`vmod_std.round`_ function instead, for example::
+varnish, use `std.time()`_ with a *real* argument and the
+`std.round()`_ function instead, for example::
 
 	std.time(real=std.round(...), fallback=...)
 
 Rounds the real *r* to the nearest integer (see
-`vmod_std.real2integer`_) and returns the corresponding time when
+`std.real2integer()`_) and returns the corresponding time when
 interpreted as a unix epoch. If conversion fails, *fallback* will be
 returned.
 
@@ -586,7 +586,7 @@ Example::
 $Function INT time2integer(TIME t, INT fallback)
 
 **DEPRECATED**: This function will be removed in a future version of
-varnish, use `vmod_std.integer`_ with a *time* argument instead, for
+varnish, use `std.integer()`_ with a *time* argument instead, for
 example::
 
 	std.integer(time=..., fallback=...)
@@ -601,7 +601,7 @@ Example::
 $Function REAL time2real(TIME t, REAL fallback)
 
 **DEPRECATED**: This function will be removed in a future version of
-varnish, use `vmod_std.real`_ with a *time* argument instead, for
+varnish, use `std.real()`_ with a *time* argument instead, for
 example::
 
 	std.real(time=..., fallback=...)

--- a/lib/libvmod_unix/vmod.vcc
+++ b/lib/libvmod_unix/vmod.vcc
@@ -98,9 +98,9 @@ All functions in this VMOD are subject to the following constraints:
 
 * If the current listener is not a Unix domain socket, or if the
   attempt to read credentials fails, then a ``VCL_Error`` message is
-  written to the log. The STRING functions (`vmod_unix.user`_ and
-  `vmod_unix.group`_) return ``NULL``, while the INT functions
-  (`vmod_unix.uid`_ and `vmod_unix.gid`_) return -1.
+  written to the log. The STRING functions (`unix.user()`_ and
+  `unix.group()`_) return ``NULL``, while the INT functions
+  (`unix.uid()`_ and `unix.gid()`_) return -1.
 
 SEE ALSO
 ========


### PR DESCRIPTION
as @slimhazard pointed out when reviewing a suggestion I made to some
vmod documentation, the vmodtool generated link target names are
confusing to users: vmod_foo.func is nothing you can use as VCL, while
foo.func() is.