### PR TITLE
A more modern random generator with almost no locking

### DIFF
--- a/bin/varnishtest/tests/m00002.vtc
+++ b/bin/varnishtest/tests/m00002.vtc
@@ -9,10 +9,10 @@ varnish v1 -vcl+backend {
 	import std;
 
 	sub vcl_deliver {
-		set resp.http.rnd1 = std.random(0, 1);
-		set resp.http.rnd2 = std.random(0, 10);
-		set resp.http.rnd3 = std.random(8, 10);
-		set resp.http.rnd4 = std.random(99, 100);
+		set resp.http.rnd1 = std.random(0, 1, true);
+		set resp.http.rnd2 = std.random(0, 10, true);
+		set resp.http.rnd3 = std.random(8, 10, true);
+		set resp.http.rnd4 = std.random(99, 100, true);
 	}
 } -start
 

--- a/bin/varnishtest/tests/m00052.vtc
+++ b/bin/varnishtest/tests/m00052.vtc
@@ -1,0 +1,163 @@
+varnishtest "Test xorshiro128** random generator"
+
+varnish v1 -vcl {
+	import std;
+	import debug;
+
+	backend default none;
+
+	sub vcl_init {
+		debug.deterministic_random();
+	}
+
+	sub vcl_recv {
+		return (synth(200, "OK"));
+	}
+	sub vcl_synth {
+		set resp.http.r1 = 1000.0 * std.random52();
+		set resp.http.r2 = 1000.0 * std.random52();
+		set resp.http.r3 = 1000.0 * std.random52();
+		set resp.http.r4 = 1000.0 * std.random52();
+		set resp.http.r5 = 1000.0 * std.random52();
+		set resp.http.r6 = 1000.0 * std.random52();
+		return (deliver);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.r1 == "457.371"
+	expect resp.http.r2 == "215.082"
+	expect resp.http.r3 == "978.593"
+	expect resp.http.r4 == "477.719"
+	expect resp.http.r5 == "340.118"
+	expect resp.http.r6 == "478.416"
+} -run
+
+# State in various threads are independent of each other. We need a
+# new varnishd instance below since threads will keep their random
+# generator even when the global state is reset, and it is possible
+# that a thread from the previous part is reused.
+
+varnish v1 -stop
+
+barrier b1 cond 2
+
+varnish v2 -vcl {
+	import std;
+	import debug;
+	import vtc;
+
+	backend default none;
+
+	sub vcl_init {
+		debug.deterministic_random();
+	}
+
+	sub vcl_recv {
+		return (synth(200, "OK"));
+	}
+	sub vcl_synth {
+		set resp.http.r = 1000.0 * std.random52();
+		vtc.sleep(0.2s);
+		return (deliver);
+	}
+} -start
+
+client c2 -connect ${v2_sock} {
+	# Note that the state here is the same as in the first client
+	txreq
+	barrier b1 sync
+	rxresp
+	expect resp.http.r == "457.371"
+	txreq
+	rxresp
+	expect resp.http.r == "215.082"
+	txreq
+	rxresp
+	expect resp.http.r == "978.593"
+} -start
+
+barrier b1 sync
+
+client c3 -connect ${v2_sock} {
+	txreq
+	rxresp
+	expect resp.http.r == "208.987"
+	txreq
+	rxresp
+	expect resp.http.r == "229.042"
+	txreq
+	rxresp
+	expect resp.http.r == "334.334"
+} -start
+
+client c2 -wait
+client c3 -wait
+
+varnish v2 -stop
+
+# Same again, but with a different order after the first
+# request. Since we have the same expect statements as above, we know
+# that the threads get their own sequence quasi random numbers
+# independenty of each other.
+
+varnish v3 -vcl {
+	import std;
+	import debug;
+	import vtc;
+
+	backend default none;
+
+	sub vcl_init {
+		debug.deterministic_random();
+	}
+
+	sub vcl_recv {
+		return (synth(200, "OK"));
+	}
+	sub vcl_synth {
+		set resp.http.r = 1000.0 * std.random52();
+		vtc.sleep(0.2s);
+		return (deliver);
+	}
+} -start
+
+barrier b2 cond 2
+barrier b3 cond 2
+
+
+client c4 -connect ${v3_sock} {
+	txreq
+	rxresp
+	barrier b2 sync
+	barrier b3 sync
+	expect resp.http.r == "457.371"
+	txreq
+	rxresp
+	expect resp.http.r == "215.082"
+	txreq
+	rxresp
+	expect resp.http.r == "978.593"
+} -start
+
+barrier b2 sync
+
+client c5 -connect ${v3_sock} {
+	txreq
+	rxresp
+	expect resp.http.r == "208.987"
+	txreq
+	rxresp
+	expect resp.http.r == "229.042"
+	txreq
+	rxresp
+	expect resp.http.r == "334.334"
+} -start
+
+barrier b3 sync
+
+client c4 -wait
+client c5 -wait

--- a/include/vrnd.h
+++ b/include/vrnd.h
@@ -32,6 +32,8 @@
 
 typedef void vrnd_lock_f(void);
 
+typedef uint64_t xorshiro_state_t[2];
+
 extern vrnd_lock_f *VRND_Lock;
 extern vrnd_lock_f *VRND_Unlock;
 
@@ -42,3 +44,5 @@ double VRND_RandomTestableDouble(void);
 void VRND_SeedTestable(unsigned int);
 void VRND_SeedAll(void);		/* Seed random(3) properly */
 
+void VRND_Seed_xshiro128ss(xorshiro_state_t seed);
+uint64_t VRND_xshiro128ss(void);

--- a/lib/libvmod_debug/vmod.vcc
+++ b/lib/libvmod_debug/vmod.vcc
@@ -292,3 +292,9 @@ Get the stringified client ip from the session attr
 $Function STRING client_port()
 
 Get the stringified client port from the session attr
+
+$Function VOID deterministic_random()
+
+Set the xorshiro algoritm to a constant initialized state. If a setup
+or test case is not timing sensitive, this should produce reproducable
+random numbers.

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -39,6 +39,7 @@
 #include "cache/cache_varnishd.h"
 #include "cache/cache_filter.h"
 
+#include "vrnd.h"
 #include "vsa.h"
 #include "vtim.h"
 #include "vcc_if.h"
@@ -1084,4 +1085,14 @@ xyzzy_client_port(VRT_CTX)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
 	return (SES_Get_String_Attr(ctx->sp, SA_CLIENT_PORT));
+}
+
+VCL_VOID
+xyzzy_deterministic_random(VRT_CTX)
+{
+	xorshiro_state_t s = {1, 1};
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	VRND_Seed_xshiro128ss(s);
 }

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -43,13 +43,16 @@ Varnish, but which for reasons of architecture fit better in a VMOD.
 Numeric functions
 =================
 
