### PR TITLE
Fixes #3136: Typos in user guide.

### DIFF
--- a/doc/sphinx/tutorial/peculiarities.rst
+++ b/doc/sphinx/tutorial/peculiarities.rst
@@ -22,7 +22,7 @@ handled.
 varnishadm
 ~~~~~~~~~~
 
-Varnish Cache has an admin console. You can connect it it through the
+Varnish Cache has an admin console. You can connect it through the
 :ref:`varnishadm(1)` command. In order to connect the user needs to be
 able to read `/etc/varnish/secret` in order to authenticate.
 

--- a/doc/sphinx/users-guide/run_security.rst
+++ b/doc/sphinx/users-guide/run_security.rst
@@ -150,7 +150,7 @@ HTTP service, but a few can do more damage than others:
 	Execute arbitrary programs
 
 :ref:`ref_param_vcc_allow_inline_c`
-        Allow inline C in VCL, which would any C code from VCL to be executed by Varnish.
+        Allow inline C in VCL, which would allow any C code from VCL to be executed by Varnish.
 
 Furthermore you may want to look at and lock down:
 


### PR DESCRIPTION
Fixed the typos in the files mentioned in the corresponding issue.