### PR TITLE
varnishtest: make process -expect-text on the same scale as vX

### DIFF
--- a/bin/varnishtest/vtc_process.c
+++ b/bin/varnishtest/vtc_process.c
@@ -313,7 +313,7 @@ term_expect_text(struct process *pp,
 		AZ(pthread_mutex_unlock(&pp->mtx));
 		usleep(d);
 		AZ(pthread_mutex_lock(&pp->mtx));
-		if (d < 300000)
+		if (d < 3000000)
 			d += d;
 	}
 	AZ(pthread_mutex_unlock(&pp->mtx));


### PR DESCRIPTION
Currently on process pX -expect-text varnishtest uses at most
300000 us pauses. This make it offscale when compared on what
varnish vX -expect does by trying 50 times with 100us pause
in a total of 5s.

Changing term_expect_text() wait 3s before failing avoid tests
to cause false positive under stress (i.e.: r02990) but putting
process pX -expect-text and varnish vX -expect at the same time
scale.

Signed-off-by: Marco Benatto <mbenatto@redhat.com>