### PR TITLE
Defer the illegal write check a bit

### DIFF
--- a/bin/varnishtest/tests/v00021.vtc
+++ b/bin/varnishtest/tests/v00021.vtc
@@ -2,14 +2,26 @@ varnishtest "VCL compiler coverage test: vcc_xref.c vcc_var.c vcc_symb.c"
 
 varnish v1 -errvcl {Variable is read only.} {
 	backend b { .host = "127.0.0.1"; }
-	sub vcl_recv { set obj.ttl = 1 w; }
+	sub vcl_deliver { set obj.ttl = 1 w; }
 }
 
 varnish v1 -errvcl {Variable is read only.} {
 	backend b { .host = "127.0.0.1"; }
 
 	sub foo { set obj.ttl = 1 w; }
-	sub vcl_recv { call foo ; }
+	sub vcl_deliver { call foo; }
+}
+
+varnish v1 -errvcl {Not available in subroutine 'vcl_recv'.} {
+	backend b { .host = "127.0.0.1"; }
+	sub vcl_recv { set obj.ttl = 1 w; }
+}
+
+varnish v1 -errvcl {Not available from subroutine 'vcl_recv'.} {
+	backend b { .host = "127.0.0.1"; }
+
+	sub foo { set obj.ttl = 1 w; }
+	sub vcl_recv { call foo; }
 }
 
 varnish v1 -errvcl "Symbol not found" {

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -125,15 +125,8 @@ vcc_act_set(struct vcc *tl, struct token *t, struct symbol *sym)
 	sym = VCC_SymbolGet(tl, SYM_VAR, SYMTAB_EXISTING, XREF_NONE);
 	ERRCHK(tl);
 	AN(sym);
-	if (sym->w_methods == 0) {
-		vcc_ErrWhere2(tl, t, tl->t);
-		if (sym->r_methods != 0)
-			VSB_printf(tl->sb, "Variable is read only.\n");
-		else
-			VSB_printf(tl->sb, "Variable cannot be set.\n");
-		return;
-	}
 	vcc_AddUses(tl, t, tl->t, sym, XREF_WRITE);
+	ERRCHK(tl);
 	type = sym->type;
 	for (ap = assign; ap->type != VOID; ap++) {
 		if (ap->type != type)

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -133,7 +133,7 @@ vcc_act_set(struct vcc *tl, struct token *t, struct symbol *sym)
 			VSB_printf(tl->sb, "Variable cannot be set.\n");
 		return;
 	}
-	vcc_AddUses(tl, t, tl->t, sym->w_methods, "Cannot be set");
+	vcc_AddUses(tl, t, tl->t, sym, XREF_WRITE);
 	type = sym->type;
 	for (ap = assign; ap->type != VOID; ap++) {
 		if (ap->type != type)
@@ -175,7 +175,7 @@ vcc_act_unset(struct vcc *tl, struct token *t, struct symbol *sym)
 		VSB_printf(tl->sb, "Variable cannot be unset.\n");
 		return;
 	}
-	vcc_AddUses(tl, t, tl->t, sym->u_methods, "Cannot be unset");
+	vcc_AddUses(tl, t, tl->t, sym, XREF_UNSET);
 	Fb(tl, 1, "%s;\n", sym->uname);
 	SkipToken(tl, ';');
 }

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -403,8 +403,16 @@ void VCC_XrefTable(struct vcc *);
 void vcc_AddCall(struct vcc *, struct token *, struct symbol *);
 void vcc_ProcAction(struct proc *p, unsigned action, struct token *t);
 int vcc_CheckAction(struct vcc *tl);
+
+
+struct xrefuse { const char *name, *err; };
+extern const struct xrefuse XREF_READ[1];
+extern const struct xrefuse XREF_WRITE[1];
+extern const struct xrefuse XREF_UNSET[1];
+extern const struct xrefuse XREF_ACTION[1];
+
 void vcc_AddUses(struct vcc *, const struct token *, const struct token *,
-     unsigned mask, const char *use);
+    const struct symbol *sym, const struct xrefuse *use);
 int vcc_CheckUses(struct vcc *tl);
 const char *vcc_MarkPriv(struct vcc *, struct procprivhead *,
     const char *);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -339,7 +339,7 @@ vcc_Eval_Var(struct vcc *tl, struct expr **e, struct token *t,
 
 	(void)type;
 	assert(sym->kind == SYM_VAR);
-	vcc_AddUses(tl, t, NULL, sym->r_methods, "Not available");
+	vcc_AddUses(tl, t, NULL, sym, XREF_READ);
 	ERRCHK(tl);
 	*e = vcc_mk_expr(sym->type, "%s", sym->rname);
 	(*e)->constant = EXPR_VAR;

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -194,9 +194,7 @@ vcc_Compound(struct vcc *tl)
 				return;
 			}
 			if (sym->action_mask != 0)
