### PR TITLE
Import vmod_header as std.hdr_* functions

### DIFF
--- a/lib/libvmod_std/Makefile.am
+++ b/lib/libvmod_std/Makefile.am
@@ -4,7 +4,10 @@ libvmod_std_la_SOURCES = \
 	vmod_std.c \
 	vmod_std_conversions.c \
 	vmod_std_fileread.c \
+	vmod_std_hdr.c \
 	vmod_std_querysort.c
 
 # Use vmodtool.py generated automake boilerplate
 include $(srcdir)/automake_boilerplate.am
+
+vmodtoolargs = --boilerplate

--- a/lib/libvmod_std/automake_boilerplate.am
+++ b/lib/libvmod_std/automake_boilerplate.am
@@ -37,6 +37,12 @@ CLEANFILES = $(builddir)/vcc_if.c $(builddir)/vcc_if.h \
 	$(builddir)/vmod_std.man.rst
 
 TESTS = \
+	tests/hdr_00001.vtc \
+	tests/hdr_00002.vtc \
+	tests/hdr_00003.vtc \
+	tests/hdr_00004.vtc \
+	tests/hdr_00005.vtc \
+	tests/hdr_00006.vtc \
 	tests/std_b00001.vtc
 
 EXTRA_DIST += $(TESTS)

--- a/lib/libvmod_std/tests/hdr_00001.vtc
+++ b/lib/libvmod_std/tests/hdr_00001.vtc
@@ -1,0 +1,40 @@
+varnishtest "Header-vmod: Test appending"
+
+server s1 {
+	timeout 10
+
+	rxreq
+	expect req.url == "/foo"
+	txresp -status 200 -hdr "foo: 1" -hdr "foo: 2"
+	rxreq
+	expect req.url == "/bar"
+	txresp -status 200 -hdr "foo: 1" -hdr "foo: 2"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_backend_response {
+		if (bereq.url == "/foo") {
+			set beresp.http.foo = "null";
+		} elsif ( bereq.url == "/bar") {
+			std.hdr_append(beresp.http.foo, "blatti");
+		}
+		return(deliver);
+	}
+} -start
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "null"
+} -run
+
+client c2 {
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == 1
+} -run
+

--- a/lib/libvmod_std/tests/hdr_00002.vtc
+++ b/lib/libvmod_std/tests/hdr_00002.vtc
@@ -1,0 +1,45 @@
+
+# This assumes that:
+#  1. Append works
+#  2. The first header is the only tested in varnishtest when multiple
+#     copies are present
+
+varnishtest "Header-vmod: Test copying"
+
+server s1 {
+	timeout 10
+	rxreq
+	expect req.url == "/foo"
+	txresp -status 200 -hdr "foo: one=1" -hdr "foo: two=2" -hdr "foo: three=3"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_backend_response {
+		if (bereq.url == "/foo") {
+			std.hdr_copy(beresp.http.foo,beresp.http.bar);
+			set beresp.http.x-one = std.hdr_get(beresp.http.bar,"one");
+			set beresp.http.x-two = std.hdr_get(beresp.http.bar,"two");
+			set beresp.http.x-three = std.hdr_get(beresp.http.bar,"three");
+			set beresp.http.y-one = std.hdr_get(beresp.http.foo,"one");
+			set beresp.http.y-two = std.hdr_get(beresp.http.foo,"two");
+			set beresp.http.y-three = std.hdr_get(beresp.http.foo,"three");
+		}
+		return(deliver);
+	}
+} -start
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.bar == "one=1"
+	expect resp.http.foo == "one=1"
+	expect resp.http.x-one == "one=1"
+	expect resp.http.x-two == "two=2"
+	expect resp.http.x-three == "three=3"
+	expect resp.http.y-one == "one=1"
+	expect resp.http.y-two == "two=2"
+	expect resp.http.y-three == "three=3"
+} -run

