### PR TITLE
Implementing ZERO_OBJ macro proposal.

### DIFF
--- a/include/miniobj.h
+++ b/include/miniobj.h
@@ -5,11 +5,11 @@
  *
  */
 
-#ifdef HAVE_EXPLICIT_BZERO
-#  define ZERO_OBJ(to, sz)	explicit_bzero(to, sz)
-#else
-#  define ZERO_OBJ(to, sz)	(void)memset(to, 0, sz)
-#endif
+#define ZERO_OBJ(to, sz)						\
+	do {								\
+		void *(*volatile z_obj)(void *, int, size_t) = memset;	\
+		(void)z_obj(to, 0, sz);					\
+	} while (0)
 
 #define INIT_OBJ(to, type_magic)					\
 	do {								\

--- a/varnish.m4
+++ b/varnish.m4
@@ -62,12 +62,6 @@ AC_DEFUN([_VARNISH_SEARCH_LIBS], [
 	LIBS="${save_LIBS}"
 ])
 
-# _VARNISH_CHECK_EXPLICIT_BZERO()
-# -------------------------------
-AC_DEFUN([_VARNISH_CHECK_EXPLICIT_BZERO], [
-	AC_CHECK_FUNCS([explicit_bzero])
-])
-
 # _VARNISH_PKG_CONFIG
 # --------------------
 AC_DEFUN([_VARNISH_PKG_CONFIG], [


### PR DESCRIPTION
- According to #3051, this does not seem too obvious to be
properly detected on Linux systems.
- Some other OSes prefer to play in their own 'backyard',
having similar feature but named differently (e.g. NetBSD)
would need addition autotools check.
- Thus proposing implementing the macro with the volatile
pointer approach rather than memory fence's, sufficient to
prevent compiler optimisations.