-				vcc_AddUses(tl, t, NULL,
-				    sym->action_mask,
-				    "Not a valid action");
+				vcc_AddUses(tl, t, NULL, sym, XREF_ACTION);
 			sym->action(tl, t, sym);
 			break;
 		default:

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -137,6 +137,9 @@ vcc_AddUses(struct vcc *tl, const struct token *t1, const struct token *t2,
 		WRONG("wrong xref use");
 
 	VTAILQ_INSERT_TAIL(&tl->curproc->uses, pu, list);
+
+	if (pu->mask == 0)
+		vcc_CheckUses(tl);
 }
 
 void
@@ -249,13 +252,40 @@ vcc_CheckAction(struct vcc *tl)
 /*--------------------------------------------------------------------*/
 
 static struct procuse *
-vcc_FindIllegalUse(const struct proc *p, const struct method *m)
+vcc_illegal_write(struct vcc *tl, struct procuse *pu, const struct method *m)
 {
-	struct procuse *pu;
 
-	VTAILQ_FOREACH(pu, &p->uses, list)
+	if (pu->mask || pu->use != XREF_WRITE)
+		return (NULL);
+
+	if (pu->sym->r_methods == 0) {
+		vcc_ErrWhere2(tl, pu->t1, pu->t2);
+		VSB_printf(tl->sb, "Variable cannot be set.\n");
+		return (NULL);
+	}
+
+	if (!(pu->sym->r_methods & m->bitval)) {
+		pu->use = XREF_READ; /* NB: change the error message. */
+		return (pu);
+	}
+
+	vcc_ErrWhere2(tl, pu->t1, pu->t2);
+	VSB_printf(tl->sb, "Variable is read only.\n");
+	return (NULL);
+}
+
+static struct procuse *
+vcc_FindIllegalUse(struct vcc *tl, const struct proc *p, const struct method *m)
+{
+	struct procuse *pu, *pw;
+
+	VTAILQ_FOREACH(pu, &p->uses, list) {
+		pw = vcc_illegal_write(tl, pu, m);
+		if (tl->err)
+			return (pw);
 		if (!(pu->mask & m->bitval))
 			return (pu);
+	}
 	return (NULL);
 }
 
