### PR TITLE
Handle workspace allocation errors in VEP_Init()

### DIFF
--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -171,6 +171,7 @@ vfp_esi_gzip_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 		return (VFP_ERROR);
 	}
 	vef->vgz = VGZ_NewGzip(vc->wrk->vsl, "G F E");
+	AN(vef->vgz);
 
 	vef->ibuf_sz = cache_param->gzip_buffer;
 	vef->ibuf = calloc(1L, vef->ibuf_sz);

--- a/bin/varnishd/cache/cache_esi_parse.c
+++ b/bin/varnishd/cache/cache_esi_parse.c
@@ -1042,7 +1042,11 @@ VEP_Init(struct vfp_ctx *vc, const struct http *req, vep_callback_t *cb,
 	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(req, HTTP_MAGIC);
 	vep = WS_Alloc(vc->resp->ws, sizeof *vep);
-	AN(vep);
+	if (vep == NULL) {
+		VSLb(vc->wrk->vsl, SLT_VCL_Error,
+		     "VEP_Init() workspace overflow");
+		return (NULL);
+	}
 
 	INIT_OBJ(vep, VEP_MAGIC);
 	vep->url = req->hd[HTTP_HDR_URL].b;

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -503,8 +503,7 @@ vfp_gzip_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 			vc->obj_flags |= OF_GZIPED;
 		}
 	}
-	if (vg == NULL)
-		return (VFP_ERROR);
+	AN(vg);
 	vfe->priv1 = vg;
 	if (vgz_getmbuf(vg))
 		return (VFP_ERROR);

--- a/bin/varnishtest/tests/r03253.vtc
+++ b/bin/varnishtest/tests/r03253.vtc
@@ -1,0 +1,26 @@
+varnishtest "ESI: sweep through tight backend workspace conditions"
+
+server s1 -repeat 100 {
+	rxreq
+	txresp -gzipbody "<html>"
+} -start
+
+varnish v1 -vcl+backend {
+	import vtc;
+	import std;
+	sub vcl_recv {
+		return (pass);
+	}
+	sub vcl_backend_response {
+		vtc.workspace_alloc(backend, -4 *
+			(std.integer(bereq.xid, 1002) - 1000) / 2);
+		set beresp.do_esi = true;
+	}
+} -start
+
+client c1 -repeat 100 {
+	txreq -url "/"
+	# some responses will fail (503), some won't. All we care
+	# about here is the fact that we don't panic
+	rxresp
+} -run


### PR DESCRIPTION
Turn assertion into VFP error

The vtc is based upon r02645.vtc and reliably reproduces the panic without the patch by sweeping through possible amounts of free workspace ranging from 4 to 400 bytes.

Fixes #3253