### PR TITLE
Move synth reason between workspaces from vcl_pipe

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -735,6 +735,14 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	switch (wrk->handling) {
 	case VCL_RET_SYNTH:
 		req->req_step = R_STP_SYNTH;
+		if (req->err_reason != NULL &&
+		    WS_Inside(bo->ws, req->err_reason, NULL)) {
+			req->err_reason = WS_Copy(req->ws, req->err_reason, -1);
+			if (req->err_reason == NULL) {
+				VSLb(req->vsl, SLT_Error, "Out of workspace");
+				req->req_step = R_STP_VCLFAIL;
+			}
+		}
 		nxt = REQ_FSM_MORE;
 		break;
 	case VCL_RET_PIPE:

--- a/bin/varnishtest/tests/r03329.vtc
+++ b/bin/varnishtest/tests/r03329.vtc
@@ -1,0 +1,24 @@
+varnishtest "Return synth from vcl_pipe with computed reason"
+
+varnish v1 -vcl {
+	import vtc;
+	backend be none;
+	sub vcl_pipe {
+		if (req.method == "OVERFLOW") {
+			vtc.workspace_alloc(client, -5);
+		}
+		return (synth(405, req.method + " not allowed"));
+	}
+} -start
+
+client c1 {
+	txreq -method TEST
+	rxresp
+	expect resp.status == 405
+	expect resp.reason == "TEST not allowed"
+
+	txreq -method OVERFLOW
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
+} -run


### PR DESCRIPTION
In vcl_pipe req is read-only and we operate bereq as a busy object, as a
result we use the busy object's workspace to back VCL expressions.  When
we use the synth transition we may build a reason field on the wrong
workspace since vcl_synth carries on in a client context.

It is possible to notice that the reason string belongs to the backend
workspace and make a copy inside the client workspace before the former
is released.

Fixes #3329