### PR TITLE
ESI workspace assert - backport

### DIFF
--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -170,6 +170,7 @@ vfp_esi_gzip_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 		return (VFP_ERROR);
 	}
 	vef->vgz = VGZ_NewGzip(vc->wrk->vsl, "G F E");
+	AN(vef->vgz);
 
 	vef->ibuf_sz = cache_param->gzip_buffer;
 	vef->ibuf = calloc(1L, vef->ibuf_sz);

--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -164,8 +164,13 @@ vfp_esi_gzip_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 	if (vef == NULL)
 		return (VFP_ERROR);
 	vc->obj_flags |= OF_GZIPED | OF_CHGGZIP | OF_ESIPROC;
-	vef->vgz = VGZ_NewGzip(vc->wrk->vsl, "G F E");
 	vef->vep = VEP_Init(vc, vc->req, vfp_vep_callback, vef);
+	if (vef->vep == NULL) {
+		FREE_OBJ(vef);
+		return (VFP_ERROR);
+	}
+	vef->vgz = VGZ_NewGzip(vc->wrk->vsl, "G F E");
+
 	vef->ibuf_sz = cache_param->gzip_buffer;
 	vef->ibuf = calloc(1L, vef->ibuf_sz);
 	if (vef->ibuf == NULL)
@@ -231,6 +236,7 @@ static enum vfp_status v_matchproto_(vfp_init_f)
 vfp_esi_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 {
 	struct vef_priv *vef;
+	struct vep_state *vep;
 
 	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(vc->req, HTTP_MAGIC);
@@ -239,11 +245,14 @@ vfp_esi_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 		    "Attempted ESI on partial (206) response");
 		return (VFP_ERROR);
 	}
+	vep = VEP_Init(vc, vc->req, NULL, NULL);
+	if (vep == NULL)
+		return (VFP_ERROR);
 	ALLOC_OBJ(vef, VEF_MAGIC);
 	if (vef == NULL)
 		return (VFP_ERROR);
 	vc->obj_flags |= OF_ESIPROC;
-	vef->vep = VEP_Init(vc, vc->req, NULL, NULL);
+	vef->vep = vep;
 	vfe->priv1 = vef;
 	return (VFP_OK);
 }

--- a/bin/varnishd/cache/cache_esi_parse.c
+++ b/bin/varnishd/cache/cache_esi_parse.c
@@ -1040,7 +1040,11 @@ VEP_Init(struct vfp_ctx *vc, const struct http *req, vep_callback_t *cb,
 	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(req, HTTP_MAGIC);
 	vep = WS_Alloc(vc->resp->ws, sizeof *vep);
-	AN(vep);
+	if (vep == NULL) {
+		VSLb(vc->wrk->vsl, SLT_VCL_Error,
+		     "VEP_Init() workspace overflow");
+		return (NULL);
+	}
 
 	INIT_OBJ(vep, VEP_MAGIC);
 	vep->url = req->hd[HTTP_HDR_URL].b;

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -479,8 +479,7 @@ vfp_gzip_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 			vc->obj_flags |= OF_GZIPED;
 		}
 	}
-	if (vg == NULL)
-		return (VFP_ERROR);
+	AN(vg);
 	vfe->priv1 = vg;
 	if (vgz_getmbuf(vg))
 		return (VFP_ERROR);

--- a/bin/varnishtest/tests/r03253.vtc
+++ b/bin/varnishtest/tests/r03253.vtc
@@ -1,0 +1,26 @@
+varnishtest "ESI: sweep through tight backend workspace conditions"
+
+server s1 -repeat 100 {
+	rxreq
+	txresp -gzipbody "<html>"
+} -start
+
+varnish v1 -vcl+backend {
+	import vtc;
+	import std;
+	sub vcl_recv {
+		return (pass);
+	}
+	sub vcl_backend_response {
+		vtc.workspace_alloc(backend, -4 *
+			(std.integer(bereq.xid, 1002) - 1000) / 2);
+		set beresp.do_esi = true;
+	}
+} -start
+
+client c1 -repeat 100 {
+	txreq -url "/"
+	# some responses will fail (503), some won't. All we care
+	# about here is the fact that we don't panic
+	rxresp
+} -run


### PR DESCRIPTION
Commits used:
0f3af407f65ac4bc6d446c61fb3e3b50747194cd
d1bd80e83a88a0caaaf7e5021472e23d244a8ac6

(needed to change the gzip[ flag back to 6.0)