### PR TITLE
RFC: Allow acceptor tasks to bail out earlier

### DIFF
--- a/bin/varnishd/cache/cache_pool.c
+++ b/bin/varnishd/cache/cache_pool.c
@@ -227,6 +227,7 @@ pool_poolherder(void *priv)
 			free(ppx->a_stat);
 			free(ppx->b_stat);
 			SES_DestroyPool(ppx);
+			Lck_Delete(&ppx->mtx);
 			FREE_OBJ(ppx);
 			VSC_C_main->pools--;
 		}


### PR DESCRIPTION
This is an attempt at solving the fundamental problem with thread pool
removal. In order to avoid a situation where an acceptor task might be
"stuck" forever in an accept call we poll the socket to get a periodic
chance to check the pool status.

To avoid the race between poll(2) and accept(2) we need the socket to
be non-blocking at this moment. If two acceptors compete for the same
connection one of them may go back to polling the socket.

This fixes the two memory leaks reported by ASAN for c80.

Refs 656982a5cf7042a8576c2e9d48defcd25d749fbd

---

After I took care of the `varnishtest` memory leaks I was aware of, I started looking at leaks from `varnishd` and the first one I ran into happened to be tricky... This patch is purely theoretical and has seen no real-world workloads.