### PR TITLE
Introduce a struct gethdr_t type

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -613,7 +613,8 @@ void http_PutResponse(struct http *to, const char *proto, uint16_t status,
 void http_FilterReq(struct http *to, const struct http *fm, unsigned how);
 void HTTP_Encode(const struct http *fm, uint8_t *, unsigned len, unsigned how);
 int HTTP_Decode(struct http *to, const uint8_t *fm);
-void http_ForceHeader(struct http *to, const char *hdr, const char *val);
+void http_ForceHeader(struct http *to, const struct gethdr_t *hdr,
+    const char *val);
 void http_PrintfHeader(struct http *to, const char *fmt, ...)
     v_printflike_(2, 3);
 void http_TimeHeader(struct http *to, const char *fmt, vtim_real now);
@@ -623,30 +624,35 @@ void http_SetH(struct http *to, unsigned n, const char *fm);
 void http_ForceField(struct http *to, unsigned n, const char *t);
 void HTTP_Setup(struct http *, struct ws *, struct vsl_log *, enum VSL_tag_e);
 void http_Teardown(struct http *ht);
-int http_GetHdr(const struct http *hp, const char *hdr, const char **ptr);
-int http_GetHdrToken(const struct http *hp, const char *hdr,
+int http_GetHdr(const struct http *hp, const struct gethdr_t *hdr,
+    const char **ptr);
+int http_GetHdrToken(const struct http *hp, const struct gethdr_t *hdr,
     const char *token, const char **pb, const char **pe);
-int http_GetHdrField(const struct http *hp, const char *hdr,
+int http_GetHdrField(const struct http *hp, const struct gethdr_t *hdr,
     const char *field, const char **ptr);
-double http_GetHdrQ(const struct http *hp, const char *hdr, const char *field);
+double http_GetHdrQ(const struct http *hp, const struct gethdr_t *hdr,
+    const char *field);
 ssize_t http_GetContentLength(const struct http *hp);
 uint16_t http_GetStatus(const struct http *hp);
 int http_IsStatus(const struct http *hp, int);
 void http_SetStatus(struct http *to, uint16_t status, const char *reason);
 const char *http_GetMethod(const struct http *hp);
-int http_HdrIs(const struct http *hp, const char *hdr, const char *val);
+int http_HdrIs(const struct http *hp, const struct gethdr_t *hdr,
+    const char *val);
 void http_CopyHome(const struct http *hp);
-void http_Unset(struct http *hp, const char *hdr);
-unsigned http_CountHdr(const struct http *hp, const char *hdr);
-void http_CollectHdr(struct http *hp, const char *hdr);
-void http_CollectHdrSep(struct http *hp, const char *hdr, const char *sep);
+void http_Unset(struct http *hp, const struct gethdr_t *hdr);
+unsigned http_CountHdr(const struct http *hp, const struct gethdr_t *hdr);
+void http_CollectHdr(struct http *hp, const struct gethdr_t *hdr);
+void http_CollectHdrSep(struct http *hp, const struct gethdr_t *hdr,
+    const char *sep);
 void http_VSL_log(const struct http *hp);
 void HTTP_Merge(struct worker *, struct objcore *, struct http *to);
 uint16_t HTTP_GetStatusPack(struct worker *, struct objcore *oc);
 int HTTP_IterHdrPack(struct worker *, struct objcore *, const char **);
 #define HTTP_FOREACH_PACK(wrk, oc, ptr) \
 	 for ((ptr) = NULL; HTTP_IterHdrPack(wrk, oc, &(ptr));)
-const char *HTTP_GetHdrPack(struct worker *, struct objcore *, const char *hdr);
+const char *HTTP_GetHdrPack(struct worker *, struct objcore *,
+    const struct gethdr_t *hdr);
 enum sess_close http_DoConnection(struct http *hp);
 
 #define HTTPH_R_PASS	(1 << 0)	/* Request (c->b) in pass mode */
@@ -654,12 +660,12 @@ enum sess_close http_DoConnection(struct http *hp);
 #define HTTPH_A_INS	(1 << 2)	/* Response (b->o) for insert */
 #define HTTPH_A_PASS	(1 << 3)	/* Response (b->o) for pass */
 
-#define HTTPH(a, b, c) extern char b[];
+#define HTTPH(a, b, c) extern const struct gethdr_t *const b;
 #include "tbl/http_headers.h"
 
-extern const char H__Status[];
-extern const char H__Proto[];
-extern const char H__Reason[];
+extern const struct gethdr_t *const H__Status;
+extern const struct gethdr_t *const H__Proto;
+extern const struct gethdr_t *const H__Reason;
 
 /* cache_main.c */
 #define VXID(u) ((u) & VSL_IDENTMASK)

--- a/bin/varnishd/cache/cache_ban.c
+++ b/bin/varnishd/cache/cache_ban.c
@@ -520,11 +520,13 @@ ban_evaluate(struct worker *wrk, const uint8_t *bsarg, struct objcore *oc,
 			break;
 		case BANS_ARG_REQHTTP:
 			AN(reqhttp);
-			(void)http_GetHdr(reqhttp, bt.arg1_spec, &p);
+			(void)http_GetHdr(reqhttp,
+			    (const struct gethdr_t *)bt.arg1_spec, &p);
 			arg1 = p;
 			break;
 		case BANS_ARG_OBJHTTP:
-			arg1 = HTTP_GetHdrPack(wrk, oc, bt.arg1_spec);
+			arg1 = HTTP_GetHdrPack(wrk, oc,
+			    (const struct gethdr_t *)bt.arg1_spec);
 			break;
 		case BANS_ARG_OBJSTATUS:
 			arg1 = HTTP_GetHdrPack(wrk, oc, H__Status);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -39,6 +39,8 @@
 #include "vcl.h"
 #include "vtim.h"
 
+const struct gethdr_t *const H_X_Varnish = GETHDR_T("X-Varnish");
+
 /*--------------------------------------------------------------------
  * Allocate an object, with fall-back to Transient.
  * XXX: This somewhat overlaps the stuff in stevedore.c
@@ -350,9 +352,10 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 	bo->storage = bo->do_pass ? stv_transient : STV_next();
 
 	if (bo->retries > 0)
-		http_Unset(bo->bereq, "\012X-Varnish:");
+		http_Unset(bo->bereq, H_X_Varnish);
 
-	http_PrintfHeader(bo->bereq, "X-Varnish: %u", VXID(bo->vsl->wid));
+	http_PrintfHeader(bo->bereq, "%s %u", H_X_Varnish->str,
+	    VXID(bo->vsl->wid));
 
 	VCL_backend_fetch_method(bo->vcl, wrk, NULL, bo, NULL);
 

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -296,9 +296,8 @@ http_IsHdr(const txt *hh, const struct gethdr_t *hdr)
 {
 
 	Tcheck(*hh);
-	AN(hdr);
-	assert(hdr->len == strlen(hdr->str));
-	assert(hdr->str[hdr->len - 1] == ':');
+	CHECK_GETHDR_T(hdr);
+	/* XXX: hh overflow? */
 	return (!strncasecmp(hdr->str, hh->b, hdr->len));
 }
 
@@ -375,8 +374,7 @@ http_CollectHdrSep(struct http *hp, const struct gethdr_t *hdr, const char *sep)
 		sep = ", ";
 	lsep = strlen(sep);
 
-	assert(hdr->len == strlen(hdr->str));
-	assert(hdr->str[hdr->len - 1] == ':');
+	CHECK_GETHDR_T(hdr);
 	f = http_findhdr(hp, hdr->len - 1, hdr->str);
 	if (f == 0)
 		return;
@@ -448,8 +446,7 @@ http_GetHdr(const struct http *hp, const struct gethdr_t *hdr, const char **ptr)
 	unsigned u;
 	const char *p;
 
-	assert(hdr->len == strlen(hdr->str));
-	assert(hdr->str[hdr->len - 1] == ':');
+	CHECK_GETHDR_T(hdr);
 	u = http_findhdr(hp, hdr->len - 1, hdr->str);
 	if (u == 0) {
 		if (ptr != NULL)
@@ -1027,11 +1024,7 @@ HTTP_GetHdrPack(struct worker *wrk, struct objcore *oc, const struct gethdr_t *h
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
-	AN(hdr);
-
-	assert(hdr->len > 0);
-	assert(hdr->len == strlen(hdr->str));
-	assert(hdr->str[hdr->len - 1] == ':');
+	CHECK_GETHDR_T(hdr);
 
 	if (hdr->str[0] == ':') {
 		/* Special cases */

--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -374,8 +374,6 @@ child_main(int sigmagic, size_t altstksz)
 	VCL_Init();
 	VCL_VRT_Init();
 
-	HTTP_Init();
-
 	VBO_Init();
 	VTP_Init();
 	VBP_Init();

--- a/bin/varnishd/cache/cache_vary.c
+++ b/bin/varnishd/cache/cache_vary.c
@@ -123,7 +123,7 @@ VRY_Create(struct busyobj *bo, struct vsb **psb)
 		    (char)(1 + (q - p)), (int)(q - p), p, 0));
 		AZ(VSB_finish(sbh));
 
-		if (http_GetHdr(bo->bereq, VSB_data(sbh), &h)) {
+		if (http_GetHdr(bo->bereq, (const void *)VSB_data(sbh), &h)) {
 			AZ(vct_issp(*h));
 			/* Trim trailing space */
 			e = strchr(h, '\0');
@@ -200,7 +200,7 @@ vry_cmp(const uint8_t *v1, const uint8_t *v2)
 		/* Different header */
 		retval = 1;
 	} else if (cache_param->http_gzip_support &&
-	    !strcasecmp(H_Accept_Encoding, (const char*) v1 + 2)) {
+	    !strcasecmp((const char*)H_Accept_Encoding, (const char*) v1 + 2)) {
 		/*
 		 * If we do gzip processing, we do not vary on Accept-Encoding,
 		 * because we want everybody to get the gzip'ed object, and
@@ -310,7 +310,8 @@ VRY_Match(struct req *req, const uint8_t *vary)
 			 */
 
 			ln = 2 + vary[2] + 2;
-			i = http_GetHdr(req->http, (const char*)(vary+2), &h);
+			i = http_GetHdr(req->http,
+			    (const struct gethdr_t*)(vary+2), &h);
 			if (i) {
 				/* Trim trailing space */
 				e = strchr(h, '\0');

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -567,9 +567,9 @@ VRT_SetHdr(VRT_CTX , VCL_HEADER hs, const char *p, ...)
 	if (p == vrt_magic_string_unset) {
 		http_Unset(hp, hs->what);
 	} else {
-		b = VRT_String(hp->ws, hs->what + 1, p, ap);
+		b = VRT_String(hp->ws, hs->what->str, p, ap);
 		if (b == NULL) {
-			VSLb(ctx->vsl, SLT_LostHeader, "%s", hs->what + 1);
+			VSLb(ctx->vsl, SLT_LostHeader, "%s", hs->what->str);
 		} else {
 			http_Unset(hp, hs->what);
 			http_SetHeader(hp, b);

--- a/bin/varnishtest/tests/r01406.vtc
+++ b/bin/varnishtest/tests/r01406.vtc
@@ -10,7 +10,7 @@ varnish v1 -arg "-p vcc_allow_inline_c=true" -vcl+backend {
 
 	C{
 		static const struct gethdr_s VGC_HDR_REQ_foo =
-		    { HDR_REQ, "\020X-CUSTOM-HEADER:"};
+		    { HDR_REQ, GETHDR_T("X-CUSTOM-HEADER") };
 	}C
 
 	sub vcl_recv {

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -60,6 +60,8 @@
  *	VRT_l_resp_body() changed
  *	VRT_l_beresp_body() changed
  *	VRT_Format_Proxy() added	// transitional interface
+ *	struct gethdr_t added
+ *	struct gethdr_s changed (same ABI)
  * 10.0 (2019-09-15)
  *	VRT_UpperLowerStrands added.
  *	VRT_synth_page now takes STRANDS argument
@@ -461,9 +463,18 @@ enum gethdr_e {
 	HDR_BERESP
 };
 
+struct gethdr_t {
+	uint8_t		len;
+	const char	str[];
+};
+
+#define GETHDR_T(name)	((const struct gethdr_t*)			\
+	    &(const struct { uint8_t _l; char _s[sizeof(name ":")]; })	\
+	    { sizeof(name), name ":" })
+
 struct gethdr_s {
-	enum gethdr_e	where;
-	const char	*what;
+	enum gethdr_e		where;
+	const struct gethdr_t	*what;
 };
 
 VCL_HTTP VRT_selecthttp(VRT_CTX, enum gethdr_e);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -472,6 +472,14 @@ struct gethdr_t {
 	    &(const struct { uint8_t _l; char _s[sizeof(name ":")]; })	\
 	    { sizeof(name), name ":" })
 
+#define CHECK_GETHDR_T(hdr)						\
+	do {								\
+		AN(hdr);						\
+		assert((hdr)->len > 0);					\
+		assert((hdr)->len == strlen((hdr)->str));		\
+		assert((hdr)->str[(hdr)->len - 1] == ':');		\
+	} while (0)
+
 struct gethdr_s {
 	enum gethdr_e		where;
 	const struct gethdr_t	*what;

--- a/lib/libvcc/vcc_var.c
+++ b/lib/libvcc/vcc_var.c
@@ -70,8 +70,8 @@ vcc_Var_Wildcard(struct vcc *tl, struct symbol *parent, struct symbol *sym)
 
 	/* Create the static identifier */
 	Fh(tl, 0, "static const struct gethdr_s %s =\n", VSB_data(vsb) + 1);
-	Fh(tl, 0, "    { %s, \"\\%03o%s:\"};\n",
-	    parent->rname, (unsigned int)strlen(sym->name) + 1, sym->name);
+	Fh(tl, 0, "    { %s, GETHDR_T(\"%s\") };\n",
+	    parent->rname, sym->name);
 
 	/* Create the symbol r/l values */
 	sym->rname = TlDup(tl, VSB_data(vsb));

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -726,9 +726,9 @@ xyzzy_sethdr(VRT_CTX, VCL_HEADER hs, VCL_STRANDS s)
 	if (s->n == 0) {
 		http_Unset(hp, hs->what);
 	} else {
-		b = VRT_StrandsWS(hp->ws, hs->what + 1, s);
+		b = VRT_StrandsWS(hp->ws, hs->what->str, s);
 		if (b == NULL) {
-			VSLb(ctx->vsl, SLT_LostHeader, "%s", hs->what + 1);
+			VSLb(ctx->vsl, SLT_LostHeader, "%s", hs->what->str);
 		} else {
 			if (*b != '\0')
 				WS_Assert_Allocated(hp->ws, b, strlen(b) + 1);


### PR DESCRIPTION
This replaces the (struct gethdr_s).what string, making it explicit in
the type system that the first octet of such strings contains a length
without changing the existing memory layout.

A convenience macro is here to create such a struct from a constant
string literal, which allows in turn to create true header constants
and drop the HTTP_Init() step.

The diff may be easier to follow with the --word-diff option.

---

This is a followup to #3214, to be reviewed after the 2020-03 release.
It breaks the VRT API but not its ABI.