### PR TITLE
Document more dynamic parameters bounds

### DIFF
--- a/bin/varnishd/common/common_param.h
+++ b/bin/varnishd/common/common_param.h
@@ -82,7 +82,8 @@ struct params {
 #define	ptyp_uint	unsigned
 #define	ptyp_vsl_buffer	unsigned
 #define	ptyp_vsl_reclen	unsigned
-#define PARAM(nm, ty, mi, ma, de, un, fl, st) ptyp_##ty nm;
+#define PARAM(nm, ty, ...)		\
+	ptyp_##ty		nm;
 #include <tbl/params.h>
 #undef ptyp_bool
 #undef ptyp_bytes

--- a/bin/varnishd/common/common_param.h
+++ b/bin/varnishd/common/common_param.h
@@ -82,7 +82,7 @@ struct params {
 #define	ptyp_uint	unsigned
 #define	ptyp_vsl_buffer	unsigned
 #define	ptyp_vsl_reclen	unsigned
-#define PARAM(nm, ty, mi, ma, de, un, fl, st, lt, fn) ptyp_##ty nm;
+#define PARAM(nm, ty, mi, ma, de, un, fl, st) ptyp_##ty nm;
 #include <tbl/params.h>
 #undef ptyp_bool
 #undef ptyp_bytes

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -766,15 +766,16 @@ MCF_DumpRstParam(void)
 
 		if (pp->units != NULL && *pp->units != '\0')
 			printf("\t* Units: %s\n", pp->units);
-		printf("\t* Default: %s\n", pp->def);
-		if (pp->dyn_min_reason != NULL)
-			printf("\t* Minimum: %s\n", pp->dyn_min_reason);
-		else if (pp->min != NULL)
-			printf("\t* Minimum: %s\n", pp->min);
-		if (pp->dyn_max_reason != NULL)
-			printf("\t* Maximum: %s\n", pp->dyn_max_reason);
-		else if (pp->max != NULL)
-			printf("\t* Maximum: %s\n", pp->max);
+#define MCF_DYN_REASON(lbl, nm)					\
+		if (pp->dyn_ ## nm ## _reason != NULL)		\
+			printf("\t* " #lbl ": %s\n",		\
+			    pp->dyn_ ## nm ## _reason);		\
+		else if (pp->nm != NULL)			\
+			printf("\t* " #lbl ": %s\n", pp->nm);
+		MCF_DYN_REASON(Default, def);
+		MCF_DYN_REASON(Minimum, min);
+		MCF_DYN_REASON(Maximum, max);
+#undef MCF_DYN_REASON
 		/*
 		 * XXX: we should mark the params with one/two flags
 		 * XXX: that say if ->min/->max are valid, so we

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -59,6 +59,7 @@ struct parspec {
 
 	const char	*dyn_min_reason;
 	const char	*dyn_max_reason;
+	const char	*dyn_def_reason;
 	char		*dyn_min;
 	char		*dyn_max;
 	char		*dyn_def;

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -43,6 +43,8 @@ struct parspec {
 	volatile void	*priv;
 	const char	*min;
 	const char	*max;
+	const char	*def;
+	const char	*units;
 	const char	*descr;
 	int		 flags;
 #define DELAYED_EFFECT	(1<<0)
@@ -54,9 +56,6 @@ struct parspec {
 #define OBJ_STICKY	(1<<6)
 #define ONLY_ROOT	(1<<7)
 #define NOT_IMPLEMENTED	(1<<8)
-
-	const char	*def;
-	const char	*units;
 
 	const char	*dyn_min_reason;
 	const char	*dyn_max_reason;

--- a/bin/varnishd/mgt/mgt_param_bits.c
+++ b/bin/varnishd/mgt/mgt_param_bits.c
@@ -252,27 +252,32 @@ tweak_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
  */
 
 struct parspec VSL_parspec[] = {
-	{ "vsl_mask", tweak_vsl_mask, NULL, NULL, NULL,
+	{ "vsl_mask", tweak_vsl_mask, NULL,
+		NULL, NULL, "default",
+		NULL,
 		"Mask individual VSL messages from being logged.\n"
 		"\tdefault\tSet default value\n"
 		"\nUse +/- prefix in front of VSL tag name to unmask/mask "
-		"individual VSL messages.",
-		0, "default", "" },
-	{ "debug", tweak_debug, NULL, NULL, NULL,
+		"individual VSL messages." },
+	{ "debug", tweak_debug, NULL,
+		NULL, NULL, "none",
+		NULL,
 		"Enable/Disable various kinds of debugging.\n"
 		"\tnone\tDisable all debugging\n\n"
 		"Use +/- prefix to set/reset individual bits:"
 #define DEBUG_BIT(U, l, d) "\n\t" #l "\t" d
 #include "tbl/debug_bits.h"
 #undef DEBUG_BIT
-		, 0, "none", "" },
-	{ "feature", tweak_feature, NULL, NULL, NULL,
+		},
+	{ "feature", tweak_feature, NULL,
+		NULL, NULL, "none",
+		NULL,
 		"Enable/Disable various minor features.\n"
 		"\tnone\tDisable all features.\n\n"
 		"Use +/- prefix to enable/disable individual feature:"
 #define FEATURE_BIT(U, l, d, ld) "\n\t" #l "\t" d
 #include "tbl/feature_bits.h"
 #undef FEATURE_BIT
-		, 0, "none", "" },
+		},
 	{ NULL, NULL, NULL }
 };

--- a/bin/varnishd/mgt/mgt_param_tbl.c
+++ b/bin/varnishd/mgt/mgt_param_tbl.c
@@ -45,9 +45,7 @@
 	"\tmax_age\tmax age of free element."
 
 struct parspec mgt_parspec[] = {
-#define PARAM(nm, ty, mi, ma, de, un, fl, st, ...)			\
-	{ #nm, tweak_##ty, &mgt_param.nm, mi, ma, de, un, st, fl,	\
-	    __VA_ARGS__ },
+#define PARAM(nm, ty, ...) { #nm, tweak_##ty, &mgt_param.nm, __VA_ARGS__ },
 #include "tbl/params.h"
 
 	{ "cc_command", tweak_string, &mgt_cc_cmd,

--- a/bin/varnishd/mgt/mgt_param_tbl.c
+++ b/bin/varnishd/mgt/mgt_param_tbl.c
@@ -45,8 +45,9 @@
 	"\tmax_age\tmax age of free element."
 
 struct parspec mgt_parspec[] = {
-#define PARAM(nm, ty, mi, ma, de, un, fl, st)				\
-	{ #nm, tweak_##ty, &mgt_param.nm, mi, ma, st, fl, de, un },
+#define PARAM(nm, ty, mi, ma, de, un, fl, st, ...)			\
+	{ #nm, tweak_##ty, &mgt_param.nm, mi, ma, st, fl, de, un,	\
+	    __VA_ARGS__ },
 #include "tbl/params.h"
 
 	{ "cc_command", tweak_string, &mgt_cc_cmd,

--- a/bin/varnishd/mgt/mgt_param_tbl.c
+++ b/bin/varnishd/mgt/mgt_param_tbl.c
@@ -46,66 +46,59 @@
 
 struct parspec mgt_parspec[] = {
 #define PARAM(nm, ty, mi, ma, de, un, fl, st, ...)			\
-	{ #nm, tweak_##ty, &mgt_param.nm, mi, ma, st, fl, de, un,	\
+	{ #nm, tweak_##ty, &mgt_param.nm, mi, ma, de, un, st, fl,	\
 	    __VA_ARGS__ },
 #include "tbl/params.h"
 
 	{ "cc_command", tweak_string, &mgt_cc_cmd,
-		NULL, NULL,
+		NULL, NULL, VCC_CC,
+		NULL,
 		"Command used for compiling the C source code to a "
 		"dlopen(3) loadable object.  Any occurrence of %s in "
 		"the string will be replaced with the source file name, "
 		"and %o will be replaced with the output file name.",
-		MUST_RELOAD,
-		VCC_CC , NULL },
+		MUST_RELOAD },
 	{ "vcl_path", tweak_string, &mgt_vcl_path,
-		NULL, NULL,
+		NULL, NULL, VARNISH_VCL_DIR,
+		NULL,
 		"Directory (or colon separated list of directories) "
 		"from which relative VCL filenames (vcl.load and "
 		"include) are to be found.  By default Varnish searches "
 		"VCL files in both the system configuration and shared "
 		"data directories to allow packages to drop their VCL "
 		"files in a standard location where relative includes "
-		"would work.",
-		0,
-		VARNISH_VCL_DIR,
-		NULL },
+		"would work." },
 	{ "vmod_path", tweak_string, &mgt_vmod_path,
-		NULL, NULL,
+		NULL, NULL, VARNISH_VMOD_DIR,
+		NULL,
 		"Directory (or colon separated list of directories) "
-		"where VMODs are to be found.",
-		0,
-		VARNISH_VMOD_DIR,
-		NULL },
+		"where VMODs are to be found." },
 	{ "vcc_err_unref", tweak_bool, &mgt_vcc_err_unref,
-		NULL, NULL,
-		"Unreferenced VCL objects result in error.",
-		0,
-		"on", "bool" },
+		NULL, NULL, "on",
+		"bool",
+		"Unreferenced VCL objects result in error." },
 	{ "vcc_allow_inline_c", tweak_bool, &mgt_vcc_allow_inline_c,
-		NULL, NULL,
-		"Allow inline C code in VCL.",
-		0,
-		"off", "bool" },
+		NULL, NULL, "off",
+		"bool",
+		"Allow inline C code in VCL." },
 	{ "vcc_unsafe_path", tweak_bool, &mgt_vcc_unsafe_path,
-		NULL, NULL,
+		NULL, NULL, "on",
+		"bool",
 		"Allow '/' in vmod & include paths.\n"
-		"Allow 'import ... from ...'.",
-		0,
-		"on", "bool" },
+		"Allow 'import ... from ...'." },
 	{ "pcre_match_limit", tweak_uint,
 		&mgt_param.vre_limits.match,
-		"1", NULL,
+		"1", NULL, "10000",
+		NULL,
 		"The limit for the number of calls to the internal match()"
 		" function in pcre_exec().\n\n"
 		"(See: PCRE_EXTRA_MATCH_LIMIT in pcre docs.)\n\n"
 		"This parameter limits how much CPU time"
-		" regular expression matching can soak up.",
-		0,
-		"10000", ""},
+		" regular expression matching can soak up." },
 	{ "pcre_match_limit_recursion", tweak_uint,
 		&mgt_param.vre_limits.match_recursion,
-		"1", NULL,
+		"1", NULL, "20",
+		NULL,
 		"The recursion depth-limit for the internal match() function"
 		" in a pcre_exec().\n\n"
 		"(See: PCRE_EXTRA_MATCH_LIMIT_RECURSION in pcre docs.)\n\n"
@@ -116,27 +109,22 @@ struct parspec mgt_parspec[] = {
 		" matching failures.\n\n"
 		"Matching failures will show up in the log as VCL_Error"
 		" messages with regexp errors -27 or -21.\n\n"
-		"Testcase r01576 can be useful when tuning this parameter.",
-		0,
-		"20", ""},
+		"Testcase r01576 can be useful when tuning this parameter." },
 	{ "pool_req", tweak_poolparam, &mgt_param.req_pool,
-		NULL, NULL,
+		NULL, NULL, "10,100,10",
+		NULL,
 		"Parameters for per worker pool request memory pool.\n\n"
-		MEMPOOL_TEXT,
-		0,
-		"10,100,10", ""},
+		MEMPOOL_TEXT },
 	{ "pool_sess", tweak_poolparam, &mgt_param.sess_pool,
-		NULL, NULL,
+		NULL, NULL, "10,100,10",
+		NULL,
 		"Parameters for per worker pool session memory pool.\n\n"
-		MEMPOOL_TEXT,
-		0,
-		"10,100,10", ""},
+		MEMPOOL_TEXT },
 	{ "pool_vbo", tweak_poolparam, &mgt_param.vbo_pool,
-		NULL, NULL,
+		NULL, NULL, "10,100,10",
+		NULL,
 		"Parameters for backend object fetch memory pool.\n\n"
-		MEMPOOL_TEXT,
-		0,
-		"10,100,10", ""},
+		MEMPOOL_TEXT },
 
 	{ NULL, NULL, NULL }
 };

--- a/bin/varnishd/mgt/mgt_param_tbl.c
+++ b/bin/varnishd/mgt/mgt_param_tbl.c
@@ -45,7 +45,7 @@
 	"\tmax_age\tmax age of free element."
 
 struct parspec mgt_parspec[] = {
-#define PARAM(nm, ty, mi, ma, de, un, fl, st, lt, fn)		\
+#define PARAM(nm, ty, mi, ma, de, un, fl, st)				\
 	{ #nm, tweak_##ty, &mgt_param.nm, mi, ma, st, fl, de, un },
 #include "tbl/params.h"
 

--- a/bin/varnishd/mgt/mgt_pool.c
+++ b/bin/varnishd/mgt/mgt_pool.c
@@ -228,7 +228,7 @@ struct parspec WRK_parspec[] = {
 		EXPERIMENTAL },
 	{ "thread_pool_stack",
 		tweak_bytes, &mgt_param.wthread_stacksize,
-		NULL, NULL, NULL,	// default set in mgt_main.c
+		NULL, NULL, NULL,	// default set in mgt_param.c
 		"bytes",
 		"Worker thread stack size.\n"
 		"This will likely be rounded up to a multiple of 4k"
@@ -264,6 +264,7 @@ struct parspec WRK_parspec[] = {
 		" overflow occurs. Setting it in 150%-200%"
 		" increments is recommended until stack overflows"
 		" cease to occur.",
-		DELAYED_EFFECT },
+		DELAYED_EFFECT,
+		NULL, NULL, "sysconf(_SC_THREAD_STACK_MIN)" },
 	{ NULL, NULL, NULL }
 };

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -369,35 +369,6 @@ PARAM(
 	/* flags */	WIZARD
 )
 
-#if 0
-/* actual location mgt_param_bits.c*/
-/* see tbl/debug_bits.h */
-PARAM(
-	/* name */	debug,
-	/* type */	debug,
-	/* min */	NULL,
-	/* max */	NULL,
-	/* def */	NULL,
-	/* units */	NULL,
-	/* descr */
-	"Enable/Disable various kinds of debugging.\n"
-	"	none	Disable all debugging\n"
-	"\n"
-	"Use +/- prefix to set/reset individual bits:\n"
-	"	req_state	VSL Request state engine\n"
-	"	workspace	VSL Workspace operations\n"
-	"	waiter	VSL Waiter internals\n"
-	"	waitinglist	VSL Waitinglist events\n"
-	"	syncvsl	Make VSL synchronous\n"
-	"	hashedge	Edge cases in Hash\n"
-	"	vclrel	Rapid VCL release\n"
-	"	lurker	VSL Ban lurker\n"
-	"	esi_chop	Chop ESI fetch to bits\n"
-	"	flush_head	Flush after http1 head\n"
-	"	vtc_mode	Varnishtest Mode"
-)
-#endif
-
 PARAM(
 	/* name */	default_grace,
 	/* type */	timeout,
@@ -453,31 +424,6 @@ PARAM(
 	"  Allocated from workspace_thread.",
 	/* flags */	WIZARD
 )
-
-#if 0
-/* actual location mgt_param_bits.c*/
-/* See tbl/feature_bits.h */
-PARAM(
-	/* name */	feature,
-	/* type */	feature,
-	/* min */	NULL,
-	/* max */	NULL,
-	/* def */	NULL,
-	/* units */	NULL,
-	/* descr */
-	"Enable/Disable various minor features.\n"
-	"	none	Disable all features.\n"
-	"\n"
-	"Use +/- prefix to enable/disable individual feature:\n"
-	"	short_panic	Short panic message.\n"
-	"	wait_silo	Wait for persistent silo.\n"
-	"	no_coredump	No coredumps.\n"
-	"	esi_ignore_https	Treat HTTPS as HTTP in ESI:includes\n"
-	"	esi_disable_xml_check	Don't check of body looks like XML\n"
-	"	esi_ignore_other_elements	Ignore non-esi XML-elements\n"
-	"	esi_remove_bom	Remove UTF-8 BOM"
-)
-#endif
 
 PARAM(
 	/* name */	fetch_chunksize,
@@ -752,34 +698,6 @@ PARAM(
 	/* flags */	EXPERIMENTAL
 )
 
-#if 0
-/* actual location mgt_param_tbl.c */
-PARAM(
-	/* name */	pcre_match_limit,
-	/* type */	uint,
-	/* min */	"1",
-	/* max */	NULL,
-	/* def */	"1.000",
-	/* units */	NULL,
-	/* descr */
-	"The limit for the  number of internal matching function calls in "
-	"a pcre_exec() execution."
-)
-
-/* actual location mgt_param_tbl.c */
-PARAM(
-	/* name */	pcre_match_limit_recursion,
-	/* type */	uint,
-	/* min */	"1",
-	/* max */	NULL,
-	/* def */	"1.000",
-	/* units */	NULL,
-	/* descr */
-	"The limit for the  number of internal matching function "
-	"recursions in a pcre_exec() execution."
-)
-#endif
-
 PARAM(
 	/* name */	ping_interval,
 	/* type */	uint,
@@ -816,47 +734,6 @@ PARAM(
 	"Idle timeout for PIPE sessions. If nothing have been received in "
 	"either direction for this many seconds, the session is closed."
 )
-
-#if 0
-/* actual location mgt_param_tbl.c */
-PARAM(
-	/* name */	pool_req,
-	/* type */	poolparam,
-	/* min */	NULL,
-	/* max */	NULL,
-	/* def */	"10,100,10",
-	/* units */	NULL,
-	/* descr */
-	"Parameters for per worker pool request memory pool.\n"
-	MEMPOOL_TEXT
-)
-
-/* actual location mgt_param_tbl.c */
-PARAM(
-	/* name */	pool_sess,
-	/* type */	poolparam,
-	/* min */	NULL,
-	/* max */	NULL,
-	/* def */	"10,100,10",
-	/* units */	NULL,
-	/* descr */
-	"Parameters for per worker pool session memory pool.\n"
-	MEMPOOL_TEXT
-)
-
-/* actual location mgt_param_tbl.c */
-PARAM(
-	/* name */	pool_vbo,
-	/* type */	poolparam,
-	/* min */	NULL,
-	/* max */	NULL,
-	/* def */	"10,100,10",
-	/* units */	NULL,
-	/* descr */
-	"Parameters for backend object fetch memory pool.\n"
-	MEMPOOL_TEXT
-)
-#endif
 
 PARAM(
 	/* name */	prefer_ipv6,
@@ -1013,7 +890,428 @@ PARAM(
 )
 #undef XYZZY
 
+#if defined(XYZZY)
+  #error "Temporary macro XYZZY already defined"
+#endif
+
+#if defined(SO_RCVTIMEO_WORKS)
+  #define XYZZY 0
+#else
+  #define XYZZY NOT_IMPLEMENTED
+#endif
+PARAM(
+	/* name */	timeout_idle,
+	/* type */	timeout,
+	/* min */	"0.000",
+	/* max */	NULL,
+	/* def */	"5.000",
+	/* units */	"seconds",
+	/* descr */
+	"Idle timeout for client connections.\n\n"
+	"A connection is considered idle until we have received the full"
+	" request headers.\n\n"
+	"This parameter is particularly relevant for HTTP1 keepalive "
+	" connections which are closed unless the next request is received"
+	" before this timeout is reached.",
+	/* flags */	XYZZY
+)
+#undef XYZZY
+
+PARAM(
+	/* name */	timeout_linger,
+	/* type */	timeout,
+	/* min */	"0.000",
+	/* max */	NULL,
+	/* def */	"0.050",
+	/* units */	"seconds",
+	/* descr */
+	"How long the worker thread lingers on an idle session before "
+	"handing it over to the waiter.\n"
+	"When sessions are reused, as much as half of all reuses happen "
+	"within the first 100 msec of the previous request completing.\n"
+	"Setting this too high results in worker threads not doing "
+	"anything for their keep, setting it too low just means that more "
+	"sessions take a detour around the waiter.",
+	/* flags */	EXPERIMENTAL
+)
+
+PARAM(
+	/* name */	vcl_cooldown,
+	/* type */	timeout,
+	/* min */	"1.000",
+	/* max */	NULL,
+	/* def */	"600.000",
+	/* units */	"seconds",
+	/* descr */
+	"How long a VCL is kept warm after being replaced as the "
+	"active VCL (granularity approximately 30 seconds)."
+)
+
+PARAM(
+	/* name */	max_vcl_handling,
+	/* type */	uint,
+	/* min */	"0",
+	/* max */	"2",
+	/* def */	"1",
+	/* units */	NULL,
+	/* descr */
+	"Behaviour when attempting to exceed max_vcl loaded VCL.\n"
+	"\n*  0 - Ignore max_vcl parameter.\n"
+	"\n*  1 - Issue warning.\n"
+	"\n*  2 - Refuse loading VCLs."
+)
+
+PARAM(
+	/* name */	max_vcl,
+	/* type */	uint,
+	/* min */	"0",
+	/* max */	NULL,
+	/* def */	"100",
+	/* units */	NULL,
+	/* descr */
+	"Threshold of loaded VCL programs.  (VCL labels are not counted.)"
+	"  Parameter max_vcl_handling determines behaviour."
+)
+
+PARAM(
+	/* name */	vsm_free_cooldown,
+	/* type */	timeout,
+	/* min */	"10.000",
+	/* max */	"600.000",
+	/* def */	"60.000",
+	/* units */	"seconds",
+	/* descr */
+	"How long VSM memory is kept warm after a deallocation "
+	"(granularity approximately 2 seconds)."
+)
+
+PARAM(
+	/* name */	vsl_buffer,
+	/* type */	vsl_buffer,
+	/* min */	"267",
+	/* max */	NULL,
+	/* def */	"4k",
+	/* units */	"bytes",
+	/* descr */
+	"Bytes of (req-/backend-)workspace dedicated to buffering VSL "
+	"records.\n"
+	"When this parameter is adjusted, most likely workspace_client "
+	"and workspace_backend will have to be adjusted by the same amount.\n\n"
+	"Setting this too high costs memory, setting it too low will cause "
+	"more VSL flushes and likely increase lock-contention on the VSL "
+	"mutex.",
+	/* flags */	0,
+	/* dyn_min_reason */	"vsl_reclen + 12 bytes"
+)
+
+PARAM(
+	/* name */	vsl_reclen,
+	/* type */	vsl_reclen,
+	/* min */	"16b",
+	/* max */	NULL,
+	/* def */	"255b",
+	/* units */	"bytes",
+	/* descr */
+	"Maximum number of bytes in SHM log record.",
+	/* flags */	0,
+	/* dyn_min_reason */	NULL,
+	/* dyn_max_reason */	"vsl_buffer - 12 bytes"
+)
+
+PARAM(
+	/* name */	vsl_space,
+	/* type */	bytes,
+	/* min */	"1M",
+	/* max */	"4G",
+	/* def */	"80M",
+	/* units */	"bytes",
+	/* descr */
+	"The amount of space to allocate for the VSL fifo buffer in the "
+	"VSM memory segment.  If you make this too small, "
+	"varnish{ncsa|log} etc will not be able to keep up.  Making it too "
+	"large just costs memory resources.",
+	/* flags */	MUST_RESTART
+)
+
+PARAM(
+	/* name */	vsm_space,
+	/* type */	bytes,
+	/* min */	"1M",
+	/* max */	"1G",
+	/* def */	"1M",
+	/* units */	"bytes",
+	/* descr */
+	"DEPRECATED: This parameter is ignored.\n"
+	"There is no global limit on amount of shared memory now."
+)
+
+PARAM(
+	/* name */	workspace_backend,
+	/* type */	bytes_u,
+	/* min */	"1k",
+	/* max */	NULL,
+	/* def */	"64k",
+	/* units */	"bytes",
+	/* descr */
+	"Bytes of HTTP protocol workspace for backend HTTP req/resp.  If "
+	"larger than 4k, use a multiple of 4k for VM efficiency.",
+	/* flags */	DELAYED_EFFECT
+)
+
+PARAM(
+	/* name */	workspace_client,
+	/* type */	bytes_u,
+	/* min */	"9k",
+	/* max */	NULL,
+	/* def */	"64k",
+	/* units */	"bytes",
+	/* descr */
+	"Bytes of HTTP protocol workspace for clients HTTP req/resp.  Use a "
+	"multiple of 4k for VM efficiency.\n"
+	"For HTTP/2 compliance this must be at least 20k, in order to "
+	"receive fullsize (=16k) frames from the client.   That usually "
+	"happens only in POST/PUT bodies.  For other traffic-patterns "
+	"smaller values work just fine.",
+	/* flags */	DELAYED_EFFECT
+)
+
+PARAM(
+	/* name */	workspace_session,
+	/* type */	bytes_u,
+	/* min */	"0.25k",
+	/* max */	NULL,
+	/* def */	"0.75k",
+	/* units */	"bytes",
+	/* descr */
+	"Allocation size for session structure and workspace.    The "
+	"workspace is primarily used for TCP connection addresses.  If "
+	"larger than 4k, use a multiple of 4k for VM efficiency.",
+	/* flags */	DELAYED_EFFECT
+)
+
+PARAM(
+	/* name */	workspace_thread,
+	/* type */	bytes_u,
+	/* min */	"0.25k",
+	/* max */	"8k",
+	/* def */	"2k",
+	/* units */	"bytes",
+	/* descr */
+	"Bytes of auxiliary workspace per thread.\n"
+	"This workspace is used for certain temporary data structures "
+	"during the operation of a worker thread.\n"
+	"One use is for the IO-vectors used during delivery. Setting "
+	"this parameter too low may increase the number of writev() "
+	"syscalls, setting it too high just wastes space.  ~0.1k + "
+	"UIO_MAXIOV * sizeof(struct iovec) (typically = ~16k for 64bit) "
+	"is considered the maximum sensible value under any known "
+	"circumstances (excluding exotic vmod use).",
+	/* flags */	DELAYED_EFFECT
+)
+
+PARAM(
+	/* name */	h2_rx_window_low_water,
+	/* type */	bytes_u,
+	/* min */	"65535",
+	/* max */	"1G",
+	/* def */	"10M",
+	/* units */	"bytes",
+	/* descr */
+	"HTTP2 Receive Window low water mark.\n"
+	"We try to keep the window at least this big\n"
+	"Only affects incoming request bodies (ie: POST, PUT etc.)",
+	/* flags */	WIZARD
+)
+
+PARAM(
+	/* name */	h2_rx_window_increment,
+	/* type */	bytes_u,
+	/* min */	"1M",
+	/* max */	"1G",
+	/* def */	"1M",
+	/* units */	"bytes",
+	/* descr */
+	"HTTP2 Receive Window Increments.\n"
+	"How big credits we send in WINDOW_UPDATE frames\n"
+	"Only affects incoming request bodies (ie: POST, PUT etc.)",
+	/* flags */	WIZARD
+)
+
+PARAM(
+	/* name */	h2_header_table_size,
+	/* type */	bytes_u,
+	/* min */	"0b",
+	/* max */	NULL,
+	/* def */	"4k",
+	/* units */	"bytes",
+	/* descr */
+	"HTTP2 header table size.\n"
+	"This is the size that will be used for the HPACK dynamic\n"
+	"decoding table."
+)
+
+PARAM(
+	/* name */	h2_max_concurrent_streams,
+	/* type */	uint,
+	/* min */	"0",
+	/* max */	NULL,
+	/* def */	"100",
+	/* units */	"streams",
+	/* descr */
+	"HTTP2 Maximum number of concurrent streams.\n"
+	"This is the number of requests that can be active\n"
+	"at the same time for a single HTTP2 connection."
+)
+
+PARAM(
+	/* name */	h2_initial_window_size,
+	/* type */	bytes_u,
+	/* min */	"0",
+	/* max */	"2147483647b",
+	/* def */	"65535b",
+	/* units */	"bytes",
+	/* descr */
+	"HTTP2 initial flow control window size."
+)
+
+PARAM(
+	/* name */	h2_max_frame_size,
+	/* type */	bytes_u,
+	/* min */	"16k",
+	/* max */	"16777215b",
+	/* def */	"16k",
+	/* units */	"bytes",
+	/* descr */
+	"HTTP2 maximum per frame payload size we are willing to accept."
+)
+
+PARAM(
+	/* name */	h2_max_header_list_size,
+	/* type */	bytes_u,
+	/* min */	"0b",
+	/* max */	NULL,
+	/* def */	"2147483647b",
+	/* units */	"bytes",
+	/* descr */
+	"HTTP2 maximum size of an uncompressed header list."
+)
+
 #if 0
+/* actual location mgt_param_bits.c*/
+/* see tbl/debug_bits.h */
+PARAM(
+	/* name */	debug,
+	/* type */	debug,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* def */	NULL,
+	/* units */	NULL,
+	/* descr */
+	"Enable/Disable various kinds of debugging.\n"
+	"	none	Disable all debugging\n"
+	"\n"
+	"Use +/- prefix to set/reset individual bits:\n"
+	"	req_state	VSL Request state engine\n"
+	"	workspace	VSL Workspace operations\n"
+	"	waiter	VSL Waiter internals\n"
+	"	waitinglist	VSL Waitinglist events\n"
+	"	syncvsl	Make VSL synchronous\n"
+	"	hashedge	Edge cases in Hash\n"
+	"	vclrel	Rapid VCL release\n"
+	"	lurker	VSL Ban lurker\n"
+	"	esi_chop	Chop ESI fetch to bits\n"
+	"	flush_head	Flush after http1 head\n"
+	"	vtc_mode	Varnishtest Mode"
+)
+
+/* actual location mgt_param_bits.c*/
+/* See tbl/feature_bits.h */
+PARAM(
+	/* name */	feature,
+	/* type */	feature,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* def */	NULL,
+	/* units */	NULL,
+	/* descr */
+	"Enable/Disable various minor features.\n"
+	"	none	Disable all features.\n"
+	"\n"
+	"Use +/- prefix to enable/disable individual feature:\n"
+	"	short_panic	Short panic message.\n"
+	"	wait_silo	Wait for persistent silo.\n"
+	"	no_coredump	No coredumps.\n"
+	"	esi_ignore_https	Treat HTTPS as HTTP in ESI:includes\n"
+	"	esi_disable_xml_check	Don't check of body looks like XML\n"
+	"	esi_ignore_other_elements	Ignore non-esi XML-elements\n"
+	"	esi_remove_bom	Remove UTF-8 BOM"
+)
+
+/* actual location mgt_param_tbl.c */
+PARAM(
+	/* name */	pcre_match_limit,
+	/* type */	uint,
+	/* min */	"1",
+	/* max */	NULL,
+	/* def */	"1.000",
+	/* units */	NULL,
+	/* descr */
+	"The limit for the  number of internal matching function calls in "
+	"a pcre_exec() execution."
+)
+
+/* actual location mgt_param_tbl.c */
+PARAM(
+	/* name */	pcre_match_limit_recursion,
+	/* type */	uint,
+	/* min */	"1",
+	/* max */	NULL,
+	/* def */	"1.000",
+	/* units */	NULL,
+	/* descr */
+	"The limit for the  number of internal matching function "
+	"recursions in a pcre_exec() execution."
+)
+
+/* actual location mgt_param_tbl.c */
+PARAM(
+	/* name */	pool_req,
+	/* type */	poolparam,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* def */	"10,100,10",
+	/* units */	NULL,
+	/* descr */
+	"Parameters for per worker pool request memory pool.\n"
+	MEMPOOL_TEXT
+)
+
+/* actual location mgt_param_tbl.c */
+PARAM(
+	/* name */	pool_sess,
+	/* type */	poolparam,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* def */	"10,100,10",
+	/* units */	NULL,
+	/* descr */
+	"Parameters for per worker pool session memory pool.\n"
+	MEMPOOL_TEXT
+)
+
+/* actual location mgt_param_tbl.c */
+PARAM(
+	/* name */	pool_vbo,
+	/* type */	poolparam,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* def */	"10,100,10",
+	/* units */	NULL,
+	/* descr */
+	"Parameters for backend object fetch memory pool.\n"
+	MEMPOOL_TEXT
+)
+
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_add_delay,
@@ -1239,54 +1537,7 @@ PARAM(
 	"stats into the global counters.",
 	/* flags */	EXPERIMENTAL
 )
-#endif
 
-#if defined(XYZZY)
-  #error "Temporary macro XYZZY already defined"
-#endif
-
-#if defined(SO_RCVTIMEO_WORKS)
-  #define XYZZY 0
-#else
-  #define XYZZY NOT_IMPLEMENTED
-#endif
-PARAM(
-	/* name */	timeout_idle,
-	/* type */	timeout,
-	/* min */	"0.000",
-	/* max */	NULL,
-	/* def */	"5.000",
-	/* units */	"seconds",
-	/* descr */
-	"Idle timeout for client connections.\n\n"
-	"A connection is considered idle until we have received the full"
-	" request headers.\n\n"
-	"This parameter is particularly relevant for HTTP1 keepalive "
-	" connections which are closed unless the next request is received"
-	" before this timeout is reached.",
-	/* flags */	XYZZY
-)
-#undef XYZZY
-
-PARAM(
-	/* name */	timeout_linger,
-	/* type */	timeout,
-	/* min */	"0.000",
-	/* max */	NULL,
-	/* def */	"0.050",
-	/* units */	"seconds",
-	/* descr */
-	"How long the worker thread lingers on an idle session before "
-	"handing it over to the waiter.\n"
-	"When sessions are reused, as much as half of all reuses happen "
-	"within the first 100 msec of the previous request completing.\n"
-	"Setting this too high results in worker threads not doing "
-	"anything for their keep, setting it too low just means that more "
-	"sessions take a detour around the waiter.",
-	/* flags */	EXPERIMENTAL
-)
-
-#if 0
 /* actual location mgt_param_tbl.c */
 PARAM(
 	/* name */	vcc_allow_inline_c,
@@ -1323,78 +1574,7 @@ PARAM(
 	"Allow '/' in vmod & include paths.\n"
 	"Allow 'import ... from ...'."
 )
-#endif
 
-PARAM(
-	/* name */	vcl_cooldown,
-	/* type */	timeout,
-	/* min */	"1.000",
-	/* max */	NULL,
-	/* def */	"600.000",
-	/* units */	"seconds",
-	/* descr */
-	"How long a VCL is kept warm after being replaced as the "
-	"active VCL (granularity approximately 30 seconds)."
-)
-
-PARAM(
-	/* name */	max_vcl_handling,
-	/* type */	uint,
-	/* min */	"0",
-	/* max */	"2",
-	/* def */	"1",
-	/* units */	NULL,
-	/* descr */
-	"Behaviour when attempting to exceed max_vcl loaded VCL.\n"
-	"\n*  0 - Ignore max_vcl parameter.\n"
-	"\n*  1 - Issue warning.\n"
-	"\n*  2 - Refuse loading VCLs."
-)
-
-PARAM(
-	/* name */	max_vcl,
-	/* type */	uint,
-	/* min */	"0",
-	/* max */	NULL,
-	/* def */	"100",
-	/* units */	NULL,
-	/* descr */
-	"Threshold of loaded VCL programs.  (VCL labels are not counted.)"
-	"  Parameter max_vcl_handling determines behaviour."
-)
-
-PARAM(
-	/* name */	vsm_free_cooldown,
-	/* type */	timeout,
-	/* min */	"10.000",
-	/* max */	"600.000",
-	/* def */	"60.000",
-	/* units */	"seconds",
-	/* descr */
-	"How long VSM memory is kept warm after a deallocation "
-	"(granularity approximately 2 seconds)."
-)
-
-PARAM(
-	/* name */	vsl_buffer,
-	/* type */	vsl_buffer,
-	/* min */	"267",
-	/* max */	NULL,
-	/* def */	"4k",
-	/* units */	"bytes",
-	/* descr */
-	"Bytes of (req-/backend-)workspace dedicated to buffering VSL "
-	"records.\n"
-	"When this parameter is adjusted, most likely workspace_client "
-	"and workspace_backend will have to be adjusted by the same amount.\n\n"
-	"Setting this too high costs memory, setting it too low will cause "
-	"more VSL flushes and likely increase lock-contention on the VSL "
-	"mutex.",
-	/* flags */	0,
-	/* dyn_min_reason */	"vsl_reclen + 12 bytes"
-)
-
-#if 0
 /* actual location mgt_param_bits.c*/
 PARAM(
 	/* name */	vsl_mask,
@@ -1411,198 +1591,6 @@ PARAM(
 	"individual VSL messages."
 )
 #endif
-
-PARAM(
-	/* name */	vsl_reclen,
-	/* type */	vsl_reclen,
-	/* min */	"16b",
-	/* max */	NULL,
-	/* def */	"255b",
-	/* units */	"bytes",
-	/* descr */
-	"Maximum number of bytes in SHM log record.",
-	/* flags */	0,
-	/* dyn_min_reason */	NULL,
-	/* dyn_max_reason */	"vsl_buffer - 12 bytes"
-)
-
-PARAM(
-	/* name */	vsl_space,
-	/* type */	bytes,
-	/* min */	"1M",
-	/* max */	"4G",
-	/* def */	"80M",
-	/* units */	"bytes",
-	/* descr */
-	"The amount of space to allocate for the VSL fifo buffer in the "
-	"VSM memory segment.  If you make this too small, "
-	"varnish{ncsa|log} etc will not be able to keep up.  Making it too "
-	"large just costs memory resources.",
-	/* flags */	MUST_RESTART
-)
-
-PARAM(
-	/* name */	vsm_space,
-	/* type */	bytes,
-	/* min */	"1M",
-	/* max */	"1G",
-	/* def */	"1M",
-	/* units */	"bytes",
-	/* descr */
-	"DEPRECATED: This parameter is ignored.\n"
-	"There is no global limit on amount of shared memory now."
-)
-
-PARAM(
-	/* name */	workspace_backend,
-	/* type */	bytes_u,
-	/* min */	"1k",
-	/* max */	NULL,
-	/* def */	"64k",
-	/* units */	"bytes",
-	/* descr */
-	"Bytes of HTTP protocol workspace for backend HTTP req/resp.  If "
-	"larger than 4k, use a multiple of 4k for VM efficiency.",
-	/* flags */	DELAYED_EFFECT
-)
-
-PARAM(
-	/* name */	workspace_client,
-	/* type */	bytes_u,
-	/* min */	"9k",
-	/* max */	NULL,
-	/* def */	"64k",
-	/* units */	"bytes",
-	/* descr */
-	"Bytes of HTTP protocol workspace for clients HTTP req/resp.  Use a "
-	"multiple of 4k for VM efficiency.\n"
-	"For HTTP/2 compliance this must be at least 20k, in order to "
-	"receive fullsize (=16k) frames from the client.   That usually "
-	"happens only in POST/PUT bodies.  For other traffic-patterns "
-	"smaller values work just fine.",
-	/* flags */	DELAYED_EFFECT
-)
-
-PARAM(
-	/* name */	workspace_session,
-	/* type */	bytes_u,
-	/* min */	"0.25k",
-	/* max */	NULL,
-	/* def */	"0.75k",
-	/* units */	"bytes",
-	/* descr */
-	"Allocation size for session structure and workspace.    The "
-	"workspace is primarily used for TCP connection addresses.  If "
-	"larger than 4k, use a multiple of 4k for VM efficiency.",
-	/* flags */	DELAYED_EFFECT
-)
-
-PARAM(
-	/* name */	workspace_thread,
-	/* type */	bytes_u,
-	/* min */	"0.25k",
-	/* max */	"8k",
-	/* def */	"2k",
-	/* units */	"bytes",
-	/* descr */
-	"Bytes of auxiliary workspace per thread.\n"
-	"This workspace is used for certain temporary data structures "
-	"during the operation of a worker thread.\n"
-	"One use is for the IO-vectors used during delivery. Setting "
-	"this parameter too low may increase the number of writev() "
-	"syscalls, setting it too high just wastes space.  ~0.1k + "
-	"UIO_MAXIOV * sizeof(struct iovec) (typically = ~16k for 64bit) "
-	"is considered the maximum sensible value under any known "
-	"circumstances (excluding exotic vmod use).",
-	/* flags */	DELAYED_EFFECT
-)
-
-PARAM(
-	/* name */	h2_rx_window_low_water,
-	/* type */	bytes_u,
-	/* min */	"65535",
-	/* max */	"1G",
-	/* def */	"10M",
-	/* units */	"bytes",
-	/* descr */
-	"HTTP2 Receive Window low water mark.\n"
-	"We try to keep the window at least this big\n"
-	"Only affects incoming request bodies (ie: POST, PUT etc.)",
-	/* flags */	WIZARD
-)
-
-PARAM(
-	/* name */	h2_rx_window_increment,
-	/* type */	bytes_u,
-	/* min */	"1M",
-	/* max */	"1G",
-	/* def */	"1M",
-	/* units */	"bytes",
-	/* descr */
-	"HTTP2 Receive Window Increments.\n"
-	"How big credits we send in WINDOW_UPDATE frames\n"
-	"Only affects incoming request bodies (ie: POST, PUT etc.)",
-	/* flags */	WIZARD
-)
-
-PARAM(
-	/* name */	h2_header_table_size,
-	/* type */	bytes_u,
-	/* min */	"0b",
-	/* max */	NULL,
-	/* def */	"4k",
-	/* units */	"bytes",
-	/* descr */
-	"HTTP2 header table size.\n"
-	"This is the size that will be used for the HPACK dynamic\n"
-	"decoding table."
-)
-
-PARAM(
-	/* name */	h2_max_concurrent_streams,
-	/* type */	uint,
-	/* min */	"0",
-	/* max */	NULL,
-	/* def */	"100",
-	/* units */	"streams",
-	/* descr */
-	"HTTP2 Maximum number of concurrent streams.\n"
-	"This is the number of requests that can be active\n"
-	"at the same time for a single HTTP2 connection."
-)
-
-PARAM(
-	/* name */	h2_initial_window_size,
-	/* type */	bytes_u,
-	/* min */	"0",
-	/* max */	"2147483647b",
-	/* def */	"65535b",
-	/* units */	"bytes",
-	/* descr */
-	"HTTP2 initial flow control window size."
-)
-
-PARAM(
-	/* name */	h2_max_frame_size,
-	/* type */	bytes_u,
-	/* min */	"16k",
-	/* max */	"16777215b",
-	/* def */	"16k",
-	/* units */	"bytes",
-	/* descr */
-	"HTTP2 maximum per frame payload size we are willing to accept."
-)
-
-PARAM(
-	/* name */	h2_max_header_list_size,
-	/* type */	bytes_u,
-	/* min */	"0b",
-	/* max */	NULL,
-	/* def */	"2147483647b",
-	/* units */	"bytes",
-	/* descr */
-	"HTTP2 maximum size of an uncompressed header list."
-)
 
 #undef PARAM
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -27,7 +27,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * PARAM(nm, ty, mi, ma, de, un, fl, st, lt, fn)
+ * PARAM(nm, ty, mi, ma, de, un, fl, st)
  */
 
 /*lint -save -e525 -e539 */
@@ -55,9 +55,7 @@ PARAM(
 	"Enabling accept_filter may prevent some requests to reach Varnish "
 	"in the first place. Malformed requests may go unnoticed and not "
 	"increase the client_req_400 counter. GET or HEAD requests with a "
-	"body may be blocked altogether.",
-	/* l-text */	NULL,
-	/* func */	NULL
+	"body may be blocked altogether."
 )
 #undef XYZZY
 
@@ -73,9 +71,7 @@ PARAM(
 	"If we run out of resources, such as file descriptors or worker "
 	"threads, the acceptor will sleep between accepts.\n"
 	"This parameter (multiplicatively) reduce the sleep duration for "
-	"each successful accept. (ie: 0.9 = reduce by 10%)",
-	/* l-text */	"",
-	/* func */	NULL
+	"each successful accept. (ie: 0.9 = reduce by 10%)"
 )
 
 PARAM(
@@ -90,9 +86,7 @@ PARAM(
 	"If we run out of resources, such as file descriptors or worker "
 	"threads, the acceptor will sleep between accepts.\n"
 	"This parameter control how much longer we sleep, each time we "
-	"fail to accept a new connection.",
-	/* l-text */	"",
-	/* func */	NULL
+	"fail to accept a new connection."
 )
 
 PARAM(
@@ -107,9 +101,7 @@ PARAM(
 	"If we run out of resources, such as file descriptors or worker "
 	"threads, the acceptor will sleep between accepts.\n"
 	"This parameter limits how long it can sleep between attempts to "
-	"accept new connections.",
-	/* l-text */	"",
-	/* func */	NULL
+	"accept new connections."
 )
 
 PARAM(
@@ -121,9 +113,7 @@ PARAM(
 	/* units */	"bool",
 	/* flags */	0,
 	/* s-text */
-	"Automatically restart the child/worker process if it dies.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Automatically restart the child/worker process if it dies."
 )
 
 PARAM(
@@ -138,9 +128,7 @@ PARAM(
 	"Eliminate older identical bans when a new ban is added.  This saves "
 	"CPU cycles by not comparing objects to identical bans.\n"
 	"This is a waste of time if you have many bans which are never "
-	"identical.",
-	/* l-text */	"",
-	/* func */	NULL
+	"identical."
 )
 
 PARAM(
@@ -170,9 +158,7 @@ PARAM(
 	"additional latency due to request ban testing is in the order of "
 	"ban_cutoff / rate(bans_lurker_tests_tested). For example, for "
 	"rate(bans_lurker_tests_tested) = 2M/s and a tolerable latency of "
-	"100ms, a good value for ban_cutoff may be 200K.",
-	/* l-text */	"",
-	/* func */	NULL
+	"100ms, a good value for ban_cutoff may be 200K."
 )
 
 PARAM(
@@ -189,9 +175,7 @@ PARAM(
 	"as part of object lookup.  Because many applications issue bans in "
 	"bursts, this parameter holds the ban-lurker off until the rush is "
 	"over.\n"
-	"This should be set to the approximate time which a ban-burst takes.",
-	/* l-text */	"",
-	/* func */	NULL
+	"This should be set to the approximate time which a ban-burst takes."
 )
 
 PARAM(
@@ -205,9 +189,7 @@ PARAM(
 	/* s-text */
 	"The ban lurker sleeps ${ban_lurker_sleep} after examining this "
 	"many objects."
-	"  Use this to pace the ban-lurker if it eats too many resources.",
-	/* l-text */	"",
-	/* func */	NULL
+	"  Use this to pace the ban-lurker if it eats too many resources."
 )
 
 PARAM(
@@ -222,9 +204,7 @@ PARAM(
 	"How long the ban lurker sleeps after examining ${ban_lurker_batch} "
 	"objects."
 	"  Use this to pace the ban-lurker if it eats too many resources.\n"
-	"A value of zero will disable the ban lurker entirely.",
-	/* l-text */	"",
-	/* func */	NULL
+	"A value of zero will disable the ban lurker entirely."
 )
 
 PARAM(
@@ -237,9 +217,7 @@ PARAM(
 	/* flags */	EXPERIMENTAL,
 	/* s-text */
 	"How long the ban lurker sleeps when giving way to lookup"
-	" due to lock contention.",
-	/* l-text */	"",
-	/* func */	NULL
+	" due to lock contention."
 )
 
 PARAM(
@@ -255,9 +233,7 @@ PARAM(
 	"wait for this many seconds for the first byte before giving up.\n"
 	"VCL can override this default value for each backend and backend "
 	"request.\n"
-	"This parameter does not apply to pipe'ed requests.",
-	/* l-text */	"",
-	/* func */	NULL
+	"This parameter does not apply to pipe'ed requests."
 )
 
 PARAM(
@@ -272,9 +248,7 @@ PARAM(
 	"We only wait for this many seconds between bytes received from "
 	"the backend before giving up the fetch.\n"
 	"VCL values, per backend or per backend request take precedence.\n"
-	"This parameter does not apply to pipe'ed requests.",
-	/* l-text */	"",
-	/* func */	NULL
+	"This parameter does not apply to pipe'ed requests."
 )
 
 PARAM(
@@ -286,9 +260,7 @@ PARAM(
 	/* units */	"seconds",
 	/* flags */	0,
 	/* s-text */
-	"Timeout before we close unused backend connections.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Timeout before we close unused backend connections."
 )
 
 PARAM(
@@ -306,9 +278,7 @@ PARAM(
 	"may worsen the situation due to the complexity of the operations "
 	"involved in the kernel.\n"
 	"This parameter prevents repeated connection attempts for the "
-	"configured duration.",
-	/* l-text */	"",
-	/* func */	NULL
+	"configured duration."
 )
 
 PARAM(
@@ -325,9 +295,7 @@ PARAM(
 	"not accepting connections or routing problems for which repeated "
 	"connection attempts are considered useless\n"
 	"This parameter prevents repeated connection attempts for the "
-	"configured duration.",
-	/* l-text */	"",
-	/* func */	NULL
+	"configured duration."
 )
 
 PARAM(
@@ -341,9 +309,7 @@ PARAM(
 	/* s-text */
 	"Maximum size of CLI response.  If the response exceeds this "
 	"limit, the response code will be 201 instead of 200 and the last "
-	"line will indicate the truncation.",
-	/* l-text */	"",
-	/* func */	NULL
+	"line will indicate the truncation."
 )
 
 PARAM(
@@ -356,9 +322,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Timeout for the childs replies to CLI requests from the "
-	"mgt_param.",
-	/* l-text */	"",
-	/* func */	NULL
+	"mgt_param."
 )
 
 PARAM(
@@ -371,9 +335,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"How much clockskew we are willing to accept between the backend "
-	"and our own clock.",
-	/* l-text */	"",
-	/* func */	NULL
+	"and our own clock."
 )
 
 PARAM(
@@ -386,9 +348,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"How much observed clock step we are willing to accept before "
-	"we panic.",
-	/* l-text */	"",
-	/* func */	NULL
+	"we panic."
 )
 
 PARAM(
@@ -403,9 +363,7 @@ PARAM(
 	"Default connection timeout for backend connections. We only try "
 	"to connect to the backend for this many seconds before giving up. "
 	"VCL can override this default value for each backend and backend "
-	"request.",
-	/* l-text */	"",
-	/* func */	NULL
+	"request."
 )
 
 PARAM(
@@ -418,9 +376,7 @@ PARAM(
 	/* flags */	WIZARD,
 	/* s-text */
 	"How long the critbit hasher keeps deleted objheads on the cooloff "
-	"list.",
-	/* l-text */	"",
-	/* func */	NULL
+	"list."
 )
 
 #if 0
@@ -449,9 +405,7 @@ PARAM(
 	"	lurker	VSL Ban lurker\n"
 	"	esi_chop	Chop ESI fetch to bits\n"
 	"	flush_head	Flush after http1 head\n"
-	"	vtc_mode	Varnishtest Mode",
-	/* l-text */	"",
-	/* func */	NULL
+	"	vtc_mode	Varnishtest Mode"
 )
 #endif
 
@@ -466,9 +420,7 @@ PARAM(
 	/* s-text */
 	"Default grace period.  We will deliver an object this long after "
 	"it has expired, provided another thread is attempting to get a "
-	"new copy.",
-	/* l-text */	"",
-	/* func */	NULL
+	"new copy."
 )
 
 PARAM(
@@ -483,9 +435,7 @@ PARAM(
 	"Default keep period.  We will keep a useless object around this "
 	"long, making it available for conditional backend fetches.  That "
 	"means that the object will be removed from the cache at the end "
-	"of ttl+grace+keep.",
-	/* l-text */	"",
-	/* func */	NULL
+	"of ttl+grace+keep."
 )
 
 PARAM(
@@ -498,9 +448,7 @@ PARAM(
 	/* flags */	OBJ_STICKY,
 	/* s-text */
 	"The TTL assigned to objects if neither the backend nor the VCL "
-	"code assigns one.",
-	/* l-text */	"",
-	/* func */	NULL
+	"code assigns one."
 )
 
 PARAM(
@@ -514,9 +462,7 @@ PARAM(
 	/* s-text */
 	"Number of io vectors to allocate for HTTP1 protocol transmission."
 	"  A HTTP1 header needs 7 + 2 per HTTP header field."
-	"  Allocated from workspace_thread.",
-	/* l-text */	"",
-	/* func */	NULL
+	"  Allocated from workspace_thread."
 )
 
 #if 0
@@ -541,9 +487,7 @@ PARAM(
 	"	esi_ignore_https	Treat HTTPS as HTTP in ESI:includes\n"
 	"	esi_disable_xml_check	Don't check of body looks like XML\n"
 	"	esi_ignore_other_elements	Ignore non-esi XML-elements\n"
-	"	esi_remove_bom	Remove UTF-8 BOM",
-	/* l-text */	"",
-	/* func */	NULL
+	"	esi_remove_bom	Remove UTF-8 BOM"
 )
 #endif
 
@@ -559,9 +503,7 @@ PARAM(
 	"The default chunksize used by fetcher. This should be bigger than "
 	"the majority of objects with short TTLs.\n"
 	"Internal limits in the storage_file module makes increases above "
-	"128kb a dubious idea.",
-	/* l-text */	"",
-	/* func */	NULL
+	"128kb a dubious idea."
 )
 
 PARAM(
@@ -574,9 +516,7 @@ PARAM(
 	/* flags */	EXPERIMENTAL,
 	/* s-text */
 	"The maximum chunksize we attempt to allocate from storage. Making "
-	"this too large may cause delays and storage fragmentation.",
-	/* l-text */	"",
-	/* func */	NULL
+	"this too large may cause delays and storage fragmentation."
 )
 
 PARAM(
@@ -592,9 +532,7 @@ PARAM(
 	"These buffers are used for in-transit data, for instance "
 	"gunzip'ed data being sent to a client.Making this space to small "
 	"results in more overhead, writes to sockets etc, making it too "
-	"big is probably just a waste of memory.",
-	/* l-text */	"",
-	/* func */	NULL
+	"big is probably just a waste of memory."
 )
 
 PARAM(
@@ -606,9 +544,7 @@ PARAM(
 	/* units */	NULL,
 	/* flags */	0,
 	/* s-text */
-	"Gzip compression level: 0=debug, 1=fast, 9=best",
-	/* l-text */	"",
-	/* func */	NULL
+	"Gzip compression level: 0=debug, 1=fast, 9=best"
 )
 
 PARAM(
@@ -621,9 +557,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Gzip memory level 1=slow/least, 9=fast/most compression.\n"
-	"Memory impact is 1=1k, 2=2k, ... 9=256k.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Memory impact is 1=1k, 2=2k, ... 9=256k."
 )
 
 PARAM(
@@ -647,10 +581,8 @@ PARAM(
 	"please see the chapter on gzip in the Varnish reference.\n"
 	"\n"
 	"When gzip support is disabled the variables beresp.do_gzip and "
-	"beresp.do_gunzip have no effect in VCL.",
+	"beresp.do_gunzip have no effect in VCL."
 	/* XXX: what about the effect on beresp.filters? */
-	/* l-text */	"",
-	/* func */	NULL
 )
 
 PARAM(
@@ -666,9 +598,7 @@ PARAM(
 	"{req|resp|bereq|beresp}.http (obj.http is autosized to the exact "
 	"number of headers).\n"
 	"Cheap, ~20 bytes, in terms of workspace memory.\n"
-	"Note that the first line occupies five header lines.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Note that the first line occupies five header lines."
 )
 
 PARAM(
@@ -680,9 +610,7 @@ PARAM(
 	/* units */	"bool",
 	/* flags */	0,
 	/* s-text */
-	"Enable support for HTTP Range headers.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Enable support for HTTP Range headers."
 )
 
 PARAM(
@@ -695,9 +623,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Maximum length of any HTTP client request header we will allow.  "
-	"The limit is inclusive its continuation lines.",
-	/* l-text */	"",
-	/* func */	NULL
+	"The limit is inclusive its continuation lines."
 )
 
 PARAM(
@@ -714,9 +640,7 @@ PARAM(
 	"ends the HTTP request.\n"
 	"The memory for the request is allocated from the client workspace "
 	"(param: workspace_client) and this parameter limits how much of "
-	"that the request is allowed to take up.",
-	/* l-text */	"",
-	/* func */	NULL
+	"that the request is allowed to take up."
 )
 
 PARAM(
@@ -729,9 +653,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Maximum length of any HTTP backend response header we will allow. "
-	" The limit is inclusive its continuation lines.",
-	/* l-text */	"",
-	/* func */	NULL
+	" The limit is inclusive its continuation lines."
 )
 
 PARAM(
@@ -748,9 +670,7 @@ PARAM(
 	"which ends the HTTP response.\n"
 	"The memory for the response is allocated from the backend workspace "
 	"(param: workspace_backend) and this parameter limits how much "
-	"of that the response is allowed to take up.",
-	/* l-text */	"",
-	/* func */	NULL
+	"of that the response is allowed to take up."
 )
 
 #if defined(XYZZY)
@@ -775,9 +695,7 @@ PARAM(
 	" May get extended if 'send_timeout' applies.\n\n"
 	"When this timeout is hit, the session is closed.\n\n"
 	"See the man page for `setsockopt(2)` or `socket(7)` under"
-	" ``SO_SNDTIMEO`` for more information.",
-	/* l-text */	"",
-	/* func */	NULL
+	" ``SO_SNDTIMEO`` for more information."
 )
 #undef XYZZY
 
@@ -790,9 +708,7 @@ PARAM(
 	/* units */	"connections",
 	/* flags */	MUST_RESTART,
 	/* s-text */
-	"Listen queue depth.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Listen queue depth."
 )
 
 PARAM(
@@ -808,9 +724,7 @@ PARAM(
 	"Objects are only moved to the front of the LRU list if they have "
 	"not been moved there already inside this timeout period.  This "
 	"reduces the amount of lock operations necessary for LRU list "
-	"access.",
-	/* l-text */	"",
-	/* func */	NULL
+	"access."
 )
 
 PARAM(
@@ -822,9 +736,7 @@ PARAM(
 	/* units */	"levels",
 	/* flags */	0,
 	/* s-text */
-	"Maximum depth of esi:include processing.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Maximum depth of esi:include processing."
 )
 
 PARAM(
@@ -836,9 +748,7 @@ PARAM(
 	/* units */	"restarts",
 	/* flags */	0,
 	/* s-text */
-	"Upper limit on how many times a request can restart.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Upper limit on how many times a request can restart."
 )
 
 PARAM(
@@ -850,9 +760,7 @@ PARAM(
 	/* units */	"retries",
 	/* flags */	0,
 	/* s-text */
-	"Upper limit on how many times a backend fetch can retry.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Upper limit on how many times a backend fetch can retry."
 )
 
 PARAM(
@@ -865,9 +773,7 @@ PARAM(
 	/* flags */	EXPERIMENTAL,
 	/* s-text */
 	"Maximum number of objects we attempt to nuke in order to make "
-	"space for a object body.",
-	/* l-text */	"",
-	/* func */	NULL
+	"space for a object body."
 )
 
 #if 0
@@ -882,9 +788,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"The limit for the  number of internal matching function calls in "
-	"a pcre_exec() execution.",
-	/* l-text */	"",
-	/* func */	NULL
+	"a pcre_exec() execution."
 )
 
 /* actual location mgt_param_tbl.c */
@@ -898,9 +802,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"The limit for the  number of internal matching function "
-	"recursions in a pcre_exec() execution.",
-	/* l-text */	"",
-	/* func */	NULL
+	"recursions in a pcre_exec() execution."
 )
 #endif
 
@@ -915,9 +817,7 @@ PARAM(
 	/* s-text */
 	"Interval between pings from parent to child.\n"
 	"Zero will disable pinging entirely, which makes it possible to "
-	"attach a debugger to the child.",
-	/* l-text */	"",
-	/* func */	NULL
+	"attach a debugger to the child."
 )
 
 PARAM(
@@ -929,9 +829,7 @@ PARAM(
 	/* units */	"connections",
 	/* flags */	0,
 	/* s-text */
-	"Maximum number of sessions dedicated to pipe transactions.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Maximum number of sessions dedicated to pipe transactions."
 )
 
 PARAM(
@@ -944,9 +842,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Idle timeout for PIPE sessions. If nothing have been received in "
-	"either direction for this many seconds, the session is closed.",
-	/* l-text */	"",
-	/* func */	NULL
+	"either direction for this many seconds, the session is closed."
 )
 
 #if 0
@@ -961,9 +857,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Parameters for per worker pool request memory pool.\n"
-	MEMPOOL_TEXT,
-	/* l-text */	"",
-	/* func */	NULL
+	MEMPOOL_TEXT
 )
 
 /* actual location mgt_param_tbl.c */
@@ -977,9 +871,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Parameters for per worker pool session memory pool.\n"
-	MEMPOOL_TEXT,
-	/* l-text */	"",
-	/* func */	NULL
+	MEMPOOL_TEXT
 )
 
 /* actual location mgt_param_tbl.c */
@@ -993,9 +885,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Parameters for backend object fetch memory pool.\n"
-	MEMPOOL_TEXT,
-	/* l-text */	"",
-	/* func */	NULL
+	MEMPOOL_TEXT
 )
 #endif
 
@@ -1009,9 +899,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Prefer IPv6 address when connecting to backends which have both "
-	"IPv4 and IPv6 addresses.",
-	/* l-text */	"",
-	/* func */	NULL
+	"IPv4 and IPv6 addresses."
 )
 
 PARAM(
@@ -1026,9 +914,7 @@ PARAM(
 	"How many parked request we start for each completed request on "
 	"the object.\n"
 	"NB: Even with the implict delay of delivery, this parameter "
-	"controls an exponential increase in number of worker threads.",
-	/* l-text */	"",
-	/* func */	NULL
+	"controls an exponential increase in number of worker threads."
 )
 
 #if defined(XYZZY)
@@ -1054,9 +940,7 @@ PARAM(
 	"When 'idle_send_timeout' is hit while sending an HTTP1 response, the"
 	" timeout is extended unless the total time already taken for sending"
 	" the response in its entirety exceeds this many seconds.\n\n"
-	"When this timeout is hit, the session is closed",
-	/* l-text */	"",
-	/* func */	NULL
+	"When this timeout is hit, the session is closed"
 )
 #undef XYZZY
 
@@ -1070,9 +954,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Objects created with (ttl+grace+keep) shorter than this are "
-	"always put in transient storage.",
-	/* l-text */	"",
-	/* func */	NULL
+	"always put in transient storage."
 )
 
 PARAM(
@@ -1085,9 +967,7 @@ PARAM(
 	/* flags */	MUST_RESTART,
 	/* s-text */
 	"Install a signal handler which tries to dump debug information on "
-	"segmentation faults, bus errors and abort signals.",
-	/* l-text */	"",
-	/* func */	NULL
+	"segmentation faults, bus errors and abort signals."
 )
 
 PARAM(
@@ -1099,9 +979,7 @@ PARAM(
 	/* units */	"bool",
 	/* flags */	0,
 	/* s-text */
-	"Log all CLI traffic to syslog(LOG_INFO).",
-	/* l-text */	"",
-	/* func */	NULL
+	"Log all CLI traffic to syslog(LOG_INFO)."
 )
 
 #if defined(HAVE_TCP_FASTOPEN)
@@ -1118,9 +996,7 @@ PARAM(
 	/* units */	"bool",
 	/* flags */	XYZZY,
 	/* s-text */
-	"Enable TCP Fast Open extension.",
-	/* l-text */	NULL,
-	/* func */	NULL
+	"Enable TCP Fast Open extension."
 )
 #undef XYZZY
 
@@ -1139,9 +1015,7 @@ PARAM(
 	/* flags */	XYZZY,
 	/* s-text */
 	"The number of seconds between TCP keep-alive probes. "
-	"Ignored for Unix domain sockets.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Ignored for Unix domain sockets."
 )
 
 PARAM(
@@ -1155,9 +1029,7 @@ PARAM(
 	/* s-text */
 	"The maximum number of TCP keep-alive probes to send before giving "
 	"up and killing the connection if no response is obtained from the "
-	"other end. Ignored for Unix domain sockets.",
-	/* l-text */	"",
-	/* func */	NULL
+	"other end. Ignored for Unix domain sockets."
 )
 
 PARAM(
@@ -1171,9 +1043,7 @@ PARAM(
 	/* s-text */
 	"The number of seconds a connection needs to be idle before TCP "
 	"begins sending out keep-alive probes. "
-	"Ignored for Unix domain sockets.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Ignored for Unix domain sockets."
 )
 #undef XYZZY
 
@@ -1194,9 +1064,7 @@ PARAM(
 	"creating threads.\n"
 	"Set this to a few milliseconds if you see the 'threads_failed' "
 	"counter grow too much.\n"
-	"Setting this too high results in insufficient worker threads.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Setting this too high results in insufficient worker threads."
 )
 
 /* actual location mgt_pool.c */
@@ -1212,9 +1080,7 @@ PARAM(
 	"Thread queue stuck watchdog.\n"
 	"\n"
 	"If no queued work have been released for this long,"
-	" the worker process panics itself.",
-	/* l-text */	"",
-	/* func */	NULL
+	" the worker process panics itself."
 )
 
 /* actual location mgt_pool.c */
@@ -1228,9 +1094,7 @@ PARAM(
 	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
 	/* s-text */
 	"Wait this long after destroying a thread.\n"
-	"This controls the decay of thread pools when idle(-ish).",
-	/* l-text */	"",
-	/* func */	NULL
+	"This controls the decay of thread pools when idle(-ish)."
 )
 
 /* actual location mgt_pool.c */
@@ -1255,9 +1119,7 @@ PARAM(
 	"\n"
 	"It may also help to increase thread_pool_timeout and "
 	"thread_pool_min, to reduce the rate at which treads are destroyed "
-	"and later recreated.",
-	/* l-text */	"",
-	/* func */	NULL
+	"and later recreated."
 )
 
 /* actual location mgt_pool.c */
@@ -1274,9 +1136,7 @@ PARAM(
 	"\n"
 	"Do not set this higher than you have to, since excess worker "
 	"threads soak up RAM and CPU and generally just get in the way of "
-	"getting work done.",
-	/* l-text */	"",
-	/* func */	NULL
+	"getting work done."
 )
 
 /* actual location mgt_pool.c */
@@ -1293,9 +1153,7 @@ PARAM(
 	"\n"
 	"Increasing this may help ramp up faster from low load situations "
 	"or when threads have expired."
-	"Minimum is 10 threads.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Minimum is 10 threads."
 )
 
 /* actual location mgt_pool.c */
@@ -1322,9 +1180,7 @@ PARAM(
 	"unused.\n"
 	"\n"
 	"Default is 0 to auto-tune (currently 5% of thread_pool_min).\n"
-	"Minimum is 1 otherwise, maximum is 95% of thread_pool_min.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Minimum is 1 otherwise, maximum is 95% of thread_pool_min."
 )
 
 /* actual location mgt_pool.c */
@@ -1339,9 +1195,7 @@ PARAM(
 	/* s-text */
 	"Worker thread stack size.\n"
 	"This will likely be rounded up to a multiple of 4k (or whatever "
-	"the page_size might be) by the kernel.",
-	/* l-text */	"",
-	/* func */	NULL
+	"the page_size might be) by the kernel."
 )
 
 /* actual location mgt_pool.c */
@@ -1357,9 +1211,7 @@ PARAM(
 	"Thread idle threshold.\n"
 	"\n"
 	"Threads in excess of thread_pool_min, which have been idle for at "
-	"least this long, will be destroyed.",
-	/* l-text */	"",
-	/* func */	NULL
+	"least this long, will be destroyed."
 )
 
 /* actual location mgt_pool.c */
@@ -1384,9 +1236,7 @@ PARAM(
 	"pool for each CPU is most likely detrimental to performance.\n"
 	"\n"
 	"Can be increased on the fly, but decreases require a restart to "
-	"take effect.",
-	/* l-text */	"",
-	/* func */	NULL
+	"take effect."
 )
 
 /* actual location mgt_pool.c */
@@ -1403,9 +1253,7 @@ PARAM(
 	"\n"
 	"This sets the number of requests we will queue, waiting for an "
 	"available thread.  Above this limit sessions will be dropped "
-	"instead of queued.",
-	/* l-text */	"",
-	/* func */	NULL
+	"instead of queued."
 )
 
 /* actual location mgt_pool.c */
@@ -1423,9 +1271,7 @@ PARAM(
 	"(request/fetch etc).\n"
 	"This parameters defines the maximum number of jobs a worker "
 	"thread may handle, before it is forced to dump its accumulated "
-	"stats into the global counters.",
-	/* l-text */	"",
-	/* func */	NULL
+	"stats into the global counters."
 )
 #endif
 
@@ -1452,9 +1298,7 @@ PARAM(
 	" request headers.\n\n"
 	"This parameter is particularly relevant for HTTP1 keepalive "
 	" connections which are closed unless the next request is received"
-	" before this timeout is reached.",
-	/* l-text */	"",
-	/* func */	NULL
+	" before this timeout is reached."
 )
 #undef XYZZY
 
@@ -1473,9 +1317,7 @@ PARAM(
 	"within the first 100 msec of the previous request completing.\n"
 	"Setting this too high results in worker threads not doing "
 	"anything for their keep, setting it too low just means that more "
-	"sessions take a detour around the waiter.",
-	/* l-text */	"",
-	/* func */	NULL
+	"sessions take a detour around the waiter."
 )
 
 #if 0
@@ -1489,9 +1331,7 @@ PARAM(
 	/* units */	"bool",
 	/* flags */	0,
 	/* s-text */
-	"Allow inline C code in VCL.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Allow inline C code in VCL."
 )
 
 /* actual location mgt_param_tbl.c */
@@ -1504,9 +1344,7 @@ PARAM(
 	/* units */	"bool",
 	/* flags */	0,
 	/* s-text */
-	"Unreferenced VCL objects result in error.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Unreferenced VCL objects result in error."
 )
 
 /* actual location mgt_param_tbl.c */
@@ -1520,9 +1358,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Allow '/' in vmod & include paths.\n"
-	"Allow 'import ... from ...'.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Allow 'import ... from ...'."
 )
 #endif
 
@@ -1536,9 +1372,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"How long a VCL is kept warm after being replaced as the "
-	"active VCL (granularity approximately 30 seconds).",
-	/* l-text */	"",
-	/* func */	NULL
+	"active VCL (granularity approximately 30 seconds)."
 )
 
 PARAM(
@@ -1553,9 +1387,7 @@ PARAM(
 	"Behaviour when attempting to exceed max_vcl loaded VCL.\n"
 	"\n*  0 - Ignore max_vcl parameter.\n"
 	"\n*  1 - Issue warning.\n"
-	"\n*  2 - Refuse loading VCLs.",
-	/* l-text */	"",
-	/* func */	NULL
+	"\n*  2 - Refuse loading VCLs."
 )
 
 PARAM(
@@ -1568,9 +1400,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Threshold of loaded VCL programs.  (VCL labels are not counted.)"
-	"  Parameter max_vcl_handling determines behaviour.",
-	/* l-text */	"",
-	/* func */	NULL
+	"  Parameter max_vcl_handling determines behaviour."
 )
 
 PARAM(
@@ -1583,9 +1413,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"How long VSM memory is kept warm after a deallocation "
-	"(granularity approximately 2 seconds).",
-	/* l-text */	"",
-	/* func */	NULL
+	"(granularity approximately 2 seconds)."
 )
 
 PARAM(
@@ -1604,9 +1432,7 @@ PARAM(
 	"Setting this too high costs memory, setting it too low will cause "
 	"more VSL flushes and likely increase lock-contention on the VSL "
 	"mutex.\n\n"
-	"The minimum tracks the vsl_reclen parameter + 12 bytes.",
-	/* l-text */	"",
-	/* func */	NULL
+	"The minimum tracks the vsl_reclen parameter + 12 bytes."
 )
 
 #if 0
@@ -1624,9 +1450,7 @@ PARAM(
 	"	default	Set default value\n"
 	"\n"
 	"Use +/- prefix in front of VSL tag name to unmask/mask "
-	"individual VSL messages.",
-	/* l-text */	"",
-	/* func */	NULL
+	"individual VSL messages."
 )
 #endif
 
@@ -1640,9 +1464,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"Maximum number of bytes in SHM log record.\n\n"
-	"The maximum tracks the vsl_buffer parameter - 12 bytes.",
-	/* l-text */	"",
-	/* func */	NULL
+	"The maximum tracks the vsl_buffer parameter - 12 bytes."
 )
 
 PARAM(
@@ -1657,9 +1479,7 @@ PARAM(
 	"The amount of space to allocate for the VSL fifo buffer in the "
 	"VSM memory segment.  If you make this too small, "
 	"varnish{ncsa|log} etc will not be able to keep up.  Making it too "
-	"large just costs memory resources.",
-	/* l-text */	"",
-	/* func */	NULL
+	"large just costs memory resources."
 )
 
 PARAM(
@@ -1672,9 +1492,7 @@ PARAM(
 	/* flags */	0,
 	/* s-text */
 	"DEPRECATED: This parameter is ignored.\n"
-	"There is no global limit on amount of shared memory now.",
-	/* l-text */	"",
-	/* func */	NULL
+	"There is no global limit on amount of shared memory now."
 )
 
 #if 0
@@ -1688,9 +1506,7 @@ PARAM(
 	/* units */	NULL,
 	/* flags */	MUST_RESTART| WIZARD,
 	/* s-text */
-	"Select the waiter kernel interface.",
-	/* l-text */	"",
-	/* func */	NULL
+	"Select the waiter kernel interface."
 )
 #endif
 
@@ -1704,9 +1520,7 @@ PARAM(
 	/* flags */	DELAYED_EFFECT,
 	/* s-text */
 	"Bytes of HTTP protocol workspace for backend HTTP req/resp.  If "
-	"larger than 4k, use a multiple of 4k for VM efficiency.",
-	/* l-text */	"",
-	/* func */	NULL
+	"larger than 4k, use a multiple of 4k for VM efficiency."
 )
 
 PARAM(
@@ -1723,9 +1537,7 @@ PARAM(
 	"For HTTP/2 compliance this must be at least 20k, in order to "
 	"receive fullsize (=16k) frames from the client.   That usually "
 	"happens only in POST/PUT bodies.  For other traffic-patterns "
-	"smaller values work just fine.",
-	/* l-text */	"",
-	/* func */	NULL
+	"smaller values work just fine."
 )
 
 PARAM(
@@ -1739,9 +1551,7 @@ PARAM(
 	/* s-text */
 	"Allocation size for session structure and workspace.    The "
 	"workspace is primarily used for TCP connection addresses.  If "
-	"larger than 4k, use a multiple of 4k for VM efficiency.",
-	/* l-text */	"",
-	/* func */	NULL
+	"larger than 4k, use a multiple of 4k for VM efficiency."
 )
 
 PARAM(
@@ -1761,9 +1571,7 @@ PARAM(
 	"syscalls, setting it too high just wastes space.  ~0.1k + "
 	"UIO_MAXIOV * sizeof(struct iovec) (typically = ~16k for 64bit) "
 	"is considered the maximum sensible value under any known "
-	"circumstances (excluding exotic vmod use).",
-	/* l-text */	"",
-	/* func */	NULL
+	"circumstances (excluding exotic vmod use)."
 )
 
 PARAM(
@@ -1777,9 +1585,7 @@ PARAM(
 	/* s-text */
 	"HTTP2 Receive Window low water mark.\n"
 	"We try to keep the window at least this big\n"
-	"Only affects incoming request bodies (ie: POST, PUT etc.)",
-	/* l-text */	"",
-	/* func */	NULL
+	"Only affects incoming request bodies (ie: POST, PUT etc.)"
 )
 
 PARAM(
@@ -1793,9 +1599,7 @@ PARAM(
 	/* s-text */
 	"HTTP2 Receive Window Increments.\n"
 	"How big credits we send in WINDOW_UPDATE frames\n"
-	"Only affects incoming request bodies (ie: POST, PUT etc.)",
-	/* l-text */	"",
-	/* func */	NULL
+	"Only affects incoming request bodies (ie: POST, PUT etc.)"
 )
 
 PARAM(
@@ -1809,9 +1613,7 @@ PARAM(
 	/* s-text */
 	"HTTP2 header table size.\n"
 	"This is the size that will be used for the HPACK dynamic\n"
-	"decoding table.",
-	/* l-text */	"",
-	/* func */	NULL
+	"decoding table."
 )
 
 PARAM(
@@ -1825,9 +1627,7 @@ PARAM(
 	/* s-text */
 	"HTTP2 Maximum number of concurrent streams.\n"
 	"This is the number of requests that can be active\n"
-	"at the same time for a single HTTP2 connection.",
-	/* l-text */	"",
-	/* func */	NULL
+	"at the same time for a single HTTP2 connection."
 )
 
 PARAM(
@@ -1839,9 +1639,7 @@ PARAM(
 	/* units */	"bytes",
 	/* flags */	0,
 	/* s-text */
-	"HTTP2 initial flow control window size.",
-	/* l-text */	"",
-	/* func */	NULL
+	"HTTP2 initial flow control window size."
 )
 
 PARAM(
@@ -1853,9 +1651,7 @@ PARAM(
 	/* units */	"bytes",
 	/* flags */	0,
 	/* s-text */
-	"HTTP2 maximum per frame payload size we are willing to accept.",
-	/* l-text */	"",
-	/* func */	NULL
+	"HTTP2 maximum per frame payload size we are willing to accept."
 )
 
 PARAM(
@@ -1867,9 +1663,7 @@ PARAM(
 	/* units */	"bytes",
 	/* flags */	0,
 	/* s-text */
-	"HTTP2 maximum size of an uncompressed header list.",
-	/* l-text */	"",
-	/* func */	NULL
+	"HTTP2 maximum size of an uncompressed header list."
 )
 
 #undef PARAM

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1453,21 +1453,6 @@ PARAM(
 	"There is no global limit on amount of shared memory now."
 )
 
-#if 0
-/* see mgt_waiter.c */
-PARAM(
-	/* name */	waiter,
-	/* type */	waiter,
-	/* min */	NULL,
-	/* max */	NULL,
-	/* def */	"kqueue (possible values: kqueue, poll)",
-	/* units */	NULL,
-	/* descr */
-	"Select the waiter kernel interface.",
-	/* flags */	MUST_RESTART| WIZARD
-)
-#endif
-
 PARAM(
 	/* name */	workspace_backend,
 	/* type */	bytes_u,

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -27,7 +27,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * PARAM(nm, ty, mi, ma, de, un, fl, st)
+ * PARAM(nm, ty, mi, ma, de, un, fl, st[, dyn_min_reason, dyn_max_reason])
  */
 
 /*lint -save -e525 -e539 */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -27,7 +27,10 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * PARAM(nm, ty, mi, ma, de, un, fl, st[, dyn_min_reason, dyn_max_reason])
+ * PARAM(nm, ty, ...)
+ *
+ * Variable arguments refer to struct parspec fields from min to
+ * dyn_def_reason.
  */
 
 /*lint -save -e525 -e539 */
@@ -48,14 +51,14 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"on",
 	/* units */	"bool",
-	/* flags */	XYZZY,
 	/* descr */
 	"Enable kernel accept-filters. This may require a kernel module to "
 	"be loaded to have an effect when enabled.\n\n"
 	"Enabling accept_filter may prevent some requests to reach Varnish "
 	"in the first place. Malformed requests may go unnoticed and not "
 	"increase the client_req_400 counter. GET or HEAD requests with a "
-	"body may be blocked altogether."
+	"body may be blocked altogether.",
+	/* flags */	XYZZY
 )
 #undef XYZZY
 
@@ -66,12 +69,12 @@ PARAM(
 	/* max */	"1",
 	/* def */	"0.9",
 	/* units */	NULL,
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"If we run out of resources, such as file descriptors or worker "
 	"threads, the acceptor will sleep between accepts.\n"
 	"This parameter (multiplicatively) reduce the sleep duration for "
-	"each successful accept. (ie: 0.9 = reduce by 10%)"
+	"each successful accept. (ie: 0.9 = reduce by 10%)",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -81,12 +84,12 @@ PARAM(
 	/* max */	"1",
 	/* def */	"0",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"If we run out of resources, such as file descriptors or worker "
 	"threads, the acceptor will sleep between accepts.\n"
 	"This parameter control how much longer we sleep, each time we "
-	"fail to accept a new connection."
+	"fail to accept a new connection.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -96,12 +99,12 @@ PARAM(
 	/* max */	"10",
 	/* def */	"0.05",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"If we run out of resources, such as file descriptors or worker "
 	"threads, the acceptor will sleep between accepts.\n"
 	"This parameter limits how long it can sleep between attempts to "
-	"accept new connections."
+	"accept new connections.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -111,7 +114,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"on",
 	/* units */	"bool",
-	/* flags */	0,
 	/* descr */
 	"Automatically restart the child/worker process if it dies."
 )
@@ -123,7 +125,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"on",
 	/* units */	"bool",
-	/* flags */	0,
 	/* descr */
 	"Eliminate older identical bans when a new ban is added.  This saves "
 	"CPU cycles by not comparing objects to identical bans.\n"
@@ -138,7 +139,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0",
 	/* units */	"bans",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Expurge long tail content from the cache to keep the number of bans "
 	"below this value. 0 disables.\n\n"
@@ -158,7 +158,8 @@ PARAM(
 	"additional latency due to request ban testing is in the order of "
 	"ban_cutoff / rate(bans_lurker_tests_tested). For example, for "
 	"rate(bans_lurker_tests_tested) = 2M/s and a tolerable latency of "
-	"100ms, a good value for ban_cutoff may be 200K."
+	"100ms, a good value for ban_cutoff may be 200K.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -168,7 +169,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"60",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"The ban lurker will ignore bans until they are this old.  "
 	"When a ban is added, the active traffic will be tested against it "
@@ -185,7 +185,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"1000",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"The ban lurker sleeps ${ban_lurker_sleep} after examining this "
 	"many objects."
@@ -199,7 +198,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0.010",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"How long the ban lurker sleeps after examining ${ban_lurker_batch} "
 	"objects."
@@ -214,10 +212,10 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0.010",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"How long the ban lurker sleeps when giving way to lookup"
-	" due to lock contention."
+	" due to lock contention.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -227,7 +225,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"60",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"Default timeout for receiving first byte from backend. We only "
 	"wait for this many seconds for the first byte before giving up.\n"
@@ -243,7 +240,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"60",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"We only wait for this many seconds between bytes received from "
 	"the backend before giving up the fetch.\n"
@@ -258,7 +254,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"60",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"Timeout before we close unused backend connections."
 )
@@ -270,7 +265,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"10.000",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"When connecting to backends, certain error codes "
 	"(EADDRNOTAVAIL, EACCESS, EPERM) signal a local resource shortage "
@@ -278,7 +272,8 @@ PARAM(
 	"may worsen the situation due to the complexity of the operations "
 	"involved in the kernel.\n"
 	"This parameter prevents repeated connection attempts for the "
-	"configured duration."
+	"configured duration.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -288,14 +283,14 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0.250",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"When connecting to backends, certain error codes (ECONNREFUSED, "
 	"ENETUNREACH) signal fundamental connection issues such as the backend "
 	"not accepting connections or routing problems for which repeated "
 	"connection attempts are considered useless\n"
 	"This parameter prevents repeated connection attempts for the "
-	"configured duration."
+	"configured duration.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -305,7 +300,6 @@ PARAM(
 	/* max */	"99999999b",
 	/* def */	"48k",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"Maximum size of CLI response.  If the response exceeds this "
 	"limit, the response code will be 201 instead of 200 and the last "
@@ -319,7 +313,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"60.000",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"Timeout for the childs replies to CLI requests from the "
 	"mgt_param."
@@ -332,7 +325,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"10",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"How much clockskew we are willing to accept between the backend "
 	"and our own clock."
@@ -345,7 +337,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"1.000",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"How much observed clock step we are willing to accept before "
 	"we panic."
@@ -358,7 +349,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"3.500",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"Default connection timeout for backend connections. We only try "
 	"to connect to the backend for this many seconds before giving up. "
@@ -373,10 +363,10 @@ PARAM(
 	/* max */	"254.000",
 	/* def */	"180.000",
 	/* units */	"seconds",
-	/* flags */	WIZARD,
 	/* descr */
 	"How long the critbit hasher keeps deleted objheads on the cooloff "
-	"list."
+	"list.",
+	/* flags */	WIZARD
 )
 
 #if 0
@@ -389,7 +379,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	NULL,
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Enable/Disable various kinds of debugging.\n"
 	"	none	Disable all debugging\n"
@@ -416,11 +405,11 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"10.000",
 	/* units */	"seconds",
-	/* flags */	OBJ_STICKY,
 	/* descr */
 	"Default grace period.  We will deliver an object this long after "
 	"it has expired, provided another thread is attempting to get a "
-	"new copy."
+	"new copy.",
+	/* flags */	OBJ_STICKY
 )
 
 PARAM(
@@ -430,12 +419,12 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0.000",
 	/* units */	"seconds",
-	/* flags */	OBJ_STICKY,
 	/* descr */
 	"Default keep period.  We will keep a useless object around this "
 	"long, making it available for conditional backend fetches.  That "
 	"means that the object will be removed from the cache at the end "
-	"of ttl+grace+keep."
+	"of ttl+grace+keep.",
+	/* flags */	OBJ_STICKY
 )
 
 PARAM(
@@ -445,10 +434,10 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"120.000",
 	/* units */	"seconds",
-	/* flags */	OBJ_STICKY,
 	/* descr */
 	"The TTL assigned to objects if neither the backend nor the VCL "
-	"code assigns one."
+	"code assigns one.",
+	/* flags */	OBJ_STICKY
 )
 
 PARAM(
@@ -458,11 +447,11 @@ PARAM(
 	/* max */	"1024",		// XXX stringify IOV_MAX
 	/* def */	"64",
 	/* units */	"struct iovec (=16 bytes)",
-	/* flags */	WIZARD,
 	/* descr */
 	"Number of io vectors to allocate for HTTP1 protocol transmission."
 	"  A HTTP1 header needs 7 + 2 per HTTP header field."
-	"  Allocated from workspace_thread."
+	"  Allocated from workspace_thread.",
+	/* flags */	WIZARD
 )
 
 #if 0
@@ -475,7 +464,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	NULL,
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Enable/Disable various minor features.\n"
 	"	none	Disable all features.\n"
@@ -498,12 +486,12 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"16k",
 	/* units */	"bytes",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"The default chunksize used by fetcher. This should be bigger than "
 	"the majority of objects with short TTLs.\n"
 	"Internal limits in the storage_file module makes increases above "
-	"128kb a dubious idea."
+	"128kb a dubious idea.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -513,10 +501,10 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0.25G",
 	/* units */	"bytes",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"The maximum chunksize we attempt to allocate from storage. Making "
-	"this too large may cause delays and storage fragmentation."
+	"this too large may cause delays and storage fragmentation.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -526,13 +514,13 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"32k",
 	/* units */	"bytes",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Size of malloc buffer used for gzip processing.\n"
 	"These buffers are used for in-transit data, for instance "
 	"gunzip'ed data being sent to a client.Making this space to small "
 	"results in more overhead, writes to sockets etc, making it too "
-	"big is probably just a waste of memory."
+	"big is probably just a waste of memory.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -542,7 +530,6 @@ PARAM(
 	/* max */	"9",
 	/* def */	"6",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Gzip compression level: 0=debug, 1=fast, 9=best"
 )
@@ -554,7 +541,6 @@ PARAM(
 	/* max */	"9",
 	/* def */	"8",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Gzip memory level 1=slow/least, 9=fast/most compression.\n"
 	"Memory impact is 1=1k, 2=2k, ... 9=256k."
@@ -567,7 +553,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"on",
 	/* units */	"bool",
-	/* flags */	0,
 	/* descr */
 	"Enable gzip support. When enabled Varnish request compressed "
 	"objects from the backend and store them compressed. If a client "
@@ -592,7 +577,6 @@ PARAM(
 	/* max */	"65535",
 	/* def */	"64",
 	/* units */	"header lines",
-	/* flags */	0,
 	/* descr */
 	"Maximum number of HTTP header lines we allow in "
 	"{req|resp|bereq|beresp}.http (obj.http is autosized to the exact "
@@ -608,7 +592,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"on",
 	/* units */	"bool",
-	/* flags */	0,
 	/* descr */
 	"Enable support for HTTP Range headers."
 )
@@ -620,7 +603,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"8k",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"Maximum length of any HTTP client request header we will allow.  "
 	"The limit is inclusive its continuation lines."
@@ -633,7 +615,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"32k",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"Maximum number of bytes of HTTP client request we will deal with. "
 	" This is a limit on all bytes up to the double blank line which "
@@ -650,7 +631,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"8k",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"Maximum length of any HTTP backend response header we will allow. "
 	" The limit is inclusive its continuation lines."
@@ -663,7 +643,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"32k",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"Maximum number of bytes of HTTP backend response we will deal "
 	"with.  This is a limit on all bytes up to the double blank line "
@@ -689,13 +668,13 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"60.000",
 	/* units */	"seconds",
-	/* flags */	XYZZY,
 	/* descr */
 	"Send timeout for individual pieces of data on client connections."
 	" May get extended if 'send_timeout' applies.\n\n"
 	"When this timeout is hit, the session is closed.\n\n"
 	"See the man page for `setsockopt(2)` or `socket(7)` under"
-	" ``SO_SNDTIMEO`` for more information."
+	" ``SO_SNDTIMEO`` for more information.",
+	/* flags */	XYZZY
 )
 #undef XYZZY
 
@@ -706,9 +685,9 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"1024",
 	/* units */	"connections",
-	/* flags */	MUST_RESTART,
 	/* descr */
-	"Listen queue depth."
+	"Listen queue depth.",
+	/* flags */	MUST_RESTART
 )
 
 PARAM(
@@ -718,13 +697,13 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"2.000",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Grace period before object moves on LRU list.\n"
 	"Objects are only moved to the front of the LRU list if they have "
 	"not been moved there already inside this timeout period.  This "
 	"reduces the amount of lock operations necessary for LRU list "
-	"access."
+	"access.",
+	/* flags */	EXPERIMENTAL
 )
 
 PARAM(
@@ -734,7 +713,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"5",
 	/* units */	"levels",
-	/* flags */	0,
 	/* descr */
 	"Maximum depth of esi:include processing."
 )
@@ -746,7 +724,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"4",
 	/* units */	"restarts",
-	/* flags */	0,
 	/* descr */
 	"Upper limit on how many times a request can restart."
 )
@@ -758,7 +735,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"4",
 	/* units */	"retries",
-	/* flags */	0,
 	/* descr */
 	"Upper limit on how many times a backend fetch can retry."
 )
@@ -770,10 +746,10 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"50",
 	/* units */	"allocations",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Maximum number of objects we attempt to nuke in order to make "
-	"space for a object body."
+	"space for a object body.",
+	/* flags */	EXPERIMENTAL
 )
 
 #if 0
@@ -785,7 +761,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"1.000",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"The limit for the  number of internal matching function calls in "
 	"a pcre_exec() execution."
@@ -799,7 +774,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"1.000",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"The limit for the  number of internal matching function "
 	"recursions in a pcre_exec() execution."
@@ -813,11 +787,11 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"3",
 	/* units */	"seconds",
-	/* flags */	MUST_RESTART,
 	/* descr */
 	"Interval between pings from parent to child.\n"
 	"Zero will disable pinging entirely, which makes it possible to "
-	"attach a debugger to the child."
+	"attach a debugger to the child.",
+	/* flags */	MUST_RESTART
 )
 
 PARAM(
@@ -827,7 +801,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0",
 	/* units */	"connections",
-	/* flags */	0,
 	/* descr */
 	"Maximum number of sessions dedicated to pipe transactions."
 )
@@ -839,7 +812,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"60.000",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"Idle timeout for PIPE sessions. If nothing have been received in "
 	"either direction for this many seconds, the session is closed."
@@ -854,7 +826,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"10,100,10",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Parameters for per worker pool request memory pool.\n"
 	MEMPOOL_TEXT
@@ -868,7 +839,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"10,100,10",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Parameters for per worker pool session memory pool.\n"
 	MEMPOOL_TEXT
@@ -882,7 +852,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"10,100,10",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Parameters for backend object fetch memory pool.\n"
 	MEMPOOL_TEXT
@@ -896,7 +865,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"off",
 	/* units */	"bool",
-	/* flags */	0,
 	/* descr */
 	"Prefer IPv6 address when connecting to backends which have both "
 	"IPv4 and IPv6 addresses."
@@ -909,12 +877,12 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"3",
 	/* units */	"requests per request",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"How many parked request we start for each completed request on "
 	"the object.\n"
 	"NB: Even with the implict delay of delivery, this parameter "
-	"controls an exponential increase in number of worker threads."
+	"controls an exponential increase in number of worker threads.",
+	/* flags */	EXPERIMENTAL
 )
 
 #if defined(XYZZY)
@@ -933,14 +901,14 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"600.000",
 	/* units */	"seconds",
-	/* flags */	XYZZY,
 	/* descr */
 	"Total timeout for ordinary HTTP1 responses. Does not apply to some"
 	" internally generated errors and pipe mode.\n\n"
 	"When 'idle_send_timeout' is hit while sending an HTTP1 response, the"
 	" timeout is extended unless the total time already taken for sending"
 	" the response in its entirety exceeds this many seconds.\n\n"
-	"When this timeout is hit, the session is closed"
+	"When this timeout is hit, the session is closed",
+	/* flags */	XYZZY
 )
 #undef XYZZY
 
@@ -951,7 +919,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"10.000",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"Objects created with (ttl+grace+keep) shorter than this are "
 	"always put in transient storage."
@@ -964,10 +931,10 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"on",
 	/* units */	"bool",
-	/* flags */	MUST_RESTART,
 	/* descr */
 	"Install a signal handler which tries to dump debug information on "
-	"segmentation faults, bus errors and abort signals."
+	"segmentation faults, bus errors and abort signals.",
+	/* flags */	MUST_RESTART
 )
 
 PARAM(
@@ -977,7 +944,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"on",
 	/* units */	"bool",
-	/* flags */	0,
 	/* descr */
 	"Log all CLI traffic to syslog(LOG_INFO)."
 )
@@ -994,9 +960,9 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"off",
 	/* units */	"bool",
-	/* flags */	XYZZY,
 	/* descr */
-	"Enable TCP Fast Open extension."
+	"Enable TCP Fast Open extension.",
+	/* flags */	XYZZY
 )
 #undef XYZZY
 
@@ -1012,10 +978,10 @@ PARAM(
 	/* max */	"100",
 	/* def */	"",
 	/* units */	"seconds",
-	/* flags */	XYZZY,
 	/* descr */
 	"The number of seconds between TCP keep-alive probes. "
-	"Ignored for Unix domain sockets."
+	"Ignored for Unix domain sockets.",
+	/* flags */	XYZZY
 )
 
 PARAM(
@@ -1025,11 +991,11 @@ PARAM(
 	/* max */	"100",
 	/* def */	"",
 	/* units */	"probes",
-	/* flags */	XYZZY,
 	/* descr */
 	"The maximum number of TCP keep-alive probes to send before giving "
 	"up and killing the connection if no response is obtained from the "
-	"other end. Ignored for Unix domain sockets."
+	"other end. Ignored for Unix domain sockets.",
+	/* flags */	XYZZY
 )
 
 PARAM(
@@ -1039,11 +1005,11 @@ PARAM(
 	/* max */	"7200",
 	/* def */	"",
 	/* units */	"seconds",
-	/* flags */	XYZZY,
 	/* descr */
 	"The number of seconds a connection needs to be idle before TCP "
 	"begins sending out keep-alive probes. "
-	"Ignored for Unix domain sockets."
+	"Ignored for Unix domain sockets.",
+	/* flags */	XYZZY
 )
 #undef XYZZY
 
@@ -1056,7 +1022,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0.000",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Wait at least this long after creating a thread.\n"
 	"\n"
@@ -1064,7 +1029,8 @@ PARAM(
 	"creating threads.\n"
 	"Set this to a few milliseconds if you see the 'threads_failed' "
 	"counter grow too much.\n"
-	"Setting this too high results in insufficient worker threads."
+	"Setting this too high results in insufficient worker threads.",
+	/* flags */	EXPERIMENTAL
 )
 
 /* actual location mgt_pool.c */
@@ -1075,12 +1041,12 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"60.000",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Thread queue stuck watchdog.\n"
 	"\n"
 	"If no queued work have been released for this long,"
-	" the worker process panics itself."
+	" the worker process panics itself.",
+	/* flags */	EXPERIMENTAL
 )
 
 /* actual location mgt_pool.c */
@@ -1091,10 +1057,10 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"1.000",
 	/* units */	"seconds",
-	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
 	/* descr */
 	"Wait this long after destroying a thread.\n"
-	"This controls the decay of thread pools when idle(-ish)."
+	"This controls the decay of thread pools when idle(-ish).",
+	/* flags */	DELAYED_EFFECT| EXPERIMENTAL
 )
 
 /* actual location mgt_pool.c */
@@ -1105,7 +1071,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0.200",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Wait at least this long after a failed thread creation before "
 	"trying to create another thread.\n"
@@ -1119,7 +1084,8 @@ PARAM(
 	"\n"
 	"It may also help to increase thread_pool_timeout and "
 	"thread_pool_min, to reduce the rate at which treads are destroyed "
-	"and later recreated."
+	"and later recreated.",
+	/* flags */	EXPERIMENTAL
 )
 
 /* actual location mgt_pool.c */
@@ -1130,13 +1096,13 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"5000",
 	/* units */	"threads",
-	/* flags */	DELAYED_EFFECT,
 	/* descr */
 	"The maximum number of worker threads in each pool.\n"
 	"\n"
 	"Do not set this higher than you have to, since excess worker "
 	"threads soak up RAM and CPU and generally just get in the way of "
-	"getting work done."
+	"getting work done.",
+	/* flags */	DELAYED_EFFECT
 )
 
 /* actual location mgt_pool.c */
@@ -1147,13 +1113,13 @@ PARAM(
 	/* max */	"5000",
 	/* def */	"100",
 	/* units */	"threads",
-	/* flags */	DELAYED_EFFECT,
 	/* descr */
 	"The minimum number of worker threads in each pool.\n"
 	"\n"
 	"Increasing this may help ramp up faster from low load situations "
 	"or when threads have expired."
-	"Minimum is 10 threads."
+	"Minimum is 10 threads.",
+	/* flags */	DELAYED_EFFECT
 )
 
 /* actual location mgt_pool.c */
@@ -1164,7 +1130,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0",
 	/* units */	"threads",
-	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
 	/* descr */
 	"The number of worker threads reserved for vital tasks "
 	"in each pool.\n"
@@ -1180,7 +1145,8 @@ PARAM(
 	"unused.\n"
 	"\n"
 	"Default is 0 to auto-tune (currently 5% of thread_pool_min).\n"
-	"Minimum is 1 otherwise, maximum is 95% of thread_pool_min."
+	"Minimum is 1 otherwise, maximum is 95% of thread_pool_min.",
+	/* flags */	DELAYED_EFFECT| EXPERIMENTAL
 )
 
 /* actual location mgt_pool.c */
@@ -1191,11 +1157,11 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"56k",
 	/* units */	"bytes",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Worker thread stack size.\n"
 	"This will likely be rounded up to a multiple of 4k (or whatever "
-	"the page_size might be) by the kernel."
+	"the page_size might be) by the kernel.",
+	/* flags */	EXPERIMENTAL
 )
 
 /* actual location mgt_pool.c */
@@ -1206,12 +1172,12 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"300.000",
 	/* units */	"seconds",
-	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
 	/* descr */
 	"Thread idle threshold.\n"
 	"\n"
 	"Threads in excess of thread_pool_min, which have been idle for at "
-	"least this long, will be destroyed."
+	"least this long, will be destroyed.",
+	/* flags */	DELAYED_EFFECT| EXPERIMENTAL
 )
 
 /* actual location mgt_pool.c */
@@ -1222,7 +1188,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"2",
 	/* units */	"pools",
-	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
 	/* descr */
 	"Number of worker thread pools.\n"
 	"\n"
@@ -1236,7 +1201,8 @@ PARAM(
 	"pool for each CPU is most likely detrimental to performance.\n"
 	"\n"
 	"Can be increased on the fly, but decreases require a restart to "
-	"take effect."
+	"take effect.",
+	/* flags */	DELAYED_EFFECT| EXPERIMENTAL
 )
 
 /* actual location mgt_pool.c */
@@ -1247,13 +1213,13 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"20",
 	/* units */	NULL,
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Permitted request queue length per thread-pool.\n"
 	"\n"
 	"This sets the number of requests we will queue, waiting for an "
 	"available thread.  Above this limit sessions will be dropped "
-	"instead of queued."
+	"instead of queued.",
+	/* flags */	EXPERIMENTAL
 )
 
 /* actual location mgt_pool.c */
@@ -1264,14 +1230,14 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"10",
 	/* units */	"requests",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"Worker threads accumulate statistics, and dump these into the "
 	"global stats counters if the lock is free when they finish a job "
 	"(request/fetch etc).\n"
 	"This parameters defines the maximum number of jobs a worker "
 	"thread may handle, before it is forced to dump its accumulated "
-	"stats into the global counters."
+	"stats into the global counters.",
+	/* flags */	EXPERIMENTAL
 )
 #endif
 
@@ -1291,14 +1257,14 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"5.000",
 	/* units */	"seconds",
-	/* flags */	XYZZY,
 	/* descr */
 	"Idle timeout for client connections.\n\n"
 	"A connection is considered idle until we have received the full"
 	" request headers.\n\n"
 	"This parameter is particularly relevant for HTTP1 keepalive "
 	" connections which are closed unless the next request is received"
-	" before this timeout is reached."
+	" before this timeout is reached.",
+	/* flags */	XYZZY
 )
 #undef XYZZY
 
@@ -1309,7 +1275,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0.050",
 	/* units */	"seconds",
-	/* flags */	EXPERIMENTAL,
 	/* descr */
 	"How long the worker thread lingers on an idle session before "
 	"handing it over to the waiter.\n"
@@ -1317,7 +1282,8 @@ PARAM(
 	"within the first 100 msec of the previous request completing.\n"
 	"Setting this too high results in worker threads not doing "
 	"anything for their keep, setting it too low just means that more "
-	"sessions take a detour around the waiter."
+	"sessions take a detour around the waiter.",
+	/* flags */	EXPERIMENTAL
 )
 
 #if 0
@@ -1329,7 +1295,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"off",
 	/* units */	"bool",
-	/* flags */	0,
 	/* descr */
 	"Allow inline C code in VCL."
 )
@@ -1342,7 +1307,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"on",
 	/* units */	"bool",
-	/* flags */	0,
 	/* descr */
 	"Unreferenced VCL objects result in error."
 )
@@ -1355,7 +1319,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"on",
 	/* units */	"bool",
-	/* flags */	0,
 	/* descr */
 	"Allow '/' in vmod & include paths.\n"
 	"Allow 'import ... from ...'."
@@ -1369,7 +1332,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"600.000",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"How long a VCL is kept warm after being replaced as the "
 	"active VCL (granularity approximately 30 seconds)."
@@ -1382,7 +1344,6 @@ PARAM(
 	/* max */	"2",
 	/* def */	"1",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Behaviour when attempting to exceed max_vcl loaded VCL.\n"
 	"\n*  0 - Ignore max_vcl parameter.\n"
@@ -1397,7 +1358,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"100",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Threshold of loaded VCL programs.  (VCL labels are not counted.)"
 	"  Parameter max_vcl_handling determines behaviour."
@@ -1410,7 +1370,6 @@ PARAM(
 	/* max */	"600.000",
 	/* def */	"60.000",
 	/* units */	"seconds",
-	/* flags */	0,
 	/* descr */
 	"How long VSM memory is kept warm after a deallocation "
 	"(granularity approximately 2 seconds)."
@@ -1423,7 +1382,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"4k",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"Bytes of (req-/backend-)workspace dedicated to buffering VSL "
 	"records.\n"
@@ -1432,6 +1390,7 @@ PARAM(
 	"Setting this too high costs memory, setting it too low will cause "
 	"more VSL flushes and likely increase lock-contention on the VSL "
 	"mutex.",
+	/* flags */	0,
 	/* dyn_min_reason */	"vsl_reclen + 12 bytes"
 )
 
@@ -1444,7 +1403,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"default",
 	/* units */	NULL,
-	/* flags */	0,
 	/* descr */
 	"Mask individual VSL messages from being logged.\n"
 	"	default	Set default value\n"
@@ -1461,9 +1419,9 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"255b",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"Maximum number of bytes in SHM log record.",
+	/* flags */	0,
 	/* dyn_min_reason */	NULL,
 	/* dyn_max_reason */	"vsl_buffer - 12 bytes"
 )
@@ -1475,12 +1433,12 @@ PARAM(
 	/* max */	"4G",
 	/* def */	"80M",
 	/* units */	"bytes",
-	/* flags */	MUST_RESTART,
 	/* descr */
 	"The amount of space to allocate for the VSL fifo buffer in the "
 	"VSM memory segment.  If you make this too small, "
 	"varnish{ncsa|log} etc will not be able to keep up.  Making it too "
-	"large just costs memory resources."
+	"large just costs memory resources.",
+	/* flags */	MUST_RESTART
 )
 
 PARAM(
@@ -1490,7 +1448,6 @@ PARAM(
 	/* max */	"1G",
 	/* def */	"1M",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"DEPRECATED: This parameter is ignored.\n"
 	"There is no global limit on amount of shared memory now."
@@ -1505,9 +1462,9 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"kqueue (possible values: kqueue, poll)",
 	/* units */	NULL,
-	/* flags */	MUST_RESTART| WIZARD,
 	/* descr */
-	"Select the waiter kernel interface."
+	"Select the waiter kernel interface.",
+	/* flags */	MUST_RESTART| WIZARD
 )
 #endif
 
@@ -1518,10 +1475,10 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"64k",
 	/* units */	"bytes",
-	/* flags */	DELAYED_EFFECT,
 	/* descr */
 	"Bytes of HTTP protocol workspace for backend HTTP req/resp.  If "
-	"larger than 4k, use a multiple of 4k for VM efficiency."
+	"larger than 4k, use a multiple of 4k for VM efficiency.",
+	/* flags */	DELAYED_EFFECT
 )
 
 PARAM(
@@ -1531,14 +1488,14 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"64k",
 	/* units */	"bytes",
-	/* flags */	DELAYED_EFFECT,
 	/* descr */
 	"Bytes of HTTP protocol workspace for clients HTTP req/resp.  Use a "
 	"multiple of 4k for VM efficiency.\n"
 	"For HTTP/2 compliance this must be at least 20k, in order to "
 	"receive fullsize (=16k) frames from the client.   That usually "
 	"happens only in POST/PUT bodies.  For other traffic-patterns "
-	"smaller values work just fine."
+	"smaller values work just fine.",
+	/* flags */	DELAYED_EFFECT
 )
 
 PARAM(
@@ -1548,11 +1505,11 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"0.75k",
 	/* units */	"bytes",
-	/* flags */	DELAYED_EFFECT,
 	/* descr */
 	"Allocation size for session structure and workspace.    The "
 	"workspace is primarily used for TCP connection addresses.  If "
-	"larger than 4k, use a multiple of 4k for VM efficiency."
+	"larger than 4k, use a multiple of 4k for VM efficiency.",
+	/* flags */	DELAYED_EFFECT
 )
 
 PARAM(
@@ -1562,7 +1519,6 @@ PARAM(
 	/* max */	"8k",
 	/* def */	"2k",
 	/* units */	"bytes",
-	/* flags */	DELAYED_EFFECT,
 	/* descr */
 	"Bytes of auxiliary workspace per thread.\n"
 	"This workspace is used for certain temporary data structures "
@@ -1572,7 +1528,8 @@ PARAM(
 	"syscalls, setting it too high just wastes space.  ~0.1k + "
 	"UIO_MAXIOV * sizeof(struct iovec) (typically = ~16k for 64bit) "
 	"is considered the maximum sensible value under any known "
-	"circumstances (excluding exotic vmod use)."
+	"circumstances (excluding exotic vmod use).",
+	/* flags */	DELAYED_EFFECT
 )
 
 PARAM(
@@ -1582,11 +1539,11 @@ PARAM(
 	/* max */	"1G",
 	/* def */	"10M",
 	/* units */	"bytes",
-	/* flags */	WIZARD,
 	/* descr */
 	"HTTP2 Receive Window low water mark.\n"
 	"We try to keep the window at least this big\n"
-	"Only affects incoming request bodies (ie: POST, PUT etc.)"
+	"Only affects incoming request bodies (ie: POST, PUT etc.)",
+	/* flags */	WIZARD
 )
 
 PARAM(
@@ -1596,11 +1553,11 @@ PARAM(
 	/* max */	"1G",
 	/* def */	"1M",
 	/* units */	"bytes",
-	/* flags */	WIZARD,
 	/* descr */
 	"HTTP2 Receive Window Increments.\n"
 	"How big credits we send in WINDOW_UPDATE frames\n"
-	"Only affects incoming request bodies (ie: POST, PUT etc.)"
+	"Only affects incoming request bodies (ie: POST, PUT etc.)",
+	/* flags */	WIZARD
 )
 
 PARAM(
@@ -1610,7 +1567,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"4k",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"HTTP2 header table size.\n"
 	"This is the size that will be used for the HPACK dynamic\n"
@@ -1624,7 +1580,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"100",
 	/* units */	"streams",
-	/* flags */	0,
 	/* descr */
 	"HTTP2 Maximum number of concurrent streams.\n"
 	"This is the number of requests that can be active\n"
@@ -1638,7 +1593,6 @@ PARAM(
 	/* max */	"2147483647b",
 	/* def */	"65535b",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"HTTP2 initial flow control window size."
 )
@@ -1650,7 +1604,6 @@ PARAM(
 	/* max */	"16777215b",
 	/* def */	"16k",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"HTTP2 maximum per frame payload size we are willing to accept."
 )
@@ -1662,7 +1615,6 @@ PARAM(
 	/* max */	NULL,
 	/* def */	"2147483647b",
 	/* units */	"bytes",
-	/* flags */	0,
 	/* descr */
 	"HTTP2 maximum size of an uncompressed header list."
 )

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -43,13 +43,13 @@
 #endif
 PARAM(
 	/* name */	accept_filter,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"on",
+	/* def */	"on",
 	/* units */	"bool",
 	/* flags */	XYZZY,
-	/* s-text */
+	/* descr */
 	"Enable kernel accept-filters. This may require a kernel module to "
 	"be loaded to have an effect when enabled.\n\n"
 	"Enabling accept_filter may prevent some requests to reach Varnish "
@@ -61,13 +61,13 @@ PARAM(
 
 PARAM(
 	/* name */	acceptor_sleep_decay,
-	/* typ */	double,
+	/* type */	double,
 	/* min */	"0",
 	/* max */	"1",
-	/* default */	"0.9",
+	/* def */	"0.9",
 	/* units */	NULL,
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"If we run out of resources, such as file descriptors or worker "
 	"threads, the acceptor will sleep between accepts.\n"
 	"This parameter (multiplicatively) reduce the sleep duration for "
@@ -76,13 +76,13 @@ PARAM(
 
 PARAM(
 	/* name */	acceptor_sleep_incr,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0",
 	/* max */	"1",
-	/* default */	"0",
+	/* def */	"0",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"If we run out of resources, such as file descriptors or worker "
 	"threads, the acceptor will sleep between accepts.\n"
 	"This parameter control how much longer we sleep, each time we "
@@ -91,13 +91,13 @@ PARAM(
 
 PARAM(
 	/* name */	acceptor_sleep_max,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0",
 	/* max */	"10",
-	/* default */	"0.05",
+	/* def */	"0.05",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"If we run out of resources, such as file descriptors or worker "
 	"threads, the acceptor will sleep between accepts.\n"
 	"This parameter limits how long it can sleep between attempts to "
@@ -106,25 +106,25 @@ PARAM(
 
 PARAM(
 	/* name */	auto_restart,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"on",
+	/* def */	"on",
 	/* units */	"bool",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Automatically restart the child/worker process if it dies."
 )
 
 PARAM(
 	/* name */	ban_dups,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"on",
+	/* def */	"on",
 	/* units */	"bool",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Eliminate older identical bans when a new ban is added.  This saves "
 	"CPU cycles by not comparing objects to identical bans.\n"
 	"This is a waste of time if you have many bans which are never "
@@ -133,13 +133,13 @@ PARAM(
 
 PARAM(
 	/* name */	ban_cutoff,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"0",
+	/* def */	"0",
 	/* units */	"bans",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Expurge long tail content from the cache to keep the number of bans "
 	"below this value. 0 disables.\n\n"
 	"When this parameter is set to a non-zero value, the ban lurker "
@@ -163,13 +163,13 @@ PARAM(
 
 PARAM(
 	/* name */	ban_lurker_age,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"60",
+	/* def */	"60",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"The ban lurker will ignore bans until they are this old.  "
 	"When a ban is added, the active traffic will be tested against it "
 	"as part of object lookup.  Because many applications issue bans in "
@@ -180,13 +180,13 @@ PARAM(
 
 PARAM(
 	/* name */	ban_lurker_batch,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"1",
 	/* max */	NULL,
-	/* default */	"1000",
+	/* def */	"1000",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"The ban lurker sleeps ${ban_lurker_sleep} after examining this "
 	"many objects."
 	"  Use this to pace the ban-lurker if it eats too many resources."
@@ -194,13 +194,13 @@ PARAM(
 
 PARAM(
 	/* name */	ban_lurker_sleep,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"0.010",
+	/* def */	"0.010",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"How long the ban lurker sleeps after examining ${ban_lurker_batch} "
 	"objects."
 	"  Use this to pace the ban-lurker if it eats too many resources.\n"
@@ -209,26 +209,26 @@ PARAM(
 
 PARAM(
 	/* name */	ban_lurker_holdoff,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"0.010",
+	/* def */	"0.010",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"How long the ban lurker sleeps when giving way to lookup"
 	" due to lock contention."
 )
 
 PARAM(
 	/* name */	first_byte_timeout,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"60",
+	/* def */	"60",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Default timeout for receiving first byte from backend. We only "
 	"wait for this many seconds for the first byte before giving up.\n"
 	"VCL can override this default value for each backend and backend "
@@ -238,13 +238,13 @@ PARAM(
 
 PARAM(
 	/* name */	between_bytes_timeout,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"60",
+	/* def */	"60",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"We only wait for this many seconds between bytes received from "
 	"the backend before giving up the fetch.\n"
 	"VCL values, per backend or per backend request take precedence.\n"
@@ -253,25 +253,25 @@ PARAM(
 
 PARAM(
 	/* name */	backend_idle_timeout,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"1",
 	/* max */	NULL,
-	/* default */	"60",
+	/* def */	"60",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Timeout before we close unused backend connections."
 )
 
 PARAM(
 	/* name */	backend_local_error_holddown,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"10.000",
+	/* def */	"10.000",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"When connecting to backends, certain error codes "
 	"(EADDRNOTAVAIL, EACCESS, EPERM) signal a local resource shortage "
 	"or configuration issue for which retrying connection attempts "
@@ -283,13 +283,13 @@ PARAM(
 
 PARAM(
 	/* name */	backend_remote_error_holddown,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"0.250",
+	/* def */	"0.250",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"When connecting to backends, certain error codes (ECONNREFUSED, "
 	"ENETUNREACH) signal fundamental connection issues such as the backend "
 	"not accepting connections or routing problems for which repeated "
@@ -300,13 +300,13 @@ PARAM(
 
 PARAM(
 	/* name */	cli_limit,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"128b",
 	/* max */	"99999999b",
-	/* default */	"48k",
+	/* def */	"48k",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Maximum size of CLI response.  If the response exceeds this "
 	"limit, the response code will be 201 instead of 200 and the last "
 	"line will indicate the truncation."
@@ -314,52 +314,52 @@ PARAM(
 
 PARAM(
 	/* name */	cli_timeout,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"60.000",
+	/* def */	"60.000",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Timeout for the childs replies to CLI requests from the "
 	"mgt_param."
 )
 
 PARAM(
 	/* name */	clock_skew,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"10",
+	/* def */	"10",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"How much clockskew we are willing to accept between the backend "
 	"and our own clock."
 )
 
 PARAM(
 	/* name */	clock_step,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"1.000",
+	/* def */	"1.000",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"How much observed clock step we are willing to accept before "
 	"we panic."
 )
 
 PARAM(
 	/* name */	connect_timeout,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"3.500",
+	/* def */	"3.500",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Default connection timeout for backend connections. We only try "
 	"to connect to the backend for this many seconds before giving up. "
 	"VCL can override this default value for each backend and backend "
@@ -368,13 +368,13 @@ PARAM(
 
 PARAM(
 	/* name */	critbit_cooloff,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"60.000",
 	/* max */	"254.000",
-	/* default */	"180.000",
+	/* def */	"180.000",
 	/* units */	"seconds",
 	/* flags */	WIZARD,
-	/* s-text */
+	/* descr */
 	"How long the critbit hasher keeps deleted objheads on the cooloff "
 	"list."
 )
@@ -384,13 +384,13 @@ PARAM(
 /* see tbl/debug_bits.h */
 PARAM(
 	/* name */	debug,
-	/* typ */	debug,
+	/* type */	debug,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	NULL,
+	/* def */	NULL,
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Enable/Disable various kinds of debugging.\n"
 	"	none	Disable all debugging\n"
 	"\n"
@@ -411,13 +411,13 @@ PARAM(
 
 PARAM(
 	/* name */	default_grace,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"10.000",
+	/* def */	"10.000",
 	/* units */	"seconds",
 	/* flags */	OBJ_STICKY,
-	/* s-text */
+	/* descr */
 	"Default grace period.  We will deliver an object this long after "
 	"it has expired, provided another thread is attempting to get a "
 	"new copy."
@@ -425,13 +425,13 @@ PARAM(
 
 PARAM(
 	/* name */	default_keep,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"0.000",
+	/* def */	"0.000",
 	/* units */	"seconds",
 	/* flags */	OBJ_STICKY,
-	/* s-text */
+	/* descr */
 	"Default keep period.  We will keep a useless object around this "
 	"long, making it available for conditional backend fetches.  That "
 	"means that the object will be removed from the cache at the end "
@@ -440,26 +440,26 @@ PARAM(
 
 PARAM(
 	/* name */	default_ttl,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"120.000",
+	/* def */	"120.000",
 	/* units */	"seconds",
 	/* flags */	OBJ_STICKY,
-	/* s-text */
+	/* descr */
 	"The TTL assigned to objects if neither the backend nor the VCL "
 	"code assigns one."
 )
 
 PARAM(
 	/* name */	http1_iovs,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"5",
 	/* max */	"1024",		// XXX stringify IOV_MAX
-	/* default */	"64",
+	/* def */	"64",
 	/* units */	"struct iovec (=16 bytes)",
 	/* flags */	WIZARD,
-	/* s-text */
+	/* descr */
 	"Number of io vectors to allocate for HTTP1 protocol transmission."
 	"  A HTTP1 header needs 7 + 2 per HTTP header field."
 	"  Allocated from workspace_thread."
@@ -470,13 +470,13 @@ PARAM(
 /* See tbl/feature_bits.h */
 PARAM(
 	/* name */	feature,
-	/* typ */	feature,
+	/* type */	feature,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	NULL,
+	/* def */	NULL,
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Enable/Disable various minor features.\n"
 	"	none	Disable all features.\n"
 	"\n"
@@ -493,13 +493,13 @@ PARAM(
 
 PARAM(
 	/* name */	fetch_chunksize,
-	/* typ */	bytes,
+	/* type */	bytes,
 	/* min */	"4k",
 	/* max */	NULL,
-	/* default */	"16k",
+	/* def */	"16k",
 	/* units */	"bytes",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"The default chunksize used by fetcher. This should be bigger than "
 	"the majority of objects with short TTLs.\n"
 	"Internal limits in the storage_file module makes increases above "
@@ -508,26 +508,26 @@ PARAM(
 
 PARAM(
 	/* name */	fetch_maxchunksize,
-	/* typ */	bytes,
+	/* type */	bytes,
 	/* min */	"64k",
 	/* max */	NULL,
-	/* default */	"0.25G",
+	/* def */	"0.25G",
 	/* units */	"bytes",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"The maximum chunksize we attempt to allocate from storage. Making "
 	"this too large may cause delays and storage fragmentation."
 )
 
 PARAM(
 	/* name */	gzip_buffer,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"2k",
 	/* max */	NULL,
-	/* default */	"32k",
+	/* def */	"32k",
 	/* units */	"bytes",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Size of malloc buffer used for gzip processing.\n"
 	"These buffers are used for in-transit data, for instance "
 	"gunzip'ed data being sent to a client.Making this space to small "
@@ -537,38 +537,38 @@ PARAM(
 
 PARAM(
 	/* name */	gzip_level,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	"9",
-	/* default */	"6",
+	/* def */	"6",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Gzip compression level: 0=debug, 1=fast, 9=best"
 )
 
 PARAM(
 	/* name */	gzip_memlevel,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"1",
 	/* max */	"9",
-	/* default */	"8",
+	/* def */	"8",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Gzip memory level 1=slow/least, 9=fast/most compression.\n"
 	"Memory impact is 1=1k, 2=2k, ... 9=256k."
 )
 
 PARAM(
 	/* name */	http_gzip_support,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"on",
+	/* def */	"on",
 	/* units */	"bool",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Enable gzip support. When enabled Varnish request compressed "
 	"objects from the backend and store them compressed. If a client "
 	"does not support gzip encoding Varnish will uncompress compressed "
@@ -587,13 +587,13 @@ PARAM(
 
 PARAM(
 	/* name */	http_max_hdr,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"32",
 	/* max */	"65535",
-	/* default */	"64",
+	/* def */	"64",
 	/* units */	"header lines",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Maximum number of HTTP header lines we allow in "
 	"{req|resp|bereq|beresp}.http (obj.http is autosized to the exact "
 	"number of headers).\n"
@@ -603,38 +603,38 @@ PARAM(
 
 PARAM(
 	/* name */	http_range_support,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"on",
+	/* def */	"on",
 	/* units */	"bool",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Enable support for HTTP Range headers."
 )
 
 PARAM(
 	/* name */	http_req_hdr_len,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"40b",
 	/* max */	NULL,
-	/* default */	"8k",
+	/* def */	"8k",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Maximum length of any HTTP client request header we will allow.  "
 	"The limit is inclusive its continuation lines."
 )
 
 PARAM(
 	/* name */	http_req_size,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"0.25k",
 	/* max */	NULL,
-	/* default */	"32k",
+	/* def */	"32k",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Maximum number of bytes of HTTP client request we will deal with. "
 	" This is a limit on all bytes up to the double blank line which "
 	"ends the HTTP request.\n"
@@ -645,26 +645,26 @@ PARAM(
 
 PARAM(
 	/* name */	http_resp_hdr_len,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"40b",
 	/* max */	NULL,
-	/* default */	"8k",
+	/* def */	"8k",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Maximum length of any HTTP backend response header we will allow. "
 	" The limit is inclusive its continuation lines."
 )
 
 PARAM(
 	/* name */	http_resp_size,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"0.25k",
 	/* max */	NULL,
-	/* default */	"32k",
+	/* def */	"32k",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Maximum number of bytes of HTTP backend response we will deal "
 	"with.  This is a limit on all bytes up to the double blank line "
 	"which ends the HTTP response.\n"
@@ -684,13 +684,13 @@ PARAM(
 #endif
 PARAM(
 	/* name */	idle_send_timeout,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"60.000",
+	/* def */	"60.000",
 	/* units */	"seconds",
 	/* flags */	XYZZY,
-	/* s-text */
+	/* descr */
 	"Send timeout for individual pieces of data on client connections."
 	" May get extended if 'send_timeout' applies.\n\n"
 	"When this timeout is hit, the session is closed.\n\n"
@@ -701,25 +701,25 @@ PARAM(
 
 PARAM(
 	/* name */	listen_depth,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"1024",
+	/* def */	"1024",
 	/* units */	"connections",
 	/* flags */	MUST_RESTART,
-	/* s-text */
+	/* descr */
 	"Listen queue depth."
 )
 
 PARAM(
 	/* name */	lru_interval,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"2.000",
+	/* def */	"2.000",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Grace period before object moves on LRU list.\n"
 	"Objects are only moved to the front of the LRU list if they have "
 	"not been moved there already inside this timeout period.  This "
@@ -729,49 +729,49 @@ PARAM(
 
 PARAM(
 	/* name */	max_esi_depth,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"5",
+	/* def */	"5",
 	/* units */	"levels",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Maximum depth of esi:include processing."
 )
 
 PARAM(
 	/* name */	max_restarts,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"4",
+	/* def */	"4",
 	/* units */	"restarts",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Upper limit on how many times a request can restart."
 )
 
 PARAM(
 	/* name */	max_retries,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"4",
+	/* def */	"4",
 	/* units */	"retries",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Upper limit on how many times a backend fetch can retry."
 )
 
 PARAM(
 	/* name */	nuke_limit,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"50",
+	/* def */	"50",
 	/* units */	"allocations",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Maximum number of objects we attempt to nuke in order to make "
 	"space for a object body."
 )
@@ -780,13 +780,13 @@ PARAM(
 /* actual location mgt_param_tbl.c */
 PARAM(
 	/* name */	pcre_match_limit,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"1",
 	/* max */	NULL,
-	/* default */	"1.000",
+	/* def */	"1.000",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"The limit for the  number of internal matching function calls in "
 	"a pcre_exec() execution."
 )
@@ -794,13 +794,13 @@ PARAM(
 /* actual location mgt_param_tbl.c */
 PARAM(
 	/* name */	pcre_match_limit_recursion,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"1",
 	/* max */	NULL,
-	/* default */	"1.000",
+	/* def */	"1.000",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"The limit for the  number of internal matching function "
 	"recursions in a pcre_exec() execution."
 )
@@ -808,13 +808,13 @@ PARAM(
 
 PARAM(
 	/* name */	ping_interval,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"3",
+	/* def */	"3",
 	/* units */	"seconds",
 	/* flags */	MUST_RESTART,
-	/* s-text */
+	/* descr */
 	"Interval between pings from parent to child.\n"
 	"Zero will disable pinging entirely, which makes it possible to "
 	"attach a debugger to the child."
@@ -822,25 +822,25 @@ PARAM(
 
 PARAM(
 	/* name */	pipe_sess_max,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"0",
+	/* def */	"0",
 	/* units */	"connections",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Maximum number of sessions dedicated to pipe transactions."
 )
 
 PARAM(
 	/* name */	pipe_timeout,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"60.000",
+	/* def */	"60.000",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Idle timeout for PIPE sessions. If nothing have been received in "
 	"either direction for this many seconds, the session is closed."
 )
@@ -849,13 +849,13 @@ PARAM(
 /* actual location mgt_param_tbl.c */
 PARAM(
 	/* name */	pool_req,
-	/* typ */	poolparam,
+	/* type */	poolparam,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"10,100,10",
+	/* def */	"10,100,10",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Parameters for per worker pool request memory pool.\n"
 	MEMPOOL_TEXT
 )
@@ -863,13 +863,13 @@ PARAM(
 /* actual location mgt_param_tbl.c */
 PARAM(
 	/* name */	pool_sess,
-	/* typ */	poolparam,
+	/* type */	poolparam,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"10,100,10",
+	/* def */	"10,100,10",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Parameters for per worker pool session memory pool.\n"
 	MEMPOOL_TEXT
 )
@@ -877,13 +877,13 @@ PARAM(
 /* actual location mgt_param_tbl.c */
 PARAM(
 	/* name */	pool_vbo,
-	/* typ */	poolparam,
+	/* type */	poolparam,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"10,100,10",
+	/* def */	"10,100,10",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Parameters for backend object fetch memory pool.\n"
 	MEMPOOL_TEXT
 )
@@ -891,26 +891,26 @@ PARAM(
 
 PARAM(
 	/* name */	prefer_ipv6,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"off",
+	/* def */	"off",
 	/* units */	"bool",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Prefer IPv6 address when connecting to backends which have both "
 	"IPv4 and IPv6 addresses."
 )
 
 PARAM(
 	/* name */	rush_exponent,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"2",
 	/* max */	NULL,
-	/* default */	"3",
+	/* def */	"3",
 	/* units */	"requests per request",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"How many parked request we start for each completed request on "
 	"the object.\n"
 	"NB: Even with the implict delay of delivery, this parameter "
@@ -928,13 +928,13 @@ PARAM(
 #endif
 PARAM(
 	/* name */	send_timeout,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"600.000",
+	/* def */	"600.000",
 	/* units */	"seconds",
 	/* flags */	XYZZY,
-	/* s-text */
+	/* descr */
 	"Total timeout for ordinary HTTP1 responses. Does not apply to some"
 	" internally generated errors and pipe mode.\n\n"
 	"When 'idle_send_timeout' is hit while sending an HTTP1 response, the"
@@ -946,39 +946,39 @@ PARAM(
 
 PARAM(
 	/* name */	shortlived,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"10.000",
+	/* def */	"10.000",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Objects created with (ttl+grace+keep) shorter than this are "
 	"always put in transient storage."
 )
 
 PARAM(
 	/* name */	sigsegv_handler,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"on",
+	/* def */	"on",
 	/* units */	"bool",
 	/* flags */	MUST_RESTART,
-	/* s-text */
+	/* descr */
 	"Install a signal handler which tries to dump debug information on "
 	"segmentation faults, bus errors and abort signals."
 )
 
 PARAM(
 	/* name */	syslog_cli_traffic,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"on",
+	/* def */	"on",
 	/* units */	"bool",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Log all CLI traffic to syslog(LOG_INFO)."
 )
 
@@ -989,13 +989,13 @@ PARAM(
 #endif
 PARAM(
 	/* name */	tcp_fastopen,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"off",
+	/* def */	"off",
 	/* units */	"bool",
 	/* flags */	XYZZY,
-	/* s-text */
+	/* descr */
 	"Enable TCP Fast Open extension."
 )
 #undef XYZZY
@@ -1007,26 +1007,26 @@ PARAM(
 #endif
 PARAM(
 	/* name */	tcp_keepalive_intvl,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"1",
 	/* max */	"100",
-	/* default */	"",
+	/* def */	"",
 	/* units */	"seconds",
 	/* flags */	XYZZY,
-	/* s-text */
+	/* descr */
 	"The number of seconds between TCP keep-alive probes. "
 	"Ignored for Unix domain sockets."
 )
 
 PARAM(
 	/* name */	tcp_keepalive_probes,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"1",
 	/* max */	"100",
-	/* default */	"",
+	/* def */	"",
 	/* units */	"probes",
 	/* flags */	XYZZY,
-	/* s-text */
+	/* descr */
 	"The maximum number of TCP keep-alive probes to send before giving "
 	"up and killing the connection if no response is obtained from the "
 	"other end. Ignored for Unix domain sockets."
@@ -1034,13 +1034,13 @@ PARAM(
 
 PARAM(
 	/* name */	tcp_keepalive_time,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"1",
 	/* max */	"7200",
-	/* default */	"",
+	/* def */	"",
 	/* units */	"seconds",
 	/* flags */	XYZZY,
-	/* s-text */
+	/* descr */
 	"The number of seconds a connection needs to be idle before TCP "
 	"begins sending out keep-alive probes. "
 	"Ignored for Unix domain sockets."
@@ -1051,13 +1051,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_add_delay,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"0.000",
+	/* def */	"0.000",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Wait at least this long after creating a thread.\n"
 	"\n"
 	"Some (buggy) systems may need a short (sub-second) delay between "
@@ -1070,13 +1070,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_watchdog,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.1",
 	/* max */	NULL,
-	/* default */	"60.000",
+	/* def */	"60.000",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Thread queue stuck watchdog.\n"
 	"\n"
 	"If no queued work have been released for this long,"
@@ -1086,13 +1086,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_destroy_delay,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.010",
 	/* max */	NULL,
-	/* default */	"1.000",
+	/* def */	"1.000",
 	/* units */	"seconds",
 	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Wait this long after destroying a thread.\n"
 	"This controls the decay of thread pools when idle(-ish)."
 )
@@ -1100,13 +1100,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_fail_delay,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.010",
 	/* max */	NULL,
-	/* default */	"0.200",
+	/* def */	"0.200",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Wait at least this long after a failed thread creation before "
 	"trying to create another thread.\n"
 	"\n"
@@ -1125,13 +1125,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_max,
-	/* typ */	thread_pool_max,
+	/* type */	thread_pool_max,
 	/* min */	"100",
 	/* max */	NULL,
-	/* default */	"5000",
+	/* def */	"5000",
 	/* units */	"threads",
 	/* flags */	DELAYED_EFFECT,
-	/* s-text */
+	/* descr */
 	"The maximum number of worker threads in each pool.\n"
 	"\n"
 	"Do not set this higher than you have to, since excess worker "
@@ -1142,13 +1142,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_min,
-	/* typ */	thread_pool_min,
+	/* type */	thread_pool_min,
 	/* min */	NULL,
 	/* max */	"5000",
-	/* default */	"100",
+	/* def */	"100",
 	/* units */	"threads",
 	/* flags */	DELAYED_EFFECT,
-	/* s-text */
+	/* descr */
 	"The minimum number of worker threads in each pool.\n"
 	"\n"
 	"Increasing this may help ramp up faster from low load situations "
@@ -1159,13 +1159,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_reserve,
-	/* typ */	thread_pool_reserve,
+	/* type */	thread_pool_reserve,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"0",
+	/* def */	"0",
 	/* units */	"threads",
 	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"The number of worker threads reserved for vital tasks "
 	"in each pool.\n"
 	"\n"
@@ -1186,13 +1186,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_stack,
-	/* typ */	bytes,
+	/* type */	bytes,
 	/* min */	"2k",
 	/* max */	NULL,
-	/* default */	"56k",
+	/* def */	"56k",
 	/* units */	"bytes",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Worker thread stack size.\n"
 	"This will likely be rounded up to a multiple of 4k (or whatever "
 	"the page_size might be) by the kernel."
@@ -1201,13 +1201,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pool_timeout,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"10.000",
 	/* max */	NULL,
-	/* default */	"300.000",
+	/* def */	"300.000",
 	/* units */	"seconds",
 	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Thread idle threshold.\n"
 	"\n"
 	"Threads in excess of thread_pool_min, which have been idle for at "
@@ -1217,13 +1217,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_pools,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"1",
 	/* max */	NULL,
-	/* default */	"2",
+	/* def */	"2",
 	/* units */	"pools",
 	/* flags */	DELAYED_EFFECT| EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Number of worker thread pools.\n"
 	"\n"
 	"Increasing the number of worker pools decreases lock "
@@ -1242,13 +1242,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_queue_limit,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"20",
+	/* def */	"20",
 	/* units */	NULL,
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Permitted request queue length per thread-pool.\n"
 	"\n"
 	"This sets the number of requests we will queue, waiting for an "
@@ -1259,13 +1259,13 @@ PARAM(
 /* actual location mgt_pool.c */
 PARAM(
 	/* name */	thread_stats_rate,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"10",
+	/* def */	"10",
 	/* units */	"requests",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"Worker threads accumulate statistics, and dump these into the "
 	"global stats counters if the lock is free when they finish a job "
 	"(request/fetch etc).\n"
@@ -1286,13 +1286,13 @@ PARAM(
 #endif
 PARAM(
 	/* name */	timeout_idle,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"5.000",
+	/* def */	"5.000",
 	/* units */	"seconds",
 	/* flags */	XYZZY,
-	/* s-text */
+	/* descr */
 	"Idle timeout for client connections.\n\n"
 	"A connection is considered idle until we have received the full"
 	" request headers.\n\n"
@@ -1304,13 +1304,13 @@ PARAM(
 
 PARAM(
 	/* name */	timeout_linger,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* default */	"0.050",
+	/* def */	"0.050",
 	/* units */	"seconds",
 	/* flags */	EXPERIMENTAL,
-	/* s-text */
+	/* descr */
 	"How long the worker thread lingers on an idle session before "
 	"handing it over to the waiter.\n"
 	"When sessions are reused, as much as half of all reuses happen "
@@ -1324,39 +1324,39 @@ PARAM(
 /* actual location mgt_param_tbl.c */
 PARAM(
 	/* name */	vcc_allow_inline_c,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"off",
+	/* def */	"off",
 	/* units */	"bool",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Allow inline C code in VCL."
 )
 
 /* actual location mgt_param_tbl.c */
 PARAM(
 	/* name */	vcc_err_unref,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"on",
+	/* def */	"on",
 	/* units */	"bool",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Unreferenced VCL objects result in error."
 )
 
 /* actual location mgt_param_tbl.c */
 PARAM(
 	/* name */	vcc_unsafe_path,
-	/* typ */	bool,
+	/* type */	bool,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"on",
+	/* def */	"on",
 	/* units */	"bool",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Allow '/' in vmod & include paths.\n"
 	"Allow 'import ... from ...'."
 )
@@ -1364,26 +1364,26 @@ PARAM(
 
 PARAM(
 	/* name */	vcl_cooldown,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"1.000",
 	/* max */	NULL,
-	/* default */	"600.000",
+	/* def */	"600.000",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"How long a VCL is kept warm after being replaced as the "
 	"active VCL (granularity approximately 30 seconds)."
 )
 
 PARAM(
 	/* name */	max_vcl_handling,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	"2",
-	/* default */	"1",
+	/* def */	"1",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Behaviour when attempting to exceed max_vcl loaded VCL.\n"
 	"\n*  0 - Ignore max_vcl parameter.\n"
 	"\n*  1 - Issue warning.\n"
@@ -1392,39 +1392,39 @@ PARAM(
 
 PARAM(
 	/* name */	max_vcl,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"100",
+	/* def */	"100",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Threshold of loaded VCL programs.  (VCL labels are not counted.)"
 	"  Parameter max_vcl_handling determines behaviour."
 )
 
 PARAM(
 	/* name */	vsm_free_cooldown,
-	/* typ */	timeout,
+	/* type */	timeout,
 	/* min */	"10.000",
 	/* max */	"600.000",
-	/* default */	"60.000",
+	/* def */	"60.000",
 	/* units */	"seconds",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"How long VSM memory is kept warm after a deallocation "
 	"(granularity approximately 2 seconds)."
 )
 
 PARAM(
 	/* name */	vsl_buffer,
-	/* typ */	vsl_buffer,
+	/* type */	vsl_buffer,
 	/* min */	"267",
 	/* max */	NULL,
-	/* default */	"4k",
+	/* def */	"4k",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Bytes of (req-/backend-)workspace dedicated to buffering VSL "
 	"records.\n"
 	"When this parameter is adjusted, most likely workspace_client "
@@ -1439,13 +1439,13 @@ PARAM(
 /* actual location mgt_param_bits.c*/
 PARAM(
 	/* name */	vsl_mask,
-	/* typ */	vsl_mask,
+	/* type */	vsl_mask,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"default",
+	/* def */	"default",
 	/* units */	NULL,
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Mask individual VSL messages from being logged.\n"
 	"	default	Set default value\n"
 	"\n"
@@ -1456,13 +1456,13 @@ PARAM(
 
 PARAM(
 	/* name */	vsl_reclen,
-	/* typ */	vsl_reclen,
+	/* type */	vsl_reclen,
 	/* min */	"16b",
 	/* max */	NULL,
-	/* default */	"255b",
+	/* def */	"255b",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"Maximum number of bytes in SHM log record.",
 	/* dyn_min_reason */	NULL,
 	/* dyn_max_reason */	"vsl_buffer - 12 bytes"
@@ -1470,13 +1470,13 @@ PARAM(
 
 PARAM(
 	/* name */	vsl_space,
-	/* typ */	bytes,
+	/* type */	bytes,
 	/* min */	"1M",
 	/* max */	"4G",
-	/* default */	"80M",
+	/* def */	"80M",
 	/* units */	"bytes",
 	/* flags */	MUST_RESTART,
-	/* s-text */
+	/* descr */
 	"The amount of space to allocate for the VSL fifo buffer in the "
 	"VSM memory segment.  If you make this too small, "
 	"varnish{ncsa|log} etc will not be able to keep up.  Making it too "
@@ -1485,13 +1485,13 @@ PARAM(
 
 PARAM(
 	/* name */	vsm_space,
-	/* typ */	bytes,
+	/* type */	bytes,
 	/* min */	"1M",
 	/* max */	"1G",
-	/* default */	"1M",
+	/* def */	"1M",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"DEPRECATED: This parameter is ignored.\n"
 	"There is no global limit on amount of shared memory now."
 )
@@ -1500,39 +1500,39 @@ PARAM(
 /* see mgt_waiter.c */
 PARAM(
 	/* name */	waiter,
-	/* typ */	waiter,
+	/* type */	waiter,
 	/* min */	NULL,
 	/* max */	NULL,
-	/* default */	"kqueue (possible values: kqueue, poll)",
+	/* def */	"kqueue (possible values: kqueue, poll)",
 	/* units */	NULL,
 	/* flags */	MUST_RESTART| WIZARD,
-	/* s-text */
+	/* descr */
 	"Select the waiter kernel interface."
 )
 #endif
 
 PARAM(
 	/* name */	workspace_backend,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"1k",
 	/* max */	NULL,
-	/* default */	"64k",
+	/* def */	"64k",
 	/* units */	"bytes",
 	/* flags */	DELAYED_EFFECT,
-	/* s-text */
+	/* descr */
 	"Bytes of HTTP protocol workspace for backend HTTP req/resp.  If "
 	"larger than 4k, use a multiple of 4k for VM efficiency."
 )
 
 PARAM(
 	/* name */	workspace_client,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"9k",
 	/* max */	NULL,
-	/* default */	"64k",
+	/* def */	"64k",
 	/* units */	"bytes",
 	/* flags */	DELAYED_EFFECT,
-	/* s-text */
+	/* descr */
 	"Bytes of HTTP protocol workspace for clients HTTP req/resp.  Use a "
 	"multiple of 4k for VM efficiency.\n"
 	"For HTTP/2 compliance this must be at least 20k, in order to "
@@ -1543,13 +1543,13 @@ PARAM(
 
 PARAM(
 	/* name */	workspace_session,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"0.25k",
 	/* max */	NULL,
-	/* default */	"0.75k",
+	/* def */	"0.75k",
 	/* units */	"bytes",
 	/* flags */	DELAYED_EFFECT,
-	/* s-text */
+	/* descr */
 	"Allocation size for session structure and workspace.    The "
 	"workspace is primarily used for TCP connection addresses.  If "
 	"larger than 4k, use a multiple of 4k for VM efficiency."
@@ -1557,13 +1557,13 @@ PARAM(
 
 PARAM(
 	/* name */	workspace_thread,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"0.25k",
 	/* max */	"8k",
-	/* default */	"2k",
+	/* def */	"2k",
 	/* units */	"bytes",
 	/* flags */	DELAYED_EFFECT,
-	/* s-text */
+	/* descr */
 	"Bytes of auxiliary workspace per thread.\n"
 	"This workspace is used for certain temporary data structures "
 	"during the operation of a worker thread.\n"
@@ -1577,13 +1577,13 @@ PARAM(
 
 PARAM(
 	/* name */	h2_rx_window_low_water,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"65535",
 	/* max */	"1G",
-	/* default */	"10M",
+	/* def */	"10M",
 	/* units */	"bytes",
 	/* flags */	WIZARD,
-	/* s-text */
+	/* descr */
 	"HTTP2 Receive Window low water mark.\n"
 	"We try to keep the window at least this big\n"
 	"Only affects incoming request bodies (ie: POST, PUT etc.)"
@@ -1591,13 +1591,13 @@ PARAM(
 
 PARAM(
 	/* name */	h2_rx_window_increment,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"1M",
 	/* max */	"1G",
-	/* default */	"1M",
+	/* def */	"1M",
 	/* units */	"bytes",
 	/* flags */	WIZARD,
-	/* s-text */
+	/* descr */
 	"HTTP2 Receive Window Increments.\n"
 	"How big credits we send in WINDOW_UPDATE frames\n"
 	"Only affects incoming request bodies (ie: POST, PUT etc.)"
@@ -1605,13 +1605,13 @@ PARAM(
 
 PARAM(
 	/* name */	h2_header_table_size,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"0b",
 	/* max */	NULL,
-	/* default */	"4k",
+	/* def */	"4k",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"HTTP2 header table size.\n"
 	"This is the size that will be used for the HPACK dynamic\n"
 	"decoding table."
@@ -1619,13 +1619,13 @@ PARAM(
 
 PARAM(
 	/* name */	h2_max_concurrent_streams,
-	/* typ */	uint,
+	/* type */	uint,
 	/* min */	"0",
 	/* max */	NULL,
-	/* default */	"100",
+	/* def */	"100",
 	/* units */	"streams",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"HTTP2 Maximum number of concurrent streams.\n"
 	"This is the number of requests that can be active\n"
 	"at the same time for a single HTTP2 connection."
@@ -1633,37 +1633,37 @@ PARAM(
 
 PARAM(
 	/* name */	h2_initial_window_size,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"0",
 	/* max */	"2147483647b",
-	/* default */	"65535b",
+	/* def */	"65535b",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"HTTP2 initial flow control window size."
 )
 
 PARAM(
 	/* name */	h2_max_frame_size,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"16k",
 	/* max */	"16777215b",
-	/* default */	"16k",
+	/* def */	"16k",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"HTTP2 maximum per frame payload size we are willing to accept."
 )
 
 PARAM(
 	/* name */	h2_max_header_list_size,
-	/* typ */	bytes_u,
+	/* type */	bytes_u,
 	/* min */	"0b",
 	/* max */	NULL,
-	/* default */	"2147483647b",
+	/* def */	"2147483647b",
 	/* units */	"bytes",
 	/* flags */	0,
-	/* s-text */
+	/* descr */
 	"HTTP2 maximum size of an uncompressed header list."
 )
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1431,8 +1431,8 @@ PARAM(
 	"and workspace_backend will have to be adjusted by the same amount.\n\n"
 	"Setting this too high costs memory, setting it too low will cause "
 	"more VSL flushes and likely increase lock-contention on the VSL "
-	"mutex.\n\n"
-	"The minimum tracks the vsl_reclen parameter + 12 bytes."
+	"mutex.",
+	/* dyn_min_reason */	"vsl_reclen + 12 bytes"
 )
 
 #if 0
@@ -1463,8 +1463,9 @@ PARAM(
 	/* units */	"bytes",
 	/* flags */	0,
 	/* s-text */
-	"Maximum number of bytes in SHM log record.\n\n"
-	"The maximum tracks the vsl_buffer parameter - 12 bytes."
+	"Maximum number of bytes in SHM log record.",
+	/* dyn_min_reason */	NULL,
+	/* dyn_max_reason */	"vsl_buffer - 12 bytes"
 )
 
 PARAM(


### PR DESCRIPTION
This is fresh from the oven, hopefully docfixes we can get in before the release.

My original intent was to use the dynamic bounds reasons fields to document `vsl_reclen` and `vsl_buffer` dependencies. It turned into the beginning of an overhaul of `params.h` but while individual patches may look large, they aren't. Using `git show -U0 <hash>` might help for the review of large-looking patches. They are really just mechanical patches, courtesy of vim macros.

Along the way, I also found that `thread_pool_stack`'s dynamic nature was not documented.

I'm planning further progress in this area after the 6.4 release. Reviewing this area last week I found more opportunities for improvement.