### PR TITLE
Improve vcl reference caching

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -446,7 +446,7 @@ vca_accept_task(struct worker *wrk, void *arg)
 
 	/* Dont hold on to (possibly) discarded VCLs */
 	if (wrk->vcl != NULL)
-		VCL_Rel(&wrk->vcl);
+		VCL_Rel(&wrk->vcl, NULL);
 
 	while (!ps->pool->die) {
 		INIT_OBJ(&wa, WRK_ACCEPT_MAGIC);

--- a/bin/varnishd/cache/cache_busyobj.c
+++ b/bin/varnishd/cache/cache_busyobj.c
@@ -180,7 +180,7 @@ VBO_ReleaseBusyObj(struct worker *wrk, struct busyobj **pbo)
 		    HSH_RUSH_POLICY);
 	}
 
-	VCL_Recache(wrk, &bo->vcl);
+	VCL_Rel(&bo->vcl, wrk);
 
 	memset(&bo->retries, 0,
 	    sizeof *bo - offsetof(struct busyobj, retries));

--- a/bin/varnishd/cache/cache_busyobj.c
+++ b/bin/varnishd/cache/cache_busyobj.c
@@ -139,7 +139,7 @@ VBO_GetBusyObj(struct worker *wrk, const struct req *req)
 
 	bo->director_req = req->director_hint;
 	bo->vcl = req->vcl;
-	VCL_Ref(bo->vcl);
+	VCL_Ref(bo->vcl, wrk);
 
 	bo->t_first = bo->t_prev = NAN;
 
@@ -180,7 +180,7 @@ VBO_ReleaseBusyObj(struct worker *wrk, struct busyobj **pbo)
 		    HSH_RUSH_POLICY);
 	}
 
-	VCL_Rel(&bo->vcl);
+	VCL_Recache(wrk, &bo->vcl);
 
 	memset(&bo->retries, 0,
 	    sizeof *bo - offsetof(struct busyobj, retries));

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -207,7 +207,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 		AZ(req->wrk);
 	}
 
-	VCL_Recache(wrk, &req->vcl);
+	VCL_Rel(&req->vcl, wrk);
 
 	req->wrk = NULL;
 	THR_SetRequest(preq);

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -180,7 +180,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 		req->vcl = req->top->vcl0;
 	else
 		req->vcl = preq->vcl;
-	VCL_Ref(req->vcl);
+	VCL_Ref(req->vcl, wrk);
 
 	assert(req->req_step == R_STP_TRANSPORT);
 	req->t_req = preq->t_req;
@@ -207,7 +207,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 		AZ(req->wrk);
 	}
 
-	VCL_Rel(&req->vcl);
+	VCL_Recache(wrk, &req->vcl);
 
 	req->wrk = NULL;
 	THR_SetRequest(preq);

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -230,7 +230,7 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 	req->restarts = 0;
 
 	if (req->vcl != NULL)
-		VCL_Recache(wrk, &req->vcl);
+		VCL_Rel(&req->vcl, wrk);
 
 	/* Charge and log byte counters */
 	if (req->vsl->wid) {

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -1097,9 +1097,7 @@ CNT_Embark(struct worker *wrk, struct req *req)
 	req->vfc->wrk = req->wrk = wrk;
 	wrk->vsl = req->vsl;
 	if (req->req_step == R_STP_TRANSPORT && req->vcl == NULL) {
-		VCL_Refresh(&wrk->vcl);
-		req->vcl = wrk->vcl;
-		wrk->vcl = NULL;
+		VCL_Refresh(&req->vcl, wrk);
 		VSLb(req->vsl, SLT_VCL_use, "%s", VCL_Name(req->vcl));
 	}
 

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -1156,7 +1156,7 @@ CNT_Request(struct req *req)
 		if (IS_TOPREQ(req)) {
 			VCL_TaskLeave(ctx, req->top->privs);
 			if (req->top->vcl0 != NULL)
-				VCL_Rel(&req->top->vcl0);
+				VCL_Rel(&req->top->vcl0, NULL);
 		}
 		VCL_TaskLeave(ctx, req->privs);
 		AN(req->vsl->wid);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -463,7 +463,7 @@ const char *VCL_Return_Name(unsigned);
 const char *VCL_Method_Name(unsigned);
 void VCL_Refresh(struct vcl **);
 void VCL_Recache(struct worker *, struct vcl **);
-void VCL_Ref(struct vcl *);
+void VCL_Ref(struct vcl *, struct worker *);
 void VCL_Rel(struct vcl **);
 VCL_BACKEND VCL_DefaultDirector(const struct vcl *);
 const struct vrt_backend_probe *VCL_DefaultProbe(const struct vcl *);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -462,9 +462,8 @@ void VCL_VRT_Init(void);
 const char *VCL_Return_Name(unsigned);
 const char *VCL_Method_Name(unsigned);
 void VCL_Refresh(struct vcl **);
-void VCL_Recache(struct worker *, struct vcl **);
 void VCL_Ref(struct vcl *, struct worker *);
-void VCL_Rel(struct vcl **);
+void VCL_Rel(struct vcl **, struct worker *);
 VCL_BACKEND VCL_DefaultDirector(const struct vcl *);
 const struct vrt_backend_probe *VCL_DefaultProbe(const struct vcl *);
 

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -461,7 +461,7 @@ void VCL_VRT_Init(void);
 /* cache_vrt_vcl.c */
 const char *VCL_Return_Name(unsigned);
 const char *VCL_Method_Name(unsigned);
-void VCL_Refresh(struct vcl **);
+void VCL_Refresh(struct vcl **, struct worker *);
 void VCL_Ref(struct vcl *, struct worker *);
 void VCL_Rel(struct vcl **, struct worker *);
 VCL_BACKEND VCL_DefaultDirector(const struct vcl *);

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -97,7 +97,7 @@ VCL_Refresh(struct vcl **vclp, struct worker *wrk)
 }
 
 static inline int
