### PR TITLE
Expose the master and worker PIDs via the CLI

### DIFF
--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -667,6 +667,31 @@ MCH_Running(void)
  */
 
 static void v_matchproto_(cli_func_t)
+mch_pid(struct cli *cli, const char * const *av, void *priv)
+{
+
+	(void)av;
+	(void)priv;
+	VCLI_Out(cli, "Master: %10jd\n", (intmax_t)getpid());
+	if (!MCH_Running())
+		return;
+	VCLI_Out(cli, "Worker: %10jd\n", (intmax_t)child_pid);
+}
+
+static void v_matchproto_(cli_func_t)
+mch_pid_json(struct cli *cli, const char * const *av, void *priv)
+{
+
+	(void)priv;
+	VCLI_JSON_begin(cli, 2, av);
+	VCLI_Out(cli, ",\n  {\"master\": %jd", (intmax_t)getpid());
+	if (MCH_Running())
+		VCLI_Out(cli, ", \"worker\": %jd", (intmax_t)child_pid);
+	VCLI_Out(cli, "}");
+	VCLI_JSON_end(cli);
+}
+
+static void v_matchproto_(cli_func_t)
 mch_cli_server_start(struct cli *cli, const char * const *av, void *priv)
 {
 
@@ -725,6 +750,7 @@ static struct cli_proto cli_mch[] = {
 	{ CLICMD_PANIC_SHOW,		"", mch_cli_panic_show,
 	  mch_cli_panic_show_json },
 	{ CLICMD_PANIC_CLEAR,		"", mch_cli_panic_clear },
+	{ CLICMD_PID,			"", mch_pid, mch_pid_json },
 	{ NULL }
 };
 

--- a/bin/varnishtest/tests/b00071.vtc
+++ b/bin/varnishtest/tests/b00071.vtc
@@ -1,0 +1,9 @@
+varnishtest "varnish-cli pid command"
+
+varnish v1 -cliexpect "^Master: +[0-9]+\n$" pid
+varnish v1 -cliok "pid -j"
+
+varnish v1 -vcl {backend be none;} -start
+
+varnish v1 -cliexpect "^Master: +[0-9]+\nWorker: +[0-9]+\n$" pid
+varnish v1 -cliok "pid -j"

--- a/bin/varnishtest/tests/u00011.vtc
+++ b/bin/varnishtest/tests/u00011.vtc
@@ -18,7 +18,7 @@ process p1 -log {varnishadm -n ${v1_name}} -start
 
 process p1 -expect-text 0 1 "Type 'quit' to close CLI session."
 
-process p1 -write "pi\t\r"
+process p1 -write "pin\t\r"
 
 process p1 -expect-text 0 1 "PONG"
 

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -400,6 +400,14 @@ CLI_CMD(STORAGE_LIST,
 	0, 0
 )
 
+CLI_CMD(PID,
+	"pid",
+	"pid [-j]",
+	"Show the pid of the master process, and the worker if it's running.",
+	"  ``-j`` specifies JSON output.",
+	0, 0
+)
+
 #undef CLI_CMD
 
 /*lint -restore */


### PR DESCRIPTION
I felt a bit embarrassed by this email from @carlosabalde:

https://varnish-cache.org/lists/pipermail/varnish-misc/2019-December/026767.html