### PR TITLE
Allow *.body to take either a STRING or a BLOB

### DIFF
--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -965,17 +965,29 @@ VRT_r_resp_do_esi(VRT_CTX)
 #define VRT_BODY_L(which)					\
 VCL_VOID							\
 VRT_l_##which##_body(VRT_CTX, enum lbody_e type,		\
-    const char *str, VCL_STRANDS s)				\
+    const char *str, VCL_BODY body)				\
 {								\
 	int n;							\
 	struct vsb *vsb;					\
+	VCL_STRANDS s;						\
+	VCL_BLOB b;						\
 								\
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);			\
+	AN(body);						\
 	CAST_OBJ_NOTNULL(vsb, ctx->specific, VSB_MAGIC);	\
-	assert(type == LBODY_SET || type == LBODY_ADD);		\
-	if (type == LBODY_SET)					\
+	if (type == LBODY_SET_STRING || type == LBODY_SET_BLOB)	\
 		VSB_clear(vsb);					\
+	if (type == LBODY_SET_BLOB || type == LBODY_ADD_BLOB) {	\
+		AZ(str);					\
+		b = body;					\
+		VSB_bcat(vsb, b->blob, b->len);			\
+		return;						\
+	}							\
 	if (str != NULL)					\
 		VSB_cat(vsb, str);				\
+	assert(type == LBODY_SET_STRING ||			\
+	    type == LBODY_ADD_STRING);				\
+	s = body;						\
 	for (n = 0; s != NULL && n < s->n; n++)			\
 		if (s->p[n] != NULL)				\
 			VSB_cat(vsb, s->p[n]);			\

--- a/bin/varnishtest/tests/r03079.vtc
+++ b/bin/varnishtest/tests/r03079.vtc
@@ -26,7 +26,7 @@ client c1 {
 	expect resp.http.x-powered-by == varnishtest1002
 } -run
 
-# set BODY [+]= STRINGS;
+# set BODY [+]= STRINGS|BLOB;
 
 varnish v1 -vcl {
 	import blob;
@@ -50,11 +50,20 @@ varnish v1 -vcl {
 				set resp.body += "world";
 			}
 		}
+		if (req.url ~ "blob") {
+			set resp.body = blob.decode(HEX, encoded="1100");
+			if (req.url ~ "reset") {
+				set resp.body = blob.decode(HEX, encoded="221100");
+			}
+			if (req.url ~ "add") {
+				set resp.body += blob.decode(HEX, encoded="221100");
+			}
+		}
 		return (deliver);
 	}
 }
 
