### PR TITLE
Fix director list membership and temperature events

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -604,7 +604,7 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 
 	if (be->director != NULL) {
 		/* for cold VCL, update initial director state */
-		if (be->probe != NULL && ! VCL_WARM(vcl))
+		if (be->probe != NULL && ! VCL_WARM(vcl->temp))
 			VBP_Update_Backend(be->probe);
 
 		Lck_Lock(&backends_mtx);

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -265,7 +265,7 @@ vcl_get(struct vcl **vcc, struct vcl *vcl)
 	(*vcc)->busy++;
 	Lck_Unlock(&vcl_mtx);
 	AZ(errno=pthread_rwlock_rdlock(&(*vcc)->temp_rwl));
-	assert(VCL_WARM(*vcc));
+	assert(VCL_WARM((*vcc)->temp));
 	AZ(errno=pthread_rwlock_unlock(&(*vcc)->temp_rwl));
 }
 
@@ -503,7 +503,7 @@ vcl_set_state(VRT_CTX, const char *state)
 	case '0':
 		if (vcl->temp == VCL_TEMP_COLD)
 			break;
-		if (vcl->busy == 0 && VCL_WARM(vcl)) {
+		if (vcl->busy == 0 && VCL_WARM(vcl->temp)) {
 			vcl->temp = VTAILQ_EMPTY(&vcl->ref_list) ?
 			    VCL_TEMP_COLD : VCL_TEMP_COOLING;
 			AZ(vcl_send_event(ctx, VCL_EVENT_COLD));

--- a/bin/varnishd/cache/cache_vcl.h
+++ b/bin/varnishd/cache/cache_vcl.h
@@ -80,7 +80,5 @@ extern const char * const VCL_TEMP_COOLING;
  * NB: The COOLING temperature is neither COLD nor WARM.
  * And LABEL is not a temperature, it's a different kind of VCL.
  */
-#define VCL_WARM(v) ((v)->temp == VCL_TEMP_WARM || (v)->temp == VCL_TEMP_BUSY)
-#define VCL_COLD(v) ((v)->temp == VCL_TEMP_INIT || (v)->temp == VCL_TEMP_COLD)
-
-
+#define VCL_WARM(t) ((t) == VCL_TEMP_WARM || (t) == VCL_TEMP_BUSY)
+#define VCL_COLD(t) ((t) == VCL_TEMP_INIT || (t) == VCL_TEMP_COLD)

--- a/bin/varnishd/cache/cache_vcl.h
+++ b/bin/varnishd/cache/cache_vcl.h
@@ -47,7 +47,6 @@ struct vcl {
 	unsigned		busy;
 	unsigned		discard;
 	const char		*temp;
-	pthread_rwlock_t	temp_rwl;
 	VTAILQ_HEAD(,vcldir)	director_list;
 	VTAILQ_HEAD(,vclref)	ref_list;
 	int			nrefs;


### PR DESCRIPTION
this PR fixes #3094 

We add missing locking for operations on the director list to ensure consistency with concurrent dynamic director additions and deletions.
We remove the temperature lock which prevented director deletions during COLD events and ensure that only backends on the director list receive events.

Please note that there is no explicit vtc, the test case has been added to vmod_debug and runs with every invocation of that vmod.

Please consider the individual commit messages for additional detail on the reasoning.