### PR TITLE
TTL logging for bereq.uncacheable / Keep Age information on passes

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -124,8 +124,9 @@ VRT_hit_for_pass(VRT_CTX, VCL_DURATION d)
 	oc->ttl = d;
 	oc->grace = 0.0;
 	oc->keep = 0.0;
-	VSLb(ctx->vsl, SLT_TTL, "HFP %.0f %.0f %.0f %.0f uncacheable",
-	    oc->ttl, oc->grace, oc->keep, oc->t_origin);
+	if (!(oc->flags & OC_F_PRIVATE))
+		VSLb(ctx->vsl, SLT_TTL, "HFP %.0f %.0f %.0f %.0f uncacheable",
+		    oc->ttl, oc->grace, oc->keep, oc->t_origin);
 }
 
 /*--------------------------------------------------------------------*/


### PR DESCRIPTION
When doing a pass, we would remove the Age header from the backend, and
create a new one based on the time the fetch was initiated. This creates
problems when calculating the time to live in downstream caches (browser
cache or layered varnishes).

This patch set makes Varnish parse the Age header and update t_origin accordingly. That makes the synthesized Age header correct in delivery.

Also a patch is added that makes us consistently not log TTL log lines for private/pass objects.