### PR TITLE
vcl.list now returns 201 on response overflow. Fixes #3038

### DIFF
--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -715,10 +715,10 @@ mcf_vcl_list(struct cli *cli, const char * const *av, void *priv)
 	(void)priv;
 
 	if (MCH_Running()) {
-		if (!mgt_cli_askchild(&status, &p, "vcl.list\n")) {
-			VCLI_SetResult(cli, status);
+		if (!mgt_cli_askchild(&status, &p, "vcl.list\n"))
 			VCLI_Out(cli, "%s", p);
-		}
+		else
+			VCLI_SetResult(cli, status);
 		free(p);
 	} else {
 		vsb = VSB_new_auto();

--- a/bin/varnishtest/tests/r03012.vtc
+++ b/bin/varnishtest/tests/r03012.vtc
@@ -1,0 +1,24 @@
+varnishtest "vcl.list and cli_limit"
+
+server s1 { }
+
+varnish v1 -vcl+backend { } -start
+varnish v1 -vcl+backend { }
+varnish v1 -vcl+backend { }
+varnish v1 -vcl+backend { }
+varnish v1 -vcl+backend { }
+varnish v1 -vcl+backend { }
+varnish v1 -vcl+backend { }
+varnish v1 -vcl+backend { }
+varnish v1 -vcl+backend { }
+varnish v1 -vcl+backend { }
+
+varnish v1 -expect n_vcl_avail == 10
+
+varnish v1 -cliok "param.set cli_limit 128b"
+
+varnish v1 -clierr 201 "vcl.list"
+
+varnish v1 -cliok "param.set cli_limit 64k"
+
+varnish v1 -cliok "vcl.list"


### PR DESCRIPTION
This makes vcl.list properly return a 201 status when its response size exceeds the cli_limit variable. This closes #3038