### PR TITLE
Add VRT_AllocStrandsWS() to allocate strands on a workspace

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -181,6 +181,30 @@ VRT_GetHdr(VRT_CTX, VCL_HEADER hs)
 }
 
 /*--------------------------------------------------------------------
+ * Alloc Strands with space for n elements on workspace
+ *
+ * Error handling is deliberately left to the caller
+ */
+
+struct strands *
+VRT_AllocStrandsWS(struct ws *ws, int n)
+{
+	struct strands *s;
+	const char **p;
+
+	s = WS_Alloc(ws, sizeof *s);
+	p = WS_Alloc(ws, n * sizeof *p);
+
+	if (s == NULL || p == NULL)
+		return (NULL);
+
+	s->n = n;
+	s->p = p;
+
+	return (s);
+}
+
+/*--------------------------------------------------------------------
  * Build STRANDS from what is essentially a STRING_LIST
  */
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -60,6 +60,7 @@
  *	VRT_l_resp_body() changed
  *	VRT_l_beresp_body() changed
  *	VRT_Format_Proxy() added	// transitional interface
+ *	VRT_AllocStrandsWS() added
  * 10.0 (2019-09-15)
  *	VRT_UpperLowerStrands added.
  *	VRT_synth_page now takes STRANDS argument
@@ -205,6 +206,9 @@ struct strands {
 	int		n;
 	const char	**p;
 };
+
+struct strands * VRT_AllocStrandsWS(struct ws *, int);
+
 
 /*
  * VCL_BLOB:


### PR DESCRIPTION
So far, we have focused on transitioning vmod arguments to STRANDS.

To take the next step and also return STRANDS (which leverages the actual benefit - not copying unmodified strand elements), vmods need to allocate a struct strands on the workspace.

This commit adds a utility function for this common task.

Implementation note: A single `WS_Alloc()` with some pointer arithmetic would suffice, but using two results in cleaner code.