### PR TITLE
POLArize Last-Modified (RFC)

### DIFF
--- a/bin/varnishd/cache/cache_rfc2616.c
+++ b/bin/varnishd/cache/cache_rfc2616.c
@@ -293,10 +293,6 @@ RFC2616_Do_Cond(const struct req *req)
 				return (0);
 			return (1);
 		}
-		AZ(ObjGetDouble(req->wrk, req->objcore, OA_LASTMODIFIED, &lm));
-		if (lm > ims)
-			return (0);
-		return (1);
 	}
 
 	return (0);

--- a/bin/varnishtest/tests/r00795.vtc
+++ b/bin/varnishtest/tests/r00795.vtc
@@ -35,7 +35,9 @@ client c1 {
 	rxresp -no_obj
 	expect resp.status == 304
 
+	# no explicit LM from backend
 	txreq -url "/bar" -hdr "If-Modified-Since: ${date}"
-	rxresp -no_obj
-	expect resp.status == 304
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 6
 } -run

--- a/bin/varnishtest/tests/v00047.vtc
+++ b/bin/varnishtest/tests/v00047.vtc
@@ -7,7 +7,10 @@ server s1 {
 
 varnish v1 -vcl+backend {
 	sub vcl_deliver {
-		if (req.http.deliver == "modify") {
+		if (req.http.deliver == "delete") {
+			unset resp.http.Last-Modified;
+		}
+		else if (req.http.deliver == "modify") {
 			set resp.http.Last-Modified = "Wed, 27 Apr 2016 16:00:00 GMT";
 		}
 	}
@@ -21,6 +24,10 @@ client c1 {
 	txreq -hdr "If-Modified-Since: Wed, 27 Apr 2016 14:00:00 GMT"
 	rxresp
 	expect resp.status == 304
+
+	txreq -hdr "If-Modified-Since: Wed, 27 Apr 2016 14:00:00 GMT" -hdr "deliver: delete"
+	rxresp
+	expect resp.status == 200
 
 	txreq -hdr "If-Modified-Since: Wed, 27 Apr 2016 12:00:00 GMT"
 	rxresp


### PR DESCRIPTION
Reviewing #3111 I was taken by surprise by the fact that existing code checks an object's `OA_LASTMODIFIED` attribute for `If-Modified-Since` processing also.

This was originally introduced with 3bd239e9b2361c96b1acf1c03bce9c50baaf838d / bug [#795](https://varnish-cache.org/trac/ticket/795)

In other words, we generate a 304 response even if there was no `Last-Modified` header in the first place. [RFC7232](https://tools.ietf.org/html/rfc7232#section-3.3) explicitly allows this...

> However, caches occasionally generate the field value based on other data, such as the Date header field of the cached message or the local clock time that the message was received, particularly when the cached message does not contain a Last-Modified field

... so we are not talking about a bug, just questions of simplicity and transparency.

Yet I think we should not use the internal attribute silently for the following reasons:
* If there is no `Last-Modified` header, how would a well-behaved client come up with an `If-Modified-Since` in the first place? So I think the code will almost never be hit anyway.
* Falling back to the object attribute takes away VCL control over Last-Modified: At least my expectation is that unsetting the header leads to no conditional handling. But with the existing code, `unset resp.http.Last-Modified` has no effect, a 304 will still be sent if the `OA_LASTMODIFIED` is earlier than the `req.http.If-Modified.Since`.

This PR shows the changes when taking away the fallback on `OA_LASTMODIFIED` and is not intended for integration as is, see 2) below.

I would like revise how we should handle this. Some options:

1. Keep the existing behavior and improve documentation that `unset resp.http.Last-Modified` has limited effect. There is a mention in the changelog for varnish 2.1.5, but not elsewhere, unless I overlook something.

2. Remove the fallback to  `OA_LASTMODIFIED` as shown herein. If this option is chosen, we might also want to remove the OA in the first place

3. Always add a `Last-Modified` header here:
https://github.com/varnishcache/varnish-cache/blob/master/bin/varnishd/cache/cache_fetch.c#L187

(3) was already dismissed in [#795](https://varnish-cache.org/trac/ticket/795). So my question is if we should rather go for option (2).