### PR TITLE
Don't report send timeouts as REM_CLOSE errors

### DIFF
--- a/bin/varnishd/http1/cache_http1.h
+++ b/bin/varnishd/http1/cache_http1.h
@@ -60,6 +60,6 @@ void V1L_Chunked(const struct worker *w);
 void V1L_EndChunk(const struct worker *w);
 void V1L_Open(struct worker *, struct ws *, int *fd, struct vsl_log *,
     vtim_real deadline, unsigned niov);
-unsigned V1L_Flush(const struct worker *w);
-unsigned V1L_Close(struct worker *w, uint64_t *cnt);
+enum sess_close V1L_Flush(const struct worker *w);
+enum sess_close V1L_Close(struct worker *w, uint64_t *cnt);
 size_t V1L_Write(const struct worker *w, const void *ptr, ssize_t len);

--- a/bin/varnishd/http1/cache_http1_line.c
+++ b/bin/varnishd/http1/cache_http1_line.c
@@ -53,7 +53,7 @@ struct v1l {
 	unsigned		magic;
 #define V1L_MAGIC		0x2f2142e5
 	int			*wfd;
-	unsigned		werr;	/* valid after V1L_Flush() */
+	enum sess_close		werr;	/* valid after V1L_Flush() */
 	struct iovec		*iov;
 	unsigned		siov;
 	unsigned		niov;
@@ -122,15 +122,15 @@ V1L_Open(struct worker *wrk, struct ws *ws, int *fd, struct vsl_log *vsl,
 		WS_Release(ws, u * sizeof(struct iovec));
 }
 
-unsigned
+enum sess_close
 V1L_Close(struct worker *wrk, uint64_t *cnt)
 {
 	struct v1l *v1l;
-	unsigned u;
+	enum sess_close sc;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	AN(cnt);
-	u = V1L_Flush(wrk);
+	sc = V1L_Flush(wrk);
 	v1l = wrk->v1l;
 	wrk->v1l = NULL;
 	CHECK_OBJ_NOTNULL(v1l, V1L_MAGIC);
@@ -139,7 +139,7 @@ V1L_Close(struct worker *wrk, uint64_t *cnt)
 		WS_Release(v1l->ws, 0);
 	WS_Reset(v1l->ws, v1l->res);
 	ZERO_OBJ(v1l, sizeof *v1l);
-	return (u);
+	return (sc);
 }
 
 static void
@@ -166,7 +166,7 @@ v1l_prune(struct v1l *v1l, size_t bytes)
 	AZ(v1l->liov);
 }
 
-unsigned
+enum sess_close
 V1L_Flush(const struct worker *wrk)
 {
 	ssize_t i;
@@ -180,7 +180,7 @@ V1L_Flush(const struct worker *wrk)
 
 	assert(v1l->niov <= v1l->siov);
 
-	if (*v1l->wfd >= 0 && v1l->liov > 0 && v1l->werr == 0) {
+	if (*v1l->wfd >= 0 && v1l->liov > 0 && v1l->werr == SC_NULL) {
 		if (v1l->ciov < v1l->siov && v1l->cliov > 0) {
 			/* Add chunk head & tail */
 			bprintf(cbuf, "00%zx\r\n", v1l->cliov);
@@ -230,10 +230,14 @@ V1L_Flush(const struct worker *wrk)
 				v1l->cnt += i;
 		}
 		if (i <= 0) {
-			v1l->werr++;
 			VSLb(v1l->vsl, SLT_Debug,
 			    "Write error, retval = %zd, len = %zd, errno = %s",
 			    i, v1l->liov, vstrerror(errno));
+			AZ(v1l->werr);
+			if (errno == EPIPE)
+				v1l->werr = SC_REM_CLOSE;
+			else
+				v1l->werr = SC_TX_ERROR;
 		}
 	}
 	v1l->liov = 0;

--- a/bin/varnishtest/tests/s00010.vtc
+++ b/bin/varnishtest/tests/s00010.vtc
@@ -33,7 +33,8 @@ varnish v1 -vcl+backend {
 } -start
 
 logexpect l1 -v v1 -g raw {
-	expect * 1001 Debug "Hit total send timeout"
+	expect * 1001 Debug	"Hit total send timeout"
+	expect * 1000 SessClose	TX_ERROR
 } -start
 
 client c1 -rcvbuf 256 {


### PR DESCRIPTION
This otherwise maintains the status quo regarding prior handling of
HTTP/1 write errors.