### PR TITLE
VTP: Add clone function and per-connection preamble

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -639,7 +639,7 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 		VRT_VSC_Hide(be->vsc_seg);
 
 	be->tcp_pool = VTP_Ref(vep->ipv4, vep->ipv6,
-	    vep->uds_path, vrt_hash_be(vrt->endpoint));
+	    vep->uds_path, vrt_hash_be(vep), NULL);
 	AN(be->tcp_pool);
 
 	vbp = vrt->probe;

--- a/bin/varnishd/cache/cache_tcp_pool.h
+++ b/bin/varnishd/cache/cache_tcp_pool.h
@@ -54,13 +54,23 @@ void PFD_RemoteName(const struct pfd *, char *, unsigned, char *, unsigned);
 
 struct VSC_vbe;
 
+struct tcp_pool *VTP_Clone(struct tcp_pool *tp, uintmax_t id,
+    const struct vsb *preamble);
+	/*
+	 * Reference a (potentially new) clone of a pool with a different id and
+	 * preamble
+	 */
+
 struct tcp_pool *VTP_Ref(const struct suckaddr *ip4, const struct suckaddr *ip6,
-    const char *uds, uintmax_t id);
+    const char *uds, uintmax_t id, const struct vsb *preamble);
 	/*
 	 * Get a reference to a TCP pool. Either one or both of ip4 or
 	 * ip6 arg must be non-NULL, or uds must be non-NULL. If recycling
 	 * is to be used, the id pointer distinguishes the pool per
 	 * protocol.
+	 *
+	 * The optional preamble is being sent first after opening a new
+	 * connection. The preamble argument is owned by the caller
 	 */
 
 void VTP_AddRef(struct tcp_pool *);


### PR DESCRIPTION
**NOTE** this PR is going to be superseded by a redesign of the backend api currently worked on by @bsdphk . I maintain this PR in the meantime as in interim solution.

I was asked in https://github.com/varnishcache/varnish-cache/pull/3128#issuecomment-560351304 to issue a separate PR for this feature alone.

This adds to the TCP Pool:

* a `preamble` attribute

The use case is to open connections with a PROXY header prefix, for example to open https connections through haproxy.

The preamble is an arbitrary byte stream sent once when the connection is opened.

It is considered an attribute of the pool, so it gets passed as an argument to `VTP_Ref()`. As with the other pool arguments, it is the caller's responsibility to ensure that the `id` argument be unique also with respect to the preamble.

Compared to other options on how to implement a preamble at higher levels, the implementation at the pool level simplifies caller code by avoidance of duplication and not having to special case new vs. recycled connections from the pool.

* `VTP_Clone()`

This is simply a convenience function to reference a pool identical to an existing one, but with a potentially different `preamble`.

This is motivated by the use case of the preamble, where a single endpoint may be used for many connections with different preambles.

The implementation is motivated by the fact that opaque handling of the address attributes of the pool (ip4, ip6, uds) simplifies caller code.