### PR TITLE
Add Ctrl-f and Ctrl-b for pagedown/up in varnishstat.

### DIFF
--- a/bin/varnishstat/varnishstat_curses.c
+++ b/bin/varnishstat/varnishstat_curses.c
@@ -62,6 +62,8 @@
 
 #define VALUE_MAX		999999999999
 
+#define CTRL(c) ((c) & 037)
+
 struct ma {
 	unsigned n, nmax;
 	double acc;
@@ -881,11 +883,13 @@ handle_keypress(int ch)
 		current++;
 		break;
 	case KEY_PPAGE:
+	case CTRL('b'):
 	case 'b':
 		current -= l_points;
 		page_start -= l_points;
 		break;
 	case KEY_NPAGE:
+	case CTRL('f'):
 	case ' ':
 		current += l_points;
 		if (page_start + l_points < n_ptarray - 1)

--- a/doc/sphinx/reference/varnishstat.rst
+++ b/doc/sphinx/reference/varnishstat.rst
@@ -79,10 +79,10 @@ The following keys control the interactive display:
 <DOWN>
 	Navigate the counter list one line down.
 
-<PAGEUP> or <b>
+<PAGEUP> or <b> or <CTRL-b>
 	Navigate the counter list one page up.
 
-<PAGEDOWN> or <SPACE>
+<PAGEDOWN> or <SPACE> or <CTRL-f>
 	Navigate the counter list one page down.
 
 <HOME>


### PR DESCRIPTION
This adds another vim-style key binding to varnishstat.

Couldn't find any good way to extend u00008.vtc to test it. The
cursor is always at column 22 and page-downing to the bottom
will break the test case when we add another counter.