### PR TITLE
VIP28: Generalize type methods

### DIFF
--- a/bin/varnishtest/tests/v00018.vtc
+++ b/bin/varnishtest/tests/v00018.vtc
@@ -138,3 +138,11 @@ varnish v1 -syntax 4.0 -errvcl {Symbol not found:} {
 		return (vcl(vcl_recv));
 	}
 }
+
+varnish v1 -errvcl {Expected '.' got ';'} {
+	import directors;
+	sub vcl_init {
+		new rr = directors.round_robin();
+		rr;
+	}
+}

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -635,6 +635,8 @@ vcc_CompileSource(struct vcc *tl, struct source *sp, const char *jfile)
 
 	vcc_Var_Init(tl);
 
+	vcc_Type_Init(tl);
+
 	Fh(tl, 0, "\nextern const struct VCL_conf VCL_conf;\n");
 
 	/* Register and lex the main source */

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -812,6 +812,7 @@ VCC_New(void)
 	VTAILQ_INIT(&tl->procs);
 	VTAILQ_INIT(&tl->sym_objects);
 	VTAILQ_INIT(&tl->sym_vmods);
+	VTAILQ_INIT(&tl->vmod_objects);
 
 	tl->nsources = 0;
 

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -386,6 +386,8 @@ extern const struct symmode SYMTAB_PARTIAL[1];
 struct symbol *VCC_SymbolGet(struct vcc *, vcc_kind_t,
     const struct symmode *, const struct symxref *);
 
