### PR TITLE
RFC: Improve thread pool parameters error messages

### DIFF
--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -708,16 +708,22 @@ MCF_ParamConf(enum mcf_which_e which, const char * const param,
 	AZ(VSB_finish(vsb));
 	switch (which) {
 	case MCF_DEFAULT:
-		pp->def = strdup(VSB_data(vsb));
-		AN(pp->def);
+		free(pp->dyn_def);
+		pp->dyn_def = strdup(VSB_data(vsb));
+		AN(pp->dyn_def);
+		pp->def = pp->dyn_def;
 		break;
 	case MCF_MINIMUM:
-		pp->min = strdup(VSB_data(vsb));
-		AN(pp->min);
+		free(pp->dyn_min);
+		pp->dyn_min = strdup(VSB_data(vsb));
+		AN(pp->dyn_min);
+		pp->min = pp->dyn_min;
 		break;
 	case MCF_MAXIMUM:
-		pp->max = strdup(VSB_data(vsb));
-		AN(pp->max);
+		free(pp->dyn_max);
+		pp->dyn_max = strdup(VSB_data(vsb));
+		AN(pp->dyn_max);
+		pp->max = pp->dyn_max;
 		break;
 	default:
 		WRONG("bad 'which'");

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -708,21 +708,15 @@ MCF_ParamConf(enum mcf_which_e which, const char * const param,
 	AZ(VSB_finish(vsb));
 	switch (which) {
 	case MCF_DEFAULT:
-		free(pp->dyn_def);
-		pp->dyn_def = strdup(VSB_data(vsb));
-		AN(pp->dyn_def);
+		REPLACE(pp->dyn_def, VSB_data(vsb));
 		pp->def = pp->dyn_def;
 		break;
 	case MCF_MINIMUM:
-		free(pp->dyn_min);
-		pp->dyn_min = strdup(VSB_data(vsb));
-		AN(pp->dyn_min);
+		REPLACE(pp->dyn_min, VSB_data(vsb));
 		pp->min = pp->dyn_min;
 		break;
 	case MCF_MAXIMUM:
-		free(pp->dyn_max);
-		pp->dyn_max = strdup(VSB_data(vsb));
-		AN(pp->dyn_max);
+		REPLACE(pp->dyn_max, VSB_data(vsb));
 		pp->max = pp->dyn_max;
 		break;
 	default:

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -74,14 +74,7 @@ tweak_t tweak_uint;
 tweak_t tweak_vsl_buffer;
 tweak_t tweak_vsl_reclen;
 
-enum tweak_e {
-	TWEAK_OK,
-	TWEAK_ERR,
-	TWEAK_BELOW_MIN,
-	TWEAK_ABOVE_MAX,
-};
-
-enum tweak_e tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest,
+int tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest,
     const char *arg, const char *min, const char *max,
     const char *min_reason, const char *max_reason);
 

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -74,10 +74,6 @@ tweak_t tweak_uint;
 tweak_t tweak_vsl_buffer;
 tweak_t tweak_vsl_reclen;
 
-int tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest,
-    const char *arg, const char *min, const char *max,
-    const char *min_reason, const char *max_reason);
-
 extern struct parspec mgt_parspec[]; /* mgt_param_tbl.c */
 extern struct parspec VSL_parspec[]; /* mgt_param_vsl.c */
 extern struct parspec WRK_parspec[]; /* mgt_pool.c */

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -72,7 +72,14 @@ tweak_t tweak_uint;
 tweak_t tweak_vsl_buffer;
 tweak_t tweak_vsl_reclen;
 
-int tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest,
+enum tweak_e {
+	TWEAK_OK,
+	TWEAK_ERR,
+	TWEAK_BELOW_MIN,
+	TWEAK_ABOVE_MAX,
+};
+
+enum tweak_e tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest,
     const char *arg, const char *min, const char *max);
 
 extern struct parspec mgt_parspec[]; /* mgt_param_tbl.c */

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -56,6 +56,8 @@ struct parspec {
 	const char	*def;
 	const char	*units;
 
+	const char	*dyn_min_reason;
+	const char	*dyn_max_reason;
 	char		*dyn_min;
 	char		*dyn_max;
 	char		*dyn_def;
@@ -80,7 +82,8 @@ enum tweak_e {
 };
 
 enum tweak_e tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest,
-    const char *arg, const char *min, const char *max);
+    const char *arg, const char *min, const char *max,
+    const char *min_reason, const char *max_reason);
 
 extern struct parspec mgt_parspec[]; /* mgt_param_tbl.c */
 extern struct parspec VSL_parspec[]; /* mgt_param_vsl.c */

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -55,6 +55,10 @@ struct parspec {
 
 	const char	*def;
 	const char	*units;
+
+	char		*dyn_min;
+	char		*dyn_max;
+	char		*dyn_def;
 };
 
 tweak_t tweak_bool;

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -156,7 +156,7 @@ tweak_bool(struct vsb *vsb, const struct parspec *par, const char *arg)
 
 /*--------------------------------------------------------------------*/
 
