### PR TITLE
RFC: Ban strcpy and strcat variants from the code base

### DIFF
--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -104,8 +104,7 @@ WS_Init(struct ws *ws, const char *id, void *space, unsigned len)
 	*ws->e = 0x15;
 	ws->f = ws->s;
 	assert(id[0] & 0x20);
-	assert(strlen(id) < sizeof ws->id);
-	strcpy(ws->id, id);
+	AZ(VSB_strcpy(ws->id, id));
 	WS_Assert(ws);
 }
 

--- a/include/vsb.h
+++ b/include/vsb.h
@@ -87,8 +87,11 @@ void		 VSB_quote_pfx(struct vsb *, const char*, const void *,
 void		 VSB_quote(struct vsb *, const void *, int len, int how);
 void		 VSB_indent(struct vsb *, int);
 int		 VSB_tofile(int fd, const struct vsb *);
+int              VSB_strncpy(char *dest, const char *src, size_t len);
 #ifdef __cplusplus
 };
 #endif
+
+#define VSB_strcpy(dest, src) VSB_strncpy(dest, src, sizeof(dest))
 
 #endif

--- a/lib/libvarnish/vsb.c
+++ b/lib/libvarnish/vsb.c
@@ -640,3 +640,16 @@ VSB_tofile(int fd, const struct vsb *s)
 	sz = write(fd, s->s_buf, s->s_len);
 	return (sz == s->s_len ? 0 : -1);
 }
+
+/*
+ * string.h
+ */
+
+int
+VSB_strncpy(char *dest, const char *src, size_t len)
+{
+	struct vsb s[1];
+
+	AN(VSB_new(s, dest, len, VSB_FIXEDLEN));
+	return (VSB_cat(s, src));
+}


### PR DESCRIPTION
This is not meant to be merged, but to illustrate how we could ban straight calls to sensitive functions such as `strcat` from the code base, or in this pull request what the replacement could look like:

- `strcpy` is replaced with `VSB_strcpy`
- it uses a VSB to get bound checks "for free"
- it behaves similarly to `bprintf`
- but it returns non-zero to signal overflow

It can't be applied mechanically throughout the source tree, but it's a trivial task when done manually.

I think this is the kind of hardening overhead we can afford, although I didn't check that every single use of those functions is not in a critical code path. I'm curious how the rest of the team feels about such a change.

I think that those functions are as safe as their bound checks, and those can become incorrect without us noticing as illustrated by #2996 where the code in question used to be correct, and turned into a minor severity bug.

To my knowledge, there is no way to enforce that the `dest` argument of `VSB_strcpy()` is a fixed-size buffer, but it also applies to `bprintf`.