### PR TITLE
Allow globbing patterns when including VCL files

### DIFF
--- a/bin/varnishtest/tests/b00072.vtc
+++ b/bin/varnishtest/tests/b00072.vtc
@@ -1,0 +1,44 @@
+varnishtest "Test globbing includes in VCL"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -errvcl "Globbing pattern matched no file (${tmpdir}/*.vcl)" {
+	vcl 4.0;
+
+	include "${tmpdir}/*.vcl";
+}
+
+shell {
+	echo 'sub vcl_deliver { set resp.http.foo = "foo"; }' > ${tmpdir}/sub_foo.vcl
+	echo 'sub vcl_deliver { set resp.http.bar = "bar"; }' > ${tmpdir}/sub_bar.vcl
+	echo 'vcl 4.0; backend default { .host = "0:0"; } include "./sub_*.vcl";' > ${tmpdir}/top.vcl
+	cat ${tmpdir}/top.vcl
+}
+
+varnish v1 -vcl+backend {
+include "${tmpdir}/sub_*.vcl";
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.foo == foo
+	expect resp.http.bar == bar
+} -run
+
+varnish v1 -errvcl {needs absolute filename of including file.} {
+	include "./sub_.vcl";
+}
+
+varnish v1 -cliok "vcl.load foo ${tmpdir}/top.vcl"
+varnish v1 -cliok "vcl.use foo"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.foo == foo
+	expect resp.http.bar == bar
+} -run

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -52,6 +52,9 @@ NEXT (2020-03-15)
 * The ``if-range`` header is now handled, allowing clients to conditionally
   request a range based on a date or an ETag.
 
+* The `include` VCL statement now resolves globbing patterns if the include
+  path starts with "/" or "./".
+
 ================================
 Varnish Cache 6.3.0 (2019-09-15)
 ================================

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -52,7 +52,9 @@
 
 #include "config.h"
 
+#include <errno.h>
 #include <fcntl.h>
+#include <glob.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
@@ -540,10 +542,12 @@ vcc_file_source(const struct vcc *tl, const char *fn)
 static void
 vcc_resolve_includes(struct vcc *tl)
 {
-	struct token *t, *t1, *t2;
+	struct token *t, *t1, *t2, *tt;
 	struct source *sp;
 	struct vsb *vsb;
 	const char *p;
+	glob_t glb;
+	char **s;
 
 	VTAILQ_FOREACH(t, &tl->tokens, list) {
 		if (t->tok != ID || !vcc_IdIs(t, "include"))
@@ -567,6 +571,8 @@ vcc_resolve_includes(struct vcc *tl)
 			return;
 		}
 
+		vsb = VSB_new_auto();
+		AN(vsb);
 		if (t1->dec[0] == '.' && t1->dec[1] == '/') {
 			/*
 			 * Nested include filenames, starting with "./" are
@@ -580,26 +586,53 @@ vcc_resolve_includes(struct vcc *tl)
 				vcc_ErrWhere(tl, t1);
 				return;
 			}
-			vsb = VSB_new_auto();
-			AN(vsb);
 			p = strrchr(t1->src->name, '/');
 			AN(p);
 			VSB_bcat(vsb, t1->src->name, p - t1->src->name);
 			VSB_cat(vsb, t1->dec + 1);
-			AZ(VSB_finish(vsb));
-			sp = vcc_file_source(tl, VSB_data(vsb));
-			VSB_destroy(&vsb);
+		} else
+			VSB_cat(vsb, t1->dec);
+
+		AZ(VSB_finish(vsb));
+
+		/* only try to glob if the path starts with "./" or "/", and if 
+		 * it contains a "*"
+		 */
+		if (((t1->dec[0] == '.' && t1->dec[1] == '/') ||
+		    t1->dec[0] == '/') && strchr(VSB_data(vsb), '*')) {
+			if (glob(VSB_data(vsb), 0, NULL, &glb)) {
+				VSB_printf(tl->sb,
+				    "Globbing pattern matched no file (%s)\n",
+				    VSB_data(vsb));
+				vcc_ErrWhere(tl, t1);
+				return;
+			}
+			tt = tl->t;
+			for (s = glb.gl_pathv; *s; s++) {
+				tl->t = tt;
+				sp = vcc_file_source(tl, *s);
+				if (sp == NULL) {
+					vcc_ErrWhere(tl, t1);
+					return;
+				}
+				VTAILQ_INSERT_TAIL(&tl->sources, sp, list);
+				sp->idx = tl->nsources++;
+				tl->t = t2;
+				vcc_Lexer(tl, sp);
+			}
+			globfree(&glb);
 		} else {
-			sp = vcc_file_source(tl, t1->dec);
+			sp = vcc_file_source(tl, VSB_data(vsb));
+			if (sp == NULL) {
+				vcc_ErrWhere(tl, t1);
+				return;
+			}
+			VTAILQ_INSERT_TAIL(&tl->sources, sp, list);
+			sp->idx = tl->nsources++;
+			tl->t = t2;
+			vcc_Lexer(tl, sp);
 		}
-		if (sp == NULL) {
-			vcc_ErrWhere(tl, t1);
-			return;
-		}
-		VTAILQ_INSERT_TAIL(&tl->sources, sp, list);
-		sp->idx = tl->nsources++;
-		tl->t = t2;
-		vcc_Lexer(tl, sp);
+		VSB_destroy(&vsb);
 
 		VTAILQ_REMOVE(&tl->tokens, t, list);
 		VTAILQ_REMOVE(&tl->tokens, t1, list);


### PR DESCRIPTION
There are a few use cases for this, but the main one is dynamic
setups where each domain is handled by a different VCL, so one can just
drop a file in a directory and reload to take it into account. A second
example are VCL that will provide default logging/logic that the admins
want to be picked up automatically without effort from the VCL writers.