### PR TITLE
Add 'arch' to the jobs, so that it tests both amd64 and arm64 on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jobs:
       stage: test
       os: linux
       dist: xenial
+      arch: amd64
       compiler: clang
       addons:
         apt:
@@ -19,6 +20,7 @@ jobs:
             - python3-docutils
             - python3-sphinx
             - libunwind-dev
+            - libpcre3-dev
       before_script:
         - ./autogen.sh
         - ./configure --with-unwind
@@ -30,7 +32,15 @@ jobs:
             make -j3 check VERBOSE=1
           fi
     - <<: *test-linux
+      arch: arm64
+    - <<: *test-linux
       compiler: gcc
+      before_script:
+        - ./autogen.sh
+        - ./configure
+    - <<: *test-linux
+      compiler: gcc
+      arch: arm64
       before_script:
         - ./autogen.sh
         - ./configure


### PR DESCRIPTION
Hello,

With this Pull Request I'd like to request to add arm64 architecture to the build matrix at TravisCI.

ARM64 is used more and more for servers too and it would be good if Varnish Cache is tested regularly.
I've ran the build and tests both on one of our arm64 machines and at [TravisCI](https://travis-ci.org/martin-g/varnish-cache/builds/639491964) and at the moment both are fine!

amd64 is the default arch at TravisCI so it is preserved!

At https://github.com/varnishcache/varnish-cache/issues?utf8=%E2%9C%93&q=is%3Aissue+arm I've seen that there were some problems on ARM based architectures in the past. Hopefully with this change the ARM specific problems will stay away in the future too.