### PR TITLE
varnishstat json schema change

### DIFF
--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -134,12 +134,10 @@ do_json(struct vsm *vsm, struct vsc *vsc)
 	int jp;
 
 	jp = 1;
-
-	printf("{\n");
 	now = time(NULL);
 
 	(void)strftime(time_stamp, 20, "%Y-%m-%dT%H:%M:%S", localtime(&now));
-	printf("  \"timestamp\": \"%s\",\n", time_stamp);
+	printf("{\n  \"timestamp\": \"%s\",\n", time_stamp);
 	(void)VSC_Iter(vsc, vsm, do_json_cb, &jp);
 	printf("\n}\n");
 }

--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -114,15 +114,13 @@ do_json_cb(void *priv, const struct VSC_point * const pt)
 	else
 		printf(",\n");
 
-	printf("  \"");
-	/* build the JSON key name.  */
-	printf("%s\": {\n", pt->name);
-	printf("    \"description\": \"%s\",\n", pt->sdesc);
+	printf("    \"%s\": {\n", pt->name);
+	printf("      \"description\": \"%s\",\n", pt->sdesc);
 
-	printf("    \"flag\": \"%c\", ", pt->semantics);
+	printf("      \"flag\": \"%c\", ", pt->semantics);
 	printf("\"format\": \"%c\",\n", pt->format);
-	printf("    \"value\": %ju", (uintmax_t)val);
-	printf("\n  }");
+	printf("      \"value\": %ju", (uintmax_t)val);
+	printf("\n    }");
 	return (0);
 }
 
@@ -137,9 +135,12 @@ do_json(struct vsm *vsm, struct vsc *vsc)
 	now = time(NULL);
 
 	(void)strftime(time_stamp, 20, "%Y-%m-%dT%H:%M:%S", localtime(&now));
-	printf("{\n  \"timestamp\": \"%s\",\n", time_stamp);
+	printf("{\n"
+	    "  \"version\": 1,\n"
+	    "  \"timestamp\": \"%s\",\n"
+	    "  \"counters\": {\n", time_stamp);
 	(void)VSC_Iter(vsc, vsm, do_json_cb, &jp);
-	printf("\n}\n");
+	printf("\n  }\n}\n");
 }
 
 

--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -123,9 +123,6 @@ do_json_cb(void *priv, const struct VSC_point * const pt)
 	printf("\"format\": \"%c\",\n", pt->format);
 	printf("    \"value\": %ju", (uintmax_t)val);
 	printf("\n  }");
-
-	if (*jp)
-		printf("\n");
 	return (0);
 }
 

--- a/bin/varnishtest/tests/u00015.vtc
+++ b/bin/varnishtest/tests/u00015.vtc
@@ -1,0 +1,19 @@
+varnishtest "varnishstat -j"
+
+server s1 -repeat 5 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {} -start
+
+client c1 -repeat 5 {
+	txreq
+	rxresp
+} -run
+
+delay 1
+
+shell { varnishstat -n ${v1_name}  -j }
+shell -expect "1" { varnishstat -n ${v1_name} -j | python3 -c 'import sys, json; print(json.load(sys.stdin)["version"])' }
+shell -expect "5" { varnishstat -n ${v1_name} -j | python3 -c 'import sys, json; print(json.load(sys.stdin)["counters"]["MAIN.client_req"]["value"])' }


### PR DESCRIPTION
fixes #3186

This changes the format in only two ways:
- counters go into their own `counters` sub-object
- new `version` field, set to 1 (since most lenient parser will say it's 0 if the field is absent)

However, it will break parsers downstream, it maybe an issue if the next release isn't a major one. I'm happy to communicate with the downstream projects I know/can reach to ease the migration.