### PR TITLE
Fix bug in probe heap comparison function

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -721,8 +721,8 @@ vbp_cmp(void *priv, const void *a, const void *b)
 	CAST_OBJ_NOTNULL(aa, a, VBP_TARGET_MAGIC);
 	CAST_OBJ_NOTNULL(bb, b, VBP_TARGET_MAGIC);
 
-	if (aa->running && !bb->running)
-		return (0);
+	if ((aa->running == 0) != (bb->running == 0))
+		return (aa->running == 0);
 
 	return (aa->due < bb->due);
 }


### PR DESCRIPTION
A case has been observed where the probe scheduling stopped. The system had some probes with very long interval (24h), and some with short intervals. It is suspected that the cause was the bug that this PR fixes, where the heap bubbled the wrong probe to the top giving a very long (24h) wait time before the next probe scheduling.

An attempt was made at creating a test case for this, but it proved very unreliable and timing sensitive so it was abandoned.
