### PR TITLE
address most other overflow vs. WS_Reset() cases

### DIFF
--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -407,6 +407,12 @@ VRT_l_beresp_storage_hint(VRT_CTX, const char *str, ...)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
 
+	// WS_Reset() could clear overflow
+	if (WS_Overflowed(ctx->ws)) {
+		VRT_fail(ctx, "overflowed workspace");
+		return;
+	}
+
 	sn = WS_Snapshot(ctx->ws);
 	va_start(ap, str);
 	p = VRT_String(ctx->ws, NULL, str, ap);

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -392,6 +392,8 @@ h2_new_session(struct worker *wrk, void *arg)
 	h2->cond = &wrk->cond;
 
 	while (h2_rxframe(wrk, h2)) {
+		// XXX do we need to check for overflowed workspace before
+		// reset?
 		WS_Reset(h2->ws, 0);
 		HTC_RxInit(h2->htc, h2->ws);
 		if (WS_Overflowed(h2->ws)) {

--- a/lib/libvmod_blob/vmod_blob.c
+++ b/lib/libvmod_blob/vmod_blob.c
@@ -378,6 +378,13 @@ encode(VRT_CTX, enum encoding enc, enum case_e kase, VCL_BLOB b)
 		return (NULL);
 
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
+
+	// WS_Reset() could clear overflow
+	if (WS_Overflowed(ctx->ws)) {
+		ERRNOMEM(ctx, "overflowed workspace");
+		return (NULL);
+	}
+
 	snap = WS_Snapshot(ctx->ws);
 	buf = WS_Front(ctx->ws);
 	space = WS_ReserveAll(ctx->ws);

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -149,6 +149,13 @@ vmod_syslog(VRT_CTX, VCL_INT fac, VCL_STRANDS s)
 	uintptr_t sn;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	// WS_Reset() could clear overflow
+	if (WS_Overflowed(ctx->ws)) {
+		VRT_fail(ctx, "overflowed workspace");
+		return;
+	}
+
 	sn = WS_Snapshot(ctx->ws);
 	p = VRT_StrandsWS(ctx->ws, NULL, s);
 	if (p != NULL)

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -202,6 +202,12 @@ vmod_ip(VRT_CTX, struct VARGS(ip) *a)
 	if (a->valid_fallback)
 		assert(VSA_Sane(a->fallback));
 
+	// WS_Reset() could clear overflow
+	if (WS_Overflowed(ctx->ws)) {
+		VRT_fail(ctx, "std.ip: overflowed workspace");
+		return (NULL);
+	}
+
 	p = WS_Alloc(ctx->ws, vsa_suckaddr_len);
 	if (p == NULL) {
 		VRT_fail(ctx, "std.ip: insufficient workspace");


### PR DESCRIPTION
Reviewers please read #3194 first

We add checks for cases where a `WS_Reset()` could reset the overflowed workspace marker to ensure that the workspace is not already overflowed before using it.

See also #3196 for `std.log()`

This concludes the fix for #3194 together with the above (except for one h2 case, maybe)