### PR TITLE
Stop pretending we are cool with cooling backends

### DIFF
--- a/bin/varnishtest/tests/v00063.vtc
+++ b/bin/varnishtest/tests/v00063.vtc
@@ -7,14 +7,31 @@ varnish v1 -expectexit 0x20
 varnish v1 -vcl+backend {
 	import debug;
 	sub vcl_init {
-		debug.cold_backend();
+		debug.cold_backend(); # prevents COOLING state
 	}
 } -start
 
 # load and use a new VCL
 varnish v1 -vcl+backend {}
 
-# expect a panic during the COLD event
+# expect a panic during the COLD event, COLD state
 varnish v1 -clierr 400 "vcl.state vcl1 cold"
+varnish v1 -cliexpect "Dynamic Backends can only be added to warm VCLs" panic.show
+varnish v1 -cliok panic.clear
+
+varnish v1 -cliok vcl.list
+
+varnish v1 -vcl+backend {
+	import debug;
+	sub vcl_init {
+		debug.cooling_backend(); # expects COOLING state
+	}
+} -start
+
+# switch the active VCL back to vcl2
+varnish v1 -cliok "vcl.use vcl2"
+
+# expect a panic during the COLD event, COOLING state
+varnish v1 -clierr 400 "vcl.state vcl3 cold"
 varnish v1 -cliexpect "Dynamic Backends can only be added to warm VCLs" panic.show
 varnish v1 -cliok panic.clear

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -256,6 +256,12 @@ Allow VCL to go cold.
 $Function VOID cold_backend(PRIV_VCL)
 
 Schedule a backend creation attempt when the VCL cools down, panic guaranteed.
+This variant does it while the VCL is in COLD state.
+
+$Function VOID cooling_backend(PRIV_VCL)
+
+Schedule a backend creation attempt when the VCL cools down, panic guaranteed.
+This variant does it while the VCL is in COOLING state.
 
 $Function VOID sndbuf(BYTES sndbuf)
 


### PR DESCRIPTION
As I was trying to add test coverage for the lines this patch removes I
did some research and realized this was actually dead code.

Consider the state machine from 57a5b9c78f66:

      .----------W>---------------.
      |              .--W>---.    v
    init ---> cold --|       |-- warm --.
              ^  ^   '---<C--'    |     |
              |  |                |     |
              |  '--- cooling <C--'     |
              |         ^               |
              |         C               |
              |         |    .---<---.  |
              '--<C-- busy --|       |--'
                             '--->---'

It says:

> The transitions marked with a 'W' or a 'C' are the ones dispatching
> WARM and COLD events respectively.
>
> Since the "busy" state is considered warm, VMODs should operate as
> such and backend creation remains possible.

In other words, when we first ran into backend creation problems with
regards to VCL temperature, it was because signals would be sent whether
the VCL would still have ongoing transactions or not, and this was fixed
by the introduction of the busy state. It was not the intention _then_
to allow backend creation in the COOLING state.

The result is that a COLD event is only dispatched when the VCL can
effectively cool down, so any VMOD creating backends in the event
function must make sure to only do it for INIT or WARM events, and any
VMOD doing asynchronous backend creation (outside of a formal VCL task)
should have some form of synchronization between its event function and
the thread creating backends, because once a COLD event is dispatched we
are effectively forbidden from doing any "warm" operation.

The COOLING state can only be reached when a VMOD holds a VCL reference
and could not otherwise transition immediately to the COLD state. This
prevents varnishd from pulling the rug under the VMOD's feet.

It is possible to add a director in the cooling state and get away with
it, but if the director in question is a VBE backend we run into two
problems: vbe_destroy expects to run in the CLI thread, and lifting the
constraint would then let the backend try to remove it self from a list
it never entered. This is a guaranteed panic, pick your flavor...

Instead of "fixing" the code as described above to tolerate a backend
creation that is guaranteed to fail in the COOLING state, we should
rather enforce that COLD events mean the end of resource creation until
the next WARM event, and that VMODs should behave accordingly.