-client c1 {
+client c2 {
 	txreq -url "/synth"
 	rxresp
 	expect resp.body == hello
@@ -74,4 +83,16 @@ client c1 {
 	txreq -url "/string/add"
 	rxresp
 	expect resp.body == helloworld
+
+	txreq -url "/blob"
+	rxresp
+	expect resp.bodylen == 2
+
+	txreq -url "/blob/reset"
+	rxresp
+	expect resp.bodylen == 3
+
+	txreq -url "/blob/add"
+	rxresp
+	expect resp.bodylen == 5
 } -run

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -302,6 +302,13 @@ BLOB
 	An opaque type to pass random bits of memory between VMOD
 	functions.
 
+BODY
+	C-type: ``const void *``
+
+	A type only used on the LHS of an assignment that can take
+	either a blob or an expression that can be converted to a
+	string.
+
 BOOL
 	C-type: ``unsigned``
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -56,6 +56,14 @@
  * Next (2021-03-15)
  *	VRT_Assign_Backend added
  *	VRT_StaticDirector added
+ *	enum lbody_e changed
+ *	- previous enum lbody_e values are defined as macros
+ *	The following functions changed to take `const char *, BODY`:
+ *	- VRT_l_beresp_body()
+ *	- VRT_l_resp_body()
+ *	BODY can either be a BLOB or a STRANDS, but only a STRANDS
+ *	can take a non-NULL const char * prefix. The changes to BODY
+ *	assignments doesn't break the ABI or the API.
  *
  * 14.0 (2021-09-15)
  *	VIN_n_Arg() no directly returns the directory name.
@@ -328,7 +336,7 @@ extern const struct vrt_blob *vrt_null_blob;
 typedef const struct vrt_acl *			VCL_ACL;
 typedef const struct director *			VCL_BACKEND;
 typedef const struct vrt_blob *			VCL_BLOB;
-typedef const char *				VCL_BODY;
+typedef const void *				VCL_BODY;
 typedef unsigned				VCL_BOOL;
 typedef int64_t					VCL_BYTES;
 typedef vtim_dur				VCL_DURATION;
@@ -615,9 +623,14 @@ VCL_STRING VRT_GetHdr(VRT_CTX, VCL_HEADER);
  */
 
 enum lbody_e {
-	LBODY_SET,
-	LBODY_ADD,
+	LBODY_SET_STRING,
+	LBODY_ADD_STRING,
+	LBODY_SET_BLOB,
+	LBODY_ADD_BLOB,
 };
+
+#define LBODY_SET LBODY_SET_STRING
+#define LBODY_ADD LBODY_ADD_STRING
 
 VCL_BYTES VRT_CacheReqBody(VRT_CTX, VCL_BYTES maxsize);
 

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -219,7 +219,7 @@ class vardef(object):
             if self.typ == "STRING":
                 s += ctyp.c + ", VCL_STRANDS)"
             elif self.typ == "BODY":
-                s += "enum lbody_e, " + ctyp.c + ", VCL_STRANDS)"
+                s += "enum lbody_e, const char *, " + ctyp.c + ")"
             else:
                 s += "VCL_" + self.typ + ")"
             varproto(s)

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -121,8 +121,8 @@ static const struct assign {
 	{ STRING,	'=',		STRANDS, "0,\n" },
 	{ HEADER,	T_INCR,		STRANDS, "VRT_GetHdr(ctx, \v),\n" },
 	{ HEADER,	'=',		STRANDS, "0,\n" },
-	{ BODY,		'=',		STRANDS, "LBODY_SET, 0,\n" },
-	{ BODY,		T_INCR,		STRANDS, "LBODY_ADD, 0,\n" },
+	{ BODY,		'=',		BODY, "LBODY_SET_" },
+	{ BODY,		T_INCR,		BODY, "LBODY_ADD_" },
 	{ VOID,		'=',		VOID }
 };
 

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -119,6 +119,8 @@ struct type {
 	const char		*tostring;
 	vcc_type_t		multype;
 	int			stringform;
+	int			bodyform;
+	int			noindent;
 };
 
 #define VCC_TYPE(UC, lc)	extern const struct type UC[1];

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -78,12 +78,14 @@ const struct type BACKEND[1] = {{
 const struct type BLOB[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"BLOB",
+	.bodyform =		1,
 	.tostring =		"VRT_BLOB_string(ctx, \v1)",
 }};
 
 const struct type BODY[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"BODY",
+	.noindent =		1,
 }};
 
 const struct type BOOL[1] = {{
@@ -199,6 +201,7 @@ const struct type STRINGS[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"STRINGS",
 	.methods =		strings_methods,
+	.bodyform =		1,
 	.tostring =		"",
 }};
 


### PR DESCRIPTION
This patch series is a different take on #3114 that takes a different approach than #3123, as announced in https://github.com/varnishcache/varnish-cache/issues/3114#issuecomment-595805313.

It does mainly four things:

- Allow `set BODY [+]= STRINGS|BODY`
- Automatic cast from `STRINGS` to `BLOB`
- Migrate `std.fileread()` logic to a new VFC [1] subsystem
- Reuse VFC in a new `blob.fileread()` function

I followed the direction we agreed on and my only peeve is that VFC lives in `libvarnish` and it might not be the best venue. In order to avoid needless BLOB allocations I need VFC to hand over a BLOB directly which creates a "reverse" dependency from `libvarnish` to `vrt.h` that is not to my liking.

The other thing I'm not too happy about is the `vcc_PeekExpr` function. I had two approaches in store to deal with the alternate type:

- peeking and rewinding (the one I picked)
- evaluating the expression with both types

In hindsight, I think I picked the complicated option, so I will likely also give a try to my alternative.

Fixes #3114
Closes #3123

[1] Varnish File Cache, I figured VFIL was too crowded for that