-int
+static int
 tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
     const char *min, const char *max,
     const char *min_reason, const char *max_reason)

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -156,7 +156,7 @@ tweak_bool(struct vsb *vsb, const struct parspec *par, const char *arg)
 
 /*--------------------------------------------------------------------*/
 
-enum tweak_e
+int
 tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
     const char *min, const char *max,
     const char *min_reason, const char *max_reason)
@@ -170,7 +170,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			minv = strtoul(min, &p, 0);
 			if (*arg == '\0' || *p != '\0') {
 				VSB_printf(vsb, "Illegal Min: %s\n", min);
-				return (TWEAK_ERR);
+				return (-1);
 			}
 		}
 		if (max != NULL) {
@@ -178,7 +178,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			maxv = strtoul(max, &p, 0);
 			if (*arg == '\0' || *p != '\0') {
 				VSB_printf(vsb, "Illegal Max: %s\n", max);
-				return (TWEAK_ERR);
+				return (-1);
 			}
 		}
 		p = NULL;
@@ -188,7 +188,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			u = strtoul(arg, &p, 0);
 			if (*arg == '\0' || *p != '\0') {
 				VSB_printf(vsb, "Not a number (%s)\n", arg);
-				return (TWEAK_ERR);
+				return (-1);
 			}
 		}
 		if (min != NULL && u < minv) {
@@ -196,14 +196,14 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			if (min_reason != NULL)
 				VSB_printf(vsb, " %s", min_reason);
 			VSB_putc(vsb, '\n');
-			return (TWEAK_BELOW_MIN);
+			return (-1);
 		}
 		if (max != NULL && u > maxv) {
 			VSB_printf(vsb, "Must be no more than %s", max);
 			if (max_reason != NULL)
 				VSB_printf(vsb, " %s", max_reason);
 			VSB_putc(vsb, '\n');
-			return (TWEAK_ABOVE_MAX);
+			return (-1);
 		}
 		*dest = u;
 	} else if (*dest == UINT_MAX && arg != JSON_FMT) {
@@ -211,7 +211,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 	} else {
 		VSB_printf(vsb, "%u", *dest);
 	}
-	return (TWEAK_OK);
+	return (0);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -156,7 +156,7 @@ tweak_bool(struct vsb *vsb, const struct parspec *par, const char *arg)
 
 /*--------------------------------------------------------------------*/
 
-int
+enum tweak_e
 tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
     const char *min, const char *max)
 {
@@ -169,7 +169,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			minv = strtoul(min, &p, 0);
 			if (*arg == '\0' || *p != '\0') {
 				VSB_printf(vsb, "Illegal Min: %s\n", min);
-				return (-1);
+				return (TWEAK_ERR);
 			}
 		}
 		if (max != NULL) {
@@ -177,7 +177,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			maxv = strtoul(max, &p, 0);
 			if (*arg == '\0' || *p != '\0') {
 				VSB_printf(vsb, "Illegal Max: %s\n", max);
-				return (-1);
+				return (TWEAK_ERR);
 			}
 		}
 		p = NULL;
