### PR TITLE
Add single-process and fuzzer mode

### DIFF
--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -426,8 +426,13 @@ mgt_f_read(const char *fn)
 	VTAILQ_INSERT_TAIL(&f_args, fa, list);
 }
 
+#ifndef LIBFUZZER_ENABLED
 int
 main(int argc, char * const *argv)
+#else
+int
+varnishd_main(int argc, char * const *argv)
+#endif
 {
 	int o, eric_fd = -1;
 	unsigned C_flag = 0;
@@ -881,6 +886,9 @@ main(int argc, char * const *argv)
 		u = MCH_Start_Child();
 	else
 		u = 0;
+#ifdef LIBFUZZER_ENABLED
+	return (u);
+#endif
 
 	if (eric_fd >= 0)
 		mgt_eric_im_done(eric_fd, u);

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -117,7 +117,10 @@ run_vcc(void *priv)
 	if (VSB_len(sb))
 		printf("%s", VSB_data(sb));
 	VSB_destroy(&sb);
-	exit(i == 0 ? 0 : 2);
+
+	/* Avoid calling destructors when in single process mode */
+	i = (i == 0) ? 0 : 2;
+	(!MGT_DO_DEBUG(DBG_EXEC_MODE)) ? exit(i) : _exit(i);
 }
 
 /*--------------------------------------------------------------------
@@ -185,7 +188,9 @@ run_dlopen(void *priv)
 	CAST_OBJ_NOTNULL(vp, priv, VCC_PRIV_MAGIC);
 	if (VCL_TestLoad(VSB_data(vp->libfile)))
 		exit(1);
-	exit(0);
+
+	/* Avoid calling destructors when in single process mode */
+	(!MGT_DO_DEBUG(DBG_EXEC_MODE)) ? exit(0) : _exit(0);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishtest/tests/b00072.vtc
+++ b/bin/varnishtest/tests/b00072.vtc
@@ -1,0 +1,40 @@
+varnishtest "Does anything get through at all ?"
+
+server s1 {
+	rxreq
+	txresp -body "012345\n"
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.do_stream = false;
+	}
+} -start
+
+varnish v1 -cliok "param.set debug +witness"
+varnish v1 -cliok "param.set debug +execute_mode"
+
+varnish v1 -vsc *
+
+varnish v1 -expect MAIN.n_object == 0
+varnish v1 -expect MAIN.sess_conn == 0
+varnish v1 -expect MAIN.client_req == 0
+varnish v1 -expect MAIN.cache_miss == 0
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -expect n_object == 1
+varnish v1 -expect sess_conn == 1
+varnish v1 -expect client_req == 1
+varnish v1 -expect cache_miss == 1
+varnish v1 -expect s_sess == 1
+varnish v1 -expect s_resp_bodybytes == 7
+varnish v1 -expect s_resp_hdrbytes == 178
+
+varnish v1 -stop
+#varnish v1 -start
+#varnish v1 -stop

--- a/include/tbl/debug_bits.h
+++ b/include/tbl/debug_bits.h
@@ -51,6 +51,7 @@ DEBUG_BIT(PROCESSORS,		processors,	"Fetch/Deliver processors")
 DEBUG_BIT(PROTOCOL,		protocol,	"Protocol debugging")
 DEBUG_BIT(VCL_KEEP,		vcl_keep,	"Keep VCL C and so files")
 DEBUG_BIT(LCK,			lck,		"Additional lock statistics")
+DEBUG_BIT(EXEC_MODE,         execute_mode,    "Varnishd exits with the child process")
 #undef DEBUG_BIT
 
 /*lint -restore */


### PR DESCRIPTION
Adds separate SINGLE_PROCESS_MODE and LIBFUZZER_ENABLED. Single-process mode allows you to run varnishd in a single process, which will let you use things like PGO and gprof profiling, but is also required for libfuzzer. Libfuzzer mode makes it so that the varnishd main function returns in a manner which does not call any exit functions. This allows for initializing varnishd once, and then fuzzing against (for example) UNIX sockets shortly after.
