### PR TITLE
Add VDP_END action for delivery processors

### DIFF
--- a/bin/varnishd/cache/cache_filter.h
+++ b/bin/varnishd/cache/cache_filter.h
@@ -99,6 +99,7 @@ void VRT_RemoveVFP(VRT_CTX, const struct vfp *);
 enum vdp_action {
 	VDP_NULL,		/* Input buffer valid after call */
 	VDP_FLUSH,		/* Input buffer will be invalidated */
+	VDP_END,		/* Last buffer or after, implies VDP_FLUSH */
 };
 
 typedef int vdp_init_f(struct req *, void **priv);
@@ -123,6 +124,7 @@ struct vdp {
 struct vdp_entry {
 	unsigned		magic;
 #define VDP_ENTRY_MAGIC		0x353eb781
+	enum vdp_action		end;	// VDP_NULL or VDP_END
 	const struct vdp	*vdp;
 	void			*priv;
 	VTAILQ_ENTRY(vdp_entry)	list;

--- a/bin/varnishd/cache/cache_range.c
+++ b/bin/varnishd/cache/cache_range.c
@@ -84,13 +84,14 @@ vrg_range_bytes(struct req *req, enum vdp_action act, void **priv,
 	l = vrg_priv->range_high - vrg_priv->range_off;
 	if (l > len)
 		l = len;
+	vrg_priv->range_off += len;
+	if (vrg_priv->range_off >= vrg_priv->range_high)
+		act = VDP_END;
 	if (l > 0)
 		retval = VDP_bytes(req, act, p, l);
-	else if (act > VDP_NULL)
+	else if (l == 0 && act > VDP_NULL)
 		retval = VDP_bytes(req, act, p, 0);
-	vrg_priv->range_off += len;
-	return (retval ||
-	    vrg_priv->range_off >= vrg_priv->range_high ? 1 : 0);
+	return (retval || act == VDP_END ? 1 : 0);
 }
 
 /*--------------------------------------------------------------------*/

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -117,12 +117,13 @@ xyzzy_rot13_bytes(struct req *req, enum vdp_action act, void **priv,
 	const char *pp;
 	int i, j, retval = 0;
 
-	(void)act;
 	AN(priv);
 	AN(*priv);
-	AN(ptr);
 	if (len <= 0)
-		return (0);
+		return (VDP_bytes(req, act, ptr, len));
+	AN(ptr);
+	if (act != VDP_END)
+		act = VDP_FLUSH;
 	q = *priv;
 	pp = ptr;
 
@@ -134,14 +135,14 @@ xyzzy_rot13_bytes(struct req *req, enum vdp_action act, void **priv,
 		else
 			q[i] = pp[j];
 		if (i == ROT13_BUFSZ - 1) {
-			retval = VDP_bytes(req, VDP_FLUSH, q, ROT13_BUFSZ);
+			retval = VDP_bytes(req, act, q, ROT13_BUFSZ);
 			if (retval != 0)
 				return (retval);
 			i = -1;
 		}
 	}
 	if (i >= 0)
-		retval = VDP_bytes(req, VDP_FLUSH, q, i + 1L);
+		retval = VDP_bytes(req, act, q, i + 1L);
 	return (retval);
 }
 


### PR DESCRIPTION
`VDP_END` marks the end of successful processing, it is issued by `VDP_DeliverObj()` and may also be sent downstream by processors ending the stream `(for return value != 0)`

`VDP_END` must at most be generated once per processor, so any VDP sending it downstream must itself not forward it a second time.

* `VDP_bytes()`

  The only relevant change is the assertion that `VDP_END` must not be received by any VDP more than once. This comes with minor restructuring of the handling of the three actions

* `VDP_DeliverObj()`

  Here, `VDP_END` is pushed down after succesful iteration over the objects. We could also send the last storage segment with `VDP_END`, but this would require a change in all stevedores. Unless there is a good case for it, I do not see much value in this minor optimization.

* ESI:

  In `ved_vdp_esi_bytes()` we now push down `VDP_END` whenever we are done with an ESI object at `esi_level == 0`.

  `ved_bytes()` handles the pushes from higher esi levels downwards, so it now changes `VDP_END` into `VDP_FLUSH`. We need to remove the additional `VDP_FLUSH` from `ved_deliver()` because the `VDP_END` from `VDP_DeliverObj()` needs to be the last bit sent and `ved_deliver()` runs at `esi_level > 0` only (it is a transport function).

  The `gzgz` VDP actually does something which would be impossible for an `esi_level == 0` VDP: push bytes from _fini. This could be reworked, but there is also no need to.

* range VDP

  Here we now send the `VDP_END` with the last segment before the end of the range is it.

  We also take the opportunity and eleminate null `VDP_bytes()` calls before the range is reached.

* rot13 debug VDP

  Here we need to ensure that we pass on `VDP_END`