### PR TITLE
Generalize type methods (take 2)

### DIFF
--- a/bin/varnishtest/tests/v00018.vtc
+++ b/bin/varnishtest/tests/v00018.vtc
@@ -133,3 +133,23 @@ varnish v1 -syntax 4.0 -errvcl {Symbol not found:} {
 		return (vcl(vcl_recv));
 	}
 }
+
+varnish v1 -errvcl {Syntax error} {
+	import directors;
+	sub vcl_recv {
+		set req.backend_hint = directors.round_robin.backend();
+	}
+}
+
+varnish v1 -errvcl {Syntax error} {
+	import directors;
+	sub vcl_recv {
+		directors.round_robin.backend();
+	}
+}
+
+varnish v1 -errvcl {Syntax error} {
+	sub vcl_recv {
+		_type.strings.upper();
+	}
+}

--- a/bin/varnishtest/tests/v00018.vtc
+++ b/bin/varnishtest/tests/v00018.vtc
@@ -153,3 +153,11 @@ varnish v1 -errvcl {Syntax error} {
 		_type.strings.upper();
 	}
 }
+
+varnish v1 -errvcl {Expected '.' got ';'} {
+	import directors;
+	sub vcl_init {
+		new rr = directors.round_robin();
+		rr;
+	}
+}

--- a/bin/varnishtest/tests/v00019.vtc
+++ b/bin/varnishtest/tests/v00019.vtc
@@ -77,3 +77,11 @@ varnish v1 -errvcl {Unknown token '--' when looking for INT} {
 		set resp.status = --200;
 	}
 }
+
+varnish v1 -errvcl "Syntax error" {
+	import debug;
+	backend be none;
+	sub vcl_init {
+		new _invalid = debug.obj();
+	}
+}

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -826,6 +826,7 @@ VCC_New(void)
 	VTAILQ_INIT(&tl->procs);
 	VTAILQ_INIT(&tl->sym_objects);
 	VTAILQ_INIT(&tl->sym_vmods);
+	VTAILQ_INIT(&tl->vmod_objects);
 
 	tl->nsources = 0;
 

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -647,6 +647,8 @@ vcc_CompileSource(struct vcc *tl, struct source *sp, const char *jfile)
 
 	vcc_Var_Init(tl);
 
+	vcc_Type_Init(tl);
+
 	Fh(tl, 0, "\nextern const struct VCL_conf VCL_conf;\n");
 
 	/* Register and lex the main source */

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -97,13 +97,23 @@ struct token {
 };
 
 /*---------------------------------------------------------------------*/
+
 typedef const struct type	*vcc_type_t;
