### PR TITLE
fix ctx->msg for cold events

### DIFF
--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -344,7 +344,7 @@ do_list(struct cli *cli, struct director *d, void *priv)
 		d->vdir->methods->list(ctx, d, la->vsb, la->p, 0);
 
 	VSB_printf(la->vsb, "\n");
-	VCL_Rel_CliCtx(&ctx);
+	AZ(VCL_Rel_CliCtx(&ctx));
 	AZ(ctx);
 
 	return (0);
@@ -389,7 +389,7 @@ do_list_json(struct cli *cli, struct director *d, void *priv)
 	VSB_indent(cli->sb, -2);
 	VCLI_Out(cli, "}");
 
-	VCL_Rel_CliCtx(&ctx);
+	AZ(VCL_Rel_CliCtx(&ctx));
 	AZ(ctx);
 
 	return (0);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -430,7 +430,7 @@ const char *VCL_Method_Name(unsigned);
 void VCL_Bo2Ctx(struct vrt_ctx *, struct busyobj *);
 void VCL_Req2Ctx(struct vrt_ctx *, struct req *);
 struct vrt_ctx *VCL_Get_CliCtx(int);
-void VCL_Rel_CliCtx(struct vrt_ctx **);
+struct vsb *VCL_Rel_CliCtx(struct vrt_ctx **);
 
 #define VCL_MET_MAC(l,u,t,b) \
     void VCL_##l##_method(struct vcl *, struct worker *, struct req *, \

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -611,6 +611,7 @@ vcl_load(struct cli *cli, struct vrt_ctx *ctx,
     const char *name, const char *fn, const char *state)
 {
 	struct vcl *vcl;
+	struct vsb *msg;
 	int i;
 
 	ASSERT_CLI();
@@ -618,13 +619,17 @@ vcl_load(struct cli *cli, struct vrt_ctx *ctx,
 	vcl = vcl_find(name);
 	AZ(vcl);
 
-	vcl = VCL_Open(fn, ctx->msg);
+	msg = VSB_new_auto();
+	vcl = VCL_Open(fn, msg);
+	AZ(VSB_finish(ctx->msg));
 	if (vcl == NULL) {
-		AZ(VSB_finish(ctx->msg));
 		VCLI_SetResult(cli, CLIS_PARAM);
 		VCLI_Out(cli, "%s", VSB_data(ctx->msg));
+		VSB_destroy(&msg);
 		return;
 	}
+
+	VSB_destroy(&msg);
 
 	vcl->loaded_name = strdup(name);
 	XXXAN(vcl->loaded_name);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -292,7 +292,6 @@ struct vrt_ctx {
 	 * msg is for error messages and exists only for
 	 * VCL_EVENT_LOAD
 	 * VCL_EVENT_WARM
-	 * VCL_EVENT_COLD
 	 */
 	struct vsb			*msg;
 	struct vsl_log			*vsl;

--- a/lib/libvmod_debug/vmod_debug.c
+++ b/lib/libvmod_debug/vmod_debug.c
@@ -499,7 +499,7 @@ event_cold(VRT_CTX, const struct vmod_priv *priv)
 	pthread_t thread;
 	struct priv_vcl *priv_vcl;
 
-	AN(ctx->msg);
+	AZ(ctx->msg);
 
 	CAST_OBJ_NOTNULL(priv_vcl, priv->priv, PRIV_VCL_MAGIC);
 


### PR DESCRIPTION
This text is a slightly edited version of the commit message from the third commit, as the other two are only preparations.

This PR adds the final bit to fix #2902: As discussed in the ticket, there should be no `VRT_CTX` `msg` vsb present for `COLD` events, yet existing code did provide it in some cases.

Comments on the most relevant changes to `cache_vcl.c` in order of appearance:

Existing code kept the CLI `VRT_CTX` around for longer than it strictly needed to just because access to the error message in `ctx->msg` was still required.

In order to be able to simplify management of the CLI `VRT_CTX`, we change `VCL_Rel_CliCtx()` to return the `ctx->msg` IFF it was requested by a _true_ argument to `VCL_Get_CliCtx()`

Regarding #2902, the main issue with existing code was that the decision on whether or not to request a `ctx->msg` was separated from where we could actually make that decision: It is (only) in
`vcl_send_event()` where we know which event is going to be issued, which, in turn, determines if we are going to need a `ctx->msg`.

Thus, we move the `VRT_CTX` management for all of the CLI operations into one place in `vcl_send_event()` and change the infrastructure around it to handle the vcl and the error message vsb instead of a `VRT_CTX`.

This allows us to (finally) ensure that `VCL_EVENT_COLD` does never have a `ctx->msg` error vsb, asserted by `AZ(havemsg)` in the switch/case statement in `vcl_send_event()`.

In `vcl_send_event()`, we also assert that if a vcl subroutine was called in the case of a LOAD or DISCARD event, only `vcl_init {}` for a LOAD event may return anything but OK.

`vcl_set_state()` contains the two use cases of `vcl_send_event()`: When we know that an event may not fail, we also assert that there is no msg vsb returned, and if it could, we keep it, as it is still required by its callers.

`vcl_cancel_load()` shows how the new infrastructure simplifies the code: Rather than having to re-setup the `VRT_CTX` for the DISCARD event, we simply output the error and have `vcl_send_event()` set up the proper handling for that event.

Basically the same pattern repeats in `vcl_load()`, `VCL_Poll()` and `vcl_cli_state()`: In these functions, we only look after error handling and output.

Fixes #2902