### PR TITLE
RFC/POC high watermarks for workspaces

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -144,6 +144,7 @@ struct ws {
 	char			*f;		/* (F)ree/front pointer */
 	char			*r;		/* (R)eserved length */
 	char			*e;		/* (E)nd of buffer */
+	const char		*h;		/* (H)igh watermark */
 };
 
 /*--------------------------------------------------------------------
@@ -784,8 +785,11 @@ unsigned WS_ReserveSize(struct ws *, unsigned);
 unsigned WS_ReserveAll(struct ws *);
 unsigned WS_ReserveLumps(struct ws *ws, size_t sz);
 void WS_MarkOverflow(struct ws *ws);
+void WS_ReleaseH(struct ws *ws, unsigned bytes, unsigned high);
+void WS_ReleaseHP(struct ws *ws, const char *ptr, const char *high);
 void WS_Release(struct ws *ws, unsigned bytes);
 void WS_ReleaseP(struct ws *ws, const char *ptr);
+unsigned WS_High(const struct ws *ws);
 void WS_Assert(const struct ws *ws);
 void WS_Reset(struct ws *ws, uintptr_t);
 void *WS_Alloc(struct ws *ws, unsigned bytes);

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -400,7 +400,7 @@ vca_make_session(struct worker *wrk, void *arg)
 	    raddr, rport, wa->acceptlsock->name, laddr, lport,
 	    sp->t_open, sp->fd);
 
-	WS_Release(wrk->aws, 0);
+	WS_ReleaseHP(wrk->aws, wrk->aws->f, wrk->aws->r);
 
 	vca_pace_good();
 	wrk->stats->sess_conn++;

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -227,6 +227,12 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 
 	/* Charge and log byte counters */
 	if (req->vsl->wid) {
+		VSLb(req->vsl, SLT_Debug, "wshwm client %u",
+		     WS_High(req->ws));
+		VSLb(req->vsl, SLT_Debug, "wshwm session %u",
+		     WS_High(req->sp->ws));
+		VSLb(req->vsl, SLT_Debug, "wshwm thread %u",
+		     WS_High(wrk->aws));
 		Req_AcctLogCharge(wrk->stats, req);
 		if (req->vsl->wid != sp->vxid)
 			VSL_End(req->vsl);

--- a/bin/varnishd/cache/cache_vary.c
+++ b/bin/varnishd/cache/cache_vary.c
@@ -262,16 +262,18 @@ void
 VRY_Finish(struct req *req, enum vry_finish_flag flg)
 {
 	uint8_t *p = NULL;
+	unsigned len = 0;
 
 	(void)VRY_Validate(req->vary_b);
 	if (flg == KEEP && req->vary_l != NULL) {
-		p = malloc(req->vary_l - req->vary_b);
+		len = req->vary_l - req->vary_b;
+		p = malloc(len);
 		if (p != NULL) {
-			memcpy(p, req->vary_b, req->vary_l - req->vary_b);
+			memcpy(p, req->vary_b, len);
 			(void)VRY_Validate(p);
 		}
 	}
-	WS_Release(req->ws, 0);
+	WS_ReleaseH(req->ws, 0, len);
 	req->vary_l = NULL;
 	req->vary_e = NULL;
 	req->vary_b = p;

--- a/bin/varnishtest/tests/l00004.vtc
+++ b/bin/varnishtest/tests/l00004.vtc
@@ -47,7 +47,7 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g request {
 	expect 0 1001	Begin		"^req .* rxreq"
 	expect * =	PipeAcct	"^49 60 4 42$"
-	expect 0 =	End
+	expect 4 =	End
 } -start
 
 client c1 {

--- a/lib/libvmod_std/vmod_std_querysort.c
+++ b/lib/libvmod_std/vmod_std_querysort.c
@@ -127,6 +127,6 @@ vmod_querysort(VRT_CTX, VCL_STRING url)
 	}
 	*p = '\0';
 
-	WS_Release(ctx->ws, 0);
+	WS_ReleaseH(ctx->ws, 0, np * sizeof(const char **));
 	return (r);
 }


### PR DESCRIPTION
Unless `DBG_WORKSPACE` is used or additional tracing added to VCL (see for example `vtc.workspace_free()`), we usually have no idea how much workspace we are actually using.

We know when it's not enough because we fail requests and increase the `ws_*_overflow` stats counters, but in particular for production deployments, we cannot (easily) answer the question how much workspace headroom is left, if it is getting any close to "too small" or if we are wasting memory for good no reason.

So we should really add a facility to improve visibility.

A trivial approach would be to just log `ws->f - ws->s` at the end of each transaction, but that would not account for the cases where we use workspace as "scratch" space for some intermediate result.

To add such reporting, we need to remember a high water mark for the maximum amount of workspace we used for some transaction.

This patch adds the `(struct ws)` `h`(igh water mark) member and demos reporting the high water mark at the end of each client request:

```
**** v1   vsl|       1009 Timestamp       c Resp: 1586355523.554209 0.489777 0.250743
**** v1   vsl|       1009 Debug           c wshwm client 34376
**** v1   vsl|       1009 Debug           c wshwm session 96
**** v1   vsl|       1009 Debug           c wshwm thread 1128
**** v1   vsl|       1009 ReqAcct         c 0 0 0 0 111 111
**** v1   vsl|       1009 End             c
```

Please note that the reporting in this patch is by no means meant to be final, we should probably have an SLT for that purpose and also need to add reporting for backend requests.

To track the high water marks for temporary allocations, we need to consider two basic patterns:

* `WS_Snapshot()` / `WS_Reset()`

  Workspace is used as normal and then reset back to a snapshot.

  To track the high watermark, we check in `WS_Reset()`if the `ws->f` pointer is a new high and, if yes, record it.

* `WS_Reserve()*` / `WS_Release()*`

  A Reservation is made and later returned fully or in part.

  For this pattern, we need to change the interface and ask callers to cooperate: They need to tell us with a `WS_Release*()` what their highest usage was.

  For this purpose, we add `WS_ReleaseH()` and `WS_ReleaseHP()` which take another argument for the caller to pass their high water mark.

This patch is related to #3277, which concerns tracing workspace usage in detail. The two are complementary in that this patch intents to provide the big picture and guidance on where to look closer, while #3277 aims to provide better means to corellate allocations with VCL code.