--- a/lib/libvmod_std/tests/hdr_00003.vtc
+++ b/lib/libvmod_std/tests/hdr_00003.vtc
@@ -1,0 +1,40 @@
+
+varnishtest "Header-vmod: Test fetching"
+
+server s1 {
+	timeout 10
+
+	rxreq
+	expect req.url == "/"
+	txresp -status 200 -hdr "foo: sillycookie=blah" -hdr "foo: realcookie=YAI"
+	rxreq
+	expect req.url == "/two"
+	txresp -status 200 -hdr "foo: sillycookie=blah" -hdr "foo: realcookie=YAI"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_backend_response {
+		if (bereq.url == "/") {
+			set beresp.http.xusr = std.hdr_get(beresp.http.foo,"realcookie=");
+		} elsif (bereq.url == "/two") {
+			set beresp.http.xusr = std.hdr_get(beresp.http.foo,"^realcookie=");
+		}
+		return(deliver);
+	}
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.xusr == "realcookie=YAI"
+
+	txreq -url "/two"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.xusr == "realcookie=YAI"
+} -run
+
+

--- a/lib/libvmod_std/tests/hdr_00004.vtc
+++ b/lib/libvmod_std/tests/hdr_00004.vtc
@@ -1,0 +1,51 @@
+# Got reports of no data being sent in return after 3.0.1, this test-case
+# tries to do some simple verification, though it fails to detect the
+# problem.
+
+
+varnishtest "Header-vmod: Send some data too"
+
+server s1 {
+	timeout 10
+	rxreq
+	expect req.url == "/foo"
+	txresp -status 200 -hdr "bar: xxx=y" -hdr "foo: one=1" -hdr "foo: two=2" -hdr "foo: three=3" -body "Hello"
+	rxreq
+	expect req.url == "/foo"
+	txresp -status 200 -hdr "Content-Type: text/html" -hdr "foo: one=1" -hdr "foo: two=2" -hdr "foo: three=3" -body "Hello"
+	rxreq
+	expect req.url == "/foo"
+	txresp -status 200 -hdr "foo: one=1" -hdr "foo: two=2" -hdr "foo: three=3" -hdr "Content-Type: text/html" -body "Hello"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_backend_response {
+		if (bereq.url == "/foo") {
+			std.hdr_remove(beresp.http.foo,"one=1");
+		}
+		set beresp.uncacheable = true;
+	}
+} -start
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "two=2"
+	expect resp.http.bar == "xxx=y"
+	expect resp.bodylen == 5
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "two=2"
+	expect resp.http.Content-Type == "text/html"
+	expect resp.bodylen == 5
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "two=2"
+	expect resp.http.Content-Type == "text/html"
+	expect resp.bodylen == 5
+} -run

--- a/lib/libvmod_std/tests/hdr_00005.vtc
+++ b/lib/libvmod_std/tests/hdr_00005.vtc
@@ -1,0 +1,48 @@
+# Bug #1 !
+# The remove-function was removing somewhat vigorously.
+# This check ensures that other headers are kept intact.
+
+varnishtest "Header-vmod: Ensure other headers remain untouched"
+
+server s1 {
+	timeout 10
+	rxreq
+	expect req.url == "/foo"
+	txresp -status 200 -hdr "bar: xxx=y" -hdr "foo: one=1" -hdr "foo: two=2" -hdr "foo: three=3"
+	rxreq
+	expect req.url == "/foo"
+	txresp -status 200 -hdr "Content-Type: text/html" -hdr "foo: one=1" -hdr "foo: two=2" -hdr "foo: three=3"
+	rxreq
+	expect req.url == "/foo"
+	txresp -status 200 -hdr "foo: one=1" -hdr "foo: two=2" -hdr "foo: three=3" -hdr "Content-Type: text/html"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_backend_response {
+		if (bereq.url == "/foo") {
+			std.hdr_remove(beresp.http.foo,"one=1");
+		}
+
+		set beresp.uncacheable = true;
+	}
+} -start
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "two=2"
+	expect resp.http.bar == "xxx=y"
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "two=2"
+	expect resp.http.Content-Type == "text/html"
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "two=2"
+	expect resp.http.Content-Type == "text/html"
+} -run

