### PR TITLE
Fix bug in probe heap comparison function - backport

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -696,8 +696,8 @@ vbp_cmp(void *priv, const void *a, const void *b)
 	CAST_OBJ_NOTNULL(aa, a, VBP_TARGET_MAGIC);
 	CAST_OBJ_NOTNULL(bb, b, VBP_TARGET_MAGIC);
 
-	if (aa->running && !bb->running)
-		return (0);
+	if ((aa->running == 0) != (bb->running == 0))
+		return (aa->running == 0);
 
 	return (aa->due < bb->due);
 }


### PR DESCRIPTION
cherry-pick from f402e5ff3063026f6ac779295b318da491a934a9