### PR TITLE
Add a strands interface to VSL and use it for std.log

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -727,10 +727,12 @@ const char *SES_Get_String_Attr(const struct sess *sp, enum sess_attr a);
 void VSLv(enum VSL_tag_e tag, uint32_t vxid, const char *fmt, va_list va);
 void VSL(enum VSL_tag_e tag, uint32_t vxid, const char *fmt, ...)
     v_printflike_(3, 4);
+void VSLs(enum VSL_tag_e tag, uint32_t vxid, const struct strands *s);
 void VSLbv(struct vsl_log *, enum VSL_tag_e tag, const char *fmt, va_list va);
 void VSLb(struct vsl_log *, enum VSL_tag_e tag, const char *fmt, ...)
     v_printflike_(3, 4);
 void VSLbt(struct vsl_log *, enum VSL_tag_e tag, txt t);
+void VSLbs(struct vsl_log *, enum VSL_tag_e tag, const struct strands *s);
 void VSLb_ts(struct vsl_log *, const char *event, vtim_real first,
     vtim_real *pprev, vtim_real now);
 void VSLb_bin(struct vsl_log *, enum VSL_tag_e, ssize_t, const void*);

--- a/bin/varnishtest/tests/m00000.vtc
+++ b/bin/varnishtest/tests/m00000.vtc
@@ -14,9 +14,30 @@ varnish v1 -vcl+backend {
 	import debug as dbg;
 	import debug as dbg;	// again
 
+	sub log {
+		std.log("VCL" + " initiated " + "log");
+		std.log("01030507090b0d0f" +
+			"11131517191b1d1f" +
+			"21232527292b2d2f" +
+			"31333537393b3d3f" +
+			"41434547494b4d4f" +
+			"51535557595b5d5f" +
+			"61636567696b6d6f" +
+			"71737577797b7d7f" +
+			"81838587898b8d8f" +
+			"91939597999b9d9f" +
+			"a1a3a5a7a9abadaf" +
+			"b1b3b5b7b9bbbdbf" +
+			"c1c3c5c7c9cbcdcf" +
+			"d1d3d5d7d9dbdddf" +
+			"e1e3e5e7e9ebedef" +
+			"f1f3f5f7f9fbfdff");
+	}
+
 	sub vcl_init {
 		new objx = dbg.obj();
 		dbg.vsc_new();
+		call log;
 	}
 
 	sub vcl_synth {
@@ -54,7 +75,7 @@ varnish v1 -vcl+backend {
 		debug.test_priv_vcl();
 		objx.test_priv_call();
 		objx.test_priv_vcl();
-		std.log("VCL" + " initiated " + "log");
+		call log;
 		std.syslog(8 + 7, "Somebody runs varnishtest");
 		debug.rot52(resp);
 	}
@@ -89,6 +110,12 @@ client c1 {
 varnish v1 -expect DEBUG.count == 1
 
 logexpect l1 -v v1 -g raw -d 1 {
+	expect * 0    CLI		{^Rd vcl.load}
+	expect 0 0    VCL_Log		{^VCL initiated log}
+	# vsl_reclen = 255b minus NUL byte (last "ff" missing)
+	expect 0 0    VCL_Log		{^01030507090b0d0f11131517191b1d1f21232527292b2d2f31333537393b3d3f41434547494b4d4f51535557595b5d5f61636567696b6d6f71737577797b7d7f81838587898b8d8f91939597999b9d9fa1a3a5a7a9abadafb1b3b5b7b9bbbdbfc1c3c5c7c9cbcdcfd1d3d5d7d9dbdddfe1e3e5e7e9ebedeff1f3f5f7f9fbfd$}
+	expect 0 0    Debug		{VCL_EVENT_WARM}
+
 	expect * 1001 VCL_call		{^DELIVER}
 	expect 0 =    RespUnset	{^foo: bAr}
 	expect 0 =    RespHeader	{^foo: BAR}
@@ -100,6 +127,7 @@ logexpect l1 -v v1 -g raw -d 1 {
 	expect 0 =    RespHeader	{^what: [1-9][0-9]}
 	expect 0 =    RespHeader	{^not: -1}
 	expect 0 =    VCL_Log		{^VCL initiated log}
+	expect 0 =    VCL_Log		{^01030507090b0d0f11131517191b1d1f21232527292b2d2f31333537393b3d3f41434547494b4d4f51535557595b5d5f61636567696b6d6f71737577797b7d7f81838587898b8d8f91939597999b9d9fa1a3a5a7a9abadafb1b3b5b7b9bbbdbfc1c3c5c7c9cbcdcfd1d3d5d7d9dbdddfe1e3e5e7e9ebedeff1f3f5f7f9fbfd$}
 	expect 0 =    RespHeader	{^Encrypted: ROT52}
 	expect 0 =    VCL_return	{^deliver}
 } -start

--- a/bin/varnishtest/tests/r03131.vtc
+++ b/bin/varnishtest/tests/r03131.vtc
@@ -11,11 +11,6 @@ varnish v1 -vcl {
 	}
 
 	sub vcl_synth {
-		set resp.http.res1 = vtc.workspace_reserve(client, 1024 * 1024);
-
-		# XXX overflow gets cleared by WS_Reset called from std.log()
-		# -> do we want this ?
-
 		vtc.workspace_alloc(session, -16);
 		std.log("res(8) = " + vtc.workspace_reserve(session, 8));
 		std.log("res(15) = " + vtc.workspace_reserve(session, 15));

--- a/bin/varnishtest/tests/v00004.vtc
+++ b/bin/varnishtest/tests/v00004.vtc
@@ -153,8 +153,6 @@ varnish v1 -vcl+backend {
 	sub recv9 {
 		std.log("STK recv9 " + debug.stk());
 		set req.http.regex = regsub(req.http.cookie, "(.*)", "\1\1\1\1\1\1\1\1");
-		set req.http.regex = regsub(req.http.regex, "(.*)",
-		  "\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1");
 		# hey geoff, this is deliberate
 		set req.http.regex = regsub(req.http.regex,
 		  "(.*)(.{5})(.{6})(.{7})(.{8})", "/\5\4\3\2\1");

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -133,19 +133,12 @@ vmod_random(VRT_CTX, VCL_REAL lo, VCL_REAL hi)
 VCL_VOID v_matchproto_(td_std_log)
 vmod_log(VRT_CTX, VCL_STRANDS s)
 {
-	const char *p;
-	uintptr_t sn;
-
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	sn = WS_Snapshot(ctx->ws);
-	p = VRT_StrandsWS(ctx->ws, NULL, s);
-	if (p != NULL) {
-		if (ctx->vsl != NULL)
-			VSLb(ctx->vsl, SLT_VCL_Log, "%s", p);
-		else
-			VSL(SLT_VCL_Log, 0, "%s", p);
-	}
-	WS_Reset(ctx->ws, sn);
+
+	if (ctx->vsl != NULL)
+		VSLbs(ctx->vsl, SLT_VCL_Log, s);
+	else
+		VSLs(SLT_VCL_Log, 0, s);
 }
 
 /* XXX use vsyslog() ? */


### PR DESCRIPTION
Since 8baf4a690fdb699923dd8438d0088f34fcb24365 we lost information about an overflowed workspace by calling `std.log()`, which resulted from use of the workspace for construction of a contiguous string from the argument constituents.

Since then, we have changed the interface to STRANDS, but this issue remained.

We now solve the case for real by pushing the string concatenation down to VSL: New versions of `VSL` and `VSLb` (coded by example of `VSLv()` and `VSLbt()`) take a strands argument and create a log record without additional copy overhead.

These solve #3194 for `std.log()`, make logging more efficient and, in particular, allow use of `std.log()` in low workspace conditions (because they do not require any).

Also improve test coverage for `std.log()`

Ref #3194