@@ -266,7 +296,7 @@ vcc_CheckUseRecurse(struct vcc *tl, const struct proc *p,
 	struct proccall *pc;
 	struct procuse *pu;
 
-	pu = vcc_FindIllegalUse(p, m);
+	pu = vcc_FindIllegalUse(tl, p, m);
 	if (pu != NULL) {
 		vcc_ErrWhere2(tl, pu->t1, pu->t2);
 		VSB_printf(tl->sb, "%s from subroutine '%s'.\n",
@@ -276,6 +306,8 @@ vcc_CheckUseRecurse(struct vcc *tl, const struct proc *p,
 		vcc_ErrWhere(tl, p->name);
 		return (1);
 	}
+	if (tl->err)
+		return (1);
 	VTAILQ_FOREACH(pc, &p->calls, list) {
 		if (vcc_CheckUseRecurse(tl, pc->sym->proc, m)) {
 			VSB_printf(tl->sb, "\n...called from \"%.*s\"\n",
@@ -297,7 +329,7 @@ vcc_checkuses(struct vcc *tl, const struct symbol *sym)
 	AN(p);
 	if (p->method == NULL)
 		return;
-	pu = vcc_FindIllegalUse(p, p->method);
+	pu = vcc_FindIllegalUse(tl, p, p->method);
 	if (pu != NULL) {
 		vcc_ErrWhere2(tl, pu->t1, pu->t2);
 		VSB_printf(tl->sb, "%s in subroutine '%.*s'.",
@@ -305,6 +337,7 @@ vcc_checkuses(struct vcc *tl, const struct symbol *sym)
 		VSB_cat(tl->sb, "\nAt: ");
 		return;
 	}
+	ERRCHK(tl);
 	if (vcc_CheckUseRecurse(tl, p, p->method)) {
 		VSB_printf(tl->sb,
 		    "\n...which is the \"%s\" subroutine\n", p->method->name);

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -55,8 +55,9 @@ struct procuse {
 	VTAILQ_ENTRY(procuse)	list;
 	const struct token	*t1;
 	const struct token	*t2;
+	const struct symbol	*sym;
+	const struct xrefuse	*use;
 	unsigned		mask;
-	const char		*use;
 	struct proc		*fm;
 };
 
@@ -100,22 +101,41 @@ vcc_CheckReferences(struct vcc *tl)
  * Returns checks
  */
 
+const struct xrefuse XREF_READ[1] = {{"xref_read", "Not available"}};
+const struct xrefuse XREF_WRITE[1] = {{"xref_write", "Cannot be set"}};
+const struct xrefuse XREF_UNSET[1] = {{"xref_unset", "Cannot be unset"}};
+const struct xrefuse XREF_ACTION[1] = {{"xref_action", "Not a valid action"}};
+
 void
 vcc_AddUses(struct vcc *tl, const struct token *t1, const struct token *t2,
-    unsigned mask, const char *use)
+    const struct symbol *sym, const struct xrefuse *use)
 {
 	struct procuse *pu;
 
 	AN(tl->curproc);
 	pu = TlAlloc(tl, sizeof *pu);
 	AN(pu);
+	AN(sym);
+	AN(use);
 	pu->t1 = t1;
 	pu->t2 = t2;
 	if (pu->t2 == NULL)
 		pu->t2 = VTAILQ_NEXT(t1, list);
-	pu->mask = mask;
+	pu->sym = sym;
 	pu->use = use;
 	pu->fm = tl->curproc;
+
+	if (pu->use == XREF_READ)
+		pu->mask = sym->r_methods;
+	else if (pu->use == XREF_WRITE)
+		pu->mask = sym->w_methods;
+	else if (pu->use == XREF_UNSET)
+		pu->mask = sym->u_methods;
+	else if (pu->use == XREF_ACTION)
+		pu->mask = sym->action_mask;
+	else
+		WRONG("wrong xref use");
+
 	VTAILQ_INSERT_TAIL(&tl->curproc->uses, pu, list);
 }
 
@@ -250,7 +270,7 @@ vcc_CheckUseRecurse(struct vcc *tl, const struct proc *p,
 	if (pu != NULL) {
 		vcc_ErrWhere2(tl, pu->t1, pu->t2);
 		VSB_printf(tl->sb, "%s from subroutine '%s'.\n",
-		    pu->use, m->name);
+		    pu->use->err, m->name);
 		VSB_printf(tl->sb, "\n...in subroutine \"%.*s\"\n",
 		    PF(pu->fm->name));
 		vcc_ErrWhere(tl, p->name);
@@ -281,7 +301,7 @@ vcc_checkuses(struct vcc *tl, const struct symbol *sym)
 	if (pu != NULL) {
 		vcc_ErrWhere2(tl, pu->t1, pu->t2);
 		VSB_printf(tl->sb, "%s in subroutine '%.*s'.",
-		    pu->use, PF(p->name));
+		    pu->use->err, PF(p->name));
 		VSB_cat(tl->sb, "\nAt: ");
 		return;
 	}


### PR DESCRIPTION
After the initial discussion from #3163, and looking more closely at how
variable access is handled in subroutines I noticed a discrepancy.

Setting a read only variable like `obj.ttl` in `vcl_recv` would result in
a misleading error message explaining that it is read only, instead of
simply not available.

This change defers the illegal write check, registering unconditionally
that the symbol was used in a set action. As a result we always get the
correct error message but depending on whether this is happening in a
vcl_ or custom subroutine we either get "in method" or "from method" in
the error message. A minor discrepancy probably worth getting rid of the
prior inconsistency.

This is covered by the v21 test case.