--- a/lib/libvmod_std/tests/hdr_00006.vtc
+++ b/lib/libvmod_std/tests/hdr_00006.vtc
@@ -1,0 +1,96 @@
+
+varnishtest "Header-vmod: Test removing"
+
+server s1 {
+	timeout 10
+	rxreq
+	expect req.url == "/foo"
+	txresp -status 200 -hdr "foo: notok=1" -hdr "foo: ok2k" -hdr "foo: notok=2"
+	rxreq
+	expect req.url == "/bar"
+	txresp -status 200 -hdr "foo: notok=1" -hdr "foo: ok2k" -hdr "foo: notok=2"
+	rxreq
+	expect req.url == "/nothing"
+	txresp -status 200 -hdr "foo: notok=1" -hdr "foo: ok2k" -hdr "foo: notok=2"
+	rxreq
+	expect req.url == "/blatti1"
+	txresp -status 200 -hdr "foo: notok=1" -hdr "foo:notok=3" -hdr "foo: ok2k" -hdr "foo: notok=2"
+	rxreq
+	expect req.url == "/blatti2"
+	txresp -status 200 -hdr "foo: notok=1" -hdr "foo: ok2k" -hdr "foo:notok=3" -hdr "foo: notok=2"
+	rxreq
+	expect req.url == "/blatti3"
+	txresp -status 200 -hdr "set-cookie: analytics=1" -hdr "set-cookie: funcookie=ok2k" -hdr "set-cookie: uglycookie=3" -hdr "set-cookie: notok=2"
+	
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_backend_response {
+		if (bereq.url == "/foo") {
+			std.hdr_remove(beresp.http.foo,"notok");
+		}
+		if (bereq.url == "/nothing") {
+			std.hdr_remove(beresp.http.foo,".");
+		}
+		if (bereq.url == "/blatti1") {
+			std.hdr_remove(beresp.http.foo,"^ no.ok=.$");
+		}
+		if (bereq.url == "/blatti2") {
+			std.hdr_remove(beresp.http.foo,"^no.ok=.$");
+		}
+		if (bereq.url == "/blatti3") {
+			std.hdr_remove(beresp.http.set-cookie,"^(?!(funcookie=))");
+		}
+		if (beresp.http.foo) {
+			set beresp.http.foo-exists = "yes";
+		} else {
+			set beresp.http.foo-exists = "no";
+		}
+
+		return(deliver);
+	}
+} -start
+
+client c1 {
+	# Remove one, "notok". Assumes ok2k (second in line) is tested next
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "ok2k"
+
+	# Remove nothing
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "notok=1"
+
+	# Remove everything (confusing names, huh?)
+	txreq -url "/nothing"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo-exists == "no"
+
+	# Remove with regex - fail due to whitespace in the regex
+	txreq -url "/blatti1"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo-exists == "yes"
+	expect resp.http.foo == "notok=1"
+
+	# Remove with regex - work (remove leading whitespace)
+	txreq -url "/blatti2"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo-exists == "yes"
+	expect resp.http.foo == "ok2k"
+	
+	# Remove everything except fun-cookie
+	txreq -url "/blatti3"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo-exists == "no"
+	expect resp.http.set-cookie == "funcookie=ok2k"
+} -run
+

--- a/lib/libvmod_std/vmod.vcc
+++ b/lib/libvmod_std/vmod.vcc
@@ -29,6 +29,7 @@
 
 $ABI strict
 $Module std 3 "Varnish Standard Module"
+$Event event_function
 
 DESCRIPTION
 ===========
@@ -39,6 +40,64 @@ DESCRIPTION
 
 *vmod_std* contains basic functions which are part and parcel of
 Varnish, but which for reasons of architecture fit better in a VMOD.
+
+Header functions
+================
+
+.. vcl-start
+
+Example::
+
+    vcl 4.0;
+    import header;
+
+    backend default { .host = "192.0.2.11"; .port = "8080"; }
+
+    sub vcl_backend_response {
+        if (beresp.http.Set-Cookie) {
+            # Add another line of Set-Cookie in the response.
+            std.hdr_append(beresp.http.Set-Cookie, "VSESS=abbabeef");
+
+            # CMS always set this, but doesn't really need it.
+            std.hdr_remove(beresp.http.Set-Cookie, "JSESSIONID=");
+        }
+    }
+
+.. vcl-end
+
+$Function VOID hdr_append(HEADER, STRANDS)
+
+Description
+        Append an extra occurrence to an existing header.
+Example
+    ::
+    std.hdr_append(beresp.http.Set-Cookie, "foo=bar")
+
+$Function VOID hdr_copy(HEADER, HEADER)
+
+Description
+        Copy all source headers to a new header.
+Example
+    ::
+    std.hdr_copy(beresp.http.set-cookie, beresp.http.x-old-cookie);
+
+$Function STRING hdr_get(PRIV_CALL, HEADER header, STRING regex)
+
+Description
+        Fetches the value of the first `header` that matches the given
+        regular expression `regex`.
+Example
+    ::
+    set beresp.http.xusr = std.hdr_get(beresp.http.set-cookie,"user=");
+
+$Function VOID hdr_remove(PRIV_CALL, HEADER header, STRING regex)
+
+Description
+        Remove all occurrences of `header` that matches `regex`.
+Example
+    ::
+    std.hdr_remove(beresp.http.set-cookie,"^(?!(funcookie=))");
+
 
 Numeric functions
 =================

