### PR TITLE
POC/VIP26: limit Transient usage for private objects

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -295,6 +295,8 @@ struct boc {
 	unsigned		refcount;
 	struct lock		mtx;
 	pthread_cond_t		cond;
+	struct lock		mtx_pipe;
+	pthread_cond_t		cond_pipe;
 	void			*stevedore_priv;
 	enum boc_state_e	state;
 	uint8_t			*vary;

--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -88,7 +88,7 @@ vfp_vep_callback(struct vfp_ctx *vc, void *priv, ssize_t l, enum vgz_flag flg)
 	VGZ_Ibuf(vef->vgz, vef->ibuf_o, l);
 	do {
 		dl = 0;
-		if (VFP_GetStorage(vc, &dl, &ptr) != VFP_OK) {
+		if (VFP_GetStorage(vc, &dl, &ptr, 0) != VFP_OK) {
 			vef->error = ENOMEM;
 			vef->tot += l;
 			return (vef->tot);

--- a/bin/varnishd/cache/cache_obj.h
+++ b/bin/varnishd/cache/cache_obj.h
@@ -37,7 +37,7 @@ typedef void objsetstate_f(struct worker *, const struct objcore *,
 typedef int objiterator_f(struct worker *, struct objcore *,
     void *priv, objiterate_f *func, int final);
 typedef int objgetspace_f(struct worker *, struct objcore *,
-     ssize_t *sz, uint8_t **ptr);
+    ssize_t *sz, uint8_t **ptr, int pipe);
 typedef void objextend_f(struct worker *, struct objcore *, ssize_t l);
 typedef void objtrimstore_f(struct worker *, struct objcore *);
 typedef void objbocdone_f(struct worker *, struct objcore *, struct boc *);

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -107,7 +107,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 			break;
 		}
 		l = yet;
-		if (VFP_GetStorage(vfc, &l, &ptr) != VFP_OK)
+		if (VFP_GetStorage(vfc, &l, &ptr, 0) != VFP_OK)
 			break;
 		AZ(vfc->failed);
 		AN(ptr);

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -332,7 +332,7 @@ cnt_synth(struct worker *wrk, struct req *req)
 		assert(szl >= 0);
 		sz = szl;
 		if (sz > 0 &&
-		    ObjGetSpace(wrk, req->objcore, &sz, &ptr) && sz >= szl) {
+		    ObjGetSpace(wrk, req->objcore, &sz, &ptr, 0) && sz >= szl) {
 			memcpy(ptr, VSB_data(synth_body), szl);
 			ObjExtend(wrk, req->objcore, szl);
 		} else if (sz > 0) {

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -242,7 +242,7 @@ void Bereq_Rollback(struct busyobj *);
 
 /* cache_fetch_proc.c */
 void VFP_Init(void);
-enum vfp_status VFP_GetStorage(struct vfp_ctx *, ssize_t *sz, uint8_t **ptr);
+enum vfp_status VFP_GetStorage(struct vfp_ctx *, ssize_t *sz, uint8_t **ptr, int pipe);
 void VFP_Extend(const struct vfp_ctx *, ssize_t sz);
 struct vfp_entry *VFP_Push(struct vfp_ctx *, const struct vfp *);
 void VFP_Setup(struct vfp_ctx *vc, struct worker *wrk);
@@ -290,7 +290,7 @@ void MPL_Free(struct mempool *mpl, void *item);
 void ObjInit(void);
 struct objcore * ObjNew(const struct worker *);
 void ObjDestroy(const struct worker *, struct objcore **);
-int ObjGetSpace(struct worker *, struct objcore *, ssize_t *sz, uint8_t **ptr);
+int ObjGetSpace(struct worker *, struct objcore *, ssize_t *sz, uint8_t **ptr, int pipe);
 void ObjExtend(struct worker *, struct objcore *, ssize_t l);
 uint64_t ObjWaitExtend(const struct worker *, const struct objcore *,
     uint64_t l);

--- a/include/tbl/locks.h
+++ b/include/tbl/locks.h
@@ -32,6 +32,7 @@
 LOCK(backend)
 LOCK(ban)
 LOCK(busyobj)
+LOCK(busyobj_pipe)
 LOCK(cli)
 LOCK(exp)
 LOCK(hcb)


### PR DESCRIPTION
It's an old attempt to limit Transient usage for private objects (named "soft pipe" initially).
It looks like this attempt is more stable since #2963 has been fixed.
I guess my approach is a little too hackish but it can be a start for https://github.com/varnishcache/varnish-cache/wiki/VIP-26:-limit-private-prefetch.
