### PR TITLE
Body Free Race Backport

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -390,7 +390,8 @@ struct busyobj {
 	 * All fields from retries and down are zeroed when the busyobj
 	 * is recycled.
 	 */
-	int			retries;
+	unsigned		retries;
+	enum req_body_state_e	initial_req_body_status;
 	struct req		*req;
 	struct sess		*sp;
 	struct worker		*wrk;

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -403,6 +403,7 @@ struct busyobj {
 	struct http		*bereq0;
 	struct http		*bereq;
 	struct http		*beresp;
+	struct objcore		*bereq_body;
 	struct objcore		*stale_oc;
 	struct objcore		*fetch_objcore;
 

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -263,11 +263,17 @@ VRB_Ignore(struct req *req)
 void
 VRB_Free(struct req *req)
 {
+	int r;
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 
-	if (req->body_oc != NULL)
-		AZ(HSH_DerefObjCore(req->wrk, &req->body_oc, 0));
+	if (req->body_oc == NULL)
+		return;
+
+	r = HSH_DerefObjCore(req->wrk, &req->body_oc, 0);
+
+	// a busyobj may have gained a reference
+	assert (r == 0 || r == 1);
 }
 
 /*----------------------------------------------------------------------

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -105,7 +105,14 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	/* Deal with any message-body the request might (still) have */
 	i = 0;
 
-	if (bo->req != NULL &&
+	if (bo->bereq_body != NULL) {
+		if (do_chunked)
+			V1L_Chunked(wrk);
+		(void)ObjIterate(bo->wrk, bo->bereq_body,
+		    bo, vbf_iter_req_body, 0);
+		if (do_chunked)
+			V1L_EndChunk(wrk);
+	} else if (bo->req != NULL &&
 	    (bo->req->req_body_status == REQ_BODY_CACHED || !onlycached)) {
 		if (do_chunked)
 			V1L_Chunked(wrk);

--- a/bin/varnishtest/tests/r03093.vtc
+++ b/bin/varnishtest/tests/r03093.vtc
@@ -1,0 +1,45 @@
+varnishtest "r03093 - fail retry on missing req body"
+
+barrier b1 sock 2
+
+server s1 {
+	rxreq
+	expect req.method == POST
+	expect req.body == foo
+	txresp -nolen -hdr "Content-Length: 3"
+	barrier b1 sync
+} -start
+
+# In this test s2 should not be called. The attempt to retry should fail because
+# the request was already released from the fetch thread in the first attempt.
+server s2 {
+	rxreq
+	expect req.method == POST
+	expect req.body == foo
+	txresp -body bar
+} -start
+
+varnish v1 -arg "-p debug=+syncvsl" -vcl+backend {
+	import vtc;
+	sub vcl_backend_fetch {
+		set bereq.http.retries = bereq.retries;
+		if (bereq.retries == 1) {
+			set bereq.backend = s2;
+		}
+	}
+	sub vcl_backend_response {
+		if (bereq.http.retries == "0") {
+			vtc.barrier_sync("${b1_sock}");
+		}
+		set beresp.do_stream = false;
+	}
+	sub vcl_backend_error {
+		return (retry);
+	}
+} -start
+
+client c1 {
+	txreq -req POST -body foo
+	rxresp
+	expect resp.status == 503
+} -run


### PR DESCRIPTION
After some consideration we decided to backport this, although it changes a private API because well the API was private and undocumented so vmod writers should not have been using it.

commits:
f88b47951415fc212c8b4bb929b5a0db2c0835c0
d4b6228e1e32cda3014eeff0a5cb60cd7a0b5474
4e6e4eedcf078795d3197792d17b1294d79ff616