### PR TITLE
Ensure we don't override Content-Encoding in a 304 conditional fetch backport

### DIFF
--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -163,7 +163,7 @@ vfp_esi_gzip_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 	ALLOC_OBJ(vef, VEF_MAGIC);
 	if (vef == NULL)
 		return (VFP_ERROR);
-	vc->obj_flags |= OF_GZIPED | OF_CHGGZIP | OF_ESIPROC;
+	vc->obj_flags |= OF_GZIPED | OF_CHGCE | OF_ESIPROC;
 	vef->vgz = VGZ_NewGzip(vc->wrk->vsl, "G F E");
 	vef->vep = VEP_Init(vc, vc->req, vfp_vep_callback, vef);
 	vef->ibuf_sz = cache_param->gzip_buffer;

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -350,11 +350,12 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 		if (bo->stale_oc != NULL &&
 		    ObjCheckFlag(bo->wrk, bo->stale_oc, OF_IMSCAND)) {
 			AZ(bo->stale_oc->flags & (OC_F_HFM|OC_F_PRIVATE));
-			if (ObjCheckFlag(bo->wrk, bo->stale_oc, OF_CHGGZIP)) {
+			if (ObjCheckFlag(bo->wrk, bo->stale_oc, OF_CHGCE)) {
 				/*
-				 * If we changed the gzip status of the object
-				 * the stored Content_Encoding controls we
-				 * must weaken any new ETag we get.
+				 * If a VFP changed C-E in the stored
+				 * object, then don't overwrite C-E from
+				 * the IMS fetch, and we must weaken any
+				 * new ETag we get.
 				 */
 				http_Unset(bo->beresp, H_Content_Encoding);
 				RFC2616_Weaken_Etag(bo->beresp);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -267,9 +267,9 @@ vbf_304_logic(struct busyobj *bo)
 			 * the IMS fetch, and we must weaken any
 			 * new ETag we get.
 			 */
-			http_Unset(bo->beresp, H_Content_Encoding);
 			RFC2616_Weaken_Etag(bo->beresp);
 		}
+		http_Unset(bo->beresp, H_Content_Encoding);
 		http_Unset(bo->beresp, H_Content_Length);
 		HTTP_Merge(bo->wrk, bo->stale_oc, bo->beresp);
 		assert(http_IsStatus(bo->beresp, 200));

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -466,14 +466,14 @@ vfp_gzip_init(struct vfp_ctx *vc, struct vfp_entry *vfe)
 		if (http_GetHdr(vc->resp, H_Content_Encoding, NULL))
 			return (VFP_NULL);
 		vg = VGZ_NewGzip(vc->wrk->vsl, vfe->vfp->priv1);
-		vc->obj_flags |= OF_GZIPED | OF_CHGGZIP;
+		vc->obj_flags |= OF_GZIPED | OF_CHGCE;
 	} else {
 		if (!http_HdrIs(vc->resp, H_Content_Encoding, "gzip"))
 			return (VFP_NULL);
 		if (vfe->vfp == &VFP_gunzip) {
 			vg = VGZ_NewGunzip(vc->wrk->vsl, vfe->vfp->priv1);
 			vc->obj_flags &= ~OF_GZIPED;
-			vc->obj_flags |= OF_CHGGZIP;
+			vc->obj_flags |= OF_CHGCE;
 		} else {
 			vg = VGZ_NewTestGunzip(vc->wrk->vsl, vfe->vfp->priv1);
 			vc->obj_flags |= OF_GZIPED;

--- a/bin/varnishtest/tests/r03169.vtc
+++ b/bin/varnishtest/tests/r03169.vtc
@@ -1,0 +1,61 @@
+varnishtest "Ensure we don't override Content-Encoding on a cond fetch"
+
+server s1 {
+    rxreq
+    txresp -hdr {ETag: "foo"} -body {****}
+
+    rxreq
+    expect req.http.If-None-Match == {"foo"}
+    txresp -status 304 -hdr {ETag: W/"foo"} -hdr "Content-Encoding: gzip"
+
+    rxreq
+    expect req.url == "/1"
+    txresp -hdr {Etag: "bar"} -gzipbody {asdf}
+
+    rxreq
+    expect req.url == "/1"
+    expect req.http.If-None-Match == {"bar"}
+    txresp -status 304
+
+} -start
+
+varnish v1 -vcl+backend {
+    sub vcl_backend_response {
+        set beresp.ttl = 1s;
+        set beresp.grace = 0s;
+        set beresp.keep = 1d;
+    }
+} -start
+
+client c1 {
+    txreq -hdr "Accept-Encoding: gzip"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.ETag == {"foo"}
+    expect resp.http.Content-Length == "4"
+    expect resp.http.Content-Encoding == <undef>
+
+    delay 1.5
+
+    txreq -hdr "Accept-Encoding: gzip"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.ETag == {W/"foo"}
+    expect resp.http.Content-Length == "4"
+    expect resp.http.Content-Encoding == <undef>
+
+    # Also check that we're still OK in the general case
+    txreq -url "/1" -hdr "Accept-Encoding: gzip"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.ETag == {"bar"}
+    expect resp.http.Content-Encoding == "gzip"
+
+    delay 1.5
+
+    txreq -url "/1" -hdr "Accept-Encoding: gzip"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.ETag == {"bar"}
+    expect resp.http.Content-Encoding == "gzip"
+} -run

--- a/include/tbl/obj_attr.h
+++ b/include/tbl/obj_attr.h
@@ -55,7 +55,7 @@
 #ifdef OBJ_FLAG
 /* upper, lower, val */
   OBJ_FLAG(GZIPED,	gziped,		(1<<1))
-  OBJ_FLAG(CHGGZIP,	chggzip,	(1<<2))
+  OBJ_FLAG(CHGCE,	chgce,		(1<<2))
   OBJ_FLAG(IMSCAND,	imscand,	(1<<3))
   OBJ_FLAG(ESIPROC,	esiproc,	(1<<4))
   #undef OBJ_FLAG


### PR DESCRIPTION
Commits:
54af42d4c328089625a59eb063e75d5c72125852
5c1fea755361664d7f2f8e23e700a0e6a00f4225
d921b1f263ba7403427cc9f8c4e82ec05469b90a

Had to change the cleanup function inside of the new function to VDI_Finish