-$Function REAL random(REAL lo, REAL hi)
+$Function REAL random(REAL lo, REAL hi, BOOL legacy=0)
 
 Returns a random real number between *lo* and *hi*.
 
-This function uses the "testable" random generator in varnishd which
-enables determinstic tests to be run (See ``m00002.vtc``).  This
-function should not be used for cryptographic applications.
+The functions uses random52 under the hood, so it should not be used
+for cryptographical applications.
+
+If *legacy* is set, then this function uses the old "testable" random
+generator in varnishd which enables determinstic tests to be run (See
+``m00002.vtc``). This option should not be used.
 
 Example::
 

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -55,6 +55,25 @@ Example::
 
 	set beresp.http.random-number = std.random(1, 100);
 
+$Function REAL random52()
+
+Description
+
+	Returns a uniformly distributed random number between 0 and 1,
+	where 0 is possible while 1 is not. The source is a quasi
+	random generator which returns unique numbers per thread. It
+	is fit for most simulations, but not cryptologically
+	strong. The names comes from the fact that there is 52 bits of
+	quasi randomness in the result.
+
+$Function INT random_mod(INT m)
+
+Description
+	Returns the result of a 64 bit quasi random number modulo the
+	argument. If the argument is negative or zero, the result is
+	instead the same 64 bit unsigned integer cast to a VCL_INT,
+	which can be negative or positive.
+
 $Function REAL round(REAL r)
 
 Rounds the real *r* to the nearest integer, but round halfway cases

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -37,6 +37,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include <syslog.h>
 #include <sys/socket.h>
 #include <fnmatch.h>
@@ -128,6 +129,27 @@ vmod_random(VRT_CTX, VCL_REAL lo, VCL_REAL hi)
 	a *= hi - lo;
 	a += lo;
 	return (a);
+}
+
+VCL_REAL
+vmod_random52(VRT_CTX)
+{
+	double t;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	// we drop the lower bits to get a uniform distribution
+	t = VRND_xshiro128ss() >> 12;
+
+	return (ldexp(t, -52));
+}
+
+VCL_INT
+vmod_random_mod(VRT_CTX, VCL_INT m)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	return (m > 0 ? VRND_xshiro128ss() % m : VRND_xshiro128ss());
 }
 
 VCL_VOID v_matchproto_(td_std_log)

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -120,12 +120,12 @@ vmod_tolower(VRT_CTX, VCL_STRANDS s)
 }
 
 VCL_REAL v_matchproto_(td_std_random)
-vmod_random(VRT_CTX, VCL_REAL lo, VCL_REAL hi)
+vmod_random(VRT_CTX, VCL_REAL lo, VCL_REAL hi, VCL_BOOL legacy)
 {
 	double a;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	a = VRND_RandomTestableDouble();
+	a = (legacy ? VRND_RandomTestableDouble() : vmod_random52(ctx));
 	a *= hi - lo;
 	a += lo;
 	return (a);


### PR DESCRIPTION
This code introduces a very fast pseudo random generator with good statistical properties and almost no locking. It leverages the `__thread` word to store individual states per thread, and the platforms which we support all have linkers which can handle this mechanism well.

The period of the pseudo random generator is 2^128-1, and each new thread gets its own sequence of 2^64 quasi random numbers at the expense of one lock/unlock operation the first time the thread calls the random generator.