### PR TITLE
varnishstat.rst: Mention default log level in curses mode

### DIFF
--- a/doc/sphinx/reference/varnishstat.rst
+++ b/doc/sphinx/reference/varnishstat.rst
@@ -30,7 +30,7 @@ The following options are available:
 CURSES MODE
 ===========
 
-When neither -1, -j or -x options are given, the application starts up
+When neither -1, -j nor -x options are given, the application starts up
 in curses mode. This shows a continuously updated view of the counter
 values, along with their description.
 
@@ -40,6 +40,8 @@ The center area shows a list of counter values.
 
 The bottom area shows the description of the currently selected
 counter.
+
+On startup, only counters at INFO level are shown.
 
 Columns
 -------


### PR DESCRIPTION
The Keybindings section is the only place mentioning differnt log levels
and one might assume that `-1` or `-j` behave the same as the default
ncurses interface.

The latter however does not show all counters by default as the single
action flags do, hence `varnishstat -f '*overload*'` will not show
`MAIN.sc_overload` by default, with `-1` however it does.

Fix grammar while here.