### PR TITLE
Use absolute paths in dlopen(3) for VCLs and VMODs

### DIFF
--- a/bin/varnishd/common/heritage.h
+++ b/bin/varnishd/common/heritage.h
@@ -73,6 +73,7 @@ struct heritage {
 	struct params			*param;
 
 	const char			*identity;
+	const char			*workdir;
 
 	char				*panic_str;
 	ssize_t				panic_str_len;

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -738,6 +738,7 @@ main(int argc, char * const *argv)
 
 	if (VIN_n_Arg(n_arg, &dirname) != 0)
 		ARGV_ERR("Invalid instance (-n) name: %s\n", vstrerror(errno));
+	heritage.workdir = dirname;
 
 	if (i_arg == NULL || *i_arg == '\0')
 		i_arg = mgt_HostName();

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -99,7 +99,7 @@ run_vcc(void *priv)
 
 	AZ(chdir(VSB_data(vp->dir)));
 
-	vcc = VCC_New();
+	vcc = VCC_New(heritage.workdir);
 	AN(vcc);
 	VCC_Builtin_VCL(vcc, builtin_vcl);
 	VCC_VCL_path(vcc, mgt_vcl_path);

--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -469,8 +469,8 @@ mgt_new_vcl(struct cli *cli, const char *vclname, const char *vclsrc,
 	if (!MCH_Running())
 		return;
 
-	if (mgt_cli_askchild(&status, &p, "vcl.load %s %s %d%s\n",
-	    vp->name, vp->fname, vp->warm, vp->state->name)) {
+	if (mgt_cli_askchild(&status, &p, "vcl.load %s %s%s %d%s\n",
+	    vp->name, heritage.workdir, vp->fname, vp->warm, vp->state->name)) {
 		mgt_vcl_del(vp);
 		VCLI_Out(cli, "%s", p);
 		VCLI_SetResult(cli, status);
@@ -539,9 +539,9 @@ mgt_push_vcls(struct cli *cli, unsigned *status, char **p)
 					return (1);
 			} else {
 				if (mgt_cli_askchild(status, p,
-				    "vcl.load \"%s\" %s %d%s\n",
-				    vp->name, vp->fname, vp->warm,
-				    vp->state->name))
+				    "vcl.load \"%s\" %s%s %d%s\n",
+				    vp->name, heritage.workdir, vp->fname,
+				    vp->warm, vp->state->name))
 					return (1);
 			}
 			vp->loaded = 1;

--- a/include/libvcc.h
+++ b/include/libvcc.h
@@ -30,7 +30,7 @@
 
 struct vcc;
 
-struct vcc *VCC_New(void);
+struct vcc *VCC_New(const char *);
 void VCC_Allow_InlineC(struct vcc *, unsigned);
 void VCC_Builtin_VCL(struct vcc *, const char *);
 void VCC_Err_Unref(struct vcc *, unsigned);

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -795,13 +795,15 @@ VCC_Compile(struct vcc *tl, struct vsb **sb,
  */
 
 struct vcc *
-VCC_New(void)
+VCC_New(const char *workdir)
 {
 	struct vcc *tl;
 	struct symbol *sym;
 	struct proc *p;
 	int i;
 
+	AN(workdir);
+	assert(*workdir == '/');
 	ALLOC_OBJ(tl, VCC_MAGIC);
 	AN(tl);
 	VTAILQ_INIT(&tl->inifin);
@@ -811,6 +813,7 @@ VCC_New(void)
 	VTAILQ_INIT(&tl->sym_objects);
 	VTAILQ_INIT(&tl->sym_vmods);
 
+	tl->workdir = workdir;
 	tl->nsources = 0;
 
 	tl->symtab = VSB_new_auto();

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -217,6 +217,7 @@ struct vcc {
 	char			*builtin_vcl;
 	struct vfil_path	*vcl_path;
 	struct vfil_path	*vmod_path;
+	const char		*workdir;
 	unsigned		err_unref;
 	unsigned		allow_inline_c;
 	unsigned		unsafe_path;

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -340,8 +340,8 @@ vcc_ParseImport(struct vcc *tl)
 	AN(vmd);
 	AN(vmd->file_id);
 	VSB_printf(ifp->ini, "\t    \"%s\",\n", vmd->file_id);
-	VSB_printf(ifp->ini, "\t    \"./vmod_cache/_vmod_%.*s.%s\"\n",
-	    PF(mod), vmd->file_id);
+	VSB_printf(ifp->ini, "\t    \"%svmod_cache/_vmod_%.*s.%s\"\n",
+	    tl->workdir, PF(mod), vmd->file_id);
 	VSB_cat(ifp->ini, "\t    ))\n");
 	VSB_cat(ifp->ini, "\t\treturn(1);");
 
@@ -350,8 +350,8 @@ vcc_ParseImport(struct vcc *tl)
 	VSB_cat(tl->symtab, "\t\"type\": \"$VMOD\",\n");
 	VSB_printf(tl->symtab, "\t\"name\": \"%.*s\",\n", PF(mod));
 	VSB_printf(tl->symtab, "\t\"file\": \"%s\",\n", fnpx);
-	VSB_printf(tl->symtab, "\t\"dst\": \"./vmod_cache/_vmod_%.*s.%s\"\n",
-	    PF(mod), vmd->file_id);
+	VSB_printf(tl->symtab, "\t\"dst\": \"%svmod_cache/_vmod_%.*s.%s\"\n",
+	    tl->workdir, PF(mod), vmd->file_id);
 	VSB_cat(tl->symtab, "    }");
 
 	/* XXX: zero the function pointer structure ?*/


### PR DESCRIPTION
This improves the out-of-the-box debugging experience for at least gdb
and lldb, allowing them to grab type information for the symbols coming
from such shared objects.

This however doesn't help further when multiple VCLs or VMODs define the
same symbols, for example in the case of similar VCLs (reload scenario)
or a VMOD upgrade (either with import+from or VMOD caching kicking in).

For the latter case, #2966 would help.