### PR TITLE
support optional concurrent access to PRIV_TOP

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -450,6 +450,7 @@ struct reqtop {
 	struct req		*topreq;
 	struct vcl		*vcl0;
 	struct vrt_privs	privs[1];
+	pthread_mutex_t		*mtx;
 };
 
 struct req {

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -166,6 +166,8 @@ struct vmod_priv *
 VRT_priv_top(VRT_CTX, const void *vmod_id)
 {
 	struct req *req;
+	struct reqtop *top;
+	struct vmod_priv *priv;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (ctx->req == NULL) {
@@ -174,12 +176,16 @@ VRT_priv_top(VRT_CTX, const void *vmod_id)
 	}
 	req = ctx->req;
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-	CHECK_OBJ_NOTNULL(req->top, REQTOP_MAGIC);
-	return (vrt_priv_dynamic(
-	    req->ws,
-	    req->top->privs,
-	    (uintptr_t)vmod_id
-	));
+	top = req->top;
+	CHECK_OBJ_NOTNULL(top, REQTOP_MAGIC);
+
+	if (top->mtx == NULL)
+		return (vrt_priv_dynamic(req->ws, top->privs,
+		    (uintptr_t)vmod_id));
+	AZ(pthread_mutex_lock(top->mtx));
+	priv = vrt_priv_dynamic(req->ws, top->privs, (uintptr_t)vmod_id);
+	AZ(pthread_mutex_unlock(top->mtx));
+	return (priv);
 }
 
 /*--------------------------------------------------------------------


### PR DESCRIPTION
context:

A previous form of this PR had already been discussed in #3011, I will reflect further down the arguments from https://github.com/varnishcache/varnish-cache/pull/3011#issuecomment-536973616

overview / motivation:

in varnish-cache, access to all ESI sub-requests happens in a single thread, but vmods (VDPs) may change this.

This patch suggests to add an optional mutex (to be allocated and initialized by vmods) which, when set, will be used to serialize access to the priv_top.

Any vmods using this facility will likely need to add additional locking for the actual data structures referenced through the PRIV_TOP and any other access to the top request.

Alternatives considered:

* use a varnish lock. Possible, but would sound like additional overhead:
  * as core code would own the vsc, it would make sense to also have a VRT function to add the locking to reqtop.
  * that in turn calls for cleanup code in VRT
  * which calls for some version of `VCL_TaskLeave` specifically for reqtop

  One might rightly argue that vmods using the lock could implement all of this, but this would add more friction and room for error.

  As, for the foreseeable future, there will probably be exactly two users of this lock, I think that simply having the `reqtop->mtx` point to some vmod-owned pthread mtx at `esi_level == 0` is the simplest, easiest and most robust option at this point.

* require the lock to be already held by the caller if the lock is non-NULL.
  This could actually reduce the number of locking operations, but would
  hold the lock for longer and when unnecessary.

  idea dropped in favor of simplicity