### PR TITLE
Reshape the HTTP/1 send loop

### DIFF
--- a/bin/varnishd/http1/cache_http1.h
+++ b/bin/varnishd/http1/cache_http1.h
@@ -60,6 +60,6 @@ void V1L_Chunked(const struct worker *w);
 void V1L_EndChunk(const struct worker *w);
 void V1L_Open(struct worker *, struct ws *, int *fd, struct vsl_log *,
     vtim_real deadline, unsigned niov);
-unsigned V1L_Flush(const struct worker *w);
-unsigned V1L_Close(struct worker *w, uint64_t *cnt);
+enum sess_close V1L_Flush(const struct worker *w);
+enum sess_close V1L_Close(struct worker *w, uint64_t *cnt);
 size_t V1L_Write(const struct worker *w, const void *ptr, ssize_t len);

--- a/bin/varnishtest/tests/s00010.vtc
+++ b/bin/varnishtest/tests/s00010.vtc
@@ -12,6 +12,7 @@ server s1 {
 
 varnish v1				\
 	-arg "-p debug=+flush_head"	\
+	-arg "-p thread_pools=1"	\
 	-arg "-p timeout_idle=1"	\
 	-arg "-p idle_send_timeout=.1"	\
 	-arg "-p send_timeout=.1"	\
@@ -25,7 +26,8 @@ varnish v1				\
 } -start
 
 logexpect l1 -v v1 {
-	expect * * Debug "Hit total send timeout"
+	expect * 1001 Debug	"Hit total send timeout"
+	expect * 1000 SessClose	TX_ERROR
 } -start
 
 client c1 -rcvbuf 128 {
@@ -45,7 +47,8 @@ varnish v1 -cliok "param.set idle_send_timeout 1"
 varnish v1 -cliok "param.reset send_timeout"
 
 logexpect l2 -v v1 {
-	expect * * Debug "Hit idle send timeout"
+	expect * 1004 Debug	"Hit idle send timeout"
+	expect * 1003 SessClose	TX_ERROR
 } -start
 
 client c1 -run

--- a/bin/varnishtest/tests/s00010.vtc
+++ b/bin/varnishtest/tests/s00010.vtc
@@ -11,6 +11,7 @@ server s1 {
 } -start
 
 varnish v1				\
+	-arg "-p debug=+flush_head"	\
 	-arg "-p timeout_idle=1"	\
 	-arg "-p idle_send_timeout=.1"	\
 	-arg "-p send_timeout=.1"	\
@@ -31,8 +32,10 @@ client c1 -rcvbuf 128 {
 	txreq
 	non_fatal
 	rxresphdrs
-	# keep the session open for 4 seconds
+	# keep the session open
 	delay 4
+	# avoid a broken pipe
+	rxrespbody
 } -start
 
 client c1 -wait
@@ -45,12 +48,5 @@ logexpect l2 -v v1 {
 	expect * * Debug "Hit idle send timeout"
 } -start
 
-client c2 -rcvbuf 128 {
-	txreq
-	rxresphdrs
-	# keep the session open for 4 seconds
-	delay 4
-} -start
-
-client c2 -wait
+client c1 -run
 logexpect l2 -wait


### PR DESCRIPTION
There is now a single `writev` call site and as documented we stop as soon
as we hit either of `send_timeout` or `idle_send_timeout`. Previously, we
would keep trying to send after reporting `idle_send_timeout` contrary to
what the documentation said, making it ineffective for HTTP/1 sessions.