### PR TITLE
Disable packaging for Ubuntu 20.04 for AARCH64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,14 +291,6 @@ workflows:
       - dist
       - tar_pkg_tools
       - package:
-          name: aarch64-ubuntu-focal
-          dist: ubuntu
-          release: focal
-          arch: aarch64
-          image: arm64v8/ubuntu:focal
-          ext: deb
-          <<: *pkg_req
-      - package:
           name: x64-ubuntu-focal
           dist: ubuntu
           release: focal
@@ -441,7 +433,6 @@ workflows:
             - x64-ubuntu-bionic
             - aarch64-ubuntu-bionic
             - x64-ubuntu-focal
-            - aarch64-ubuntu-focal
             - x64-debian-stretch
             - aarch64-debian-stretch
             - x64-debian-buster


### PR DESCRIPTION
Because at the moment it fails with:

```
Install Build-Depends packages...

+ yes

+ mk-build-deps --install debian/control

semop(1): encountered an error: Function not implemented

Error in the build process: exit status 1

dpkg: error: cannot access archive 'varnish-build-deps_20200517-weekly~focal-1_all.deb': No such file or directory

mk-build-deps: dpkg --unpack failed

+ true

+ echo 'Build the packages...'

Build the packages...

+ dpkg-buildpackage -us -uc -j16

dpkg-buildpackage: info: source package varnish

dpkg-buildpackage: info: source version 20200517-weekly~focal-1

dpkg-buildpackage: info: source distribution UNRELEASED

dpkg-buildpackage: info: source changed by Denis Braekhus <denis@varnish-software.com>

dpkg-buildpackage: info: host architecture arm64

 dpkg-source --before-build .

dpkg-checkbuilddeps: error: Unmet build dependencies: dh-systemd libedit-dev libjemalloc-dev libncurses-dev libpcre3-dev python3-docutils python3-sphinx

dpkg-buildpackage: warning: build dependencies/conflicts unsatisfied; aborting

dpkg-buildpackage: warning: (Use -d flag to override.)

Exited with code exit status 3
CircleCI received exit code 3
```