### PR TITLE
Added the syntax 'backend name none;'

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -792,7 +792,6 @@ cnt_recv_prep(struct req *req, const char *ci)
 
 		/* By default we use the first backend */
 		req->director_hint = VCL_DefaultDirector(req->vcl);
-		AN(req->director_hint);
 
 		req->d_ttl = -1;
 		req->d_grace = -1;

--- a/bin/varnishtest/tests/v00060.vtc
+++ b/bin/varnishtest/tests/v00060.vtc
@@ -1,0 +1,45 @@
+varnishtest "NULL backend allowed"
+
+server s1 {
+	rxreq
+	txresp
+
+} -start
+
+varnish v1 -vcl {
+	backend default none;
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+# Test NULL none default backend
+
+varnish v1 -vcl+backend {
+	backend null_backend none;
+        backend null_backend_uppercase None;
+        sub vcl_recv {
+                if (req.url ~ "/no_backend_lowercase") {
+                        set req.backend_hint = null_backend;
+                } else if (req.url ~ "no_backend_uppercase") {
+                        set req.backend_hint = null_backend_uppercase;
+                }
+        }
+}
+
+client c1 {
+        txreq
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/no_backend_lowercase"
+	rxresp
+	expect resp.status == 503
+
+        txreq -url "/no_backend_uppercase"
+	rxresp
+	expect resp.status == 503
+} -run

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -321,6 +321,16 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 	    "?proxy_header",
 	    NULL);
 
+	if (tl->t->tok == ID && (vcc_IdIs(tl->t, "none") || vcc_IdIs(tl->t, "None"))) {
+		vsb = VSB_new_auto();
+		AN(vsb);
+		tl->fb = vsb;
+		Fb(tl, 0, "\n\t%s = (NULL);\n", vgcname);
+		vcc_NextToken(tl);
+		SkipToken(tl, ';');
+		return;
+	}
+
 	SkipToken(tl, '{');
 
 	vsb = VSB_new_auto();


### PR DESCRIPTION
This brings in the feature for allowing null backend declarations via the syntax discussed [here](https://github.com/varnishcache/varnish-cache/pull/3008). The syntax is as follows:

```
backend default none;
```