### PR TITLE
Log truncated CLI responses as such

### DIFF
--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -347,7 +347,7 @@ mgt_cli_cb_after(const struct cli *cli)
 
 	MGT_Complain(C_CLI, "CLI %s Wr %03u %s",
 	    cli->ident, cli->result, VSB_data(cli->sb));
-	if (cli->priv == stderr &&
+	if (cli->priv == stderr && cli->result != CLIS_TRUNCATED &&
 	    cli->result != CLIS_OK && *VSB_data(cli->cmd) != '-') {
 		MGT_Complain(C_ERR, "-I file CLI command failed (%d)\n%s\n",
 		    cli->result, VSB_data(cli->sb));

--- a/bin/varnishtest/tests/u00000.vtc
+++ b/bin/varnishtest/tests/u00000.vtc
@@ -74,9 +74,17 @@ shell -err -expect {Warning: Ignoring deprecated second subargument} {
 
 # Code coverage of mgt_main, (VCL compiler and RSTdump etc) (former a00017)
 
-# Test -F mode with no VCL loaded
+# Test -F mode with no VCL loaded, and -I cli_limit truncation
 
-process p1 "exec varnishd -n ${tmpdir}/v1 -F -f '' -a :0 -l2m,1m" -log -start
+shell {
+	cat >truncation.cli <<-EOF
+	param.set cli_limit 128
+	param.show
+	param.reset cli_limit
+	EOF
+}
+
+process p1 "exec varnishd -n ${tmpdir}/v1 -I truncation.cli -F -f '' -a :0 -l2m,1m" -log -start
 
 delay 2
 

--- a/include/vsb.h
+++ b/include/vsb.h
@@ -61,6 +61,7 @@ struct vsb	*VSB_new(struct vsb *, char *, int, int);
 #define		 VSB_new_auto()				\
 	VSB_new(NULL, NULL, 0, VSB_AUTOEXTEND)
 void		 VSB_clear(struct vsb *);
+int		 VSB_truncate(struct vsb *, size_t);
 int		 VSB_bcat(struct vsb *, const void *, ssize_t);
 int		 VSB_cat(struct vsb *, const char *);
 int		 VSB_printf(struct vsb *, const char *, ...)

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -323,11 +323,6 @@ cls_exec(struct VCLS_fd *cfd, char * const *av)
 
 	AZ(VSB_finish(cli->sb));
 
-	if (cs->after != NULL)
-		cs->after(cli);
-
-	cli->cls = NULL;
-
 	s = VSB_data(cli->sb);
 	len = VSB_len(cli->sb);
 	lim = *cs->limit;
@@ -337,6 +332,11 @@ cls_exec(struct VCLS_fd *cfd, char * const *av)
 		strcpy(s + (lim - strlen(trunc)), trunc);
 		assert(strlen(s) <= lim);
 	}
+
+	if (cs->after != NULL)
+		cs->after(cli);
+
+	cli->cls = NULL;
 	if (VCLI_WriteResult(cfd->fdo, cli->result, s) ||
 	    cli->result == CLIS_CLOSE)
 		retval = 1;

--- a/lib/libvarnish/vsb.c
+++ b/lib/libvarnish/vsb.c
@@ -250,6 +250,20 @@ VSB_clear(struct vsb *s)
 	s->s_indent = 0;
 }
 
+int
+VSB_truncate(struct vsb *s, size_t len)
+{
+
+	assert_VSB_integrity(s);
+	assert_VSB_state(s, 0);
+
+	if (s->s_error != 0 || len > s->s_len)
+		return (-1);
+
+	s->s_len = len;
+	return (0);
+}
+
 /*
  * Append a byte to an vsb.  This is the core function for appending
  * to an vsb and is the main place that deals with extending the


### PR DESCRIPTION
Following my own suggestion in #3091 I looked closer at CLI forwarding and CLI truncation. Looking at the truncation part I got rid of an `strcpy` shenanigan, for which I swear this is pure coincidence!