### PR TITLE
Add error handling to the VFP/VDP API & streamline definition-time privs

### DIFF
--- a/bin/varnishd/cache/cache_filter.h
+++ b/bin/varnishd/cache/cache_filter.h
@@ -34,6 +34,13 @@ struct vfp_entry;
 struct vfp_ctx;
 struct vdp_ctx;
 
+enum vrt_filter_err {
+	FLT_OK = 0,
+	FLT_DUPLICATE = -1,
+	FLT_CONFLICT = -2,	// name conflict
+	FLT_MISSING = -3
+};
+
 /* Fetch processors --------------------------------------------------*/
 
 enum vfp_status {
@@ -91,8 +98,8 @@ struct vfp_ctx {
 enum vfp_status VFP_Suck(struct vfp_ctx *, void *p, ssize_t *lp);
 enum vfp_status VFP_Error(struct vfp_ctx *, const char *fmt, ...)
     v_printflike_(2, 3);
-void VRT_AddVFP(VRT_CTX, const struct vfp *);
-void VRT_RemoveVFP(VRT_CTX, const struct vfp *);
+enum vrt_filter_err VRT_AddVFP(VRT_CTX, const struct vfp *);
+enum vrt_filter_err VRT_RemoveVFP(VRT_CTX, const struct vfp *);
 
 /* Deliver processors ------------------------------------------------*/
 
@@ -147,5 +154,5 @@ struct vdp_ctx {
 };
 
 int VDP_bytes(struct vdp_ctx *, enum vdp_action act, const void *, ssize_t);
-void VRT_AddVDP(VRT_CTX, const struct vdp *);
-void VRT_RemoveVDP(VRT_CTX, const struct vdp *);
+enum vrt_filter_err VRT_AddVDP(VRT_CTX, const struct vdp *);
+enum vrt_filter_err VRT_RemoveVDP(VRT_CTX, const struct vdp *);

--- a/bin/varnishd/cache/cache_filter.h
+++ b/bin/varnishd/cache/cache_filter.h
@@ -60,7 +60,7 @@ struct vfp {
 	vfp_init_f		*init;
 	vfp_pull_f		*pull;
 	vfp_fini_f		*fini;
-	const void		*priv1;
+	const void		*vfp_priv;
 };
 
 struct vfp_entry {
@@ -126,6 +126,7 @@ struct vdp {
 	vdp_init_f		*init;
 	vdp_bytes_f		*bytes;
 	vdp_fini_f		*fini;
+	const void		*vdp_priv;
 };
 
 struct vdp_entry {

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -488,17 +488,17 @@ vfp_gzip_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 	if (vfe->vfp == &VFP_gzip) {
 		if (http_GetHdr(vc->resp, H_Content_Encoding, NULL))
 			return (VFP_NULL);
-		vg = VGZ_NewGzip(vc->wrk->vsl, vfe->vfp->priv1);
+		vg = VGZ_NewGzip(vc->wrk->vsl, vfe->vfp->vfp_priv);
 		vc->obj_flags |= OF_GZIPED | OF_CHGCE;
 	} else {
 		if (!http_HdrIs(vc->resp, H_Content_Encoding, "gzip"))
 			return (VFP_NULL);
 		if (vfe->vfp == &VFP_gunzip) {
-			vg = VGZ_NewGunzip(vc->wrk->vsl, vfe->vfp->priv1);
+			vg = VGZ_NewGunzip(vc->wrk->vsl, vfe->vfp->vfp_priv);
 			vc->obj_flags &= ~OF_GZIPED;
 			vc->obj_flags |= OF_CHGCE;
 		} else {
-			vg = VGZ_NewTestGunzip(vc->wrk->vsl, vfe->vfp->priv1);
+			vg = VGZ_NewTestGunzip(vc->wrk->vsl, vfe->vfp->vfp_priv);
 			vc->obj_flags |= OF_GZIPED;
 		}
 	}
@@ -703,7 +703,7 @@ const struct vfp VFP_gunzip = {
 	.init = vfp_gzip_init,
 	.pull = vfp_gunzip_pull,
 	.fini = vfp_gzip_fini,
-	.priv1 = "U F -",
+	.vfp_priv = "U F -",
 };
 
 const struct vfp VFP_gzip = {
@@ -711,7 +711,7 @@ const struct vfp VFP_gzip = {
 	.init = vfp_gzip_init,
 	.pull = vfp_gzip_pull,
 	.fini = vfp_gzip_fini,
-	.priv1 = "G F -",
+	.vfp_priv = "G F -",
 };
 
 const struct vfp VFP_testgunzip = {
@@ -719,5 +719,5 @@ const struct vfp VFP_testgunzip = {
 	.init = vfp_gzip_init,
 	.pull = vfp_testgunzip_pull,
 	.fini = vfp_gzip_fini,
-	.priv1 = "u F -",
+	.vfp_priv = "u F -",
 };

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -53,6 +53,11 @@
  * Whenever something is deleted or changed in a way which is not
  * binary/load-time compatible, increment MAJOR version
  *
+ * NEXT (2022-03-15)
+ *	VRT_AddVDP() signature changed for error handling
+ *	VRT_AddVFP() signature changed for error handling
+ *	VRT_RemoveVDP() signature changed for error handling
+ *	VRT_RemoveVFP() signature changed for error handling
  * 14.0 (2021-09-15)
  *	VIN_n_Arg() no directly returns the directory name.
  *	VSB_new() and VSB_delete() removed

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -451,10 +451,13 @@ event_load(VRT_CTX, struct vmod_priv *priv)
 	priv->priv = priv_vcl;
 	priv->methods = priv_vcl_methods;
 
-	VRT_AddVFP(ctx, &xyzzy_rot13);
+	if (VRT_AddVFP(ctx, &xyzzy_rot13) ||
+	    VRT_AddVDP(ctx, &xyzzy_vdp_rot13) ||
+	    VRT_AddVDP(ctx, &xyzzy_vdp_pedantic)) {
+		VSB_cat(ctx->msg, "VFP/VDP registration error");
+		return (-1);
+	}
 
-	VRT_AddVDP(ctx, &xyzzy_vdp_rot13);
-	VRT_AddVDP(ctx, &xyzzy_vdp_pedantic);
 	return (0);
 }
 
@@ -621,9 +624,9 @@ event_discard(VRT_CTX, void *priv)
 
 	AZ(ctx->msg);
 
-	VRT_RemoveVFP(ctx, &xyzzy_rot13);
-	VRT_RemoveVDP(ctx, &xyzzy_vdp_rot13);
-	VRT_RemoveVDP(ctx, &xyzzy_vdp_pedantic);
+	AZ(VRT_RemoveVFP(ctx, &xyzzy_rot13));
+	AZ(VRT_RemoveVDP(ctx, &xyzzy_vdp_rot13));
+	AZ(VRT_RemoveVDP(ctx, &xyzzy_vdp_pedantic));
 
 	if (--loads)
 		return (0);


### PR DESCRIPTION
There is no way for a vmod to determine if a filter name is already taken, so we add error handling for the cases that

* A filter is already registered when adding or not registered when removing
* A filter name is already taken

----

edit: As it concerns the same code, I added a second commit to streamline the defintiion-time priv of struct vfp/vdp