+struct symbol *VCC_TypeSymbol(struct vcc *, vcc_kind_t, vcc_type_t);
+
 typedef void symwalk_f(struct vcc *tl, const struct symbol *s);
 void VCC_WalkSymbols(struct vcc *tl, symwalk_f *func, vcc_kind_t);
 

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -98,6 +98,15 @@ struct token {
 
 typedef const struct type	*vcc_type_t;
 
+/*
+ * A type attribute is information already existing, requiring no processing
+ * or resource usage.
+ *
+ * A type method call and may do (significant processing, change things, eat
+ * workspace etc).
+ *
+ * XXX: type methods might move in a more comprehensive direction.
+ */
 struct vcc_method {
 	vcc_type_t		type;
 	const char		*name;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -318,6 +318,7 @@ char *TlDup(struct vcc *tl, const char *s);
 /* vcc_expr.c */
 void vcc_Expr(struct vcc *tl, vcc_type_t typ);
 sym_act_f vcc_Act_Call;
+sym_act_f vcc_Act_Obj;
 void vcc_Expr_Init(struct vcc *tl);
 sym_expr_t vcc_Eval_Var;
 sym_expr_t vcc_Eval_Handle;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -108,6 +108,8 @@ typedef const struct type	*vcc_type_t;
  * XXX: type methods might move in a more comprehensive direction.
  */
 struct vcc_method {
+	unsigned		magic;
+#define VCC_METHOD_MAGIC	0x594108cd
 	vcc_type_t		type;
 	const char		*name;
 	const char		*impl;
@@ -406,6 +408,7 @@ void vcc_AddToken(struct vcc *tl, unsigned tok, const char *b,
 
 /* vcc_types.c */
 vcc_type_t VCC_Type(const char *p);
+void vcc_Type_Init(struct vcc *tl);
 
 /* vcc_var.c */
 sym_wildcard_t vcc_Var_Wildcard;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -95,13 +95,23 @@ struct token {
 };
 
 /*---------------------------------------------------------------------*/
+
 typedef const struct type	*vcc_type_t;
+
+struct vcc_method {
+	vcc_type_t		type;
+	const char		*name;
+	const char		*impl;
+	int			func;
+};
 
 struct type {
 	unsigned		magic;
 #define TYPE_MAGIC		0xfae932d9
 
 	const char		*name;
+	const struct vcc_method	*methods;
+
 	const char		*tostring;
 	vcc_type_t		multype;
 	int			stringform;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -74,6 +74,7 @@ struct expr;
 struct vcc;
 struct vjsn_val;
 struct symbol;
+struct vmod_obj;
 
 struct source {
 	VTAILQ_ENTRY(source)	list;
@@ -261,6 +262,7 @@ struct vcc {
 
 	VTAILQ_HEAD(, symbol)	sym_objects;
 	VTAILQ_HEAD(, symbol)	sym_vmods;
+	VTAILQ_HEAD(, vmod_obj)	vmod_objects;
 
 	unsigned		unique;
 	unsigned		vmod_count;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -98,24 +98,6 @@ struct token {
 
 typedef const struct type	*vcc_type_t;
 
-/*
- * A type attribute is information already existing, requiring no processing
- * or resource usage.
- *
- * A type method call and may do (significant processing, change things, eat
- * workspace etc).
- *
- * XXX: type methods might move in a more comprehensive direction.
- */
-struct vcc_method {
-	unsigned		magic;
-#define VCC_METHOD_MAGIC	0x594108cd
-	vcc_type_t		type;
-	const char		*name;
-	const char		*impl;
-	int			func;
-};
-
 struct type {
 	unsigned		magic;
 #define TYPE_MAGIC		0xfae932d9
@@ -338,6 +320,7 @@ void vcc_Expr_Init(struct vcc *tl);
 sym_expr_t vcc_Eval_Var;
 sym_expr_t vcc_Eval_Handle;
 sym_expr_t vcc_Eval_SymFunc;
+sym_expr_t vcc_Eval_TypeMethod;
 void vcc_Eval_Func(struct vcc *, const struct vjsn_val *,
     const char *, const struct symbol *);
 void VCC_GlobalSymbol(struct symbol *, vcc_type_t fmt, const char *pfx);
@@ -410,6 +393,7 @@ void vcc_AddToken(struct vcc *tl, unsigned tok, const char *b,
 
 /* vcc_types.c */
 vcc_type_t VCC_Type(const char *p);
+const char * VCC_Type_EvalMethod(struct vcc *, const struct symbol *);
 void vcc_Type_Init(struct vcc *tl);
 
 /* vcc_var.c */

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -814,6 +814,7 @@ static void
 vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 {
 	const struct vcc_method *vm;
+	const struct symbol *sym;
 
 	*e = NULL;
 	vcc_expr5(tl, e, fmt);
@@ -823,14 +824,8 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		vcc_NextToken(tl);
 		ExpectErr(tl, ID);
 
-		vm = (*e)->fmt->methods;
-		while (vm != NULL && vm->type != NULL) {
-			if (vcc_IdIs(tl->t, vm->name))
-				break;
-			vm++;
-		}
-
-		if (vm == NULL || vm->type == NULL) {
+		sym = VCC_TypeSymbol(tl, SYM_METHOD, (*e)->fmt);
+		if (sym == NULL) {
 			VSB_cat(tl->sb, "Unknown property ");
 			vcc_ErrToken(tl, tl->t);
 			VSB_printf(tl->sb,
@@ -838,6 +833,8 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			vcc_ErrWhere(tl, tl->t);
 			return;
 		}
+		CAST_OBJ_NOTNULL(vm, sym->eval_priv, VCC_METHOD_MAGIC);
+
 		vcc_NextToken(tl);
 		*e = vcc_expr_edit(tl, vm->type, vm->impl, *e, NULL);
 		ERRCHK(tl);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -810,11 +810,23 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
  *      Expr5 [ '.' (type_attribute | type_method()) ]*
  */
 
+void
+vcc_Eval_TypeMethod(struct vcc *tl, struct expr **e, struct token *t,
+    struct symbol *sym, vcc_type_t fmt)
+{
+	const char *impl;
+
+	(void)t;
+	impl = VCC_Type_EvalMethod(tl, sym);
+	ERRCHK(tl);
+	AN(impl);
+	*e = vcc_expr_edit(tl, fmt, impl, *e, NULL);
+}
+
 static void
 vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 {
-	const struct vcc_method *vm;
-	const struct symbol *sym;
+	struct symbol *sym;
 
 	*e = NULL;
 	vcc_expr5(tl, e, fmt);
@@ -833,20 +845,13 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			vcc_ErrWhere(tl, tl->t);
 			return;
 		}
-		CAST_OBJ_NOTNULL(vm, sym->eval_priv, VCC_METHOD_MAGIC);
 
-		vcc_NextToken(tl);
-		*e = vcc_expr_edit(tl, vm->type, vm->impl, *e, NULL);
+		AN(sym->eval);
+		sym->eval(tl, e, tl->t, sym, sym->type);
 		ERRCHK(tl);
 		if ((*e)->fmt == STRING) {
 			(*e)->fmt = STRINGS;
 			(*e)->nstr = 1;
-		}
-		if (vm->func) {
-			ExpectErr(tl, '(');
-			vcc_NextToken(tl);
-			ExpectErr(tl, ')');
-			vcc_NextToken(tl);
 		}
 	}
 }

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1424,6 +1424,7 @@ vcc_Act_Obj(struct vcc *tl, struct token *t, struct symbol *sym)
 	struct expr *e = NULL;
 
 	assert(sym->kind == SYM_INSTANCE);
+	ExpectErr(tl, '.');
 	tl->t = t;
 	vcc_expr4(tl, &e, sym->type);
 	ERRCHK(tl);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -808,37 +808,12 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
  * SYNTAX:
  *    Expr4:
  *      Expr5 [ '.' (type_attribute | type_method()) ]*
- *
- * type_attributes is information already existing, requiring no
- * processing or resource usage.
- *
- * type_methods are calls and may do (significant processing, change things,
- * eat workspace etc.
  */
-
-static const struct vcc_methods {
-	vcc_type_t		type_from;
-	vcc_type_t		type_to;
-	const char		*method;
-	const char		*impl;
-	int			func;
-} vcc_methods[] = {
-	//{ BACKEND, BOOL,	"healthy",	"VRT_Healthy(ctx, \v1, 0)" },
-
-#define VRTSTVVAR(nm, vtype, ctype, dval) \
-	{ STEVEDORE, vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
-#include "tbl/vrt_stv_var.h"
-
-	{ STRINGS, STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
-	{ STRINGS, STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
-
-	{ NULL, NULL,		NULL,		NULL},
-};
 
 static void
 vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 {
-	const struct vcc_methods *vm;
+	const struct vcc_method *vm;
 
 	*e = NULL;
 	vcc_expr5(tl, e, fmt);
@@ -848,14 +823,14 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		vcc_NextToken(tl);
 		ExpectErr(tl, ID);
 
-		for(vm = vcc_methods; vm->type_from != NULL; vm++) {
-
-			if (vm->type_from == (*e)->fmt &&
-			    vcc_IdIs(tl->t, vm->method))
+		vm = (*e)->fmt->methods;
+		while (vm != NULL && vm->type != NULL) {
+			if (vcc_IdIs(tl->t, vm->name))
 				break;
+			vm++;
 		}
 
-		if (vm->type_from == NULL) {
+		if (vm == NULL || vm->type == NULL) {
 			VSB_cat(tl->sb, "Unknown property ");
 			vcc_ErrToken(tl, tl->t);
 			VSB_printf(tl->sb,
@@ -864,7 +839,7 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			return;
 		}
 		vcc_NextToken(tl);
-		*e = vcc_expr_edit(tl, vm->type_to, vm->impl, *e, NULL);
+		*e = vcc_expr_edit(tl, vm->type, vm->impl, *e, NULL);
 		ERRCHK(tl);
 		if ((*e)->fmt == STRING) {
 			(*e)->fmt = STRINGS;

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -180,7 +180,7 @@ vcc_Compound(struct vcc *tl)
 			tl->err = 1;
 			return;
 		case ID:
-			sym = VCC_SymbolGet(tl, SYM_NONE, SYMTAB_NOERR,
+			sym = VCC_SymbolGet(tl, SYM_NONE, SYMTAB_PARTIAL,
 			    XREF_NONE);
 			if (sym == NULL) {
 				VSB_printf(tl->sb, "Symbol not found.\n");

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -381,8 +381,13 @@ VCC_MkSym(struct vcc *tl, const char *b, vcc_kind_t kind, int vlo, int vhi)
 	st = vcc_symtab_str(tl->syms, b, NULL);
 	AN(st);
 	sym = vcc_sym_in_tab(tl, st, kind, vlo, vhi);
-	AZ(sym);
-	sym = vcc_new_symbol(tl, st, kind, vlo, vhi);
+	if (sym != NULL) {
+		assert(sym->kind == SYM_METHOD);
+		AN(sym->vmod_name);
+	} else {
+		sym = vcc_new_symbol(tl, st, kind, vlo, vhi);
+		AN(sym);
+	}
 	sym->noref = 1;
 	return (sym);
 }

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -341,6 +341,31 @@ VCC_SymbolGet(struct vcc *tl, vcc_kind_t kind,
 }
 
 struct symbol *
+VCC_TypeSymbol(struct vcc *tl, vcc_kind_t kind, vcc_type_t type)
+{
+	struct token t[1], *t0;
+	struct symbol *sym;
+	struct vsb *buf;
+
+	buf = VSB_new_auto();
+	AN(buf);
+	VSB_printf(buf, "%s::%.*s", type->name, PF(tl->t));
+	AZ(VSB_finish(buf));
+
+	/* NB: we create a fake token but errors are handled by the caller. */
+	memcpy(t, tl->t, sizeof *t);
+	t->b = VSB_data(buf);
+	t->e = t->b + VSB_len(buf);
+
+	t0 = tl->t;
+	tl->t = t;
+	sym = VCC_SymbolGet(tl, kind, SYMTAB_NOERR, XREF_NONE);
+	tl->t = t0;
+	VSB_destroy(&buf);
+	return (sym);
+}
+
+struct symbol *
 VCC_MkSym(struct vcc *tl, const char *b, vcc_kind_t kind, int vlo, int vhi)
 {
 	struct symtab *st;

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -34,6 +34,24 @@
 
 #include "vcc_compile.h"
 
+/*
+ * A type attribute is information already existing, requiring no processing
+ * or resource usage.
+ *
+ * A type method call and may do (significant processing, change things, eat
+ * workspace etc).
+ *
+ * XXX: type methods might move in a more comprehensive direction.
+ */
+struct vcc_method {
+	unsigned		magic;
+#define VCC_METHOD_MAGIC	0x594108cd
+	vcc_type_t		type;
+	const char		*name;
+	const char		*impl;
+	int			func;
+};
+
 const struct type ACL[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"ACL",
@@ -224,11 +242,36 @@ vcc_type_init(struct vcc *tl, vcc_type_t type)
 			break;
 		AN(sym);
 		sym->type = vm->type;
+		sym->eval = vcc_Eval_TypeMethod;
 		sym->eval_priv = vm;
 		VSB_clear(buf);
 	}
 
 	VSB_destroy(&buf);
+}
+
+const char *
+VCC_Type_EvalMethod(struct vcc *tl, const struct symbol *sym)
+{
+	const struct vcc_method *vm;
+
+	AN(sym);
+	AN(sym->kind == SYM_METHOD);
+	CAST_OBJ_NOTNULL(vm, sym->eval_priv, VCC_METHOD_MAGIC);
+
+	vcc_NextToken(tl);
+	if (vm->func) {
+		Expect(tl, '(');
+		if (tl->err)
+			return (NULL);
+		vcc_NextToken(tl);
+		Expect(tl, ')');
+		if (tl->err)
+			return (NULL);
+		vcc_NextToken(tl);
+	}
+
+	return (vm->impl);
 }
 
 void

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -125,9 +125,9 @@ const struct type REAL[1] = {{
 
 static const struct vcc_method stevedore_methods[] = {
 #define VRTSTVVAR(nm, vtype, ctype, dval) \
-	{ vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
+	{ VCC_METHOD_MAGIC, vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
 #include "tbl/vrt_stv_var.h"
-	{ NULL },
+	{ VCC_METHOD_MAGIC, NULL },
 };
 
 const struct type STEVEDORE[1] = {{
@@ -151,9 +151,11 @@ const struct type STRANDS[1] = {{
 }};
 
 static const struct vcc_method strings_methods[] = {
-	{ STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
-	{ STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
-	{ NULL },
+	{ VCC_METHOD_MAGIC, STRING, "upper",
+	    "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
+	{ VCC_METHOD_MAGIC, STRING, "lower",
+	    "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
+	{ VCC_METHOD_MAGIC, NULL },
 };
 
 const struct type STRINGS[1] = {{
@@ -199,3 +201,40 @@ VCC_Type(const char *p)
 	return (NULL);
 }
 
+static void
+vcc_type_init(struct vcc *tl, vcc_type_t type)
+{
+	const struct vcc_method *vm;
+	struct symbol *sym;
+	struct vsb *buf;
+
+	vm = type->methods;
+	if (tl->err || vm == NULL)
+		return;
+
+	buf = VSB_new_auto();
+	AN(buf);
+
+	for (; vm->type != NULL; vm++) {
+		VSB_printf(buf, "%s::%s", type->name, vm->name);
+		AZ(VSB_finish(buf));
+		sym = VCC_MkSym(tl, VSB_data(buf), SYM_METHOD, VCL_LOW,
+		    VCL_HIGH);
+		if (tl->err)
+			break;
+		AN(sym);
+		sym->type = vm->type;
+		sym->eval_priv = vm;
+		VSB_clear(buf);
+	}
+
+	VSB_destroy(&buf);
+}
+
+void
+vcc_Type_Init(struct vcc *tl)
+{
+
+#define VCC_TYPE(UC, lc)	vcc_type_init(tl, UC);
+#include "tbl/vcc_types.h"
+}

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -123,9 +123,17 @@ const struct type REAL[1] = {{
 	.multype =		REAL,
 }};
 
+static const struct vcc_method stevedore_methods[] = {
+#define VRTSTVVAR(nm, vtype, ctype, dval) \
+	{ vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
+#include "tbl/vrt_stv_var.h"
+	{ NULL },
+};
+
 const struct type STEVEDORE[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"STEVEDORE",
+	.methods =		stevedore_methods,
 	.tostring =		"VRT_STEVEDORE_string(\v1)",
 }};
 
@@ -142,9 +150,16 @@ const struct type STRANDS[1] = {{
 	.tostring =		"VRT_CollectStrands(ctx,\v+\n\v1\v-\n)",
 }};
 
+static const struct vcc_method strings_methods[] = {
+	{ STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
+	{ STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
+	{ NULL },
+};
+
 const struct type STRINGS[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"STRINGS",
+	.methods =		strings_methods,
 	.tostring =		"",
 }};
 

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -489,6 +489,10 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 	sy2 = VCC_SymbolGet(tl, SYM_OBJECT, SYMTAB_EXISTING, XREF_NONE);
 	ERRCHK(tl);
 	AN(sy2);
+
+	/* Scratch the generic INSTANCE type */
+	sy1->type = sy2->type;
+
 	CAST_OBJ_NOTNULL(vv, sy2->eval_priv, VJSN_VAL_MAGIC);
 	// vv = object name
 

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -47,6 +47,14 @@ struct vmod_open {
 	const char		*err;
 };
 
+struct vmod_obj {
+	unsigned		magic;
+#define VMOD_OBJ_MAGIC		0x349885f8
+	char			*name;
+	struct type		type[1];
+	VTAILQ_ENTRY(vmod_obj)	list;
+};
+
 static int
 vcc_path_dlopen(void *priv, const char *fn)
 {
@@ -127,6 +135,28 @@ vcc_json_always(struct vcc *tl, const struct vjsn *vj, const char *vmod_name)
 	}
 }
 
+static void
+vcc_vmod_RegisterObject(struct vcc *tl, struct symbol *sym)
+{
+	struct vmod_obj *obj;
+	struct vsb *buf;
+
+	buf = VSB_new_auto();
+	AN(buf);
+	VSB_printf(buf, "%s.%s", sym->vmod_name, sym->name);
+	AZ(VSB_finish(buf));
+
+	ALLOC_OBJ(obj, VMOD_OBJ_MAGIC);
+	AN(obj);
+	REPLACE(obj->name, VSB_data(buf));
+
+	INIT_OBJ(obj->type, TYPE_MAGIC);
+	obj->type->name = obj->name;
+	sym->type = obj->type;
+	VTAILQ_INSERT_TAIL(&tl->vmod_objects, obj, list);
+	VSB_destroy(&buf);
+}
+
 static void v_matchproto_(sym_wildcard_t)
 vcc_json_wildcard(struct vcc *tl, struct symbol *msym, struct symbol *tsym)
 {
@@ -152,6 +182,7 @@ vcc_json_wildcard(struct vcc *tl, struct symbol *msym, struct symbol *tsym)
 			tsym->kind = SYM_OBJECT;
 			tsym->eval_priv = vv2;
 			tsym->vmod_name = msym->vmod_name;
+			vcc_vmod_RegisterObject(tl, tsym);
 			return;
 		}
 	}

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -528,7 +528,6 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 	sy1->def_e = tl->t;
 
 	vf = VTAILQ_FIRST(&vv->children);
-	vv = VTAILQ_NEXT(vv, list);
 	assert(vf->type == VJSN_STRING);
 	assert(!strcmp(vf->value, "$FINI"));
 

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -326,6 +326,21 @@ vcc_CheckUses(struct vcc *tl)
 
 /*---------------------------------------------------------------------*/
 
+static int sym_type_len = 0;
+
+static void v_matchproto_(symwalk_f)
+vcc_xreftable_len(struct vcc *tl, const struct symbol *sym)
+{
+	int len;
+
+	(void)tl;
+	CHECK_OBJ_NOTNULL(sym, SYMBOL_MAGIC);
+	CHECK_OBJ_NOTNULL(sym->type, TYPE_MAGIC);
+	len = strlen(sym->type->name);
+	if (sym_type_len < len)
+		sym_type_len = len;
+}
+
 static void v_matchproto_(symwalk_f)
 vcc_xreftable(struct vcc *tl, const struct symbol *sym)
 {
@@ -334,7 +349,7 @@ vcc_xreftable(struct vcc *tl, const struct symbol *sym)
 	CHECK_OBJ_NOTNULL(sym->kind, KIND_MAGIC);
 	CHECK_OBJ_NOTNULL(sym->type, TYPE_MAGIC);
 	Fc(tl, 0, " * %-8s ", sym->kind->name);
-	Fc(tl, 0, " %-9s ", sym->type->name);
+	Fc(tl, 0, " %-*s ", sym_type_len, sym->type->name);
 	Fc(tl, 0, " %2u %2u ", sym->lorev, sym->hirev);
 	VCC_SymName(tl->fc, sym);
 	if (sym->wildcard != NULL)
@@ -347,6 +362,7 @@ VCC_XrefTable(struct vcc *tl)
 {
 
 	Fc(tl, 0, "\n/*\n * Symbol Table\n *\n");
+	VCC_WalkSymbols(tl, vcc_xreftable_len, SYM_NONE);
 	VCC_WalkSymbols(tl, vcc_xreftable, SYM_NONE);
 	Fc(tl, 0, "*/\n\n");
 }


### PR DESCRIPTION
This is not a complete implementation of what we've discussed regarding VIP28, but only a first step.

With this patch set VMOD objects now have a dedicated type, and any type may have methods. This is handled via the symbol table, consider the following snippet:

```vcl
new fb1 = directors.fallback();
new fb2 = directors.fallback();
```

Currently you could get the following entries in the symbol table:

```
object    VOID      41 41 directors.fallback
instance  INSTANCE  41 41 fb1
func      VOID      40 41 fb1.add_backend
func      BACKEND   40 41 fb1.backend
func      VOID      40 41 fb1.remove_backend
instance  INSTANCE  41 41 fb2
func      VOID      40 41 fb2.add_backend
func      BACKEND   40 41 fb2.backend
func      VOID      40 41 fb2.remove_backend

```

With this change it would be reduced to the following:

```
object    directors.fallback  41 41 directors.fallback
method    VOID                40 41 directors.fallback::add_backend
method    BACKEND             40 41 directors.fallback::backend
method    VOID                40 41 directors.fallback::remove_backend
instance  directors.fallback  41 41 fb1
instance  directors.fallback  41 41 fb2
```

With the current methods available to the native VCL types, the following entries are now always present in the symbol table:

```
method    BYTES      40 41 STEVEDORE::free_space
method    BOOL       40 41 STEVEDORE::happy
method    BYTES      40 41 STEVEDORE::used_space
method    STRING     40 41 STRINGS::lower
method    STRING     40 41 STRINGS::upper
```

Other than shaping the internals for future VIP28 material, this patch set doesn't change any VCL behavior.