### PR TITLE
Wasn't 6.4.0 released on March 16th 2020?

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -27,7 +27,7 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
-Varnish Cache 6.4.0 (2019-09-16)
+Varnish Cache 6.4.0 (2020-03-16)
 ================================
 
 * The ``MAIN.sess_drop`` counter is gone.


### PR DESCRIPTION
On `doc/changes.rst` the date associated with *Varnish Cache 6.4.0* was  *2019-09-16*.

Wasn't *6.4.0* released on *March 16th 2020*?