### PR TITLE
[Discuss] Expand VCL object support

### DIFF
--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -160,6 +160,16 @@ VRT_priv_task(VRT_CTX, const void *vmod_id)
 	));
 }
 
+void **
+VRT_priv_task_object(VRT_CTX, void *vmod_id, vmod_priv_free_f *free)
+{
+	struct vmod_priv *priv;
+
+	priv = VRT_priv_task(ctx, vmod_id);
+	priv->free = free;
+	return (&priv->priv);
+}
+
 struct vmod_priv *
 VRT_priv_top(VRT_CTX, const void *vmod_id)
 {

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -166,6 +166,7 @@ VRT_priv_task_object(VRT_CTX, void *vmod_id, vmod_priv_free_f *free)
 	struct vmod_priv *priv;
 
 	priv = VRT_priv_task(ctx, vmod_id);
+	// TODO this is ws, move NULL check to splice_cb
 	priv->free = free;
 	return (&priv->priv);
 }

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -538,6 +538,7 @@ struct vmod_priv {
 
 void VRT_priv_fini(const struct vmod_priv *p);
 struct vmod_priv *VRT_priv_task(VRT_CTX, const void *vmod_id);
+void **VRT_priv_task_object(VRT_CTX, void *vmod_id, vmod_priv_free_f *free);
 struct vmod_priv *VRT_priv_top(VRT_CTX, const void *vmod_id);
 
 /* Stevedore related functions */

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -405,8 +405,7 @@ vcc_Action_Init(struct vcc *tl)
 	ACT(hash_data,	vcc_act_hash_data,
 		VCL_MET_HASH);
 	ACT(if,		vcc_Act_If,	0);
-	ACT(new,	vcc_Act_New,
-		VCL_MET_INIT);
+	ACT(new,	vcc_Act_New,	0);
 	ACT(return,	vcc_act_return,	0);
 	ACT(set,	vcc_act_set,	0);
 	ACT(synthetic,	vcc_act_synthetic,

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -645,6 +645,8 @@ vcc_Eval_SymFunc(struct vcc *tl, struct expr **e, struct token *t,
 	(void)fmt;
 	assert(sym->kind == SYM_FUNC);
 	AN(sym->eval_priv);
+	if(sym->r_methods)
+		vcc_AddUses(tl, t, tl->t, sym->r_methods, "Not available");
 
 	vcc_func(tl, e, sym->eval_priv, sym->extra, sym);
 	ERRCHK(tl);
@@ -1409,6 +1411,8 @@ vcc_Act_Call(struct vcc *tl, struct token *t, struct symbol *sym)
 	struct expr *e;
 
 	e = NULL;
+	if(sym->r_methods)
+		vcc_AddUses(tl, t, tl->t, sym->r_methods, "Not available");
 	vcc_func(tl, &e, sym->eval_priv, sym->extra, sym);
 	if (!tl->err) {
 		vcc_expr_fmt(tl->fb, tl->indent, e);

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -197,7 +197,9 @@ vcc_Compound(struct vcc *tl)
 				vcc_AddUses(tl, t, NULL,
 				    sym->action_mask,
 				    "Not a valid action");
+			Fb_splice_push(tl);
 			sym->action(tl, t, sym);
+			Fb_splice_pop(tl);
 			break;
 		default:
 			/* We deliberately do not mention inline C */
@@ -266,6 +268,7 @@ vcc_ParseFunction(struct vcc *tl)
 	}
 	CHECK_OBJ_NOTNULL(p, PROC_MAGIC);
 	tl->fb = p->body;
+	VTAILQ_INIT(&tl->fb_splices);
 	Fb(tl, 1, "  /* ... from ");
 	vcc_Coord(tl, p->body, NULL);
 	Fb(tl, 0, " */\n");
@@ -277,6 +280,7 @@ vcc_ParseFunction(struct vcc *tl)
 	tl->indent -= INDENT;
 	tl->fb = NULL;
 	tl->curproc = NULL;
+	AN(VTAILQ_EMPTY(&tl->fb_splices));
 }
 
 /*--------------------------------------------------------------------

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -490,6 +490,7 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 	buf = VSB_new_auto();
 	AN(buf);
 	if (request_scope)
+		// TODO this needs to move into the splice_cb
 		VSB_printf(buf, ", (%s**)\n  "
 		    "VRT_priv_task_object(ctx, &%s, &vo_free_%s),\n  \"%s\"",
 		    s_struct, sy1->rname, sy1->name, sy1->name);
@@ -525,6 +526,7 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 	buf = VSB_new_auto();
 	AN(buf);
 	if (request_scope)
+		// TODO move to splice_cb with double null check
 		VSB_printf(buf, ", (%s*)\n  "
 		    "((VRT_priv_task(ctx, &%s))->priv)",
 		    s_struct, sy1->rname);
@@ -546,7 +548,10 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 		AN(sy3);
 		func_sym(sy3, sy2->vmod_name, VTAILQ_NEXT(vf, list));
 		sy3->extra = p;
+		sy3->rname = sy1->rname;
 		sy3->r_methods = mask;
+		sy3->request_scope = request_scope;
+		sy3->null_ok = null_ok;
 		vv = VTAILQ_NEXT(vv, list);
 	}
 	VSB_destroy(&buf);

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -528,6 +528,7 @@ class Stanza(object):
         self.vcc = vcc
         self.rstlbl = None
         self.null_ok = False
+        self.request_scope = False
         self.methods = None
         self.proto = None
         self.parse()
@@ -734,9 +735,17 @@ class ObjectStanza(Stanza):
     ''' $Object TYPE class ( ARGUMENTS ) '''
 
     def parse(self):
-        if self.toks[1] == "NULL_OK":
-            self.toks.pop(1)
-            self.null_ok = True
+        while True:
+            if self.toks[1] == "NULL_OK":
+                self.toks.pop(1)
+                self.null_ok = True
+                continue
+            elif self.toks[1] == "REQUEST_SCOPE":
+                self.toks.pop(1)
+                self.request_scope = True
+                continue
+            else:
+                break
         self.proto = ProtoType(self, retval=False)
         self.proto.obj = "x" + self.proto.name
 
@@ -797,7 +806,8 @@ class ObjectStanza(Stanza):
         ll = [
             "$OBJ",
             self.proto.name,
-            {"NULL_OK": self.null_ok},
+            {"NULL_OK": self.null_ok,
+            "REQUEST_SCOPE": self.request_scope},
             "struct %s%s_%s" %
             (self.vcc.sympfx, self.vcc.modname, self.proto.name),
         ]


### PR DESCRIPTION
This is a thread for discussion about expanding VCL object support. The reason its a PR is because this is a fully working prototype. A good writeup on this is here:

https://github.com/varnishcache/varnish-cache/wiki/VIP9:-Expand-VCL-object-support

A thing to note is that this is just __expanding VCL object support__. This is not meant to solve all VCL based variable problems. This solution can live side by side with constants and real typed variables and even hybrid global/request objects. Basically, objects have been really useful in VCL and this PR expands their scope.

This VIP does address a lot of the usage questions and objections which have popped up over the years. So rather than list all of the gritty details, I will ask that you try this PR out and kick the tires a bit before coming up with the objections.

The goal here would be to get some kind of consensus that this is viable before investing more time in this. I do expect to rewrite a lot of this in the next iteration. Also, if other want to take this and run with it, go for it, I have a lot of tasks on my plate which need attention at the moment.