### PR TITLE
a vmod type for vcl subs & VRT_call()

### DIFF
--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -39,9 +39,11 @@
 
 #include "vcl.h"
 #include "vtim.h"
+#include "vbm.h"
 
 #include "cache_director.h"
 #include "cache_vcl.h"
+#include "vcc_interface.h"
 
 /*--------------------------------------------------------------------*/
 
@@ -444,10 +446,13 @@ VRT_VCL_Allow_Discard(struct vclref **refp)
 
 static void
 vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
-    void *specific, unsigned method, vcl_func_f *func)
+    void *specific, unsigned method, vcl_func_f *func, unsigned track_call)
 {
-	uintptr_t aws;
+	uintptr_t rws = 0, aws;
 	struct vrt_ctx ctx;
+	struct vbitmap *vbm;
+	void *p;
+	size_t sz;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	INIT_OBJ(&ctx, VRT_CTX_MAGIC);
@@ -468,6 +473,15 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 	assert(ctx.now != 0);
 	ctx.specific = specific;
 	ctx.method = method;
+	if (track_call > 0) {
+		rws = WS_Snapshot(wrk->aws);
+		sz = VBITMAP_SZ(track_call);
+		p = WS_Alloc(wrk->aws, sz);
+		// No use to attempt graceful failure, all VCL calls will fail
+		AN(p);
+		vbm = vbit_init(p, sz);
+		ctx.called = vbm;
+	}
 	aws = WS_Snapshot(wrk->aws);
 	wrk->cur_method = method;
 	wrk->seen_methods |= method;
@@ -484,6 +498,8 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 	 * wrk->aws, but they can reserve and return from it.
 	 */
 	assert(aws == WS_Snapshot(wrk->aws));
+	if (rws != 0)
+		WS_Reset(wrk->aws, rws);
 }
 
 #define VCL_MET_MAC(func, upper, typ, bitmap)				\
@@ -496,7 +512,7 @@ VCL_##func##_method(struct vcl *vcl, struct worker *wrk,		\
 	CHECK_OBJ_NOTNULL(vcl->conf, VCL_CONF_MAGIC);			\
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);				\
 	vcl_call_method(wrk, req, bo, specific,				\
-	    VCL_MET_ ## upper, vcl->conf->func##_func);			\
+	    VCL_MET_ ## upper, vcl->conf->func##_func, vcl->conf->nsub);\
 	AN((1U << wrk->handling) & bitmap);				\
 }
 

