### PR TITLE
RFC: Expansion of probe .request definitions

### DIFF
--- a/bin/varnishtest/tests/RFC.vtc
+++ b/bin/varnishtest/tests/RFC.vtc
@@ -1,0 +1,52 @@
+varnishtest "probe request expansion"
+
+barrier b1 cond 3
+
+server s1 {
+	rxreq
+	expect req.http.date != <undef>
+	expect req.http.host == s1.example.org
+	expect req.http.user-agent == Varnish/%{version}
+	expect req.http.connection == close
+	txresp
+	barrier b1 sync
+	expect_close
+} -start
+
+server s2 {
+	rxreq
+	expect req.http.date != <undef>
+	expect req.http.host == s2.example.org
+	expect req.http.user-agent == Varnish/%{version}
+	expect req.http.connection == close
+	txresp
+	barrier b1 sync
+	expect_close
+} -start
+
+varnish v1 -vcl {
+	probe default {
+		.request =
+		    "HEALTH * HTTP/1.1"
+		    "Date: %{now}"
+		    "%{host_header}"
+		    "User-Agent: Varnish/%{version}"
+		    "Connection: close";
+	}
+	backend s1 {
+		.host = "${s1_sock}";
+		.host_header = "s1.example.org";
+	}
+	backend s2 {
+		.host = "${s2_sock}";
+		.host_header = "s2.example.org";
+	}
+	sub vcl_recv {
+		set req.backend_hint = s2; # reference s2
+	}
+} -start
+
+barrier b1 sync
+
+server s1 -wait
+server s2 -wait


### PR DESCRIPTION
It is possible to share a probe between multiple backends today, but it
becomes impossible to share a probe with a .request field with a proper
Host header.

Either the backend is in cahoots with Varnish and will expect a specific
domain for health checks (for example Host: health) or we simply don't
send the header despite its mandatory status in HTTP/1.1.

This patch introduces incomplete and rudimentary %{variable} expansion
in the probe request in a way that could be outsourced in an include
table used both to build a probe request or generate documentation.

An initial set of two variables is implemented:

- %{host_header} for the reason mentioned above
- %{now} in order to generate a Date header

We could imagine more variables like %{version} as suggested by the test
case. The %{...} syntax was selected to avoid conflicts with varnishtest
macros and is only here to illustrate the mechanics. This is something I
would tend to check at vcl.load time, this is completely missing from
this RFC.