### PR TITLE
varnish.m4: Fix documentation mistake

### DIFF
--- a/varnish.m4
+++ b/varnish.m4
@@ -437,7 +437,7 @@ clean-vsc-$1:
 #     @BUILD_VSC_FOO@
 #     @BUILD_VSC_BAR@
 #
-# They take care of turning VSC_foo.vsc and VCS_bar.vcs into C code and
+# They take care of turning VSC_foo.vsc and VCS_bar.vsc into C code and
 # RST documentation.
 #
 # Just like the vcc_*_if.[ch] files, you need to manually add the generated

--- a/varnish.m4
+++ b/varnish.m4
@@ -429,7 +429,7 @@ clean-vsc-$1:
 # to declare sets of counters, but does not associates them automatically
 # with their respective VMODs:
 #
-#     VARNISH_UTILITIES([foo bar])
+#     VARNISH_COUNTERS([foo bar])
 #
 # Two build rules will be available for use in Makefile.am for the counters
 # foo and bar:


### PR DESCRIPTION
I think this got copied and pasted from the VARNISH_UTILITIES macro below. If I understand correctly, the macro is called VARNISH_COUNTERS and should be used as `VARNISH_COUNTERS([foo bar])`.