### PR TITLE
Single-process and libfuzzer build options

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -621,7 +621,7 @@ vca_acct(void *arg)
 
 /*--------------------------------------------------------------------*/
 
-static void v_matchproto_(cli_func_t)
+/*static*/ void v_matchproto_(cli_func_t)
 ccf_start(struct cli *cli, const char * const *av, void *priv)
 {
 	struct listen_sock *ls;

--- a/bin/varnishd/cache/cache_cli.c
+++ b/bin/varnishd/cache/cache_cli.c
@@ -102,10 +102,20 @@ CLI_Run(void)
 	AN(cli);
 	cli->auth = 255;	// Non-zero to disable paranoia in vcli_serve
 
+#ifdef SINGLE_PROCESS_MODE
+	extern void v_matchproto_(cli_func_t)
+		ccf_start(struct cli *cli, const char * const *av, void *priv);
+	ccf_start(NULL, NULL, NULL);
+	// push VCLs
+	extern int direct_load_vcls(struct cli *cli);
+	direct_load_vcls(cli);
+#endif
+#ifndef LIBFUZZER_ENABLED
 	do {
 		i = VCLS_Poll(cache_cls, cli, -1);
 	} while (i == 0);
 	VSL(SLT_CLI, 0, "EOF on CLI connection, worker stops");
+#endif
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -409,9 +409,11 @@ child_main(int sigmagic, size_t altstksz)
 
 	CLI_Run();
 
+#ifndef LIBFUZZER_ENABLED
 	VCA_Shutdown();
 	BAN_Shutdown();
 	STV_close();
 
 	printf("Child dies\n");
+#endif
 }

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -735,7 +735,7 @@ vcl_cli_list_json(struct cli *cli, const char * const *av, void *priv)
 	VCLI_JSON_end(cli);
 }
 
-static void v_matchproto_(cli_func_t)
+/*static*/ void v_matchproto_(cli_func_t)
 vcl_cli_load(struct cli *cli, const char * const *av, void *priv)
 {
 	struct vrt_ctx *ctx;
@@ -830,7 +830,7 @@ vcl_cli_label(struct cli *cli, const char * const *av, void *priv)
 	vcl->nlabels++;
 }
 
-static void v_matchproto_(cli_func_t)
+/*static*/ void v_matchproto_(cli_func_t)
 vcl_cli_use(struct cli *cli, const char * const *av, void *priv)
 {
 	struct vcl *vcl;

--- a/bin/varnishd/hpack/vhp_gen_hufdec.c
+++ b/bin/varnishd/hpack/vhp_gen_hufdec.c
@@ -210,6 +210,16 @@ tbl_print(const struct tbl *tbl)
 			tbl_print(tbl->e[u].next);
 }
 
+static void
+tbl_free(struct tbl* table)
+{
+	for (unsigned i = 0; i < table->n; i++) {
+		if (table->e[i].next != NULL)
+			tbl_free(table->e[i].next);
+	}
+	free(table);
+}
+
 int
 main(int argc, const char **argv)
 {
@@ -250,5 +260,6 @@ main(int argc, const char **argv)
 	tbl_print(top);
 	printf("};\n");
 
+	tbl_free(top);
 	return (0);
 }

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -325,6 +325,7 @@ mgt_launch_child(struct cli *cli)
 
 	AN(heritage.param);
 	AN(heritage.panic_str);
+#ifndef SINGLE_PROCESS_MODE
 	if ((pid = fork()) < 0) {
 		perror("Could not fork child");
 		exit(1);		// XXX Harsh ?
@@ -359,6 +360,7 @@ mgt_launch_child(struct cli *cli)
 			assert(close(i) == -1);
 			assert(errno == EBADF);
 		}
+#endif
 
 		mgt_ProcTitle("Child");
 
@@ -385,8 +387,16 @@ mgt_launch_child(struct cli *cli)
 		 */
 		// VSMW_Destroy(&heritage.proc_vsmw);
 
+
+#ifdef SINGLE_PROCESS_MODE
+		free(p);
+		child_state = CH_RUNNING;
+		// do we need to do more here? goto?
+		return;
+#else
 		exit(0);
 	}
+#endif
 	assert(pid > 1);
 	MGT_Complain(C_DEBUG, "Child (%jd) Started", (intmax_t)pid);
 	VSC_C_mgt->child_start++;

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -426,8 +426,13 @@ mgt_f_read(const char *fn)
 	VTAILQ_INSERT_TAIL(&f_args, fa, list);
 }
 
+#ifndef LIBFUZZER_ENABLED
 int
 main(int argc, char * const *argv)
+#else
+int
+varnishd_main(int argc, char * const *argv)
+#endif
 {
 	int o, eric_fd = -1;
 	unsigned C_flag = 0;
@@ -881,6 +886,9 @@ main(int argc, char * const *argv)
 		u = MCH_Start_Child();
 	else
 		u = 0;
+#ifdef LIBFUZZER_ENABLED
+	return u;
+#endif
 
 	if (eric_fd >= 0)
 		mgt_eric_im_done(eric_fd, u);

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -117,7 +117,11 @@ run_vcc(void *priv)
 	if (VSB_len(sb))
 		printf("%s", VSB_data(sb));
 	VSB_destroy(&sb);
+#ifndef LIBFUZZER_ENABLED
 	exit(i == 0 ? 0 : 2);
+#else
+	_exit(i == 0 ? 0 : 2);
+#endif
 }
 
 /*--------------------------------------------------------------------
@@ -185,7 +189,11 @@ run_dlopen(void *priv)
 	CAST_OBJ_NOTNULL(vp, priv, VCC_PRIV_MAGIC);
 	if (VCL_TestLoad(VSB_data(vp->libfile)))
 		exit(1);
+#ifndef LIBFUZZER_ENABLED
 	exit(0);
+#else
+	_exit(0);
+#endif
 }
 
 /*--------------------------------------------------------------------


### PR DESCRIPTION
Adds varnishd support for instrumented fuzzing, PGO, callgraphs etc. by adding a single-process mode as well as an extra LIBFUZZER option. Note that I have a CMake build system I use for both varnish and varnish-plus so I didn't make any changes to autocrap.

Kinda hacky, so feel free to commit to this branch.
