### PR TITLE
Avoid referencing explicit executable paths

### DIFF
--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -170,7 +170,7 @@ run_cc(void *priv)
 	AZ(VSB_finish(sb));
 
 	(void)umask(027);
-	(void)execl("/bin/sh", "/bin/sh", "-c", VSB_data(sb), (char*)0);
+	(void)execlp("sh", "sh", "-c", VSB_data(sb), (char*)0);
 	VSB_destroy(&sb);				// For flexelint
 }
 

--- a/bin/varnishtest/vtc_haproxy.c
+++ b/bin/varnishtest/vtc_haproxy.c
@@ -739,7 +739,7 @@ haproxy_start(struct haproxy *h)
 		closefd(&h->fds[1]);
 		closefd(&h->fds[2]);
 		closefd(&h->fds[3]);
-		AZ(execl("/bin/sh", "/bin/sh", "-c", VSB_data(vsb), (char*)0));
+		AZ(execlp("sh", "sh", "-c", VSB_data(vsb), (char*)0));
 		exit(1);
 	}
 	VSB_destroy(&vsb);

--- a/bin/varnishtest/vtc_main.c
+++ b/bin/varnishtest/vtc_main.c
@@ -214,7 +214,7 @@ cleaner_do(const char *dirname)
 		assert(write(cleaner_fd, buf, strlen(buf)) == strlen(buf));
 		return;
 	}
-	bprintf(buf, "exec /bin/rm -rf %s\n", dirname);
+	bprintf(buf, "exec rm -rf %s\n", dirname);
 	AZ(system(buf));
 }
 
@@ -243,12 +243,12 @@ cleaner_setup(void)
 			assert(q[-1] == '\n');
 			q[-1] = '\0';
 
-			/* Dont expend a shell on running /bin/rm */
+			/* Dont expend a shell on running rm */
 			pp = fork();
 			assert(pp >= 0);
 			if (pp == 0)
-				exit(execl(
-				    "/bin/rm", "rm", "-rf", buf, (char*)0));
+				exit(execlp(
+				    "rm", "rm", "-rf", buf, (char*)0));
 			assert(waitpid(pp, &st, 0) == pp);
 			AZ(st);
 		}

--- a/bin/varnishtest/vtc_process.c
+++ b/bin/varnishtest/vtc_process.c
@@ -695,7 +695,7 @@ process_start(struct process *p)
 		AZ(unsetenv("TERMCAP"));
 		// Not using NULL because GCC is now even more demented...
 		assert(write(STDERR_FILENO, "+", 1) == 1);
-		AZ(execl("/bin/sh", "/bin/sh", "-c", VSB_data(cl), (char*)0));
+		AZ(execlp("sh", "sh", "-c", VSB_data(cl), (char*)0));
 		exit(1);
 	}
 	vtc_log(p->vl, 3, "PID: %ld", (long)p->pid);

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -458,7 +458,7 @@ varnish_launch(struct varnish *v)
 		closefd(&v->fds[2]);
 		closefd(&v->fds[3]);
 		VSUB_closefrom(STDERR_FILENO + 1);
-		AZ(execl("/bin/sh", "/bin/sh", "-c", VSB_data(vsb), (char*)0));
+		AZ(execlp("sh", "sh", "-c", VSB_data(vsb), (char*)0));
 		exit(1);
 	} else {
 		vtc_log(v->vl, 3, "PID: %ld", (long)v->pid);


### PR DESCRIPTION
Not all systems have an executable available at `/bin/*`, such as on NixOS. These executables are present in other places specified on the `PATH`. From the man page of `execl(3)`:

> If the specified filename includes a slash character, then PATH is ignored, and the file at the specified pathname is executed.

This PR removes all the path segments from the `path` argument but the filename.