### PR TITLE
Stop VCL processing if vcl_recv failed

### DIFF
--- a/bin/varnishtest/tests/b00072.vtc
+++ b/bin/varnishtest/tests/b00072.vtc
@@ -1,0 +1,21 @@
+varnishtest "failure in vcl_recv"
+
+varnish v1 -vcl {
+	import vtc;
+
+	backend be none;
+
+	sub vcl_recv {
+		return (fail);
+	}
+
+	sub vcl_hash {
+		vtc.panic("on purpose");
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run


### PR DESCRIPTION
VCL failure should abort execution, but `vcl_recv` would possibly modify
`req` and even continue execution in `vcl_hash`.

Better diff with the --ignore-all-space option.

---

I noticed this reviewing a test log, working on something unrelated. In my case `vcl_recv` failed because of a workspace overflow.

There may be other scenarios (`vcl_hit`?) where that happens, I didn't have time to dig.