--- a/bin/varnishtest/tests/m00053.vtc
+++ b/bin/varnishtest/tests/m00053.vtc
@@ -1,0 +1,194 @@
+varnishtest "VCL_SUB type basics"
+
+varnish v1 -vcl {
+	import std;
+	import debug;
+
+	backend dummy None;
+
+	# call: 1 ref: 5 + 1
+	sub foo {
+		set resp.http.it = "works";
+	}
+	# call: 1 ref: 1 + 1 (from bar walk)
+	sub barbar {
+		# called from bar only, must be marked dynamic
+		call barbarbar;
+	}
+	# call: 2 (1 from bar walk, 1 from barbar walk)
+	# ref: 2 + 1
+	sub barbarbar {
+		# 2nd level call from dynamic
+	}
+	# call: 0 ref: 1
+	sub bar {
+		set beresp.http.it = "works";
+		call barbar;
+	}
+	# call: 0 ref: 1
+	sub indirect {
+		debug.call(foo);
+	}
+	# call: 0 ref: 1
+	sub direct {
+		call foo;
+	}
+	# call: 0 ref: 2
+	sub recursive {
+		std.log("recursive called");
+		debug.call(recursive);
+	}
+	# call: 1 ref: 1
+	sub recursive_indirect {
+		std.log("recursive_indirect called");
+		debug.call(recursive_indirect);
+	}
+	# call: 1 ref: 1
+	sub rollback {
+		std.rollback(req);
+	}
+	# call: 0 ref: 1
+	sub priv_top {
+		debug.test_priv_top("only works on client side");
+	}
+
+	sub vcl_recv {
+		if (req.url == "/wrong") {
+			debug.call(foo);
+		}
+		if (req.url == "/recursive") {
+			debug.call(recursive);
+		}
+		if (req.url == "/recursive_indirect") {
+			call recursive_indirect;
+		}
+		if (req.url == "/priv_top") {
+			return (pass);
+		}
+		return (synth(200));
+	}
+	sub vcl_synth {
+		if (req.url == "/foo") {
+			debug.call(foo);
+		} else if (req.url == "/direct") {
+			debug.call(direct);
+		} else if (req.url == "/indirect") {
+			debug.call(indirect);
+		} else if (req.url == "/rollback") {
+			debug.call(rollback);
+		} else if (req.url == "/callthenrollback") {
+			debug.call(foo);
+			call rollback;
+			if (! resp.http.it) {
+				set resp.http.rolledback = true;
+			}
+			debug.call(foo);
+		} else if (req.url == "/checkwrong") {
+			synthetic(debug.check_call(bar));
+			set resp.status = 500;
+		}
+		return (deliver);
+	}
+	sub vcl_backend_fetch {
+		debug.call(priv_top);
+	}
+	sub vcl_backend_error {
+		# falling through to None backend would be success
+		set beresp.status = 200;
+		return (deliver);
+	}
+} -start
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.it == "works"
+
+	txreq -url "/direct"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.it == "works"
+
+	txreq -url "/indirect"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.it == "works"
+
+	txreq -url "/callthenrollback"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.rolledback == "true"
+	expect resp.http.it == "works"
+
+	txreq -url "/wrong"
+	rxresp
+	expect resp.status == 503
+} -start
+logexpect l2 -v v1 -g vxid -q {ReqURL ~ "^/recursive$"} {
+	expect *  *	VCL_Log	"^recursive called"
+	fail add  *	VCL_Log	"^recursive called"
+	expect 0  =	VCL_Error	{^Recursive call to "sub recursive..}
+	expect 0  =	VCL_return	"^fail"
+	expect *  =	End
+	fail clear
+} -start
+client c2 {
+	txreq -url "/recursive"
+	rxresp
+	expect resp.status == 503
+} -start
+logexpect l3 -v v1 -g vxid -q {ReqURL ~ "^/recursive_indirect$"} {
+	expect *  *	VCL_Log	"^recursive_indirect called"
+	fail add  *	VCL_Log	"^recursive_indirect called"
+	expect 0  =	VCL_Error	{^Recursive call to "sub recursive_indirect..}
+	expect 0  =	VCL_return	"^fail"
+	expect *  =	End
+	fail clear
+} -start
+client c3 {
+	txreq -url "/recursive_indirect"
+	rxresp
+	expect resp.status == 503
+} -start
+client c4 {
+	txreq -url "/rollback"
+	rxresp
+	expect resp.status == 200
+} -start
+client c5 {
+	txreq -url "/checkwrong"
+	rxresp
+	expect resp.status == 500
+	expect resp.body == {Dynamic call to "sub bar{}" not allowed from here}
+} -start
+client c6 {
+	txreq -url "/priv_top"
+	rxresp
+	expect resp.status == 503
+} -start
+
+varnish v1 -errvcl {Impossible Subroutine('<vcl.inline>' Line 8 Pos 13)} {
+	import std;
+	import debug;
+
+	backend dummy None;
+
+	sub impossible {
+		set req.http.impossible = beresp.reason;
+	}
+	sub vcl_recv {
+		if (req.url == "/impossible") {
+			debug.call(impossible);
+		}
+	}
+}
+
+client c1 -wait
+client c2 -wait
+logexpect l2 -wait
+client c3 -wait
+logexpect l3 -wait
+client c4 -wait
+client c5 -wait
+client c6 -wait

--- a/bin/varnishtest/tests/m00054.vtc
+++ b/bin/varnishtest/tests/m00054.vtc
@@ -1,0 +1,36 @@
+varnishtest "VCL_SUB wrong vmod behavior"
+
+varnish v1 -arg "-p feature=+no_coredump" -vcl {
+	import debug;
+
+	backend dummy None;
+
+	sub foo {
+		set resp.http.it = "works";
+	}
+
+	sub vcl_init {
+		debug.bad_memory(foo);
+	}
+} -start
+
+varnish v1 -vcl {
+	import debug;
+	backend dummy None;
+
+	sub vcl_recv {
+		debug.call(debug.total_recall());
+	}
+
+}
+
+client c1 {
+	txreq -url "/foo"
+	expect_close
+} -run
+
+varnish v1 -wait-stopped
+varnish v1 -cliexpect "Assert error in VPI_Call_Check" "panic.show"
+varnish v1 -cliok "panic.clear"
+varnish v1 -expect MGT.child_panic == 1
+varnish v1 -expectexit 0x40

--- a/bin/varnishtest/tests/v00020.vtc
+++ b/bin/varnishtest/tests/v00020.vtc
@@ -246,6 +246,17 @@ varnish v1 -errvcl {Not available in subroutine 'vcl_recv'.} {
 	}
 }
 
+varnish v1 -cliok "param.set vcc_err_unref off"
+
+varnish v1 -errvcl {Impossible Subroutine} {
+	backend b { .host = "127.0.0.1"; }
+	sub foo {
+		set req.http.foo = 100 + beresp.status;
+	}
+}
+
+varnish v1 -cliok "param.set vcc_err_unref on"
+
 varnish v1 -errvcl {
 ('<vcl.inline>' Line 4 Pos 44) -- (Pos 49)
         sub foo { set req.http.foo = 100 + beresp.status; }

--- a/bin/varnishtest/tests/v00021.vtc
+++ b/bin/varnishtest/tests/v00021.vtc
@@ -49,11 +49,6 @@ Subroutine recurses on
         sub foo { call foo; }
 -----------------------###---
 
-
-...called from "vcl_recv"
-('<vcl.inline>' Line 6 Pos 29)
-        sub vcl_recv { call foo; }
-----------------------------###---
 } {
 	backend b { .host = "${localhost}"; }
 
@@ -62,16 +57,9 @@ Subroutine recurses on
 }
 
 varnish v1 -errvcl {
-Subroutine recurses on
-('<vcl.inline>' Line 6 Pos 13)
-        sub foo { call bar; }
-------------###--------------
-
-
-...called from "bar"
-('<vcl.inline>' Line 5 Pos 24)
+('<vcl.inline>' Line 5 Pos 13)
         sub bar { call foo; }
------------------------###---
+------------###--------------
 
 
 ...called from "foo"
@@ -80,10 +68,11 @@ Subroutine recurses on
 -----------------------###---
 
 
-...called from "vcl_recv"
-('<vcl.inline>' Line 7 Pos 29)
-        sub vcl_recv { call foo; }
-----------------------------###---
+...called from "bar"
+('<vcl.inline>' Line 5 Pos 24)
+        sub bar { call foo; }
+-----------------------###---
+
 } {
 	backend b { .host = "${localhost}"; }
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -56,6 +56,19 @@ Varnish Cache Next (2021-03-15)
 * All shard ``Error`` and ``Notice`` messages now use the unified
   prefix ``vmod_directors: shard %s``.
 
+* The ``VCL_SUB`` data type is now supported for VMODs to save
+  references to subroutines to be called later using
+  ``VRT_call()``. Calls from a wrong context (e.g. calling a
+  subroutine accessing ``req`` from the backend side) and recursive
+  calls fail the VCL.
+
+* ``VRT_check_call()`` can be used to check if a ``VRT_call()`` would
+  succeed in order to avoid the potential VCL failure in case it would
+  not.
+
+  It returns ``NULL`` if ``VRT_call()`` would make the call or an
+  error string why not.
+
 ================================
 Varnish Cache 6.5.1 (2020-09-25)
 ================================

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -460,6 +460,26 @@ TIME
 
 	An absolute time, as in 1284401161.
 
+VCL_SUB
+	C-type: ``const struct vcl_sub *``
+
+	Opaque handle on a VCL subroutine.
+
+	References to subroutines can be passed into VMODs as
+	arguments and called later through ``VRT_call()``. The scope
+	strictly is the VCL: vmods must ensure that ``VCL_SUB``
+	references never be called from a different VCL.
+
+	``VRT_call()`` fails the VCL for recursive calls and when the
+	``VCL_SUB`` can not be called from the current context
+	(e.g. calling a subroutine accessing ``req`` from the backend
+	side).
+
+	``VRT_check_call()`` can be used to check if a ``VRT_call()``
+	would succeed in order to avoid the potential VCL failure.  It
+	returns ``NULL`` if ``VRT_call()`` would make the call or an
+	error string why not.
+
 VOID
 	C-type: ``void``
 

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -81,3 +81,15 @@ struct vpi_ii {
 
 void VPI_re_init(struct vre **, const char *);
 void VPI_re_fini(struct vre *);
+
+/* VCL_SUB type */
+
+struct vcl_sub {
+	unsigned		magic;
+#define VCL_SUB_MAGIC		0x12c1750b
+	const unsigned		methods;	// ok &= ctx->method
+	const char * const	name;
+	const struct VCL_conf	*vcl_conf;
+	vcl_func_f		*func;
+	unsigned		n;
+};

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -92,4 +92,6 @@ struct vcl_sub {
 	const struct VCL_conf	*vcl_conf;
 	vcl_func_f		*func;
 	unsigned		n;
+	unsigned		nref;
+	unsigned		called;
 };

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -95,3 +95,8 @@ struct vcl_sub {
 	unsigned		nref;
 	unsigned		called;
 };
+
+enum vcl_func_fail_e VPI_Call_Check(VRT_CTX, const struct VCL_conf *conf,
+    unsigned methods, unsigned n);
+void VPI_Call_Begin(VRT_CTX, unsigned n);
+void VPI_Call_End(VRT_CTX, unsigned n);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -70,6 +70,8 @@
  *	VRT_re_fini removed
  *	VRT_re_match signature changed
  *	VRT_regsub signature changed
+ *	VRT_call() added
+ *	VRT_check_call() added
  * 12.0 (2020-09-15)
  *	Added VRT_DirectorResolve()
  *	Added VCL_STRING VRT_BLOB_string(VRT_CTX, VCL_BLOB)
@@ -339,13 +341,19 @@ struct vrt_ctx {
 #define VRT_CTX		const struct vrt_ctx *ctx
 void VRT_CTX_Assert(VRT_CTX);
 
+enum vcl_func_call_e {
+	VSUB_STATIC,	// VCL "call" action, only allowed from VCC
+	VSUB_DYNAMIC,	// VRT_call()
+	VSUB_CHECK	// VRT_check_call()
+};
+
 enum vcl_func_fail_e {
 	VSUB_E_OK,
 	VSUB_E_RECURSE, // call would recurse
 	VSUB_E_METHOD	// can not be called from this method
 };
 
-typedef void vcl_func_f(VRT_CTX);
+typedef void vcl_func_f(VRT_CTX, enum vcl_func_call_e, enum vcl_func_fail_e *);
 
 /***********************************************************************
  * This is the interface structure to a compiled VMOD
@@ -415,6 +423,10 @@ char *VRT_Strands(char *, size_t, VCL_STRANDS);
 VCL_STRING VRT_StrandsWS(struct ws *, const char *, VCL_STRANDS);
 VCL_STRING VRT_CollectStrands(VRT_CTX, VCL_STRANDS);
 VCL_STRING VRT_UpperLowerStrands(VRT_CTX, VCL_STRANDS s, int up);
+
+/* VCL_SUB */
+VCL_STRING VRT_check_call(VRT_CTX, VCL_SUB);
+VCL_VOID VRT_call(VRT_CTX, VCL_SUB);
 
 /* Functions to turn types into canonical strings */
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -211,6 +211,7 @@ struct vsc_seg;
 struct vsl_log;
 struct vsmw_cluster;
 struct ws;
+struct vcl_sub;
 
 /***********************************************************************
  * VCL_STRANDS:
@@ -283,6 +284,7 @@ typedef const struct vre *			VCL_REGEX;
 typedef const struct stevedore *		VCL_STEVEDORE;
 typedef const struct strands *			VCL_STRANDS;
 typedef const char *				VCL_STRING;
+typedef const struct vcl_sub *			VCL_SUB;
 typedef vtim_real				VCL_TIME;
 typedef struct vcl *				VCL_VCL;
 typedef void					VCL_VOID;
@@ -334,6 +336,8 @@ struct vrt_ctx {
 
 #define VRT_CTX		const struct vrt_ctx *ctx
 void VRT_CTX_Assert(VRT_CTX);
+
+typedef void vcl_func_f(VRT_CTX);
 
 /***********************************************************************
  * This is the interface structure to a compiled VMOD

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -332,6 +332,8 @@ struct vrt_ctx {
 	 *    synth+error:	struct vsb *
 	 */
 	void				*specific;
+	/* if present, vbitmap of called subs */
+	void				*called;
 };
 
 #define VRT_CTX		const struct vrt_ctx *ctx

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -339,6 +339,12 @@ struct vrt_ctx {
 #define VRT_CTX		const struct vrt_ctx *ctx
 void VRT_CTX_Assert(VRT_CTX);
 
+enum vcl_func_fail_e {
+	VSUB_E_OK,
+	VSUB_E_RECURSE, // call would recurse
+	VSUB_E_METHOD	// can not be called from this method
+};
+
 typedef void vcl_func_f(VRT_CTX);
 
 /***********************************************************************

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -666,7 +666,6 @@ fo.write("""
 typedef int vcl_event_f(VRT_CTX, enum vcl_event_e);
 typedef int vcl_init_f(VRT_CTX);
 typedef void vcl_fini_f(VRT_CTX);
-typedef void vcl_func_f(VRT_CTX);
 
 struct VCL_conf {
 	unsigned		magic;
@@ -679,6 +678,7 @@ struct VCL_conf {
 	const struct vpi_ref	*ref;
 
 	int			nsrc;
+	unsigned		nsub;
 	const char		**srcname;
 	const char		**srcbody;
 

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -53,7 +53,7 @@ vcc_act_call(struct vcc *tl, struct token *t, struct symbol *sym)
 	if (sym != NULL) {
 		vcc_AddCall(tl, t0, sym);
 		VCC_GlobalSymbol(sym, SUB, "VGC_function");
-		Fb(tl, 1, "%s(ctx);\n", sym->rname);
+		Fb(tl, 1, "%s(ctx);\n", sym->lname);
 		SkipToken(tl, ';');
 	}
 }

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -315,7 +315,7 @@ vcc_act_return_vcl(struct vcc *tl)
 static void v_matchproto_(sym_act_f)
 vcc_act_return(struct vcc *tl, struct token *t, struct symbol *sym)
 {
-	unsigned hand;
+	unsigned hand, mask;
 	const char *h;
 
 	(void)t;
@@ -335,6 +335,7 @@ vcc_act_return(struct vcc *tl, struct token *t, struct symbol *sym)
 		if (vcc_IdIs(tl->t, #l)) {		\
 			hand = VCL_RET_ ## U;		\
 			h = #U;				\
+			mask = B;			\
 		}
 #include "tbl/vcl_returns.h"
 	if (h == NULL) {
@@ -344,7 +345,7 @@ vcc_act_return(struct vcc *tl, struct token *t, struct symbol *sym)
 	}
 	assert(hand < VCL_RET_MAX);
 
-	vcc_ProcAction(tl->curproc, hand, tl->t);
+	vcc_ProcAction(tl->curproc, hand, mask, tl->t);
 	vcc_NextToken(tl);
 	if (tl->t->tok == '(') {
 		if (hand == VCL_RET_SYNTH || hand == VCL_RET_ERROR)

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -53,7 +53,8 @@ vcc_act_call(struct vcc *tl, struct token *t, struct symbol *sym)
 	if (sym != NULL) {
 		vcc_AddCall(tl, t0, sym);
 		VCC_GlobalSymbol(sym, SUB, "VGC_function");
-		Fb(tl, 1, "%s(ctx);\n", sym->lname);
+
+		Fb(tl, 1, "%s(ctx, VSUB_STATIC, NULL);\n", sym->lname);
 		SkipToken(tl, ';');
 	}
 }

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -176,6 +176,7 @@ vcc_EmitProc(struct vcc *tl, struct proc *p)
 	AZ(VSB_finish(p->cname));
 	AZ(VSB_finish(p->prologue));
 	AZ(VSB_finish(p->body));
+	AN(p->sym);
 
 	Fh(tl, 1, "vcl_func_f %s;\n", VSB_data(p->cname));
 	Fh(tl, 1, "const struct vcl_sub sub_%s[1] = {{\n",
@@ -185,7 +186,9 @@ vcc_EmitProc(struct vcc *tl, struct proc *p)
 	Fh(tl, 1, "\t.name\t\t= \"%.*s\",\n", PF(p->name));
 	Fh(tl, 1, "\t.vcl_conf\t= &VCL_conf,\n");
 	Fh(tl, 1, "\t.func\t\t= %s,\n", VSB_data(p->cname));
-	Fh(tl, 1, "\t.n\t\t= %d\n", tl->nsub++);
+	Fh(tl, 1, "\t.n\t\t= %d,\n", tl->nsub++);
+	Fh(tl, 1, "\t.nref\t\t= %d,\n", p->sym->nref);
+	Fh(tl, 1, "\t.called\t\t= %d\n", p->called);
 	Fh(tl, 1, "}};\n");
 	/*
 	 * TODO: v_dont_optimize for custom subs called from vcl_init/fini only

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -161,6 +161,7 @@ vcc_NewProc(struct vcc *tl, struct symbol *sym)
 	p->cname = VSB_new_auto();
 	AN(p->cname);
 	sym->proc = p;
+	p->sym = sym;
 	return (p);
 }
 

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -59,6 +59,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "vcc_compile.h"
 
@@ -160,6 +161,7 @@ vcc_NewProc(struct vcc *tl, struct symbol *sym)
 	AN(p->body);
 	p->cname = VSB_new_auto();
 	AN(p->cname);
+	p->okmask = VCL_MET_TASK_ALL;
 	sym->proc = p;
 	p->sym = sym;
 	return (p);
@@ -170,11 +172,21 @@ vcc_EmitProc(struct vcc *tl, struct proc *p)
 {
 	struct vsb *vsbm;
 
+	AN(p->okmask);
 	AZ(VSB_finish(p->cname));
 	AZ(VSB_finish(p->prologue));
 	AZ(VSB_finish(p->body));
 
 	Fh(tl, 1, "vcl_func_f %s;\n", VSB_data(p->cname));
+	Fh(tl, 1, "const struct vcl_sub sub_%s[1] = {{\n",
+	   VSB_data(p->cname));
+	Fh(tl, 1, "\t.magic\t\t= VCL_SUB_MAGIC,\n");
+	Fh(tl, 1, "\t.methods\t= 0x%x,\n", p->okmask);
+	Fh(tl, 1, "\t.name\t\t= \"%.*s\",\n", PF(p->name));
+	Fh(tl, 1, "\t.vcl_conf\t= &VCL_conf,\n");
+	Fh(tl, 1, "\t.func\t\t= %s,\n", VSB_data(p->cname));
+	Fh(tl, 1, "\t.n\t\t= %d\n", tl->nsub++);
+	Fh(tl, 1, "}};\n");
 	/*
 	 * TODO: v_dont_optimize for custom subs called from vcl_init/fini only
 	 *
@@ -526,6 +538,7 @@ EmitStruct(const struct vcc *tl)
 	Fc(tl, 0, "\t.ref = VGC_ref,\n");
 	Fc(tl, 0, "\t.nref = VGC_NREFS,\n");
 	Fc(tl, 0, "\t.nsrc = VGC_NSRCS,\n");
+	Fc(tl, 0, "\t.nsub = %d,\n", tl->nsub);
 	Fc(tl, 0, "\t.srcname = srcname,\n");
 	Fc(tl, 0, "\t.srcbody = srcbody,\n");
 	Fc(tl, 0, "\t.nvmod = %u,\n", tl->vmod_count);

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -200,15 +200,8 @@ vcc_EmitProc(struct vcc *tl, struct proc *p)
 	Fh(tl, 1, "\t.nref\t\t= %d,\n", p->sym->nref);
 	Fh(tl, 1, "\t.called\t\t= %d\n", p->called);
 	Fh(tl, 1, "}};\n");
-	/*
-	 * TODO: v_dont_optimize for custom subs called from vcl_init/fini only
-	 *
-	 * Needs infrastructure similar to that in #3163 : custom subs need a
-	 * mask containing the builtin subs calling the custom sub. If that is
-	 * no larger than VCL_MET_TASK_H, we can enable v_dont_optimize
-	 */
 	Fc(tl, 1, "\nvoid %sv_matchproto_(vcl_func_f)\n",
-	   p->method && p->method->bitval & VCL_MET_TASK_H ?
+	   ((mask & VCL_MET_TASK_H) && (mask & ~VCL_MET_TASK_H) == 0) ?
 	   "v_dont_optimize " : "");
 	Fc(tl, 1, "%s(VRT_CTX)\n{\n", VSB_data(p->cname));
 	vsbm = VSB_new_auto();

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -538,7 +538,7 @@ EmitStruct(const struct vcc *tl)
 	Fc(tl, 0, "\t.ref = VGC_ref,\n");
 	Fc(tl, 0, "\t.nref = VGC_NREFS,\n");
 	Fc(tl, 0, "\t.nsrc = VGC_NSRCS,\n");
-	Fc(tl, 0, "\t.nsub = %d,\n", tl->nsub);
+	Fc(tl, 0, "\t.nsub = %d,\n", tl->subref > 0 ? tl->nsub : 0);
 	Fc(tl, 0, "\t.srcname = srcname,\n");
 	Fc(tl, 0, "\t.srcbody = srcbody,\n");
 	Fc(tl, 0, "\t.nvmod = %u,\n", tl->vmod_count);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -215,6 +215,7 @@ struct proc {
 	struct vsb		*cname;
 	struct vsb		*prologue;
 	struct vsb		*body;
+	struct symbol		*sym;
 };
 
 struct inifin {

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -211,6 +211,7 @@ struct proc {
 	unsigned		ret_bitmap;
 	unsigned		called;
 	unsigned		active;
+	unsigned		okmask;
 	struct token		*return_tok[VCL_RET_MAX];
 	struct vsb		*cname;
 	struct vsb		*prologue;
@@ -265,6 +266,7 @@ struct vcc {
 						 */
 	struct vsb		*sb;
 	int			err;
+	unsigned		nsub;
 	struct proc		*curproc;
 	VTAILQ_HEAD(, proc)	procs;
 
@@ -427,7 +429,7 @@ void VCC_InstanceInfo(struct vcc *tl);
 void VCC_XrefTable(struct vcc *);
 
 void vcc_AddCall(struct vcc *, struct token *, struct symbol *);
-void vcc_ProcAction(struct proc *p, unsigned action, struct token *t);
+void vcc_ProcAction(struct proc *, unsigned, unsigned, struct token *);
 int vcc_CheckAction(struct vcc *tl);
 
 

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -267,6 +267,7 @@ struct vcc {
 	struct vsb		*sb;
 	int			err;
 	unsigned		nsub;
+	unsigned		subref;	// SUB arguments present
 	struct proc		*curproc;
 	VTAILQ_HEAD(, proc)	procs;
 

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -446,6 +446,8 @@ vcc_do_arg(struct vcc *tl, struct func_arg *fa)
 		vcc_do_enum(tl, fa, PF(tl->t));
 		SkipToken(tl, ID);
 	} else {
+		if (fa->type == SUB)
+			tl->subref++;
 		vcc_expr0(tl, &e2, fa->type);
 		ERRCHK(tl);
 		assert(e2->fmt == fa->type);

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -251,7 +251,7 @@ vcc_ParseFunction(struct vcc *tl)
 		VCC_GlobalSymbol(sym, SUB, "VGC_function");
 		p = vcc_NewProc(tl, sym);
 		p->name = t;
-		VSB_printf(p->cname, "%s", sym->rname);
+		VSB_printf(p->cname, "%s", sym->lname);
 	} else if (p->method == NULL) {
 		VSB_printf(tl->sb, "Subroutine '%s' redefined\n", sym->name);
 		vcc_ErrWhere(tl, t);

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -471,6 +471,14 @@ VCC_GlobalSymbol(struct symbol *sym, vcc_type_t type, const char *pfx)
 	VSB_printf(vsb, "%s_", pfx);
 	VCC_PrintCName(vsb, sym->name, NULL);
 	AZ(VSB_finish(vsb));
+	sym->lname = strdup(VSB_data(vsb));
+	if (type == SUB) {
+		VSB_destroy(&vsb);
+		vsb = VSB_new_auto();
+		AN(vsb);
+		VSB_printf(vsb, "sub_%s", sym->lname);
+		AZ(VSB_finish(vsb));
+	}
 	sym->rname = strdup(VSB_data(vsb));
 	AN(sym->rname);
 	VSB_destroy(&vsb);

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -195,6 +195,10 @@ vcc_CheckActionRecurse(struct vcc *tl, struct proc *p, unsigned bitmap)
 		vcc_ErrWhere(tl, p->name);
 		return (1);
 	}
+
+	// more references than calls -> sub is referenced for dynamic calls
+	u = (p->sym->nref > p->called);
+
 	p->active = 1;
 	VTAILQ_FOREACH(pc, &p->calls, list) {
 		if (pc->sym->proc == NULL) {
@@ -204,6 +208,7 @@ vcc_CheckActionRecurse(struct vcc *tl, struct proc *p, unsigned bitmap)
 			return (1);
 		}
 		pc->sym->proc->called++;
+		pc->sym->nref += u;
 		if (vcc_CheckActionRecurse(tl, pc->sym->proc, bitmap)) {
 			VSB_printf(tl->sb, "\n...called from \"%.*s\"\n",
 			    PF(p->name));

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -161,11 +161,12 @@ vcc_AddCall(struct vcc *tl, struct token *t, struct symbol *sym)
 }
 
 void
-vcc_ProcAction(struct proc *p, unsigned returns, struct token *t)
+vcc_ProcAction(struct proc *p, unsigned returns, unsigned mask, struct token *t)
 {
 
 	assert(returns < VCL_RET_MAX);
 	p->ret_bitmap |= (1U << returns);
+	p->okmask &= mask;
 	/* Record the first instance of this return */
 	if (p->return_tok[returns] == NULL)
 		p->return_tok[returns] = t;
@@ -212,6 +213,7 @@ vcc_CheckActionRecurse(struct vcc *tl, struct proc *p, unsigned bitmap)
 			vcc_ErrWhere(tl, pc->t);
 			return (1);
 		}
+		p->okmask &= pc->sym->proc->okmask;
 	}
 	p->active = 0;
 	p->called++;
@@ -279,22 +281,27 @@ vcc_illegal_write(struct vcc *tl, struct procuse *pu, const struct method *m)
 }
 
 static struct procuse *
-vcc_FindIllegalUse(struct vcc *tl, const struct proc *p, const struct method *m)
+vcc_FindIllegalUse(struct vcc *tl, struct proc *p, const struct method *m)
 {
-	struct procuse *pu, *pw;
+	struct procuse *pu, *pw, *r = NULL;
 
 	VTAILQ_FOREACH(pu, &p->uses, list) {
+		p->okmask &= pu->mask;
+		if (m == NULL)
+			continue;
 		pw = vcc_illegal_write(tl, pu, m);
+		if (r != NULL)
+			continue;
 		if (tl->err)
-			return (pw);
-		if (!(pu->mask & m->bitval))
-			return (pu);
+			r = pw;
+		else if (!(pu->mask & m->bitval))
+			r = pu;
 	}
-	return (NULL);
+	return (r);
 }
 
 static int
-vcc_CheckUseRecurse(struct vcc *tl, const struct proc *p,
+vcc_CheckUseRecurse(struct vcc *tl, struct proc *p,
     const struct method *m)
 {
 	struct proccall *pc;
@@ -319,6 +326,7 @@ vcc_CheckUseRecurse(struct vcc *tl, const struct proc *p,
 			vcc_ErrWhere(tl, pc->t);
 			return (1);
 		}
+		p->okmask &= pc->sym->proc->okmask;
 	}
 	return (0);
 }
@@ -331,8 +339,6 @@ vcc_checkuses(struct vcc *tl, const struct symbol *sym)
 
 	p = sym->proc;
 	AN(p);
-	if (p->method == NULL)
-		return;
 	pu = vcc_FindIllegalUse(tl, p, p->method);
 	if (pu != NULL) {
 		vcc_ErrWhere2(tl, pu->t1, pu->t2);

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -203,6 +203,7 @@ vcc_CheckActionRecurse(struct vcc *tl, struct proc *p, unsigned bitmap)
 			vcc_ErrWhere(tl, pc->t);
 			return (1);
 		}
+		pc->sym->proc->called++;
 		if (vcc_CheckActionRecurse(tl, pc->sym->proc, bitmap)) {
 			VSB_printf(tl->sb, "\n...called from \"%.*s\"\n",
 			    PF(p->name));
@@ -212,7 +213,6 @@ vcc_CheckActionRecurse(struct vcc *tl, struct proc *p, unsigned bitmap)
 		p->okmask &= pc->sym->proc->okmask;
 	}
 	p->active = 0;
-	p->called++;
 	return (0);
 }
 

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -115,6 +115,7 @@ CTYPES = {
     'STRANDS':     "VCL_STRANDS",
     'STRING':      "VCL_STRING",
     'STRING_LIST': "const char *, ...",
+    'SUB':         "VCL_SUB",
     'TIME':        "VCL_TIME",
     'VOID':        "VCL_VOID",
 }

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1309,3 +1309,25 @@ xyzzy_check_call(VRT_CTX, VCL_SUB sub)
 {
 	return (VRT_check_call(ctx, sub));
 }
+
+/* the next two are to test WRONG vmod behavior:
+ * holding a VCL_SUB reference across vcls
+ */
+
+static VCL_SUB wrong = NULL;
+
+VCL_VOID v_matchproto_(td_xyzzy_bad_memory)
+xyzzy_bad_memory(VRT_CTX, VCL_SUB sub)
+{
+	(void) ctx;
+
+	wrong = sub;
+}
+
+VCL_SUB v_matchproto_(td_xyzzy_total_recall)
+xyzzy_total_recall(VRT_CTX)
+{
+	(void) ctx;
+
+	return (wrong);
+}

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1295,3 +1295,17 @@ xyzzy_just_return_regex(VRT_CTX, VCL_REGEX r)
 	AN(r);
 	return (r);
 }
+
+/*---------------------------------------------------------------------*/
+
+VCL_VOID v_matchproto_(td_xyzzy_call)
+xyzzy_call(VRT_CTX, VCL_SUB sub)
+{
+	VRT_call(ctx, sub);
+}
+
+VCL_STRING v_matchproto_(td_xyzzy_check_call)
+xyzzy_check_call(VRT_CTX, VCL_SUB sub)
+{
+	return (VRT_check_call(ctx, sub));
+}

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -332,3 +332,11 @@ string saying why not.
 $Function VOID call(SUB)
 
 Call a sub
+
+$Function VOID bad_memory(SUB)
+
+To test *WRONG* behavior
+
+$Function SUB total_recall()
+
+To test *WRONG* behavior

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -323,3 +323,12 @@ Test if the argument is a valid header according to RFC7230 section 3.2.
 $Function REGEX just_return_regex(REGEX)
 
 Take a REGEX argument and return it.
+
+$Function STRING check_call(SUB)
+
+Check if a sub can be called. Returns the NULL string if yes, or a
+string saying why not.
+
+$Function VOID call(SUB)
+
+Call a sub


### PR DESCRIPTION
use case
-----------

This PR implements a vmod type for vcl subs with the goal of being able to use vcl subs as parameters to vmod function/method calls, which allows them to call back into VCL subs. The primary, obvious use case is a clean interface for [vmod_dispatch](https://code.uplex.de/uplex-varnish/libvmod-dispatch). Another use case I have in mind would be the option to add iterator vmod functions, for example to tokenize a string and call a sub for each token with a task variable set.

implementation
--------------------

We add to VRT and initialize for each vcl sub a `struct vcl_sub` which contains:

* a methods bitmask defining which contexts this sub may be called from
* the name as seen from vcl
* the function pointer to the `vcl_func_f`

As the latter two are trivial, I will only go into detail about the methods bitmask:

It contains the `VCL_MET_*` bits of contexts which may potentially call this sub and is intended for later use with checks like

```
if (sub->methods & ctx->method)
    sub->func(ctx);
else
    VRT_fail(ctx, "not allowed here");
```

(see also `vmod_debug` poc code from the second commit) 

In existing code, we check if used objects and returned actions are allowed within the respective calling context.

To build the methods bitmask, we now begin with an all-one bitfield and clear the bits of methods which would not be allowed for any used object or returned action.

vcc interface
----------------

for the VCC interface, we keep the VCL sub c function name in the symbol's `lname`, and put the pointer to the `struct vcl_sub` in the `rname`. This way, we require only a few additional changes and I believe that the semantics match: The "assignable" name is the c function name, while any read access to a VCL sub has to go through the "read" name.
