### PR TITLE
fix out-of-tree builds

### DIFF
--- a/doc/sphinx/Makefile.am
+++ b/doc/sphinx/Makefile.am
@@ -5,9 +5,9 @@
 SPHINXOPTS    =
 SPHINXBUILD   = $(SPHINX) -W -q -N
 PAPER         = a4
-BUILDDIR      = $(builddir)/build
+BUILDDIR      = build
 
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees -D latex_elements.papersize=$(PAPER) $(SPHINXOPTS) $(srcdir)
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees -D latex_elements.papersize=$(PAPER) $(SPHINXOPTS) $(builddir)
 
 .PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
 
@@ -27,12 +27,22 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/* $(CLEANFILES)
 
+# use index.rst as an indicator if we have copied already
+.PHONY: link_srcdir
+link_srcdir:
+	if test "x$(srcdir)" != "x$(builddir)" && test ! -f index.rst ; then \
+		d=`pwd`/$(builddir) ; \
+		cd $(srcdir) && find . -type f | cpio -dmp $${d} || true ; \
+	fi
+
 # work around for make html called within doc/sphinx
 .PHONY: graphviz
 graphviz:
 	cd ../graphviz && $(MAKE) html
 
-sphinx_prereq: graphviz conf.py
+sphinx_prereq: link_srcdir graphviz conf.py
+
+all: link_srcdir
 
 html: sphinx_prereq
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/sphinx/Makefile.am
+++ b/doc/sphinx/Makefile.am
@@ -30,9 +30,13 @@ clean:
 # use index.rst as an indicator if we have copied already
 .PHONY: link_srcdir
 link_srcdir:
-	if test "x$(srcdir)" != "x$(builddir)" && test ! -f index.rst ; then \
-		d=`pwd`/$(builddir) ; \
-		cd $(srcdir) && find . -type f | cpio -dmp $${d} || true ; \
+	if test "x$(srcdir)" != "x$(builddir)" && test ! -f index.rst; then \
+		s=`realpath $(srcdir)`; \
+		for f in `cd $$s && find . -type f`; do \
+			d=`dirname $$f`; \
+			test -d $$d || mkdir -p $$d; \
+			test -f $$f || ln -s $$s/$$f $$f; \
+		done \
 	fi
 
 # work around for make html called within doc/sphinx

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -31,69 +31,69 @@ RST2ANY_FLAGS = --halt=2
 BUILD_MAN = $(AM_V_GEN) $(RST2MAN) $(RST2ANY_FLAGS)
 
 varnish-cli.7: $(top_builddir)/doc/sphinx/reference/varnish-cli.rst \
-	$(top_srcdir)/doc/sphinx/include/cli.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnish-cli.rst $@
+	$(top_builddir)/doc/sphinx/include/cli.rst
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnish-cli.rst $@
 
 varnish-counters.7: $(top_builddir)/doc/sphinx/reference/varnish-counters.rst \
-	$(top_srcdir)/doc/sphinx/include/counters.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnish-counters.rst $@
+	$(top_builddir)/doc/sphinx/include/counters.rst
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnish-counters.rst $@
 
-vcl.7: $(top_srcdir)/doc/sphinx/reference/vcl.rst \
-	$(top_srcdir)/doc/sphinx/reference/vcl_var.rst \
+vcl.7: $(top_builddir)/doc/sphinx/reference/vcl.rst \
+	$(top_builddir)/doc/sphinx/reference/vcl_var.rst \
 	$(top_srcdir)/bin/varnishd/builtin.vcl
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/vcl.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/vcl.rst $@
 
 vsl.7: $(top_builddir)/doc/sphinx/reference/vsl.rst \
 	$(top_builddir)/doc/sphinx/include/vsl-tags.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/vsl.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/vsl.rst $@
 
 vsl-query.7: $(top_builddir)/doc/sphinx/reference/vsl-query.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/vsl-query.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/vsl-query.rst $@
 
 varnishadm.1: $(top_builddir)/doc/sphinx/reference/varnishadm.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnishadm.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnishadm.rst $@
 
 varnishd.1: \
 	$(top_builddir)/doc/sphinx/reference/varnishd.rst \
 	$(top_builddir)/doc/sphinx/include/params.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnishd.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnishd.rst $@
 
 varnishncsa.1: \
 	$(top_builddir)/doc/sphinx/reference/varnishncsa.rst \
 	$(top_builddir)/doc/sphinx/include/varnishncsa_options.rst \
 	$(top_builddir)/doc/sphinx/include/varnishncsa_synopsis.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnishncsa.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnishncsa.rst $@
 
 varnishlog.1: \
 	$(top_builddir)/doc/sphinx/reference/varnishlog.rst \
 	$(top_builddir)/doc/sphinx/include/varnishlog_options.rst \
 	$(top_builddir)/doc/sphinx/include/varnishlog_synopsis.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnishlog.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnishlog.rst $@
 
 varnishstat.1: $(top_builddir)/doc/sphinx/reference/varnishstat.rst \
 	$(top_builddir)/doc/sphinx/include/varnishstat_options.rst \
 	$(top_builddir)/doc/sphinx/include/varnishstat_synopsis.rst \
 	$(top_builddir)/doc/sphinx/include/varnishstat_bindings.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnishstat.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnishstat.rst $@
 
 varnishtest.1: $(top_builddir)/doc/sphinx/reference/varnishtest.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnishtest.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnishtest.rst $@
 
 vtc.7: $(top_builddir)/doc/sphinx/reference/vtc.rst \
 	$(top_builddir)/doc/sphinx/include/vtc-syntax.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/vtc.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/vtc.rst $@
 
 varnishtop.1: \
 	$(top_builddir)/doc/sphinx/reference/varnishtop.rst \
 	$(top_builddir)/doc/sphinx/include/varnishtop_options.rst \
 	$(top_builddir)/doc/sphinx/include/varnishtop_synopsis.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnishtop.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnishtop.rst $@
 
 varnishhist.1: \
 	$(top_builddir)/doc/sphinx/reference/varnishhist.rst \
 	$(top_builddir)/doc/sphinx/include/varnishhist_options.rst \
 	$(top_builddir)/doc/sphinx/include/varnishhist_synopsis.rst
-	$(BUILD_MAN) $(top_srcdir)/doc/sphinx/reference/varnishhist.rst $@
+	$(BUILD_MAN) $(top_builddir)/doc/sphinx/reference/varnishhist.rst $@
 
 vmod_cookie.3: $(top_builddir)/lib/libvmod_cookie/vmod_cookie.man.rst
 	$(BUILD_MAN) $? $@


### PR DESCRIPTION
This PR fixes #3309 with the symlink approach:

For out-of-tree builds (aka [VPATH builds aka parallel builds](https://www.gnu.org/software/automake/manual/html_node/VPATH-Builds.html) in automake parlor), we symlink all documentation source files to the builddir in order to find generated documentation and documentation source files within the same tree.

More background is given in #3309