### PR TITLE
Diffentiate "no backend" from "none resolved" in VDI_Resolve()

### DIFF
--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -103,24 +103,26 @@ VRT_VDI_Resolve(VRT_CTX, VCL_BACKEND d)
 static VCL_BACKEND
 VDI_Resolve(VRT_CTX)
 {
-	const struct director *d;
+	VCL_BACKEND d;
 	struct busyobj *bo;
 
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	bo = ctx->bo;
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
-	CHECK_OBJ_ORNULL(bo->director_req, DIRECTOR_MAGIC);
-	d = VRT_VDI_Resolve(ctx, bo->director_req);
-	CHECK_OBJ_ORNULL(d, DIRECTOR_MAGIC);
-	if (d == NULL) {
-		VSLb(bo->vsl, SLT_FetchError, "No backend");
-	} else {
-		AN(d->vdir);
 
-		if (d->vdir->admin_health->health == 0)
-			d = NULL;
+	if (bo->director_req == NULL) {
+		VSLb(bo->vsl, SLT_FetchError, "No backend");
+		return (NULL);
 	}
 
-	return (d);
+	CHECK_OBJ(bo->director_req, DIRECTOR_MAGIC);
+	d = VRT_VDI_Resolve(ctx, bo->director_req);
+	if (d != NULL)
+		return (d);
+
+	VSLb(bo->vsl, SLT_FetchError,
+	    "Director %s returned no backend", bo->director_req->vcl_name);
+	return (NULL);
 }
 
 /* Get a set of response headers -------------------------------------*/

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -81,7 +81,7 @@ VDI_Ahealth(const struct director *d)
 /* Resolve director --------------------------------------------------*/
 
 VCL_BACKEND
-VRT_VDI_Resolve(VRT_CTX, VCL_BACKEND d)
+VRT_DirectorResolve(VRT_CTX, VCL_BACKEND d)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
@@ -116,7 +116,7 @@ VDI_Resolve(VRT_CTX)
 	}
 
 	CHECK_OBJ(bo->director_req, DIRECTOR_MAGIC);
-	d = VRT_VDI_Resolve(ctx, bo->director_req);
+	d = VRT_DirectorResolve(ctx, bo->director_req);
 	if (d != NULL)
 		return (d);
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -54,7 +54,7 @@
  * binary/load-time compatible, increment MAJOR version
  *
  * NEXT (2020-09-15)
- *	VRT_VDI_Resolve() added
+ *	VRT_DirectorResolve() added
  * 11.0 (2020-03-16)
  *	Changed type of vsa_suckaddr_len from int to size_t
  *	New prefix_{ptr|len} fields in vrt_backend
@@ -437,7 +437,7 @@ struct vrt_backend_probe {
 	VRT_BACKEND_PROBE_FIELDS(const)
 };
 
-VCL_BACKEND VRT_VDI_Resolve(VRT_CTX, VCL_BACKEND);
+VCL_BACKEND VRT_DirectorResolve(VRT_CTX, VCL_BACKEND);
 
 /***********************************************************************
  * Implementation details of ACLs

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -839,7 +839,7 @@ static const struct vcc_methods {
 
 	{ STRINGS, STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
 	{ STRINGS, STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
-	{ BACKEND, BACKEND, "resolve", "VRT_VDI_Resolve(ctx, \v1)", 1 },
+	{ BACKEND, BACKEND, "resolve", "VRT_DirectorResolve(ctx, \v1)", 1 },
 
 	{ NULL, NULL,		NULL,		NULL},
 };


### PR DESCRIPTION
recover a minor improvement from #2680:

This commit is to emit slightly different error messages to differentiate between the cases "no backend set in vcl" and "none returned from the director".

Another error logging change from #2680 was to check for administratively unhealthy, but we should better leave that check to the backend (see #3299)