### PR TITLE
Ensure we don't recycle a closed backend connection

### DIFF
--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -81,6 +81,9 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 			    "%s", vstrerror(errno));
 			return (i);
 		}
+		if (i == 0)
+			htc->doclose = SC_RESP_CLOSE;
+
 	}
 	return (i + l);
 }

--- a/bin/varnishtest/tests/r03266.vtc
+++ b/bin/varnishtest/tests/r03266.vtc
@@ -1,0 +1,19 @@
+varnishtest "Don't recycle a closed backend connection"
+
+# broken origin: sends eof-encoded HTTP/1.1 response
+server s1 {
+	rxreq
+	send "HTTP/1.1 200 OK\r\n\r\n"
+	send "foobar"
+} -start
+
+varnish v1 -vcl+backend {} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+varnish v1 -expect fetch_failed == 0
+varnish v1 -expect fetch_eof == 1
+varnish v1 -expect backend_recycle == 0


### PR DESCRIPTION
Fixes: #3266

I'm a bit unsure about using ``SC_RESP_CLOSE`` as the ``doclose`` flag here. Short of adding a new one, that is the closest I could find. 