### PR TITLE
param.reset to initial (-p) values

### DIFF
--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -173,7 +173,7 @@ enum mcf_which_e {
 void MCF_ParamConf(enum mcf_which_e, const char *param, const char *, ...)
     v_printflike_(3, 4);
 
-void MCF_ParamSet(struct cli *, const char *param, const char *val);
+void MCF_ParamSet(struct cli *, const char *param, const char *val, int init);
 void MCF_ParamProtect(struct cli *, const char *arg);
 void MCF_DumpRstParam(void);
 void MCF_AddParams(struct parspec *ps);

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -636,7 +636,7 @@ main(int argc, char * const *argv)
 			if (av[1] != NULL && av[2] != NULL && av[3] != NULL)
 				ARGV_ERR("Too many sub arguments to -l\n");
 			if (av[1] != NULL) {
-				MCF_ParamSet(cli, "vsl_space", av[1]);
+				MCF_ParamSet(cli, "vsl_space", av[1], 1);
 				cli_check(cli);
 			}
 			if (av[1] != NULL && av[2] != NULL) {
@@ -661,7 +661,7 @@ main(int argc, char * const *argv)
 				ARGV_ERR("\t-p lacks '='\n");
 			AN(p);
 			*p++ = '\0';
-			MCF_ParamSet(cli, optarg, p);
+			MCF_ParamSet(cli, optarg, p, 1);
 			*--p = '=';
 			cli_check(cli);
 			break;
@@ -683,7 +683,7 @@ main(int argc, char * const *argv)
 				T_arg = optarg;
 			break;
 		case 't':
-			MCF_ParamSet(cli, "default_ttl", optarg);
+			MCF_ParamSet(cli, "default_ttl", optarg, 1);
 			break;
 		case 'W':
 			W_arg = optarg;

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -55,6 +55,7 @@ struct parspec {
 
 	const char	*def;
 	const char	*units;
+	char		*init;
 
 	const char	*dyn_min_reason;
 	const char	*dyn_max_reason;

--- a/bin/varnishtest/tests/b00008.vtc
+++ b/bin/varnishtest/tests/b00008.vtc
@@ -1,6 +1,6 @@
 varnishtest "Test CLI commands and parameter functions"
 
-varnish v1 -arg "-b ${bad_ip}:9080"
+varnish v1 -arg "-b ${bad_ip}:9080 -p first_byte_timeout=17"
 
 varnish v1 -cliok "help"
 
@@ -43,6 +43,8 @@ varnish v1 -cliok "param.set first_byte_timeout 120"
 varnish v1 -cliexpect 120 "param.show first_byte_timeout"
 varnish v1 -cliok "param.reset first_byte_timeout"
 varnish v1 -cliexpect 60 "param.show first_byte_timeout"
+varnish v1 -cliok "param.reset -i first_byte_timeout"
+varnish v1 -cliexpect 17 "param.show first_byte_timeout"
 
 varnish v1 -cliok "param.set cli_limit 128"
 

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -149,10 +149,13 @@ CLI_CMD(VCL_LABEL,
 
 CLI_CMD(PARAM_RESET,
 	"param.reset",
-	"param.reset <param>",
+	"param.reset [-i] <param>",
 	"Reset parameter to default value.",
-	"",
-	1,1
+	"If -i is specified, apply the ``initial`` value given to the parameter"
+	" from the ``varnishd`` start line (``-p`` argument). If there was no"
+	" initial value, use the default one. Notes that it also impact the -t"
+	" and -l ``varnishd`` arguments.",
+	1,2
 )
 
 CLI_CMD(PARAM_SHOW,


### PR DESCRIPTION
Add a new argument to `param.reset` to instruct it to reset not to the hard-coded default value but to the initial value specified in the command line.

I'm not a fan of the pointer dance to replace `pp->init` in `MCF_ParamSet()` but I felt it was better than removing the `const` qualifier.