-vcl_cancache(const struct vcl *vcl)
+vcl_cacheable(const struct vcl *vcl)
 {
 	return (vcl == vcl_active || vcl->nlabels > 0);
 }
@@ -142,18 +142,18 @@ VCL_Rel(struct vcl **vclp, struct worker *wrk)
 
 	/* lockless case first */
 	if (wrk != NULL && wrk->vcl == NULL &&
-	    vcl_cancache(vcl)) {
+	    vcl_cacheable(vcl)) {
 		wrk->vcl = vcl;
 		return;
 	}
 
 	Lck_Lock(&vcl_mtx);
 
-	if (wrk == NULL || ! vcl_cancache(vcl))
+	if (wrk == NULL || ! vcl_cacheable(vcl))
 		vcl_rel(vcl);
 
 	if (wrk != NULL && wrk->vcl != NULL &&
-	    (vcl != NULL || ! vcl_cancache(wrk->vcl)))
+	    (vcl != NULL || ! vcl_cacheable(wrk->vcl)))
 		vcl_rel(wrk->vcl);
 
 	Lck_Unlock(&vcl_mtx);

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -78,16 +78,22 @@ VCL_Method_Name(unsigned m)
 /*--------------------------------------------------------------------*/
 
 void
-VCL_Refresh(struct vcl **vcc)
+VCL_Refresh(struct vcl **vclp, struct worker *wrk)
 {
+	AN(vclp);
+	AZ(*vclp);
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 
 	while (vcl_active == NULL)
 		(void)usleep(100000);
 
-	if (*vcc == vcl_active)
+	*vclp = wrk->vcl;
+	wrk->vcl = NULL;
+
+	if (*vclp == vcl_active)
 		return;
 
-	VCL_Update(vcc, NULL);
+	VCL_Update(vclp, NULL);
 }
 
 static inline int

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -109,11 +109,18 @@ VCL_Recache(struct worker *wrk, struct vcl **vclp)
 }
 
 void
-VCL_Ref(struct vcl *vcl)
+VCL_Ref(struct vcl *vcl, struct worker *wrk)
 {
 
 	CHECK_OBJ_NOTNULL(vcl, VCL_MAGIC);
+	CHECK_OBJ_ORNULL(wrk, WORKER_MAGIC);
 	assert(!vcl->temp->is_cold);
+
+	if (wrk && vcl == wrk->vcl) {
+		wrk->vcl = NULL;
+		return;
+	}
+
 	Lck_Lock(&vcl_mtx);
 	assert(vcl->busy > 0);
 	vcl->busy++;
@@ -357,7 +364,7 @@ VRT_VCL_Prevent_Cold(VRT_CTX, const char *desc)
 	ref->vcl = ctx->vcl;
 	REPLACE(ref->desc, desc);
 
-	VCL_Ref(ctx->vcl);
+	VCL_Ref(ctx->vcl, NULL);
 
 	Lck_Lock(&vcl_mtx);
 	VTAILQ_INSERT_TAIL(&ctx->vcl->ref_list, ref, list);

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -348,7 +348,7 @@ h2_new_session(struct worker *wrk, void *arg)
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 
 	if (wrk->vcl)
-		VCL_Rel(&wrk->vcl);
+		VCL_Rel(&wrk->vcl, NULL);
 
 	assert(req->transport == &H2_transport);
 


### PR DESCRIPTION
This PR consists of two commits, and I would kindly ask reviewers to also read the individual commit messages.

* The first commit enables vcl reference caching also for backend requests and ESI subrequests
* The second commit changes the `VCL_Recache()` function to also cache references to VCLs used for labels, which should increase chances of the cache being hit when labels are used.
