### PR TITLE
RFC: handle non-symbolic HTTP header names in pure VCL

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -177,6 +177,44 @@ VRT_GetHdr(VRT_CTX, VCL_HEADER hs)
 	return (p);
 }
 
+/*--------------------------------------------------------------------*/
+
+VCL_HEADER
+VRT_Header(VRT_CTX, VCL_HTTP hp, VCL_STRING name)
+{
+	struct gethdr_s *hs;
+	int len;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
+	AN(name);
+
+	len = strlen(name);
+	/* TODO: check header name validity */
+
+	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
+	hs = WS_Alloc(ctx->ws, sizeof *hs);
+	XXXAN(hs);
+
+	if (hp == ctx->http_req)
+		hs->where = HDR_REQ;
+	else if (hp == ctx->http_req_top)
+		hs->where = HDR_REQ_TOP;
+	else if (hp == ctx->http_bereq)
+		hs->where = HDR_BEREQ;
+	else if (hp == ctx->http_beresp)
+		hs->where = HDR_BERESP;
+	else if (hp == ctx->http_resp)
+		hs->where = HDR_RESP;
+	else
+		hs->where = HDR_OBJ;
+
+	hs->what = WS_Printf(ctx->ws, "%c%s:", len + 1, name);
+	XXXAN(hs->what);
+
+	return (hs);
+}
+
 /*--------------------------------------------------------------------
  * Build STRANDS from what is essentially a STRING_LIST
  */

--- a/bin/varnishtest/tests/r02573.vtc
+++ b/bin/varnishtest/tests/r02573.vtc
@@ -1,0 +1,22 @@
+varnishtest "Valid header names, invalid VCL symbols"
+
+varnish v1 -vcl {
+	backend be none;
+
+	sub vcl_recv {
+		return (synth(200));
+	}
+
+	sub vcl_synth {
+		set resp.http.req_http_foo = req.http("req.http.foo");
+		set resp.http.seven_hello = req.http("7" + "hello");
+	}
+} -start
+
+client c1 {
+	txreq -hdr "req.http.foo: bar" -hdr "7hello: world"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.req_http_foo == bar
+	expect resp.http.seven_hello == world
+} -run

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -54,6 +54,7 @@
  * unreleased (planned for 2020-03-15)
  *	New prefix_{ptr|len} fields in vrt_backend
  *	VRT_HashStrands32() added
+ *	VRT_Header() added
  * 10.0 (2019-09-15)
  *	VRT_UpperLowerStrands added.
  *	VRT_synth_page now takes STRANDS argument
@@ -435,6 +436,7 @@ struct gethdr_s {
 
 VCL_HTTP VRT_selecthttp(VRT_CTX, enum gethdr_e);
 VCL_STRING VRT_GetHdr(VRT_CTX, VCL_HEADER);
+VCL_HEADER VRT_Header(VRT_CTX, VCL_HTTP, VCL_STRING);
 
 /***********************************************************************
  * req related

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -829,6 +829,8 @@ static const struct vcc_methods {
 	{ STRINGS, STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 0 },
 	{ STRINGS, STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 0 },
 
+	{ HTTP, HEADER, "http", "VRT_Header(ctx, \v1, \v2)", 1, { STRING } },
+
 	{ NULL, NULL,		NULL,		NULL},
 };
 

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -860,17 +860,17 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			return;
 		}
 		vcc_NextToken(tl);
-		*e = vcc_expr_edit(tl, vm->type_to, vm->impl, *e, NULL);
-		ERRCHK(tl);
-		if ((*e)->fmt == STRING) {
-			(*e)->fmt = STRINGS;
-			(*e)->nstr = 1;
-		}
 		if (vm->func) {
 			ExpectErr(tl, '(');
 			vcc_NextToken(tl);
 			ExpectErr(tl, ')');
 			vcc_NextToken(tl);
+		}
+		*e = vcc_expr_edit(tl, vm->type_to, vm->impl, *e, NULL);
+		ERRCHK(tl);
+		if ((*e)->fmt == STRING) {
+			(*e)->fmt = STRINGS;
+			(*e)->nstr = 1;
 		}
 	}
 }


### PR DESCRIPTION
This came up recently in this thread:

https://varnish-cache.org/lists/pipermail/varnish-misc/2019-October/026685.html

I still find the outcome of referring to a third-party VMOD embarrassing and now that we opened a breach with type properties and methods, I think we should enter the breach and expand VCL capabilities.

In this example, I added limited parameters capabilities to type methods (positional only, not optional, etc) and implemented a method for the HTTP type. This is particularly sneaky because I took advantage of the lack of conflicts between type methods and the symbol table, so I ended up with a very similar syntax:

```vcl
req.http("7hello");
```

See individual patches for more information.

See also #2573 and https://github.com/varnishcache/varnish-cache/issues/3102#issuecomment-544980358