### PR TITLE
Handle malformed paths for param.set

### DIFF
--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -217,8 +217,8 @@ void mgt_vcl_startup(struct cli *, const char *vclsrc, const char *origin,
 int mgt_push_vcls(struct cli *, unsigned *status, char **p);
 int mgt_has_vcl(void);
 extern char *mgt_cc_cmd;
-extern const char *mgt_vcl_path;
-extern const char *mgt_vmod_path;
+extern struct vfil_path *mgt_vcl_path;
+extern struct vfil_path *mgt_vmod_path;
 extern unsigned mgt_vcc_err_unref;
 extern unsigned mgt_vcc_allow_inline_c;
 extern unsigned mgt_vcc_unsafe_path;

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -73,7 +73,6 @@ static char		*Cn_arg;
 static struct vpf_fh *pfh1 = NULL;
 static struct vpf_fh *pfh2 = NULL;
 
-static struct vfil_path *vcl_path = NULL;
 static VTAILQ_HEAD(,f_arg) f_args = VTAILQ_HEAD_INITIALIZER(f_args);
 
 static const char opt_spec[] = "a:b:Cdf:Fh:i:I:j:l:M:n:P:p:r:S:s:T:t:VW:x:";
@@ -418,8 +417,8 @@ mgt_f_read(const char *fn)
 	ALLOC_OBJ(fa, F_ARG_MAGIC);
 	AN(fa);
 	REPLACE(fa->farg, fn);
-	VFIL_setpath(&vcl_path, mgt_vcl_path);
-	if (VFIL_searchpath(vcl_path, NULL, &f, fn, &fnp) || f == NULL) {
+	AN(mgt_vcl_path);
+	if (VFIL_searchpath(mgt_vcl_path, NULL, &f, fn, &fnp) || f == NULL) {
 		ARGV_ERR("Cannot read -f file '%s' (%s)\n",
 		    fnp != NULL ? fnp : fn, vstrerror(errno));
 	}

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -69,6 +69,7 @@ tweak_t tweak_bytes_u;
 tweak_t tweak_double;
 tweak_t tweak_poolparam;
 tweak_t tweak_string;
+tweak_t tweak_path;
 tweak_t tweak_timeout;
 tweak_t tweak_uint;
 tweak_t tweak_vsl_buffer;

--- a/bin/varnishd/mgt/mgt_param_tbl.c
+++ b/bin/varnishd/mgt/mgt_param_tbl.c
@@ -55,7 +55,7 @@ struct parspec mgt_parspec[] = {
 		"and %o will be replaced with the output file name.",
 		MUST_RELOAD,
 		VCC_CC , NULL },
-	{ "vcl_path", tweak_string, &mgt_vcl_path,
+	{ "vcl_path", tweak_path, &mgt_vcl_path,
 		NULL, NULL,
 		"Directory (or colon separated list of directories) "
 		"from which relative VCL filenames (vcl.load and "
@@ -67,7 +67,7 @@ struct parspec mgt_parspec[] = {
 		0,
 		VARNISH_VCL_DIR,
 		NULL },
-	{ "vmod_path", tweak_string, &mgt_vmod_path,
+	{ "vmod_path", tweak_path, &mgt_vmod_path,
 		NULL, NULL,
 		"Directory (or colon separated list of directories) "
 		"where VMODs are to be found.",

--- a/bin/varnishd/mgt/mgt_param_tbl.c
+++ b/bin/varnishd/mgt/mgt_param_tbl.c
@@ -42,6 +42,9 @@
 	"\tmax_pool\tmaximum size of free pool.\n"			\
 	"\tmax_age\tmax age of free element."
 
+#define TWEAK_PATH_TEXT							\
+	"All components of the path must be absolute directories."
+
 struct parspec mgt_parspec[] = {
 #define PARAM(nm, ty, mi, ma, de, un, fl, st, lt, fn)		\
 	{ #nm, tweak_##ty, &mgt_param.nm, mi, ma, st, fl, de, un },
@@ -63,14 +66,16 @@ struct parspec mgt_parspec[] = {
 		"VCL files in both the system configuration and shared "
 		"data directories to allow packages to drop their VCL "
 		"files in a standard location where relative includes "
-		"would work.",
+		"would work.\n\n"
+		TWEAK_PATH_TEXT,
 		0,
 		VARNISH_VCL_DIR,
 		NULL },
 	{ "vmod_path", tweak_path, &mgt_vmod_path,
 		NULL, NULL,
 		"Directory (or colon separated list of directories) "
-		"where VMODs are to be found.",
+		"where VMODs are to be found.\n\n"
+		TWEAK_PATH_TEXT,
 		0,
 		VARNISH_VMOD_DIR,
 		NULL },

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -41,6 +41,7 @@
 
 #include "mgt/mgt_param.h"
 #include "vav.h"
+#include "vfil.h"
 #include "vnum.h"
 
 const char * const JSON_FMT = (const char *)&JSON_FMT;
@@ -379,6 +380,33 @@ tweak_string(struct vsb *vsb, const struct parspec *par, const char *arg)
 		VSB_quote(vsb, *p, -1, VSB_QUOTE_JSON|VSB_QUOTE_CSTR);
 	} else {
 		REPLACE(*p, arg);
+	}
+	return (0);
+}
+
+/*--------------------------------------------------------------------*/
+
+int
+tweak_path(struct vsb *vsb, const struct parspec *par, const char *arg)
+{
+	struct vfil_path **p = TRUST_ME(par->priv);
+	const char *err;
+
+	if (arg == NULL) {
+		AN(p);
+		VFIL_quotepath(*p, vsb, 0);
+	} else if (arg == JSON_FMT) {
+		AN(p);
+		(void)VSB_putc(vsb, '"');
+		VFIL_quotepath(*p, vsb, VSB_QUOTE_JSON);
+		(void)VSB_putc(vsb, '"');
+	} else {
+		err = VFIL_setpath(p, arg);
+		if (err != NULL) {
+			VSB_printf(vsb,
+			    "Invalid path component at: '%s'\n", err);
+			return (-1);
+		}
 	}
 	return (0);
 }

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -61,8 +61,8 @@ struct vcc_priv {
 };
 
 char *mgt_cc_cmd;
-const char *mgt_vcl_path;
-const char *mgt_vmod_path;
+struct vfil_path *mgt_vcl_path;
+struct vfil_path *mgt_vmod_path;
 unsigned mgt_vcc_err_unref;
 unsigned mgt_vcc_allow_inline_c;
 unsigned mgt_vcc_unsafe_path;

--- a/bin/varnishtest/tests/m00003.vtc
+++ b/bin/varnishtest/tests/m00003.vtc
@@ -66,3 +66,6 @@ varnish v1 -cliexpect "Invalid path component at: ':/previous/empty'" \
 
 # we let this one get a free pass
 varnish v1 -cliok "param.set vmod_path /last/empty:"
+
+varnish v1 -cliexpect "Invalid path component at: ':'" \
+	"param.set vmod_path /next/empty::"

--- a/bin/varnishtest/tests/m00003.vtc
+++ b/bin/varnishtest/tests/m00003.vtc
@@ -69,3 +69,7 @@ varnish v1 -cliok "param.set vmod_path /last/empty:"
 
 varnish v1 -cliexpect "Invalid path component at: ':'" \
 	"param.set vmod_path /next/empty::"
+
+shell -err -expect "Invalid path component at: 'invalid'" {
+	varnishd -d -n ${tmpdir}/tmp -p vmod_path=invalid -f ${tmpdir}/invalid
+}

--- a/bin/varnishtest/tests/m00003.vtc
+++ b/bin/varnishtest/tests/m00003.vtc
@@ -54,4 +54,15 @@ varnish v1 -errvcl {Wrong file for VMOD wrong3} {
 	import wrong3 from "${tmpdir}/libvmod_wrong.so";
 }
 
-shell "rm -f ${tmpdir}/libvmod_wrong.so"
+varnish v1 -clierr 106 "param.set vmod_path /absolute/path:relative/path"
+varnish v1 -cliexpect "Invalid path component at: 'relative/path'" \
+	"param.set vmod_path /absolute/path:relative/path"
+
+varnish v1 -cliexpect "Invalid path component at: ':/previous/empty'" \
+	"param.set vmod_path :/previous/empty"
+
+varnish v1 -cliexpect "Invalid path component at: ':/previous/empty'" \
+	"param.set vmod_path /next/empty::/previous/empty"
+
+# we let this one get a free pass
+varnish v1 -cliok "param.set vmod_path /last/empty:"

--- a/include/libvcc.h
+++ b/include/libvcc.h
@@ -29,14 +29,15 @@
  */
 
 struct vcc;
+struct vfil_path;
 
 struct vcc *VCC_New(void);
 void VCC_Allow_InlineC(struct vcc *, unsigned);
 void VCC_Builtin_VCL(struct vcc *, const char *);
 void VCC_Err_Unref(struct vcc *, unsigned);
 void VCC_Unsafe_Path(struct vcc *, unsigned);
-void VCC_VCL_path(struct vcc *, const char *);
-void VCC_VMOD_path(struct vcc *, const char *);
+void VCC_VCL_path(struct vcc *, const struct vfil_path *);
+void VCC_VMOD_path(struct vcc *, const struct vfil_path *);
 void VCC_Predef(struct vcc *, const char *type, const char *name);
 void VCC_VCL_Range(unsigned *, unsigned *);
 

--- a/include/vfil.h
+++ b/include/vfil.h
@@ -40,7 +40,7 @@ int VFIL_nonblocking(int fd);
 int VFIL_fsinfo(int fd, unsigned *pbs, uintmax_t *size, uintmax_t *space);
 int VFIL_allocate(int fd, uintmax_t size, int insist);
 void VFIL_destroypath(struct vfil_path **);
-void VFIL_setpath(struct vfil_path **, const char *path);
+const char *VFIL_setpath(struct vfil_path **, const char *path);
 typedef int vfil_path_func_f(void *priv, const char *fn);
 int VFIL_searchpath(const struct vfil_path *, vfil_path_func_f *func,
     void *priv, const char *fni, char **fno);

--- a/include/vfil.h
+++ b/include/vfil.h
@@ -29,6 +29,7 @@
  */
 
 struct vfil_path;
+struct vsb;
 
 /* from libvarnish/vfil.c */
 
@@ -44,3 +45,4 @@ const char *VFIL_setpath(struct vfil_path **, const char *path);
 typedef int vfil_path_func_f(void *priv, const char *fn);
 int VFIL_searchpath(const struct vfil_path *, vfil_path_func_f *func,
     void *priv, const char *fni, char **fno);
+void VFIL_quotepath(const struct vfil_path *, struct vsb *, int);

--- a/include/vfil.h
+++ b/include/vfil.h
@@ -39,8 +39,8 @@ int VFIL_writefile(const char *pfx, const char *fn, const char *buf, size_t sz);
 int VFIL_nonblocking(int fd);
 int VFIL_fsinfo(int fd, unsigned *pbs, uintmax_t *size, uintmax_t *space);
 int VFIL_allocate(int fd, uintmax_t size, int insist);
-void VFIL_setpath(struct vfil_path**, const char *path);
+void VFIL_destroypath(struct vfil_path **);
+void VFIL_setpath(struct vfil_path **, const char *path);
 typedef int vfil_path_func_f(void *priv, const char *fn);
 int VFIL_searchpath(const struct vfil_path *, vfil_path_func_f *func,
     void *priv, const char *fni, char **fno);
-

--- a/lib/libvarnish/vfil.c
+++ b/lib/libvarnish/vfil.c
@@ -419,3 +419,17 @@ VFIL_searchpath(const struct vfil_path *vp, vfil_path_func_f *func, void *priv,
 	VSB_destroy(&vsb);
 	return (-1);
 }
+
+void
+VFIL_quotepath(const struct vfil_path *vp, struct vsb *vsb, int how)
+{
+	const char * const *dir;
+	const char *sep;
+
+	CHECK_OBJ_NOTNULL(vp, VFIL_PATH_MAGIC);
+	AN(vsb);
+	for (dir = vp->dirs, sep = ""; *dir != NULL; dir++, sep = ":") {
+		(void)VSB_quote(vsb, sep, -1, how);
+		(void)VSB_quote(vsb, *dir, -1, how);
+	}
+}

--- a/lib/libvarnish/vfil.c
+++ b/lib/libvarnish/vfil.c
@@ -304,6 +304,16 @@ struct vfil_path {
  */
 
 void
+VFIL_destroypath(struct vfil_path **pp)
+{
+	struct vfil_path *p;
+
+	TAKE_OBJ_NOTNULL(p, pp, VFIL_PATH_MAGIC);
+	free(p->str);
+	FREE_OBJ(p);
+}
+
+void
 VFIL_setpath(struct vfil_path **pp, const char *path)
 {
 	struct vfil_path vp[1];
@@ -331,11 +341,8 @@ VFIL_setpath(struct vfil_path **pp, const char *path)
 	VSB_bcat(vsb, &p, sizeof p);
 	AZ(VSB_finish(vsb));
 
-	if (*pp != NULL) {
-		CHECK_OBJ(*pp, VFIL_PATH_MAGIC);
-		free((*pp)->str);
-		FREE_OBJ(*pp);
-	}
+	if (*pp != NULL)
+		VFIL_destroypath(pp);
 
 	*pp = malloc(VSB_len(vsb));
 	AN(*pp);

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -852,11 +852,12 @@ VCC_Builtin_VCL(struct vcc *vcc, const char *str)
  */
 
 void
-VCC_VCL_path(struct vcc *vcc, const char *str)
+VCC_VCL_path(struct vcc *vcc, const struct vfil_path *path)
 {
 
 	CHECK_OBJ_NOTNULL(vcc, VCC_MAGIC);
-	VFIL_setpath(&vcc->vcl_path, str);
+	AN(path);
+	vcc->vcl_path = path;
 }
 
 /*--------------------------------------------------------------------
@@ -864,11 +865,12 @@ VCC_VCL_path(struct vcc *vcc, const char *str)
  */
 
 void
-VCC_VMOD_path(struct vcc *vcc, const char *str)
+VCC_VMOD_path(struct vcc *vcc, const struct vfil_path *path)
 {
 
 	CHECK_OBJ_NOTNULL(vcc, VCC_MAGIC);
-	VFIL_setpath(&vcc->vmod_path, str);
+	AN(path);
+	vcc->vmod_path = path;
 }
 
 /*--------------------------------------------------------------------

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -215,8 +215,8 @@ struct vcc {
 	int			syntax;
 
 	char			*builtin_vcl;
-	struct vfil_path	*vcl_path;
-	struct vfil_path	*vmod_path;
+	const struct vfil_path	*vcl_path;
+	const struct vfil_path	*vmod_path;
 	unsigned		err_unref;
 	unsigned		allow_inline_c;
 	unsigned		unsafe_path;


### PR DESCRIPTION
The bar is not very high, it needs to either be an empty string or a
list of absolute directories separated by colon characters. But that
validation is pretty strict.

---

When we discussed #3172 during last bugwash the question of validating path parameters came up. In this patch series I first trimmed some fat, then implemented a absolute path validation, and plugged everything into parameter handling and libvcc.

A nice side effect to this change is that we only ever build VCL and VMOD paths once per change, including once for the initial value. So between the single allocation for the data structure and no longer rebuilding both paths whenever we load a VCL it's a bit of churn that goes away, admittedly not in a critical part of the code base.

Another interesting result of this change is that we now have a single call site for `VFIL_setpath()`, and that could still be the case if #3181 reached consensus.

I deliberately left "path escape" out of the scope. By that I mean using `"../"` directory components to attempt reading files outside of the designated path. There was no clear "we should do that" feeling from the bugwash, contrary to the absolute paths question.

There might be other means to escape the path, like creating symbolic links, I don't know whether we could really do something about that. And next thing you know someone's gonna yell that we broke their `../` use case.