### PR TITLE
respect `send_timeout` for "dripping" http1 writes

### DIFF
--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -97,9 +97,8 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	}
 
 	VTCP_blocking(*htc->rfd);	/* XXX: we should timeout instead */
-	/* XXX: what is the right timeout ? Isn't send_timeout client side? */
-	V1L_Open(wrk, wrk->aws, htc->rfd, bo->vsl,
-	    bo->t_prev + cache_param->send_timeout, 0);
+	/* XXX: need a send_timeout for the backend side */
+	V1L_Open(wrk, wrk->aws, htc->rfd, bo->vsl, nan(""), 0);
 	hdrbytes = HTTP1_Write(wrk, hp, HTTP1_Req);
 
 	/* Deal with any message-body the request might (still) have */

--- a/bin/varnishtest/tests/r03189.vtc
+++ b/bin/varnishtest/tests/r03189.vtc
@@ -1,0 +1,28 @@
+varnishtest "h1 send_timeout and streaming of dripping chunks"
+
+barrier b cond 2
+
+server s1 {
+	rxreq
+	txresp -nolen -hdr "Transfer-Encoding: chunked"
+	chunkedlen 1
+	delay 1
+	non_fatal
+	barrier b sync
+	chunkedlen 1
+	delay 1
+	chunkedlen 0
+} -start
+
+varnish v1				\
+	-arg "-p idle_send_timeout=.1"	\
+	-arg "-p send_timeout=.8"	\
+	-vcl+backend { } -start
+
+client c1 {
+	txreq
+	rxresphdrs
+	rxchunk
+	barrier b sync
+	expect_close
+} -run

--- a/bin/varnishtest/tests/s00011.vtc
+++ b/bin/varnishtest/tests/s00011.vtc
@@ -1,10 +1,8 @@
 varnishtest "backend send timeouts"
 
 server s1 {
+	non_fatal
 	rxreq
-	expect req.method == POST
-	expect req.body == helloworld
-	txresp
 } -start
 
 varnish v1 -vcl+backend "" -start
@@ -21,5 +19,5 @@ client c1 {
 	delay 2
 	send world
 	rxresp
-	expect resp.status == 200
+	expect resp.status == 503
 } -run


### PR DESCRIPTION
problem
---

Previously, we only checked `v1l->deadline` (which gets initialized from the `send_timeout` session attribute or parameter) only for short writes, so for successful "dripping" http1 writes (streaming from a backend busy object with small chunks), we did not respect the timeout.

solution
---

This patch restructures `V1L_Flush()` to always check the deadline before a write by turning a `while() { ... }` into a `do { ... } while` with the same continuation criteria: `while (i != v1l->liov)` is turned into `if (i == v1l->liov) break;` and `while (i > 0 || errno == EWOULDBLOCK)` is kept to retry short writes.

This also reduces the `writev()` call sites to one.

Fixes #3189

(potentially breaking) changes
---

After (if) the patch is accepted, we should put a prominent warning into the release docs to re-check `send_timeout`.

This is particularly important as `send_timeout` is now enforced also for sending request bodies to the backend (see s00011.vtc)