--- a/lib/libvmod_std/vmod_std_hdr.c
+++ b/lib/libvmod_std/vmod_std_hdr.c
@@ -1,0 +1,273 @@
+/*-
+ * Copyright (c) 2011-2016 Varnish Software
+ * All rights reserved.
+ *
+ * Author: Kristian Lyngstol <kristian@bohemians.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <cache/cache.h>
+#include <vcl.h>
+
+//#ifndef VRT_H_INCLUDED
+//#  include <vrt.h>
+//#endif
+
+//#ifndef VDEF_H_INCLUDED
+//#  include <vdef.h>
+//#endif
+
+#include "vcc_if.h"
+
+/*
+ * This mutex is used to avoid having two threads that initializes the same
+ * regex at the same time. While it means that there's a single, global
+ * lock for all libvmod-header actions dealing with regular expressions,
+ * the contention only applies on the first request that calls that
+ * specific function.
+ */
+pthread_mutex_t header_mutex;
+
+/*
+ * Initialize the regex *s on priv, if it hasn't already been done.
+ * XXX: We have to recheck the condition after grabbing the lock to avoid a
+ * XXX: race condition.
+ */
+static void
+header_init_re(struct vmod_priv *priv, const char *s)
+{
+	if (priv->priv == NULL) {
+		assert(pthread_mutex_lock(&header_mutex) == 0);
+		if (priv->priv == NULL) {
+			VRT_re_init(&priv->priv, s);
+			priv->free = VRT_re_fini;
+		}
+		pthread_mutex_unlock(&header_mutex);
+	}
+}
+
+/*
+ * Returns true if the *hdr header is the one pointed to by *hh.
+ *
+ * FIXME: duplication from varnishd.
+ */
+static int
+header_http_IsHdr(const txt *hh, const char *hdr)
+{
+	unsigned l;
+
+	Tcheck(*hh);
+	AN(hdr);
+	l = hdr[0];
+	assert(l == strlen(hdr + 1));
+	assert(hdr[l] == ':');
+	hdr++;
+	return (!strncasecmp(hdr, hh->b, l));
+}
+
+/*
+ * Return true if the hp->hd[u] header matches *hdr and the regex *re
+ * matches the content.
+ *
+ * If re is NULL, content is not tested and as long as it's the right
+ * header, a match is returned.
+ */
+static int
+header_http_match(VRT_CTX, const struct http *hp, unsigned u, void *re,
+    const char *hdr)
+{
+	const char *start;
+	unsigned l;
+
+	assert(hdr);
+	assert(hp);
+
+	Tcheck(hp->hd[u]);
+	if (hp->hd[u].b == NULL)
+		return (0);
+
+	l = hdr[0];
+
+	if (!header_http_IsHdr(&hp->hd[u], hdr))
+		return (0);
+
+	if (re == NULL)
+		return (1);
+
+	start = hp->hd[u].b + l;
+	while (*start != '\0' && *start == ' ')
+		start++;
+
+	if (!*start)
+		return (0);
+	if (VRT_re_match(ctx, start, re))
+		return (1);
+
+	return (0);
+}
+
+/*
+ * Returns the (first) header named as *hdr that also matches the regular
+ * expression *re.
+ */
+static unsigned
+header_http_findhdr(VRT_CTX, const struct http *hp, const char *hdr,
+    void *re)
+{
+        unsigned u;
+
+        for (u = HTTP_HDR_FIRST; u < hp->nhd; u++) {
+		if (header_http_match(ctx, hp, u, re, hdr))
+			return (u);
+        }
+        return (0);
+}
+
+/*
+ * Removes all copies of the header that matches *hdr with content that
+ * matches *re. Same as http_Unset(), plus regex.
+ */
+static void
+header_http_Unset(VRT_CTX, struct http *hp, const char *hdr, void *re)
+{
+	unsigned u, v;
+
+	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
+
+	for (v = u = HTTP_HDR_FIRST; u < hp->nhd; u++) {
+		if (hp->hd[u].b == NULL)
+			continue;
+		if (header_http_match(ctx, hp, u, re, hdr))
+			continue;
+		if (v != u) {
+			memcpy(&hp->hd[v], &hp->hd[u], sizeof *hp->hd);
+			memcpy(&hp->hdf[v], &hp->hdf[u], sizeof *hp->hdf);
+		}
+		v++;
+	}
+	hp->nhd = v;
+}
+
+/*
+ * Copies all occurrences of *hdr to a destination header *dst_h. Uses
+ * vmod_header_append(), so all copies are kept intact.
+ *
+ * XXX: Not sure I like the idea of iterating a list of headers while
+ * XXX: adding to it. It may be correct now, but perhaps not so much in
+ * XXX: the future.
+ */
+static void
+header_http_cphdr(VRT_CTX, const struct http *hp, const char *hdr,
+    VCL_HEADER dst)
+{
+        unsigned u;
+	const char *p;
+	struct strands s; 
+
+        for (u = HTTP_HDR_FIRST; u < hp->nhd; u++) {
+		if (!header_http_match(ctx, hp, u, NULL, hdr))
+			continue;
+
+		p = hp->hd[u].b + hdr[0];
+		while (*p == ' ' || *p == '\t')
+			p++;
+		s.n = 1;
+		s.p = &p;
+                vmod_hdr_append(ctx, dst, &s);
+        }
+}
+
+/*
+ * vmod entrypoint. Sets up the header mutex.
+ */
+int v_matchproto_(vmod_event_f)
+vmod_event_function(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
+{
+	(void)ctx;
+	(void)priv;
+
+	if (e != VCL_EVENT_LOAD)
+		return (0);
+	assert(pthread_mutex_init(&header_mutex, NULL) == 0);
+	return (0);
+}
+
+VCL_VOID v_matchproto_(td_header_append)
+vmod_hdr_append(VRT_CTX, VCL_HEADER hdr, VCL_STRANDS s)
+{
+	struct http *hp;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	hp = VRT_selecthttp(ctx, hdr->where);
+	http_SetHeader(hp, VRT_StrandsWS(ctx->ws, hdr->what + 1, s));
+}
+
+VCL_STRING v_matchproto_(td_header_get)
+vmod_hdr_get(VRT_CTX, struct vmod_priv *priv, VCL_HEADER hdr, VCL_STRING s)
+{
+	struct http *hp;
+	unsigned u;
+	const char *p;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	header_init_re(priv, s);
+
+	hp = VRT_selecthttp(ctx, hdr->where);
+	u = header_http_findhdr(ctx, hp, hdr->what, priv->priv);
+	if (u == 0)
+		return (NULL);
+	p = hp->hd[u].b + hdr->what[0];
+	while (*p == ' ' || *p == '\t')
+		p++;
+	return (p);
+}
+
+VCL_VOID v_matchproto_(td_header_copy)
+vmod_hdr_copy(VRT_CTX, VCL_HEADER src, VCL_HEADER dst)
+{
+	struct http *src_hp;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	src_hp = VRT_selecthttp(ctx, src->where);
+	header_http_cphdr(ctx, src_hp, src->what, dst);
+}
+
+VCL_VOID v_matchproto_(td_header_remove)
+vmod_hdr_remove(VRT_CTX, struct vmod_priv *priv, VCL_HEADER hdr, VCL_STRING s)
+{
+	struct http *hp;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	header_init_re(priv, s);
+
+	hp = VRT_selecthttp(ctx, hdr->where);
+	header_http_Unset(ctx, hp, hdr->what, priv->priv);
+}


### PR DESCRIPTION
follow-up of https://github.com/varnishcache/varnish-cache/pull/3055.

Functions are prefixed with `hdr_` but I've no real opinion on that.