### PR TITLE
Ensure we don't override Content-Encoding in a 304 conditional fetch backport

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -365,9 +365,9 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 				 * the stored Content_Encoding controls we
 				 * must weaken any new ETag we get.
 				 */
-				http_Unset(bo->beresp, H_Content_Encoding);
 				RFC2616_Weaken_Etag(bo->beresp);
 			}
+			http_Unset(bo->beresp, H_Content_Encoding);
 			http_Unset(bo->beresp, H_Content_Length);
 			HTTP_Merge(bo->wrk, bo->stale_oc, bo->beresp);
 			assert(http_IsStatus(bo->beresp, 200));

--- a/bin/varnishtest/tests/r03169.vtc
+++ b/bin/varnishtest/tests/r03169.vtc
@@ -1,0 +1,61 @@
+varnishtest "Ensure we don't override Content-Encoding on a cond fetch"
+
+server s1 {
+    rxreq
+    txresp -hdr {ETag: "foo"} -body {****}
+
+    rxreq
+    expect req.http.If-None-Match == {"foo"}
+    txresp -status 304 -hdr {ETag: W/"foo"} -hdr "Content-Encoding: gzip"
+
+    rxreq
+    expect req.url == "/1"
+    txresp -hdr {Etag: "bar"} -gzipbody {asdf}
+
+    rxreq
+    expect req.url == "/1"
+    expect req.http.If-None-Match == {"bar"}
+    txresp -status 304
+
+} -start
+
+varnish v1 -vcl+backend {
+    sub vcl_backend_response {
+        set beresp.ttl = 1s;
+        set beresp.grace = 0s;
+        set beresp.keep = 1d;
+    }
+} -start
+
+client c1 {
+    txreq -hdr "Accept-Encoding: gzip"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.ETag == {"foo"}
+    expect resp.http.Content-Length == "4"
+    expect resp.http.Content-Encoding == <undef>
+
+    delay 1.5
+
+    txreq -hdr "Accept-Encoding: gzip"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.ETag == {W/"foo"}
+    expect resp.http.Content-Length == "4"
+    expect resp.http.Content-Encoding == <undef>
+
+    # Also check that we're still OK in the general case
+    txreq -url "/1" -hdr "Accept-Encoding: gzip"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.ETag == {"bar"}
+    expect resp.http.Content-Encoding == "gzip"
+
+    delay 1.5
+
+    txreq -url "/1" -hdr "Accept-Encoding: gzip"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.ETag == {"bar"}
+    expect resp.http.Content-Encoding == "gzip"
+} -run


### PR DESCRIPTION
Commits from VCP:
e68a10b6603edb95b3c90ed679bc3c816fa5ef77

We diverging from the ``master`` idea that an new vcl sub be introduced: https://github.com/varnishcache/varnish-cache/issues/3169