@@ -187,16 +187,16 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 			u = strtoul(arg, &p, 0);
 			if (*arg == '\0' || *p != '\0') {
 				VSB_printf(vsb, "Not a number (%s)\n", arg);
-				return (-1);
+				return (TWEAK_ERR);
 			}
 		}
 		if (min != NULL && u < minv) {
 			VSB_printf(vsb, "Must be at least %s\n", min);
-			return (-1);
+			return (TWEAK_BELOW_MIN);
 		}
 		if (max != NULL && u > maxv) {
 			VSB_printf(vsb, "Must be no more than %s\n", max);
-			return (-1);
+			return (TWEAK_ABOVE_MAX);
 		}
 		*dest = u;
 	} else if (*dest == UINT_MAX && arg != JSON_FMT) {
@@ -204,7 +204,7 @@ tweak_generic_uint(struct vsb *vsb, volatile unsigned *dest, const char *arg,
 	} else {
 		VSB_printf(vsb, "%u", *dest);
 	}
-	return (0);
+	return (TWEAK_OK);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/mgt/mgt_pool.c
+++ b/bin/varnishd/mgt/mgt_pool.c
@@ -58,8 +58,7 @@ tweak_thread_pool_min(struct vsb *vsb, const struct parspec *par,
     const char *arg)
 {
 
-	if (tweak_generic_uint(vsb, par->priv, arg, par->min, par->max,
-	    par->dyn_min_reason, par->dyn_max_reason))
+	if (tweak_uint(vsb, par, arg))
 		return (-1);
 
 	MCF_ParamConf(MCF_MINIMUM, "thread_pool_max",
@@ -74,8 +73,7 @@ tweak_thread_pool_max(struct vsb *vsb, const struct parspec *par,
     const char *arg)
 {
 
-	if (tweak_generic_uint(vsb, par->priv, arg, par->min, par->max,
-	    par->dyn_min_reason, par->dyn_max_reason))
+	if (tweak_uint(vsb, par, arg))
 		return (-1);
 
 	MCF_ParamConf(MCF_MAXIMUM, "thread_pool_min",

--- a/bin/varnishd/mgt/mgt_pool.c
+++ b/bin/varnishd/mgt/mgt_pool.c
@@ -57,38 +57,30 @@ static int
 tweak_thread_pool_min(struct vsb *vsb, const struct parspec *par,
     const char *arg)
 {
-	enum tweak_e tweak;
 
-	tweak = tweak_generic_uint(vsb, par->priv, arg, par->min, par->max,
-	    par->dyn_min_reason, par->dyn_max_reason);
+	if (tweak_generic_uint(vsb, par->priv, arg, par->min, par->max,
+	    par->dyn_min_reason, par->dyn_max_reason))
+		return (-1);
 
-	if (tweak == TWEAK_OK) {
-		MCF_ParamConf(MCF_MINIMUM, "thread_pool_max",
-		    "%u", mgt_param.wthread_min);
-		MCF_ParamConf(MCF_MAXIMUM, "thread_pool_reserve",
-		    "%u", mgt_param.wthread_min * 950 / 1000);
-		return (0);
-	}
-
-	return (-1);
+	MCF_ParamConf(MCF_MINIMUM, "thread_pool_max",
+	    "%u", mgt_param.wthread_min);
+	MCF_ParamConf(MCF_MAXIMUM, "thread_pool_reserve",
+	    "%u", mgt_param.wthread_min * 950 / 1000);
+	return (0);
 }
 
 static int
 tweak_thread_pool_max(struct vsb *vsb, const struct parspec *par,
     const char *arg)
 {
-	enum tweak_e tweak;
 
-	tweak = tweak_generic_uint(vsb, par->priv, arg, par->min, par->max,
-	    par->dyn_min_reason, par->dyn_max_reason);
+	if (tweak_generic_uint(vsb, par->priv, arg, par->min, par->max,
+	    par->dyn_min_reason, par->dyn_max_reason))
+		return (-1);
 
-	if (tweak == TWEAK_OK) {
-		MCF_ParamConf(MCF_MAXIMUM, "thread_pool_min",
-		    "%u", mgt_param.wthread_max);
-		return (0);
-	}
-
-	return (-1);
+	MCF_ParamConf(MCF_MAXIMUM, "thread_pool_min",
+	    "%u", mgt_param.wthread_max);
+	return (0);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/mgt/mgt_pool.c
+++ b/bin/varnishd/mgt/mgt_pool.c
@@ -81,7 +81,10 @@ tweak_thread_pool_max(struct vsb *vsb, const struct parspec *par,
 	return (0);
 }
 
-/*--------------------------------------------------------------------*/
+/*--------------------------------------------------------------------
+ * The thread pool parameter definitions used to generate the varnishd
+ * manual. Check the generated RST after updating.
+ */
 
 struct parspec WRK_parspec[] = {
 	{ "thread_pools", tweak_uint, &mgt_param.wthread_pools,

--- a/bin/varnishtest/tests/r03098.vtc
+++ b/bin/varnishtest/tests/r03098.vtc
@@ -1,0 +1,25 @@
+varnishtest "Explain how param.(re)?set may fail"
+
+# NB: we don't need or want to start the cache process
+
+varnish v1 -cliok "param.set thread_pool_max 10000"
+varnish v1 -cliok "param.set thread_pool_min  8000"
+
+# NB: "varnish v1 -cliexpect" wouldn't work with a non-200 status
+shell -err -expect "Must be at least 8000 (thread_pool_min)" {
+	exec varnishadm -n ${v1_name} param.reset thread_pool_max
+}
+
+varnish v1 -cliok "param.set thread_pool_min  8"
+varnish v1 -cliok "param.set thread_pool_max 10"
+
+shell -err -expect "Must be no more than 10 (thread_pool_max)" {
+	exec varnishadm -n ${v1_name} param.reset thread_pool_min
+}
+
+varnish v1 -cliok "param.reset thread_pool_max"
+varnish v1 -cliok "param.reset thread_pool_min"
+
+shell -err -expect "Must be no more than 95 (95% of thread_pool_min)" {
+	exec varnishadm -n ${v1_name} param.set thread_pool_reserve 96
+}

--- a/tools/coccinelle/replace.cocci
+++ b/tools/coccinelle/replace.cocci
@@ -1,0 +1,12 @@
+/*
+ * This patch simplifies code using the REPLACE() macro.
+ */
+
+@@
+expression ptr, val;
+@@
+
+- free(ptr);
+- ptr = strdup(val);
+- AN(ptr);
++ REPLACE(ptr, val);


### PR DESCRIPTION
Inform users when the parameter we try to change depends on another
parameter.

This is not meant to be merged as-is, we could have a new VSB function
to trim the end of the string if it matches the one passed as the second
argument. In this case, we would trim the trailing newline only of the
CLI response didn't overflow in the first place, adding the extra
information on the same line. Alternatively we could also simply add the
explanation for the dynamic bounds on the next line.

Feedback welcome.

Fixes #3098