### PR TITLE
Centralize control over Range headers in the range VDP

### DIFF
--- a/bin/varnishd/cache/cache_range.c
+++ b/bin/varnishd/cache/cache_range.c
@@ -246,7 +246,14 @@ vrg_range_init(struct req *req, void **priv)
 	const char *r;
 	const char *err;
 
-	assert(http_GetHdr(req->http, H_Range, &r));
+	if (http_GetStatus(req->resp) != 200)
+		return (1);
+	if (! http_GetHdr(req->http, H_Range, &r)) {
+		// XXX can we exclude more cases where we know upfront that we
+		// cannot realiably fulfil range requests?
+		http_ForceHeader(req->resp, H_Accept_Ranges, "bytes");
+		return (1);
+	}
 	if (!vrg_ifrange(req))	// rfc7233,l,455,456
 		return (1);
 	err = vrg_dorange(req, r, priv);

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -409,9 +409,6 @@ cnt_transmit(struct worker *wrk, struct req *req)
 		VSLb(req->vsl, SLT_Error, "Failure to push processors");
 		req->doclose = SC_OVERLOAD;
 	} else {
-		if (cache_param->http_range_support && status == 200)
-			http_ForceHeader(req->resp, H_Accept_Ranges, "bytes");
-
 		if (status < 200 || status == 204) {
 			// rfc7230,l,1691,1695
 			http_Unset(req->resp, H_Content_Length);

--- a/bin/varnishd/cache/cache_vrt_filter.c
+++ b/bin/varnishd/cache/cache_vrt_filter.c
@@ -371,9 +371,7 @@ resp_default_filter_list(void *arg, struct vsb *vsb)
 	    !RFC2616_Req_Gzip(req->http))
 		VSB_cat(vsb, " gunzip");
 
-	if (cache_param->http_range_support &&
-	    http_GetStatus(req->resp) == 200 &&
-	    http_GetHdr(req->http, H_Range, NULL))
+	if (cache_param->http_range_support)
 		VSB_cat(vsb, " range");
 }
 

--- a/bin/varnishtest/tests/c00034.vtc
+++ b/bin/varnishtest/tests/c00034.vtc
@@ -9,26 +9,50 @@ varnish v1 -vcl+backend {
 	sub vcl_backend_response {
 		set beresp.do_stream = false;
 	}
+	sub vcl_deliver {
+		if (req.http.vtc-no-range) {
+			set resp.filters =
+			    regsub(resp.filters, "\brange\b", "");
+		}
+	}
 } -start
 
 varnish v1 -cliok "param.set http_range_support off"
 
 client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Accept-Ranges == "<undef>"
+	expect resp.bodylen == 100
+
 	txreq -hdr "Range: bytes=0-9"
 	rxresp
 	expect resp.status == 200
+	expect resp.http.Accept-Ranges == "<undef>"
 	expect resp.bodylen == 100
 } -run
 
-varnish v1 -expect s_resp_bodybytes == 100
+varnish v1 -expect s_resp_bodybytes == 200
 
 varnish v1 -vsl_catchup
 
 varnish v1 -cliok "param.set http_range_support on"
 
 client c1 {
-	# Invalid range requests
+	# range support on -> Accept-Ranges
+	txreq
+	rxresp
+	expect resp.http.Accept-Ranges == "bytes"
+	expect resp.bodylen == 100
 
+	# range support off in vcl
+	txreq -hdr "vtc-no-range: 1"
+	rxresp
+	expect resp.http.Accept-Ranges == "<undef>"
+	expect resp.bodylen == 100
+
+	# Invalid range requests
 	txreq -hdr "Range: bytes =0-9"
 	rxresp
 	expect resp.status == 416
@@ -73,7 +97,7 @@ client c1 {
 	expect resp.bodylen == 0
 } -run
 
-varnish v1 -expect s_resp_bodybytes == 100
+varnish v1 -expect s_resp_bodybytes == 400
 
 varnish v1 -vsl_catchup
 
@@ -123,7 +147,7 @@ client c1 {
 	expect resp.http.content-range == "bytes 0-99/100"
 } -run
 
-varnish v1 -expect s_resp_bodybytes == 501
+varnish v1 -expect s_resp_bodybytes == 801
 
 varnish v1 -vsl_catchup
 
@@ -188,6 +212,7 @@ client c1 {
 		-hdr "Accept-encoding: gzip"
 	rxresp
 	expect resp.status == 200
+	expect resp.http.Accept-Ranges == "<undef>"
 	gunzip
 	expect resp.bodylen == 100
 } -run

--- a/bin/varnishtest/tests/e00015.vtc
+++ b/bin/varnishtest/tests/e00015.vtc
@@ -94,16 +94,16 @@ client c1 {
 	expect resp.bodylen == 73
 	expect resp.status == 200
 	expect resp.http.was == true
-	expect resp.http.filter0 == "esi gunzip"
-	expect resp.http.filters == "gunzip"
+	expect resp.http.filter0 == "esi gunzip range"
+	expect resp.http.filters == "gunzip range"
 
 	txreq -url "/esi"
 	rxresp
 	expect resp.bodylen == 76
 	expect resp.status == 200
 	expect resp.http.was == true
-	expect resp.http.filter0 == "esi"
-	expect resp.http.filters == "esi"
+	expect resp.http.filter0 == "esi range"
+	expect resp.http.filters == "esi range"
 
 	# see Note on Range above
 	txreq -url "/esi" -hdr "Range: bytes=1-2"
@@ -118,7 +118,7 @@ client c1 {
 	expect resp.bodylen == 120
 	expect resp.status == 200
 	expect resp.http.was == true
-	expect resp.http.filters == "esi gunzip"
+	expect resp.http.filters == "esi gunzip range"
 
 	# see Note on Range above
 	txreq -url "/recurse" -hdr "Range: bytes=1-2"

--- a/bin/varnishtest/tests/m00017.vtc
+++ b/bin/varnishtest/tests/m00017.vtc
@@ -293,6 +293,7 @@ varnish v1 -vcl+backend {
 			std.rollback(req);
 			set req.http.response = "123";
 			set req.http.response2 = "Another response";
+			set resp.filters = "";
 			if (req.url == "/9") {
 				vtc.workspace_alloc(client, -200);
 			} else if (req.url == "/10") {

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -542,8 +542,11 @@ PARAM(
 	/* def */	"on",
 	/* units */	"bool",
 	/* descr */
-	"Enable support for HTTP Range headers."
-	/* XXX: what about the effect on beresp.filters? */
+	"Enable support for HTTP Range headers by adding the range delivery "
+	"processor by default.\n"
+	"This has the same effect as adding \"range\" to resp.filters.\n"
+	"Likewise, if this parameter is on, range support can be disabled "
+	"per request by removing \"range\" from resp.filters."
 )
 
 PARAM(


### PR DESCRIPTION
This is an alternative approach to the ideas recorded in #3251: By centralizing control over the range-request related headers, range handling can be disabled by removing the `range` vdp from the response filters.

By default, we now always push the `range` VDP as long as `http_range_support` is on. If that is the case, behaviour is just the same as before, but the `Accept-Ranges` response header is now set in the range VDP's init callback.

The difference is that, if the range vdp is removed from the filters, no `Accept-Ranges` header will be sent.

Note that the `range` vdp will not be active during body delivery if it only sets `Accept-Ranges` (by returning 1 from the init callback).

Fixes #3251