### PR TITLE
Backport backend none 60 vcc warning fix - 6.0

### DIFF
--- a/bin/varnishtest/tests/v00060.vtc
+++ b/bin/varnishtest/tests/v00060.vtc
@@ -43,3 +43,9 @@ client c1 {
 	rxresp
 	expect resp.status == 503
 } -run
+
+varnish v1 -cliok "param.set vcc_err_unref off"
+varnish v1 -vcl {
+	backend bad { .host = "${bad_backend}"; }
+	backend nil none;
+}

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -330,6 +330,9 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 		Fb(tl, 0, "\n\t%s = (NULL);\n", vgcname);
 		vcc_NextToken(tl);
 		SkipToken(tl, ';');
+		ifp = New_IniFin(tl);
+		VSB_printf(ifp->ini, "\t(void)%s;\n", vgcname);
+		VSB_printf(ifp->fin, "\t\t(void)%s;\n", vgcname);
 		return;
 	}
 


### PR DESCRIPTION
Cherry-picked from 3ff7628628b0c1fb846fd86576bd1c9048517251