### PR TITLE
reduce vcl_mtx contention with an implicing VCL_Rel() in vcl_get()

### DIFF
--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -259,10 +259,21 @@ VCL_Panic(struct vsb *vsb, const char *nm, const struct vcl *vcl)
 void
 vcl_get(struct vcl **vcc, struct vcl *vcl)
 {
+	struct vcl *old;
+
 	AN(vcc);
-	AZ(*vcc);
+
+	old = *vcc;
+	*vcc = NULL;
+
+	CHECK_OBJ_ORNULL(old, VCL_MAGIC);
 
 	Lck_Lock(&vcl_mtx);
+	if (old != NULL) {
+		assert(old->busy > 0);
+		old->busy--;
+	}
+
 	if (vcl == NULL)
 		vcl = vcl_active; /* Sample vcl_active under lock to avoid
 				   * race */

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -260,6 +260,7 @@ void
 vcl_get(struct vcl **vcc, struct vcl *vcl)
 {
 	AN(vcc);
+	AZ(*vcc);
 
 	Lck_Lock(&vcl_mtx);
 	if (vcl == NULL)

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -257,7 +257,7 @@ VCL_Panic(struct vsb *vsb, const char *nm, const struct vcl *vcl)
 /*--------------------------------------------------------------------*/
 
 void
-vcl_get(struct vcl **vcc, struct vcl *vcl)
+VCL_Update(struct vcl **vcc, struct vcl *vcl)
 {
 	struct vcl *old;
 

--- a/bin/varnishd/cache/cache_vcl.h
+++ b/bin/varnishd/cache/cache_vcl.h
@@ -70,7 +70,7 @@ struct vclref {
 extern struct lock		vcl_mtx;
 extern struct vcl		*vcl_active; /* protected by vcl_mtx */
 struct vcl *vcl_find(const char *);
-void vcl_get(struct vcl **, struct vcl *);
+void VCL_Update(struct vcl **, struct vcl *);
 
 struct vcltemp {
 	const char * const	name;

--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -108,8 +108,6 @@ VPI_vcl_select(VRT_CTX, VCL_VCL vcl)
 		AZ(req->top->vcl0);
 		req->top->vcl0 = req->vcl;
 		req->vcl = NULL;
-	} else {
-		VCL_Rel(&req->vcl);
 	}
 	vcl_get(&req->vcl, vcl);
 	VSLb(ctx->req->vsl, SLT_VCL_use, "%s via %s",

--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -109,7 +109,7 @@ VPI_vcl_select(VRT_CTX, VCL_VCL vcl)
 		req->top->vcl0 = req->vcl;
 		req->vcl = NULL;
 	}
-	vcl_get(&req->vcl, vcl);
+	VCL_Update(&req->vcl, vcl);
 	VSLb(ctx->req->vsl, SLT_VCL_use, "%s via %s",
 	    req->vcl->loaded_name, vcl->loaded_name);
 }

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -84,8 +84,6 @@ VCL_Refresh(struct vcl **vcc)
 
 	if (*vcc == vcl_active)
 		return;
-	if (*vcc != NULL)
-		VCL_Rel(vcc);	/* XXX: optimize locking */
 
 	vcl_get(vcc, NULL);
 }

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -85,7 +85,7 @@ VCL_Refresh(struct vcl **vcc)
 	if (*vcc == vcl_active)
 		return;
 
-	vcl_get(vcc, NULL);
+	VCL_Update(vcc, NULL);
 }
 
 void


### PR DESCRIPTION
Both callers of `vcl_get()`, `VPI_vcl_select()` and `VCL_Refresh()`, potentially have to unref another vcl first.
    
For `VCL_Refresh()`, this happens when the active vcl changes and the previously active vcl is cached in `(struct worker).vcl`, which can be assumed to always be the case on a busy system.

For `VPI_vcl_select()`, this happens when switching vcls at `esi_level > 0`.

To summarize, this patch will primarily reduce contention on the `vcl_mtx` after a `vcl.use` CLI command on a busy system and for `return(use(vcl))` with ESI.

I added a trivial `AZ(*vcc)` patch and ran the checks before the actual patch to ensure that really the previous use of `vcl_get()` was only ever with `vcc` pointing to NULL (that is trivially clear from the caller code, but anyway...).