### PR TITLE
Poxy vulnerability mitigation for builtin.vcl

### DIFF
--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -37,9 +37,6 @@ vcl 4.0;
 # Client side
 
 sub vcl_recv {
-    if (req.http.host) {
-        set req.http.host = req.http.host.lower();
-    }
     if (req.method == "PRI") {
         /* This will never happen in properly formed traffic (see: RFC7540) */
         return (synth(405));
@@ -54,6 +51,9 @@ sub vcl_recv {
       req.proto ~ "^(?i)HTTP/1.1") {
         /* In HTTP/1.1, Host is required. */
         return (synth(400));
+    }
+    if (req.http.host) {
+        set req.http.host = req.http.host.lower();
     }
     if (req.method != "GET" &&
       req.method != "HEAD" &&

--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -44,6 +44,11 @@ sub vcl_recv {
         /* This will never happen in properly formed traffic (see: RFC7540) */
         return (synth(405));
     }
+    if (req.http.proxy) {
+        /* Poxy mitigation. Standards-compliant HTTP clients and servers will
+           never read or send this header. See https://httpoxy.org/#fix-now  */
+        return (synth(400));
+    }
     if (!req.http.host &&
       req.esi_level == 0 &&
       req.proto ~ "^(?i)HTTP/1.1") {


### PR DESCRIPTION
While `builtin.vcl` is certainly no place to try defending against numerous possible web exploits, this specific case is an easy security win at almost no cost, in today's botnet landscape.
And Varnish is just the the perfect place for it.

Perhaps you feel different. But the only reason, that I can see, where this could be unwanted, is if a backend server is used to track attempted exploits.