### PR TITLE
support concurrent access to PRIV_TOP

### DIFF
--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -166,6 +166,9 @@ struct vmod_priv *
 VRT_priv_top(VRT_CTX, const void *vmod_id)
 {
 	struct req *req;
+	struct sess *sp;
+	struct reqtop *top;
+	struct vmod_priv *priv;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	if (ctx->req == NULL) {
@@ -174,12 +177,15 @@ VRT_priv_top(VRT_CTX, const void *vmod_id)
 	}
 	req = ctx->req;
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-	CHECK_OBJ_NOTNULL(req->top, REQTOP_MAGIC);
-	return (vrt_priv_dynamic(
-	    req->ws,
-	    req->top->privs,
-	    (uintptr_t)vmod_id
-	));
+	sp = ctx->sp;
+	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
+	top = req->top;
+	CHECK_OBJ_NOTNULL(top, REQTOP_MAGIC);
+
+	Lck_Lock(&sp->mtx);
+	priv = vrt_priv_dynamic(req->ws, top->privs, (uintptr_t)vmod_id);
+	Lck_Unlock(&sp->mtx);
+	return (priv);
 }
 
 /*--------------------------------------------------------------------


### PR DESCRIPTION
this PR was already OK'd via #3129, I just wanted to keep the previous PR for future reference and not force-push a different implementation.

To be merged after the release freeze

---

in varnish-cache, access to all ESI sub-requests happens in a single thread, but vmods (VDPs) may add concurrency.

We thus protect access to PRIV_TOP with the session mutex.

Any vmods using this facility will likely need to add additional locking for the actual data structures referenced through the `PRIV_TOP` and any other access to the top request.

For alternatives previously considered, see #3139