### PR TITLE
Fix formatting on 'ESI on invalid XML'

### DIFF
--- a/doc/sphinx/users-guide/esi.rst
+++ b/doc/sphinx/users-guide/esi.rst
@@ -107,7 +107,7 @@ ESI on invalid XML
 
 The ESI parser expects the XML to be reasonably well formed, but
 this may fail if you are ESI including non-XML files.  You can
-make the ESI parser disrecard anything but ESI tags by setting:
+make the ESI parser disrecard anything but ESI tags by setting::
 
    param.set feature +esi_ignore_other_elements
 


### PR DESCRIPTION
There's a tiny typo in the documentation users-guide/esi.rst which causes a wrong formatting in the section "ESI on invalid XML":

![image](https://user-images.githubusercontent.com/3702203/75010014-5f505700-547c-11ea-960e-17c7de3bf0ea.png)