### PR TITLE
fix regression: ban-lurker skips objects

### DIFF
--- a/bin/varnishd/cache/cache_ban_lurker.c
+++ b/bin/varnishd/cache/cache_ban_lurker.c
@@ -289,7 +289,7 @@ ban_lurker_test_ban(struct worker *wrk, struct vsl_log *vsl, struct ban *bt,
 			VSC_C_main->bans_lurker_obj_killed += lok;
 			VSC_C_main->bans_lurker_obj_killed_cutoff += lokc;
 			tested = tested_tests = lok = lokc = 0;
-			if (oc->ban == bt) {
+			if (oc->ban == bt && bt != bd) {
 				bt->refcount--;
 				VTAILQ_REMOVE(&bt->objcore, oc, ban_list);
 				oc->ban = bd;
@@ -340,7 +340,7 @@ ban_lurker_work(struct worker *wrk, struct vsl_log *vsl)
 	bd = NULL;
 	VTAILQ_INIT(&obans);
 	for (; b != NULL; b = VTAILQ_NEXT(b, list)) {
-		if (bd != NULL && bd != b)
+		if (bd != NULL)
 			ban_lurker_test_ban(wrk, vsl, b, &obans, bd,
 			    count > cutoff);
 		if (b->flags & BANS_FLAG_COMPLETED)

--- a/bin/varnishtest/tests/c00049.vtc
+++ b/bin/varnishtest/tests/c00049.vtc
@@ -33,6 +33,15 @@ server s1 {
 	expect req.url == /4
 	txresp -hdr "Foo: bar4.1"
 
+	rxreq
+	expect req.url == /r1
+	txresp
+	rxreq
+	expect req.url == /r2
+	txresp
+	rxreq
+	expect req.url == /r3
+	txresp
 } -start
 
 varnish v1 -vcl+backend {} -start
@@ -132,8 +141,8 @@ varnish v1 -expect bans_deleted == 2
 varnish v1 -expect bans_tested == 0
 varnish v1 -expect bans_tests_tested == 0
 varnish v1 -expect bans_obj_killed == 0
-varnish v1 -expect bans_lurker_tested == 8
-varnish v1 -expect bans_lurker_tests_tested == 9
+varnish v1 -expect bans_lurker_tested == 10
+varnish v1 -expect bans_lurker_tests_tested == 11
 varnish v1 -expect bans_lurker_obj_killed == 4
 varnish v1 -expect bans_dups == 0
 
@@ -157,8 +166,8 @@ varnish v1 -expect bans_deleted == 2
 varnish v1 -expect bans_tested == 1
 varnish v1 -expect bans_tests_tested == 1
 varnish v1 -expect bans_obj_killed == 0
-varnish v1 -expect bans_lurker_tested == 8
-varnish v1 -expect bans_lurker_tests_tested == 9
+varnish v1 -expect bans_lurker_tested == 10
+varnish v1 -expect bans_lurker_tests_tested == 11
 varnish v1 -expect bans_lurker_obj_killed == 4
 varnish v1 -expect bans_dups == 0
 
@@ -182,8 +191,8 @@ varnish v1 -expect bans_deleted == 5
 varnish v1 -expect bans_tested == 2
 varnish v1 -expect bans_tests_tested == 2
 varnish v1 -expect bans_obj_killed == 1
-varnish v1 -expect bans_lurker_tested == 8
-varnish v1 -expect bans_lurker_tests_tested == 9
+varnish v1 -expect bans_lurker_tested == 10
+varnish v1 -expect bans_lurker_tests_tested == 11
 varnish v1 -expect bans_lurker_obj_killed == 4
 varnish v1 -expect bans_dups == 0
 
@@ -217,10 +226,41 @@ varnish v1 -expect bans_deleted == 10
 varnish v1 -expect bans_tested == 2
 varnish v1 -expect bans_tests_tested == 2
 varnish v1 -expect bans_obj_killed == 1
-varnish v1 -expect bans_lurker_tested == 8
-varnish v1 -expect bans_lurker_tests_tested == 9
+varnish v1 -expect bans_lurker_tested == 10
+varnish v1 -expect bans_lurker_tests_tested == 11
 varnish v1 -expect bans_lurker_obj_killed == 4
 varnish v1 -expect bans_lurker_obj_killed_cutoff == 3
 varnish v1 -expect bans_dups == 0
+
+varnish v1 -expect n_object == 0
+
+client c1 {
+	txreq -url /r1
+	rxresp
+} -run
+
+varnish v1 -cliok "ban req.http.nevermatch == 1"
+
+client c1 {
+	txreq -url /r2
+	rxresp
+} -run
+
+varnish v1 -cliok "ban req.http.nevermatch == 2"
+
+client c1 {
+	txreq -url /r3
+	rxresp
+} -run
+
+varnish v1 -cliok "ban req.http.nevermatch == 3"
+
+varnish v1 -cliok "ban.list"
+
+varnish v1 -cliok "ban obj.http.status != 0"
+
+delay 1
+
+varnish v1 -cliok "ban.list"
 
 varnish v1 -expect n_object == 0


### PR DESCRIPTION
I was hoping this would have made it into 6.0, but didn't. So asking for it expicitly.

This is a cherry-pick of 44ea36eb050fc8bdabc4a834bedd4e77c154a2ff from master

93d805014df919f9be761c6d8ad4ed86eb90c2cb made execution of
ban_lurker_test_ban() conditional on bd != b, which effectively caused
objects hanging off bans below request bans to not get tested against
relevant bans.

Because object bans (from the obans list) are being marked completed,
the objects which were skipped would also be missed to get evaluated
against the relevant bans at lookup time unless they were evaluated in
request context. So, in effect, we would simply miss to test bans.

Fixes #3007

Maybe related to #3006