+
+struct vcc_method {
+	vcc_type_t		type;
+	const char		*name;
+	const char		*impl;
+	int			func;
+};
 
 struct type {
 	unsigned		magic;
 #define TYPE_MAGIC		0xfae932d9
 
 	const char		*name;
+	const struct vcc_method	*methods;
+
 	const char		*tostring;
 	vcc_type_t		multype;
 	int			stringform;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -76,6 +76,7 @@ struct expr;
 struct vcc;
 struct vjsn_val;
 struct symbol;
+struct vmod_obj;
 
 struct source {
 	VTAILQ_ENTRY(source)	list;
@@ -263,6 +264,7 @@ struct vcc {
 
 	VTAILQ_HEAD(, symbol)	sym_objects;
 	VTAILQ_HEAD(, symbol)	sym_vmods;
+	VTAILQ_HEAD(, vmod_obj)	vmod_objects;
 
 	unsigned		unique;
 	unsigned		vmod_count;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -100,6 +100,15 @@ struct token {
 
 typedef const struct type	*vcc_type_t;
 
+/*
+ * A type attribute is information already existing, requiring no processing
+ * or resource usage.
+ *
+ * A type method call and may do (significant processing, change things, eat
+ * workspace etc).
+ *
+ * XXX: type methods might move in a more comprehensive direction.
+ */
 struct vcc_method {
 	vcc_type_t		type;
 	const char		*name;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -100,24 +100,6 @@ struct token {
 
 typedef const struct type	*vcc_type_t;
 
-/*
- * A type attribute is information already existing, requiring no processing
- * or resource usage.
- *
- * A type method call and may do (significant processing, change things, eat
- * workspace etc).
- *
- * XXX: type methods might move in a more comprehensive direction.
- */
-struct vcc_method {
-	unsigned		magic;
-#define VCC_METHOD_MAGIC	0x594108cd
-	vcc_type_t		type;
-	const char		*name;
-	const char		*impl;
-	int			func;
-};
-
 struct type {
 	unsigned		magic;
 #define TYPE_MAGIC		0xfae932d9
@@ -340,6 +322,7 @@ void vcc_Expr_Init(struct vcc *tl);
 sym_expr_t vcc_Eval_Var;
 sym_expr_t vcc_Eval_Handle;
 sym_expr_t vcc_Eval_SymFunc;
+sym_expr_t vcc_Eval_TypeMethod;
 void vcc_Eval_Func(struct vcc *, const struct vjsn_val *,
     const char *, const struct symbol *);
 void VCC_GlobalSymbol(struct symbol *, vcc_type_t fmt, const char *pfx);
@@ -413,6 +396,7 @@ void vcc_AddToken(struct vcc *tl, unsigned tok, const char *b,
 
 /* vcc_types.c */
 vcc_type_t VCC_Type(const char *p);
+const char * VCC_Type_EvalMethod(struct vcc *, const struct symbol *);
 void vcc_Type_Init(struct vcc *tl);
 
 /* vcc_var.c */

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -110,6 +110,8 @@ typedef const struct type	*vcc_type_t;
  * XXX: type methods might move in a more comprehensive direction.
  */
 struct vcc_method {
+	unsigned		magic;
+#define VCC_METHOD_MAGIC	0x594108cd
 	vcc_type_t		type;
 	const char		*name;
 	const char		*impl;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -320,6 +320,7 @@ char *TlDup(struct vcc *tl, const char *s);
 /* vcc_expr.c */
 void vcc_Expr(struct vcc *tl, vcc_type_t typ);
 sym_act_f vcc_Act_Call;
+sym_act_f vcc_Act_Obj;
 void vcc_Expr_Init(struct vcc *tl);
 sym_expr_t vcc_Eval_Var;
 sym_expr_t vcc_Eval_Handle;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -388,6 +388,8 @@ extern const struct symmode SYMTAB_PARTIAL[1];
 struct symbol *VCC_SymbolGet(struct vcc *, vcc_kind_t,
     const struct symmode *, const struct symxref *);
 
+struct symbol *VCC_TypeSymbol(struct vcc *, vcc_kind_t, vcc_type_t);
+
 typedef void symwalk_f(struct vcc *tl, const struct symbol *s);
 void VCC_WalkSymbols(struct vcc *tl, symwalk_f *func, vcc_kind_t);
 

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -409,6 +409,7 @@ void vcc_AddToken(struct vcc *tl, unsigned tok, const char *b,
 
 /* vcc_types.c */
 vcc_type_t VCC_Type(const char *p);
+void vcc_Type_Init(struct vcc *tl);
 
 /* vcc_var.c */
 sym_wildcard_t vcc_Var_Wildcard;

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -818,11 +818,23 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
  *      Expr5 [ '.' (type_attribute | type_method()) ]*
  */
 
+void
+vcc_Eval_TypeMethod(struct vcc *tl, struct expr **e, struct token *t,
+    struct symbol *sym, vcc_type_t fmt)
+{
+	const char *impl;
+
+	(void)t;
+	impl = VCC_Type_EvalMethod(tl, sym);
+	ERRCHK(tl);
+	AN(impl);
+	*e = vcc_expr_edit(tl, fmt, impl, *e, NULL);
+}
+
 static void
 vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 {
-	const struct vcc_method *vm;
-	const struct symbol *sym;
+	struct symbol *sym;
 
 	*e = NULL;
 	vcc_expr5(tl, e, fmt);
@@ -841,20 +853,13 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			vcc_ErrWhere(tl, tl->t);
 			return;
 		}
-		CAST_OBJ_NOTNULL(vm, sym->eval_priv, VCC_METHOD_MAGIC);
 
-		vcc_NextToken(tl);
-		*e = vcc_expr_edit(tl, vm->type, vm->impl, *e, NULL);
+		AN(sym->eval);
+		sym->eval(tl, e, tl->t, sym, sym->type);
 		ERRCHK(tl);
 		if ((*e)->fmt == STRING) {
 			(*e)->fmt = STRINGS;
 			(*e)->nstr = 1;
-		}
-		if (vm->func) {
-			ExpectErr(tl, '(');
-			vcc_NextToken(tl);
-			ExpectErr(tl, ')');
-			vcc_NextToken(tl);
 		}
 	}
 }

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1430,6 +1430,7 @@ vcc_Act_Obj(struct vcc *tl, struct token *t, struct symbol *sym)
 	struct expr *e = NULL;
 
 	assert(sym->kind == SYM_INSTANCE);
+	ExpectErr(tl, '.');
 	tl->t = t;
 	vcc_expr4(tl, &e, sym->type);
 	ERRCHK(tl);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -50,6 +50,7 @@ struct expr {
 #define EXPR_CONST	(1<<1)
 #define EXPR_STR_CONST	(1<<2)		// Last STRING_LIST elem is "..."
 	struct token	*t1, *t2;
+	struct symbol	*instance;
 	int		nstr;
 };
 
@@ -484,6 +485,17 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 		sa = NULL;
 	}
 	vv = VTAILQ_NEXT(vv, list);
+	if (sym->kind == SYM_METHOD) {
+		if (*e == NULL) {
+			VSB_cat(tl->sb, "Syntax error.");
+			tl->err = 1;
+			return;
+		}
+		vcc_NextToken(tl);
+		AZ(extra);
+		AN((*e)->instance);
+		extra = (*e)->instance->rname;
+	}
 	SkipToken(tl, '(');
 	if (extra == NULL) {
 		extra = "";
@@ -651,7 +663,7 @@ vcc_Eval_SymFunc(struct vcc *tl, struct expr **e, struct token *t,
 
 	(void)t;
 	(void)fmt;
-	assert(sym->kind == SYM_FUNC);
+	assert(sym->kind == SYM_FUNC || sym->kind == SYM_METHOD);
 	AN(sym->eval_priv);
 
 	vcc_func(tl, e, sym->eval_priv, sym->extra, sym);
@@ -700,6 +712,12 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		sym = VCC_SymbolGet(tl, SYM_NONE, SYMTAB_PARTIAL, XREF_REF);
 		ERRCHK(tl);
 		AN(sym);
+		if (sym->kind == SYM_INSTANCE) {
+			AZ(*e);
+			*e = vcc_new_expr(sym->type);
+			(*e)->instance = sym;
+			return;
+		}
 		if (sym->kind == SYM_FUNC && sym->type == VOID) {
 			VSB_cat(tl->sb, "Function returns VOID:\n");
 			vcc_ErrWhere(tl, tl->t);
@@ -848,8 +866,7 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		if (sym == NULL) {
 			VSB_cat(tl->sb, "Unknown property ");
 			vcc_ErrToken(tl, tl->t);
-			VSB_printf(tl->sb,
-			 " for type %s\n", (*e)->fmt->name);
+			VSB_printf(tl->sb, " for type %s\n", (*e)->fmt->name);
 			vcc_ErrWhere(tl, tl->t);
 			return;
 		}
@@ -1405,6 +1422,23 @@ vcc_Act_Call(struct vcc *tl, struct token *t, struct symbol *sym)
 	}
 	vcc_delete_expr(e);
 }
+
+void v_matchproto_(sym_act_f)
+vcc_Act_Obj(struct vcc *tl, struct token *t, struct symbol *sym)
+{
+
+	struct expr *e = NULL;
+
+	assert(sym->kind == SYM_INSTANCE);
+	tl->t = t;
+	vcc_expr4(tl, &e, sym->type);
+	ERRCHK(tl);
+	vcc_expr_fmt(tl->fb, tl->indent, e);
+	vcc_delete_expr(e);
+	SkipToken(tl, ';');
+	VSB_cat(tl->fb, ";\n");
+}
+
 /*--------------------------------------------------------------------
  */
 

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -822,6 +822,7 @@ static void
 vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 {
 	const struct vcc_method *vm;
+	const struct symbol *sym;
 
 	*e = NULL;
 	vcc_expr5(tl, e, fmt);
@@ -831,14 +832,8 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		vcc_NextToken(tl);
 		ExpectErr(tl, ID);
 
-		vm = (*e)->fmt->methods;
-		while (vm != NULL && vm->type != NULL) {
-			if (vcc_IdIs(tl->t, vm->name))
-				break;
-			vm++;
-		}
-
-		if (vm == NULL || vm->type == NULL) {
+		sym = VCC_TypeSymbol(tl, SYM_METHOD, (*e)->fmt);
+		if (sym == NULL) {
 			VSB_cat(tl->sb, "Unknown property ");
 			vcc_ErrToken(tl, tl->t);
 			VSB_printf(tl->sb,
@@ -846,6 +841,8 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			vcc_ErrWhere(tl, tl->t);
 			return;
 		}
+		CAST_OBJ_NOTNULL(vm, sym->eval_priv, VCC_METHOD_MAGIC);
+
 		vcc_NextToken(tl);
 		*e = vcc_expr_edit(tl, vm->type, vm->impl, *e, NULL);
 		ERRCHK(tl);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -816,37 +816,12 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
  * SYNTAX:
  *    Expr4:
  *      Expr5 [ '.' (type_attribute | type_method()) ]*
- *
- * type_attributes is information already existing, requiring no
- * processing or resource usage.
- *
- * type_methods are calls and may do (significant processing, change things,
- * eat workspace etc.
  */
-
-static const struct vcc_methods {
-	vcc_type_t		type_from;
-	vcc_type_t		type_to;
-	const char		*method;
-	const char		*impl;
-	int			func;
-} vcc_methods[] = {
-	//{ BACKEND, BOOL,	"healthy",	"VRT_Healthy(ctx, \v1, 0)" },
-
-#define VRTSTVVAR(nm, vtype, ctype, dval) \
-	{ STEVEDORE, vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
-#include "tbl/vrt_stv_var.h"
-
-	{ STRINGS, STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
-	{ STRINGS, STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
-
-	{ NULL, NULL,		NULL,		NULL},
-};
 
 static void
 vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 {
-	const struct vcc_methods *vm;
+	const struct vcc_method *vm;
 
 	*e = NULL;
 	vcc_expr5(tl, e, fmt);
@@ -856,14 +831,14 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		vcc_NextToken(tl);
 		ExpectErr(tl, ID);
 
-		for(vm = vcc_methods; vm->type_from != NULL; vm++) {
-
-			if (vm->type_from == (*e)->fmt &&
-			    vcc_IdIs(tl->t, vm->method))
+		vm = (*e)->fmt->methods;
+		while (vm != NULL && vm->type != NULL) {
+			if (vcc_IdIs(tl->t, vm->name))
 				break;
+			vm++;
 		}
 
-		if (vm->type_from == NULL) {
+		if (vm == NULL || vm->type == NULL) {
 			VSB_cat(tl->sb, "Unknown property ");
 			vcc_ErrToken(tl, tl->t);
 			VSB_printf(tl->sb,
@@ -872,7 +847,7 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			return;
 		}
 		vcc_NextToken(tl);
-		*e = vcc_expr_edit(tl, vm->type_to, vm->impl, *e, NULL);
+		*e = vcc_expr_edit(tl, vm->type, vm->impl, *e, NULL);
 		ERRCHK(tl);
 		if ((*e)->fmt == STRING) {
 			(*e)->fmt = STRINGS;

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -182,7 +182,7 @@ vcc_Compound(struct vcc *tl)
 			tl->err = 1;
 			return;
 		case ID:
-			sym = VCC_SymbolGet(tl, SYM_NONE, SYMTAB_NOERR,
+			sym = VCC_SymbolGet(tl, SYM_NONE, SYMTAB_PARTIAL,
 			    XREF_NONE);
 			if (sym == NULL) {
 				VSB_printf(tl->sb, "Symbol not found.\n");

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -364,6 +364,7 @@ VCC_TypeSymbol(struct vcc *tl, vcc_kind_t kind, vcc_type_t type)
 	sym = VCC_SymbolGet(tl, kind, SYMTAB_NOERR, XREF_NONE);
 	tl->t = t0;
 	VSB_destroy(&buf);
+
 	return (sym);
 }
 

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -343,6 +343,31 @@ VCC_SymbolGet(struct vcc *tl, vcc_kind_t kind,
 }
 
 struct symbol *
+VCC_TypeSymbol(struct vcc *tl, vcc_kind_t kind, vcc_type_t type)
+{
+	struct token t[1], *t0;
+	struct symbol *sym;
+	struct vsb *buf;
+
+	buf = VSB_new_auto();
+	AN(buf);
+	VSB_printf(buf, "_type.%s.%.*s", type->name, PF(tl->t));
+	AZ(VSB_finish(buf));
+
+	/* NB: we create a fake token but errors are handled by the caller. */
+	memcpy(t, tl->t, sizeof *t);
+	t->b = VSB_data(buf);
+	t->e = t->b + VSB_len(buf);
+
+	t0 = tl->t;
+	tl->t = t;
+	sym = VCC_SymbolGet(tl, kind, SYMTAB_NOERR, XREF_NONE);
+	tl->t = t0;
+	VSB_destroy(&buf);
+	return (sym);
+}
+
+struct symbol *
 VCC_MkSym(struct vcc *tl, const char *b, vcc_kind_t kind, int vlo, int vhi)
 {
 	struct symtab *st;

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -351,7 +351,9 @@ VCC_TypeSymbol(struct vcc *tl, vcc_kind_t kind, vcc_type_t type)
 
 	buf = VSB_new_auto();
 	AN(buf);
-	VSB_printf(buf, "_type.%s.%.*s", type->name, PF(tl->t));
+	if (!strchr(type->name, '.'))
+		VSB_cat(buf, "_type.");
+	VSB_printf(buf, "%s.%.*s", type->name, PF(tl->t));
 	AZ(VSB_finish(buf));
 
 	/* NB: we create a fake token but errors are handled by the caller. */

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -125,9 +125,17 @@ const struct type REAL[1] = {{
 	.multype =		REAL,
 }};
 
+static const struct vcc_method stevedore_methods[] = {
+#define VRTSTVVAR(nm, vtype, ctype, dval) \
+	{ vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
+#include "tbl/vrt_stv_var.h"
+	{ NULL },
+};
+
 const struct type STEVEDORE[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"STEVEDORE",
+	.methods =		stevedore_methods,
 	.tostring =		"VRT_STEVEDORE_string(\v1)",
 }};
 
@@ -144,9 +152,16 @@ const struct type STRANDS[1] = {{
 	.tostring =		"VRT_CollectStrands(ctx,\v+\n\v1\v-\n)",
 }};
 
+static const struct vcc_method strings_methods[] = {
+	{ STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
+	{ STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
+	{ NULL },
+};
+
 const struct type STRINGS[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"STRINGS",
+	.methods =		strings_methods,
 	.tostring =		"",
 }};
 

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -201,3 +201,9 @@ VCC_Type(const char *p)
 	return (NULL);
 }
 
+void
+vcc_Type_Init(struct vcc *tl)
+{
+
+	AN(VCC_MkSym(tl, "_type", SYM_RESERVED, VCL_LOW, VCL_HIGH));
+}

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -36,6 +36,24 @@
 
 #include "vcc_compile.h"
 
+/*
+ * A type attribute is information already existing, requiring no processing
+ * or resource usage.
+ *
+ * A type method call and may do (significant processing, change things, eat
+ * workspace etc).
+ *
+ * XXX: type methods might move in a more comprehensive direction.
+ */
+struct vcc_method {
+	unsigned		magic;
+#define VCC_METHOD_MAGIC	0x594108cd
+	vcc_type_t		type;
+	const char		*name;
+	const char		*impl;
+	int			func;
+};
+
 const struct type ACL[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"ACL",
@@ -232,10 +250,35 @@ vcc_type_init(struct vcc *tl, vcc_type_t type)
 			break;
 		AN(sym);
 		sym->type = vm->type;
+		sym->eval = vcc_Eval_TypeMethod;
 		sym->eval_priv = vm;
 	}
 
 	VSB_destroy(&buf);
+}
+
+const char *
+VCC_Type_EvalMethod(struct vcc *tl, const struct symbol *sym)
+{
+	const struct vcc_method *vm;
+
+	AN(sym);
+	AN(sym->kind == SYM_METHOD);
+	CAST_OBJ_NOTNULL(vm, sym->eval_priv, VCC_METHOD_MAGIC);
+
+	vcc_NextToken(tl);
+	if (vm->func) {
+		Expect(tl, '(');
+		if (tl->err)
+			return (NULL);
+		vcc_NextToken(tl);
+		Expect(tl, ')');
+		if (tl->err)
+			return (NULL);
+		vcc_NextToken(tl);
+	}
+
+	return (vm->impl);
 }
 
 void

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -127,9 +127,9 @@ const struct type REAL[1] = {{
 
 static const struct vcc_method stevedore_methods[] = {
 #define VRTSTVVAR(nm, vtype, ctype, dval) \
-	{ vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
+	{ VCC_METHOD_MAGIC, vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
 #include "tbl/vrt_stv_var.h"
-	{ NULL },
+	{ VCC_METHOD_MAGIC, NULL },
 };
 
 const struct type STEVEDORE[1] = {{
@@ -153,9 +153,11 @@ const struct type STRANDS[1] = {{
 }};
 
 static const struct vcc_method strings_methods[] = {
-	{ STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
-	{ STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
-	{ NULL },
+	{ VCC_METHOD_MAGIC, STRING, "upper",
+	    "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
+	{ VCC_METHOD_MAGIC, STRING, "lower",
+	    "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
+	{ VCC_METHOD_MAGIC, NULL },
 };
 
 const struct type STRINGS[1] = {{
@@ -201,9 +203,47 @@ VCC_Type(const char *p)
 	return (NULL);
 }
 
+static void
+vcc_type_init(struct vcc *tl, vcc_type_t type)
+{
+	const struct vcc_method *vm;
+	struct symbol *sym;
+	struct vsb *buf;
+
+	/* NB: Don't bother even creating a type symbol if there are no
+	 * methods attached to it.
+	 */
+	if (type->methods == NULL)
+		return;
+
+	buf = VSB_new_auto();
+	AN(buf);
+	VSB_printf(buf, "_type.%s", type->name);
+	AZ(VSB_finish(buf));
+	AN(VCC_MkSym(tl, VSB_data(buf), SYM_NONE, VCL_LOW, VCL_HIGH));
+
+	for (vm = type->methods; vm->type != NULL; vm++) {
+		VSB_clear(buf);
+		VSB_printf(buf, "_type.%s.%s", type->name, vm->name);
+		AZ(VSB_finish(buf));
+		sym = VCC_MkSym(tl, VSB_data(buf), SYM_METHOD, VCL_LOW,
+		    VCL_HIGH);
+		if (tl->err)
+			break;
+		AN(sym);
+		sym->type = vm->type;
+		sym->eval_priv = vm;
+	}
+
+	VSB_destroy(&buf);
+}
+
 void
 vcc_Type_Init(struct vcc *tl)
 {
 
 	AN(VCC_MkSym(tl, "_type", SYM_RESERVED, VCL_LOW, VCL_HIGH));
+
+#define VCC_TYPE(UC, lc)	vcc_type_init(tl, UC);
+#include "tbl/vcc_types.h"
 }

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -49,6 +49,14 @@ struct vmod_open {
 	const char		*err;
 };
 
+struct vmod_obj {
+	unsigned		magic;
+#define VMOD_OBJ_MAGIC		0x349885f8
+	char			*name;
+	struct type		type[1];
+	VTAILQ_ENTRY(vmod_obj)	list;
+};
+
 static int
 vcc_path_dlopen(void *priv, const char *fn)
 {
@@ -202,6 +210,29 @@ vcc_vmod_kind(const char *type)
 }
 
 static void
+vcc_VmodObject(struct vcc *tl, struct symbol *sym)
+{
+	struct vmod_obj *obj;
+	struct vsb *buf;
+
+	buf = VSB_new_auto();
+	AN(buf);
+
+	VSB_printf(buf, "%s.%s", sym->vmod_name, sym->name);
+	AZ(VSB_finish(buf));
+
+	ALLOC_OBJ(obj, VMOD_OBJ_MAGIC);
+	AN(obj);
+	REPLACE(obj->name, VSB_data(buf));
+
+	INIT_OBJ(obj->type, TYPE_MAGIC);
+	obj->type->name = obj->name;
+	sym->type = obj->type;
+	VTAILQ_INSERT_TAIL(&tl->vmod_objects, obj, list);
+	VSB_destroy(&buf);
+}
+
+static void
 vcc_VmodSymbols(struct vcc *tl, struct symbol *msym)
 {
 	const struct vjsn *vj;
@@ -264,6 +295,7 @@ vcc_VmodSymbols(struct vcc *tl, struct symbol *msym)
 			assert(kind == SYM_OBJECT);
 			fsym->eval_priv = vv2;
 			fsym->vmod_name = msym->vmod_name;
+			vcc_VmodObject(tl, fsym);
 		}
 	}
 

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -203,7 +203,7 @@ vcc_vmod_kind(const char *type)
 			return (kind);	\
 	} while (0)
 	VMOD_KIND("$OBJ", SYM_OBJECT);
-	VMOD_KIND("$METHOD", SYM_FUNC);
+	VMOD_KIND("$METHOD", SYM_METHOD);
 	VMOD_KIND("$FUNC", SYM_FUNC);
 #undef VMOD_KIND
 	return (SYM_NONE);
@@ -244,7 +244,7 @@ vcc_VmodSymbols(struct vcc *tl, struct symbol *msym)
 	if (msym->kind == SYM_VMOD) {
 		CAST_OBJ_NOTNULL(vj, msym->eval_priv, VJSN_MAGIC);
 		vv = VTAILQ_FIRST(&vj->value->children);
-	} else if (msym->kind == SYM_INSTANCE || msym->kind == SYM_OBJECT) {
+	} else if (msym->kind == SYM_OBJECT) {
 		CAST_OBJ_NOTNULL(vv, msym->eval_priv, VJSN_VAL_MAGIC);
 	} else {
 		WRONG("symbol kind");
@@ -289,13 +289,10 @@ vcc_VmodSymbols(struct vcc *tl, struct symbol *msym)
 
 		if (kind == SYM_FUNC) {
 			func_sym(fsym, msym->vmod_name, VTAILQ_NEXT(vv2, list));
-			/* XXX: until we use SYM_METHOD only, string check. */
-			if (!strcmp(vv1->value, "$METHOD")) {
-				fsym->extra = msym->rname;
-				/* XXX: cohabitation temporary hack */
-				if (msym->kind == SYM_OBJECT)
-					fsym->kind = SYM_METHOD;
-			}
+		} else if (kind == SYM_METHOD) {
+			func_sym(fsym, msym->vmod_name, VTAILQ_NEXT(vv2, list));
+			fsym->extra = msym->rname;
+			fsym->kind = SYM_METHOD;
 		} else {
 			assert(kind == SYM_OBJECT);
 			fsym->eval_priv = vv2;
@@ -489,6 +486,7 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 	ERRCHK(tl);
 	AN(isym);
 	isym->noref = 1;
+	isym->action = vcc_Act_Obj;
 
 	SkipToken(tl, '=');
 	ExpectErr(tl, ID);
@@ -504,7 +502,6 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 
 	isym->vmod_name = osym->vmod_name;
 	isym->eval_priv = vv;
-	vcc_VmodSymbols(tl, isym);
 
 	vv = VTAILQ_NEXT(vv, list);
 	// vv = flags

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -495,6 +495,10 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 	osym = VCC_SymbolGet(tl, SYM_OBJECT, SYMTAB_EXISTING, XREF_NONE);
 	ERRCHK(tl);
 	AN(osym);
+
+	/* Scratch the generic INSTANCE type */
+	isym->type = osym->type;
+
 	CAST_OBJ_NOTNULL(vv, osym->eval_priv, VJSN_VAL_MAGIC);
 	// vv = object name
 

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -73,13 +73,43 @@ vcc_path_dlopen(void *priv, const char *fn)
 	return (0);
 }
 
+static void vcc_VmodObject(struct vcc *tl, struct symbol *sym);
+static void vcc_VmodSymbols(struct vcc *tl, struct symbol *sym);
+
 static void
-func_sym(struct symbol *sym, const char *vmod_name, const struct vjsn_val *v)
+func_sym(struct vcc *tl, vcc_kind_t kind, struct symbol *psym,
+    const struct vjsn_val *v)
 {
+	struct symbol *sym;
+	struct vsb *buf;
+
+	buf = VSB_new_auto();
+	AN(buf);
+
+	VSB_clear(buf);
+	VCC_SymName(buf, psym);
+	VSB_printf(buf, ".%s", v->value);
+	AZ(VSB_finish(buf));
+	sym = VCC_MkSym(tl, VSB_data(buf), kind, VCL_LOW, VCL_HIGH);
+	AN(sym);
+	VSB_destroy(&buf);
+
+	if (kind == SYM_OBJECT) {
+		sym->eval_priv = v;
+		sym->vmod_name = psym->vmod_name;
+		vcc_VmodObject(tl, sym);
+		vcc_VmodSymbols(tl, sym);
+		return;
+	}
+
+	if (kind == SYM_METHOD)
+		sym->extra = psym->rname;
+
+	v = VTAILQ_NEXT(v, list);
 
 	assert(v->type == VJSN_ARRAY);
 	sym->action = vcc_Act_Call;
-	sym->vmod_name = vmod_name;
+	sym->vmod_name = psym->vmod_name;
 	sym->eval = vcc_Eval_SymFunc;
 	sym->eval_priv = v;
 	v = VTAILQ_FIRST(&v->children);
@@ -233,25 +263,20 @@ vcc_VmodObject(struct vcc *tl, struct symbol *sym)
 }
 
 static void
-vcc_VmodSymbols(struct vcc *tl, struct symbol *msym)
+vcc_VmodSymbols(struct vcc *tl, struct symbol *sym)
 {
 	const struct vjsn *vj;
 	const struct vjsn_val *vv, *vv1, *vv2;
-	struct symbol *fsym;
 	vcc_kind_t kind;
-	struct vsb *buf;
 
-	if (msym->kind == SYM_VMOD) {
-		CAST_OBJ_NOTNULL(vj, msym->eval_priv, VJSN_MAGIC);
+	if (sym->kind == SYM_VMOD) {
+		CAST_OBJ_NOTNULL(vj, sym->eval_priv, VJSN_MAGIC);
 		vv = VTAILQ_FIRST(&vj->value->children);
-	} else if (msym->kind == SYM_OBJECT) {
-		CAST_OBJ_NOTNULL(vv, msym->eval_priv, VJSN_VAL_MAGIC);
+	} else if (sym->kind == SYM_OBJECT) {
+		CAST_OBJ_NOTNULL(vv, sym->eval_priv, VJSN_VAL_MAGIC);
 	} else {
 		WRONG("symbol kind");
 	}
-
-	buf = VSB_new_auto();
-	AN(buf);
 
 	for (; vv != NULL; vv = VTAILQ_NEXT(vv, list)) {
 		if (vv->type != VJSN_ARRAY)
@@ -266,43 +291,8 @@ vcc_VmodSymbols(struct vcc *tl, struct symbol *msym)
 		if (kind == SYM_NONE)
 			continue;
 
-		/* NB: currently VMOD object methods are effectively function
-		 * symbols (SYM_FUNC) because they are declared per instance
-		 * instead of per object. Once they become proper methods
-		 * symbols (SYM_METHOD) we can move the symbol creation inside
-		 * the func_sym() function and replace the rest of the loop
-		 * with a single statement:
-		 *
-		 *     func_sym(kind, msym, vv2);
-		 *
-		 * Then based on kind, the func_sym() function would account
-		 * for the slight differences between the 3 kinds of VMOD
-		 * functions (function, object constructor, object method).
-		 */
-
-		VSB_clear(buf);
-		VCC_SymName(buf, msym);
-		VSB_printf(buf, ".%s", vv2->value);
-		AZ(VSB_finish(buf));
-		fsym = VCC_MkSym(tl, VSB_data(buf), kind, VCL_LOW, VCL_HIGH);
-		AN(fsym);
-
-		if (kind == SYM_FUNC) {
-			func_sym(fsym, msym->vmod_name, VTAILQ_NEXT(vv2, list));
-		} else if (kind == SYM_METHOD) {
-			func_sym(fsym, msym->vmod_name, VTAILQ_NEXT(vv2, list));
-			fsym->extra = msym->rname;
-			fsym->kind = SYM_METHOD;
-		} else {
-			assert(kind == SYM_OBJECT);
-			fsym->eval_priv = vv2;
-			fsym->vmod_name = msym->vmod_name;
-			vcc_VmodObject(tl, fsym);
-			vcc_VmodSymbols(tl, fsym);
-		}
+		func_sym(tl, kind, sym, vv2);
 	}
-
-	VSB_destroy(&buf);
 }
 
 void

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -244,7 +244,7 @@ vcc_VmodSymbols(struct vcc *tl, struct symbol *msym)
 	if (msym->kind == SYM_VMOD) {
 		CAST_OBJ_NOTNULL(vj, msym->eval_priv, VJSN_MAGIC);
 		vv = VTAILQ_FIRST(&vj->value->children);
-	} else if (msym->kind == SYM_INSTANCE) {
+	} else if (msym->kind == SYM_INSTANCE || msym->kind == SYM_OBJECT) {
 		CAST_OBJ_NOTNULL(vv, msym->eval_priv, VJSN_VAL_MAGIC);
 	} else {
 		WRONG("symbol kind");
@@ -281,21 +281,27 @@ vcc_VmodSymbols(struct vcc *tl, struct symbol *msym)
 		 */
 
 		VSB_clear(buf);
-		VSB_printf(buf, "%s.%s", msym->name, vv2->value);
+		VCC_SymName(buf, msym);
+		VSB_printf(buf, ".%s", vv2->value);
 		AZ(VSB_finish(buf));
 		fsym = VCC_MkSym(tl, VSB_data(buf), kind, VCL_LOW, VCL_HIGH);
 		AN(fsym);
 
 		if (kind == SYM_FUNC) {
 			func_sym(fsym, msym->vmod_name, VTAILQ_NEXT(vv2, list));
-			/* XXX: until we use SYM_METHOD, string check. */
-			if (!strcmp(vv1->value, "$METHOD"))
+			/* XXX: until we use SYM_METHOD only, string check. */
+			if (!strcmp(vv1->value, "$METHOD")) {
 				fsym->extra = msym->rname;
+				/* XXX: cohabitation temporary hack */
+				if (msym->kind == SYM_OBJECT)
+					fsym->kind = SYM_METHOD;
+			}
 		} else {
 			assert(kind == SYM_OBJECT);
 			fsym->eval_priv = vv2;
 			fsym->vmod_name = msym->vmod_name;
 			vcc_VmodObject(tl, fsym);
+			vcc_VmodSymbols(tl, fsym);
 		}
 	}
 


### PR DESCRIPTION
In the first iteration (#3147) I used the `::` notation to fit type methods in the VCC symbol table in a way that would avoid symbol conflicts:

- some reserved keywords like `acl` or `backend` are type names
- by default when vmod_blob is imported its symbol is a type name

During the review the `::` hack was understandably not well received, and after a fairly long discussion I pushed a few changes directly to master, took a slightly different direction (like unwildcarding VMOD symbols) and then solved the symbol conflict by introducing a `_type` namespace in the symbol table.

This is otherwise the same as #3147: it does not (intend to) change existing behavior and only prepare libvcc to accommodate future changes in the scope of VIP28. The difference is that we can keep vmod_blob as-is (or hopefully slightly different after #3143) and we maintain a hierarchical symbol table.

For everything else, please refer to the commit log. It's a mixed bag of new commits and cherry-picks from #3147. And some changes from #3147 already landed in master.