### PR TITLE
Breaking changes to the workspace API

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -790,7 +790,7 @@ void *WS_Alloc(struct ws *ws, unsigned bytes);
 void *WS_Copy(struct ws *ws, const void *str, int len);
 uintptr_t WS_Snapshot(struct ws *ws);
 int WS_Overflowed(const struct ws *ws);
-void *WS_Printf(struct ws *ws, const char *fmt, ...) v_printflike_(2, 3);
+const char *WS_Printf(struct ws *ws, const char *fmt, ...) v_printflike_(2, 3);
 int WS_Inside(const struct ws *, const void *, const void *);
 void WS_Assert_Allocated(const struct ws *ws, const void *ptr, ssize_t len);
 

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -797,12 +797,20 @@ void WS_Assert_Allocated(const struct ws *ws, const void *ptr, ssize_t len);
 void WS_VSB_new(struct vsb *, struct ws *);
 char *WS_VSB_finish(struct vsb *, struct ws *, size_t *);
 
-static inline char*
-WS_Front(const struct ws *ws)
+static inline void *
+WS_Reservation(const struct ws *ws)
+{
+
+	WS_Assert(ws);
+	return (ws->r != NULL ? ws->f : NULL);
+}
+
+static inline unsigned
+WS_ReservationSize(const struct ws *ws)
 {
 
 	AN(ws->r);
-	return ws->f;
+	return (ws->r - ws->f);
 }
 
 /* cache_rfc2616.c */

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -778,8 +778,6 @@ void WRK_BgThread(pthread_t *thr, const char *name, bgthread_t *func,
 
 void WS_Init(struct ws *ws, const char *id, void *space, unsigned len);
 
-/* WS_Reserve(): Use WS_ReserveSize() or WS_ReserveAll() */
-unsigned WS_Reserve(struct ws *ws, unsigned bytes) v_deprecated_;
 unsigned WS_ReserveSize(struct ws *, unsigned);
 unsigned WS_ReserveAll(struct ws *);
 unsigned WS_ReserveLumps(struct ws *ws, size_t sz);

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -136,10 +136,12 @@ struct lock { void *priv; };	// Opaque
  * Workspace structure for quick memory allocation.
  */
 
+#define WS_ID_SIZE 4
+
 struct ws {
 	unsigned		magic;
 #define WS_MAGIC		0x35fac554
-	char			id[4];		/* identity */
+	char			id[WS_ID_SIZE];	/* identity */
 	char			*s;		/* (S)tart of buffer */
 	char			*f;		/* (F)ree/front pointer */
 	char			*r;		/* (R)eserved length */
@@ -793,6 +795,7 @@ int WS_Overflowed(const struct ws *ws);
 const char *WS_Printf(struct ws *ws, const char *fmt, ...) v_printflike_(2, 3);
 int WS_Inside(const struct ws *, const void *, const void *);
 void WS_Assert_Allocated(const struct ws *ws, const void *ptr, ssize_t len);
+void WS_Id(const struct ws *ws, char *id);
 
 void WS_VSB_new(struct vsb *, struct ws *);
 char *WS_VSB_finish(struct vsb *, struct ws *, size_t *);

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -800,6 +800,8 @@ char *WS_VSB_finish(struct vsb *, struct ws *, size_t *);
 static inline char*
 WS_Front(const struct ws *ws)
 {
+
+	AN(ws->r);
 	return ws->f;
 }
 

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -373,7 +373,7 @@ vca_make_session(struct worker *wrk, void *arg)
 	VTCP_blocking(wa->acceptsock);
 
 	/* Turn accepted socket into a session */
-	AN(wrk->aws->r);
+	AN(WS_Reservation(wrk->aws));
 	sp = SES_New(wrk->pool);
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 	wrk->stats->s_sess++;

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -674,7 +674,7 @@ HSH_Purge(struct worker *wrk, struct objhead *oh, vtim_real ttl_now,
 		more = 0;
 		spc = ospc;
 		nobj = 0;
-		ocp = (void*)wrk->aws->f;
+		ocp = WS_Reservation(wrk->aws);
 		Lck_Lock(&oh->mtx);
 		assert(oh->refcnt > 0);
 		VTAILQ_FOREACH(oc, &oh->objcs, hsh_list) {

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -403,7 +403,7 @@ http_CollectHdrSep(struct http *hp, const char *hdr, const char *sep)
 		if (b == NULL) {
 			/* Found second header, start our collection */
 			ml = WS_ReserveAll(hp->ws);
-			b = hp->ws->f;
+			b = WS_Reservation(hp->ws);
 			e = b + ml;
 			x = Tlen(hp->hd[f]);
 			if (b + x >= e) {
@@ -444,7 +444,7 @@ http_CollectHdrSep(struct http *hp, const char *hdr, const char *sep)
 	hp->nhd = (uint16_t)d;
 	AN(e);
 	*b = '\0';
-	hp->hd[f].b = hp->ws->f;
+	hp->hd[f].b = WS_Reservation(hp->ws);
 	hp->hd[f].e = b;
 	WS_ReleaseP(hp->ws, b + 1);
 }

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -282,7 +282,7 @@ http_SetH(struct http *to, unsigned n, const char *fm)
 static void
 http_PutField(struct http *to, int field, const char *string)
 {
-	char *p;
+	const char *p;
 
 	CHECK_OBJ_NOTNULL(to, HTTP_MAGIC);
 	p = WS_Copy(to->ws, string, -1);
@@ -1182,7 +1182,7 @@ void
 http_CopyHome(const struct http *hp)
 {
 	unsigned u, l;
-	char *p;
+	const char *p;
 
 	for (u = 0; u < hp->nhd; u++) {
 		if (hp->hd[u].b == NULL) {

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -112,10 +112,11 @@ http_VSL_log(const struct http *hp)
 static void
 http_fail(const struct http *hp)
 {
+	char id[WS_ID_SIZE];
 
 	VSC_C_main->losthdr++;
-	hp->ws->id[0] |= 0x20;		// cheesy tolower()
-	VSLb(hp->vsl, SLT_Error, "out of workspace (%s)", hp->ws->id);
+	WS_Id(hp->ws, id);
+	VSLb(hp->vsl, SLT_Error, "out of workspace (%s)", id);
 	WS_MarkOverflow(hp->ws);
 }
 

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -117,7 +117,7 @@ http_fail(const struct http *hp)
 	VSC_C_main->losthdr++;
 	WS_Id(hp->ws, id);
 	VSLb(hp->vsl, SLT_Error, "out of workspace (%s)", id);
-	WS_MarkOverflow(hp->ws);
+	assert(WS_Overflowed(hp->ws));
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -1127,6 +1127,6 @@ CNT_Request(struct req *req)
 		VRB_Free(req);
 		req->wrk = NULL;
 	}
-	assert(nxt == REQ_FSM_DISEMBARK || req->ws->r == NULL);
+	assert(nxt == REQ_FSM_DISEMBARK || WS_Reservation(req->ws) == NULL);
 	return (nxt);
 }

--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -482,7 +482,7 @@ SES_Wait(struct sess *sp, const struct transport *xp)
 		return;
 	}
 
-	wp = (void*)WS_Front(sp->ws);
+	wp = WS_Reservation(sp->ws);
 	INIT_OBJ(wp, WAITED_MAGIC);
 	wp->fd = sp->fd;
 	wp->priv1 = sp;

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -465,6 +465,15 @@ void WRK_Init(void);
 
 /* cache_ws.c */
 void WS_Rollback(struct ws *, uintptr_t);
+void *WS_AtOffset(const struct ws *ws, unsigned off, unsigned len);
+
+static inline unsigned
+WS_ReservationOffset(const struct ws *ws)
+{
+
+	AN(ws->r);
+	return (ws->f - ws->s);
+}
 
 /* http1/cache_http1_pipe.c */
 void V1P_Init(void);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -464,6 +464,8 @@ void VMOD_Panic(struct vsb *);
 void WRK_Init(void);
 
 /* cache_ws.c */
+void WS_Panic(const struct ws *ws, struct vsb *vsb);
+
 void WS_Rollback(struct ws *, uintptr_t);
 void *WS_AtOffset(const struct ws *ws, unsigned off, unsigned len);
 

--- a/bin/varnishd/cache/cache_vary.c
+++ b/bin/varnishd/cache/cache_vary.c
@@ -260,6 +260,15 @@ VRY_Finish(struct req *req, enum vry_finish_flag flg)
 {
 	uint8_t *p = NULL;
 
+	if (req->vary_b + 2 >= req->vary_e) {
+		AZ(req->vary_l);
+		req->vary_b = NULL;
+		req->vary_e = NULL;
+		WS_Release(req->ws, 0);
+		WS_MarkOverflow(req->ws);
+		return;
+	}
+
 	(void)VRY_Validate(req->vary_b);
 	if (flg == KEEP && req->vary_l != NULL) {
 		p = malloc(req->vary_l - req->vary_b);

--- a/bin/varnishd/cache/cache_vary.c
+++ b/bin/varnishd/cache/cache_vary.c
@@ -219,9 +219,6 @@ vry_cmp(const uint8_t *v1, const uint8_t *v2)
 
 /**********************************************************************
  * Prepare predictive vary string
- *
- * XXX: Strictly speaking vary_b and vary_e could be replaced with
- * XXX: req->ws->{f,r}.   Space in struct req vs. code-readability...
  */
 
 void

--- a/bin/varnishd/cache/cache_vary.c
+++ b/bin/varnishd/cache/cache_vary.c
@@ -234,10 +234,10 @@ VRY_Prep(struct req *req)
 		AZ(req->vary_e);
 		(void)WS_ReserveAll(req->ws);
 	} else {
-		AN(req->ws->r);
+		AN(WS_Reservation(req->ws));
 	}
-	req->vary_b = (void*)req->ws->f;
-	req->vary_e = (void*)req->ws->r;
+	req->vary_b = WS_Reservation(req->ws);
+	req->vary_e = req->vary_b + WS_ReservationSize(req->ws);
 	if (req->vary_b + 2 < req->vary_e)
 		req->vary_b[2] = '\0';
 }

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -554,7 +554,7 @@ VRT_UpperLowerStrands(VRT_CTX, VCL_STRANDS s, int up)
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 	AN(s);
 	u = WS_ReserveAll(ctx->ws);
-	r = b = WS_Front(ctx->ws);
+	r = b = WS_Reservation(ctx->ws);
 	e = b + u;
 	for (i = 0; i < s->n; i++) {
 		if (s->p[i] == NULL || s->p[i][0] == '\0')

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -366,7 +366,7 @@ VRT_String(struct ws *ws, const char *h, const char *p, va_list ap)
 	va_list aq;
 
 	u = WS_ReserveAll(ws);
-	e = b = ws->f;
+	e = b = WS_Reservation(ws);
 	e += u;
 
 	va_copy(aq, ap);
@@ -422,7 +422,7 @@ VRT_String(struct ws *ws, const char *h, const char *p, va_list ap)
 		return (NULL);
 	}
 	e = b;
-	b = ws->f;
+	b = WS_Reservation(ws);
 	WS_Release(ws, e - b);
 	return (b);
 }
@@ -710,7 +710,7 @@ VRT_IP_string(VRT_CTX, VCL_IP ip)
 		WS_Release(ctx->ws, 0);
 		return (NULL);
 	}
-	p = ctx->ws->f;
+	p = WS_Reservation(ctx->ws);
 	VTCP_name(ip, p, len, NULL, 0);
 	WS_Release(ctx->ws, strlen(p) + 1);
 	return (p);

--- a/bin/varnishd/cache/cache_vrt_re.c
+++ b/bin/varnishd/cache/cache_vrt_re.c
@@ -130,7 +130,7 @@ VRT_regsub(VRT_CTX, int all, const char *str, void *re,
 	}
 
 	u = WS_ReserveAll(ctx->ws);
-	res_e = res_b = b0 = ctx->ws->f;
+	res_e = res_b = b0 = WS_Reservation(ctx->ws);
 	res_e += u;
 
 	do {

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -246,9 +246,9 @@ Pool_Task_Arg(struct worker *wrk, enum task_prio prio, task_func_t *func,
 	}
 	AZ(wrk2->task->func);
 	assert(arg_len <= WS_ReserveSize(wrk2->aws, arg_len));
-	memcpy(wrk2->aws->f, arg, arg_len);
+	memcpy(WS_Reservation(wrk2->aws), arg, arg_len);
 	wrk2->task->func = func;
-	wrk2->task->priv = wrk2->aws->f;
+	wrk2->task->priv = WS_Reservation(wrk2->aws);
 	Lck_Unlock(&pp->mtx);
 	// see signaling_note at the top for explanation
 	if (retval)

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -38,7 +38,7 @@
 
 #define WS_REDZONE_END		'\x15'
 
-static const void * const snap_overflowed = &snap_overflowed;
+static const uintptr_t snap_overflowed = (uintptr_t)&snap_overflowed;
 
 void
 WS_Assert(const struct ws *ws)
@@ -146,7 +146,7 @@ WS_Reset(struct ws *ws, uintptr_t pp)
 
 	WS_Assert(ws);
 	AN(pp);
-	if (pp == (uintptr_t)snap_overflowed) {
+	if (pp == snap_overflowed) {
 		DSL(DBG_WORKSPACE, 0, "WS_Reset(%p, overflowed)", ws);
 		AN(WS_Overflowed(ws));
 		return;
@@ -254,7 +254,7 @@ WS_Snapshot(struct ws *ws)
 	assert(ws->r == NULL);
 	if (WS_Overflowed(ws)) {
 		DSL(DBG_WORKSPACE, 0, "WS_Snapshot(%p) = overflowed", ws);
-		return ((uintptr_t) snap_overflowed);
+		return (snap_overflowed);
 	}
 	DSL(DBG_WORKSPACE, 0, "WS_Snapshot(%p) = %p", ws, ws->f);
 	return ((uintptr_t)ws->f);

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -36,6 +36,8 @@
 
 #include <stdio.h>
 
+#define WS_REDZONE_END		'\x15'
+
 static const void * const snap_overflowed = &snap_overflowed;
 
 void
@@ -60,7 +62,7 @@ WS_Assert(const struct ws *ws)
 		assert(ws->r <= ws->e);
 		assert(PAOK(ws->r));
 	}
-	assert(*ws->e == 0x15);
+	assert(*ws->e == WS_REDZONE_END);
 }
 
 int
@@ -105,7 +107,7 @@ WS_Init(struct ws *ws, const char *id, void *space, unsigned len)
 	assert(PAOK(space));
 	len = PRNDDN(len - 1);
 	ws->e = ws->s + len;
-	*ws->e = 0x15;
+	*ws->e = WS_REDZONE_END;
 	ws->f = ws->s;
 	assert(id[0] & 0x20);		// cheesy islower()
 	bstrcpy(ws->id, id);

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -415,3 +415,35 @@ WS_VSB_finish(struct vsb *vsb, struct ws *ws, size_t *szp)
 		*szp = 0;
 	return (NULL);
 }
+
+/*--------------------------------------------------------------------*/
+
+void
+WS_Panic(const struct ws *ws, struct vsb *vsb)
+{
+
+	VSB_printf(vsb, "ws = %p {\n", ws);
+	if (PAN_already(vsb, ws))
+		return;
+	VSB_indent(vsb, 2);
+	PAN_CheckMagic(vsb, ws, WS_MAGIC);
+	if (ws->id[0] != '\0' && (!(ws->id[0] & 0x20)))	// cheesy islower()
+		VSB_cat(vsb, "OVERFLOWED ");
+	VSB_printf(vsb, "id = \"%s\",\n", ws->id);
+	VSB_printf(vsb, "{s, f, r, e} = {%p", ws->s);
+	if (ws->f >= ws->s)
+		VSB_printf(vsb, ", +%ld", (long) (ws->f - ws->s));
+	else
+		VSB_printf(vsb, ", %p", ws->f);
+	if (ws->r >= ws->s)
+		VSB_printf(vsb, ", +%ld", (long) (ws->r - ws->s));
+	else
+		VSB_printf(vsb, ", %p", ws->r);
+	if (ws->e >= ws->s)
+		VSB_printf(vsb, ", +%ld", (long) (ws->e - ws->s));
+	else
+		VSB_printf(vsb, ", %p", ws->e);
+	VSB_cat(vsb, "},\n");
+	VSB_indent(vsb, -2);
+	VSB_cat(vsb, "},\n");
+}

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -107,7 +107,7 @@ WS_Init(struct ws *ws, const char *id, void *space, unsigned len)
 	ws->e = ws->s + len;
 	*ws->e = 0x15;
 	ws->f = ws->s;
-	assert(id[0] & 0x20);
+	assert(id[0] & 0x20);		// cheesy islower()
 	bstrcpy(ws->id, id);
 	WS_Assert(ws);
 }
@@ -368,7 +368,7 @@ WS_Overflowed(const struct ws *ws)
 	CHECK_OBJ_NOTNULL(ws, WS_MAGIC);
 	AN(ws->id[0]);
 
-	if (ws->id[0] & 0x20)
+	if (ws->id[0] & 0x20)		// cheesy islower()
 		return (0);
 	return (1);
 }

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -351,6 +351,17 @@ WS_Overflowed(const struct ws *ws)
 	return (1);
 }
 
+void *
+WS_AtOffset(const struct ws *ws, unsigned off, unsigned len)
+{
+	char *ptr;
+
+	WS_Assert(ws);
+	ptr = ws->s + off;
+	WS_Assert_Allocated(ws, ptr, len);
+	return (ptr);
+}
+
 /*---------------------------------------------------------------------
  * Build a VSB on a workspace.
  * Usage pattern:

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -98,6 +98,7 @@ WS_Assert_Allocated(const struct ws *ws, const void *ptr, ssize_t len)
 void
 WS_Init(struct ws *ws, const char *id, void *space, unsigned len)
 {
+	unsigned l;
 
 	DSL(DBG_WORKSPACE, 0,
 	    "WS_Init(%p, \"%s\", %p, %u)", ws, id, space, len);
@@ -105,9 +106,9 @@ WS_Init(struct ws *ws, const char *id, void *space, unsigned len)
 	INIT_OBJ(ws, WS_MAGIC);
 	ws->s = space;
 	assert(PAOK(space));
-	len = PRNDDN(len - 1);
-	ws->e = ws->s + len;
-	*ws->e = WS_REDZONE_END;
+	l = PRNDDN(len - 1);
+	ws->e = ws->s + l;
+	memset(ws->e, WS_REDZONE_END, len - l);
 	ws->f = ws->s;
 	assert(id[0] & 0x20);		// cheesy islower()
 	bstrcpy(ws->id, id);

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -307,30 +307,6 @@ WS_ReserveSize(struct ws *ws, unsigned bytes)
 	return (pdiff(ws->f, ws->r));
 }
 
-/* REL_20200915 remove */
-unsigned
-WS_Reserve(struct ws *ws, unsigned bytes)
-{
-	unsigned b2;
-
-	WS_Assert(ws);
-	assert(ws->r == NULL);
-
-	b2 = PRNDDN(ws->e - ws->f);
-	if (bytes != 0 && bytes < b2)
-		b2 = PRNDUP(bytes);
-
-	if (ws->f + b2 > ws->e) {
-		WS_MarkOverflow(ws);
-		return (0);
-	}
-	ws->r = ws->f + b2;
-	DSL(DBG_WORKSPACE, 0, "WS_Reserve(%p, %u/%u) = %u",
-	    ws, b2, bytes, pdiff(ws->f, ws->r));
-	WS_Assert(ws);
-	return (pdiff(ws->f, ws->r));
-}
-
 unsigned
 WS_ReserveLumps(struct ws *ws, size_t sz)
 {

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -224,7 +224,7 @@ WS_Copy(struct ws *ws, const void *str, int len)
 	return (r);
 }
 
-void *
+const char *
 WS_Printf(struct ws *ws, const char *fmt, ...)
 {
 	unsigned u, v;

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -115,6 +115,16 @@ WS_Init(struct ws *ws, const char *id, void *space, unsigned len)
 }
 
 void
+WS_Id(const struct ws *ws, char *id)
+{
+
+	WS_Assert(ws);
+	AN(id);
+	memcpy(id, ws->id, WS_ID_SIZE);
+	id[0] |= 0x20;			// cheesy tolower()
+}
+
+void
 WS_MarkOverflow(struct ws *ws)
 {
 	CHECK_OBJ_NOTNULL(ws, WS_MAGIC);

--- a/bin/varnishd/cache/cache_ws.c
+++ b/bin/varnishd/cache/cache_ws.c
@@ -377,7 +377,7 @@ WS_VSB_new(struct vsb *vsb, struct ws *ws)
 	if (WS_Overflowed(ws) || u < 2)
 		AN(VSB_init(vsb, bogus, sizeof bogus));
 	else
-		AN(VSB_init(vsb, WS_Front(ws), u));
+		AN(VSB_init(vsb, WS_Reservation(ws), u));
 }
 
 char *
@@ -389,7 +389,7 @@ WS_VSB_finish(struct vsb *vsb, struct ws *ws, size_t *szp)
 	WS_Assert(ws);
 	if (!VSB_finish(vsb)) {
 		p = VSB_data(vsb);
-		if (p == WS_Front(ws)) {
+		if (p == WS_Reservation(ws)) {
 			WS_Release(ws, VSB_len(vsb) + 1);
 			if (szp != NULL)
 				*szp = VSB_len(vsb);

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -84,7 +84,7 @@ http1_req(struct worker *wrk, void *arg)
 
 	THR_SetRequest(req);
 	req->transport = &HTTP1_transport;
-	AZ(wrk->aws->r);
+	AZ(WS_Reservation(wrk->aws));
 	HTTP1_Session(wrk, req);
 	AZ(wrk->v1l);
 	WS_Assert(wrk->aws);
@@ -311,7 +311,7 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 			assert(isnan(req->t_req));
 			AZ(req->vcl);
 			AZ(req->esi_level);
-			AN(req->htc->ws->r);
+			AN(WS_Reservation(req->htc->ws));
 
 			hs = HTC_RxStuff(req->htc, HTTP1_Complete,
 			    &req->t_first, &req->t_req,
@@ -319,7 +319,7 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 			    sp->t_idle + SESS_TMO(sp, timeout_idle),
 			    NAN,
 			    cache_param->http_req_size);
-			AZ(req->htc->ws->r);
+			AZ(WS_Reservation(req->htc->ws));
 			if (hs < HTC_S_EMPTY) {
 				req->acct.req_hdrbytes +=
 				    req->htc->rxbuf_e - req->htc->rxbuf_b;
@@ -354,8 +354,8 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 			if (H2_prism_complete(req->htc) == HTC_S_COMPLETE) {
 				if (!FEATURE(FEATURE_HTTP2)) {
 					SES_Close(req->sp, SC_REQ_HTTP20);
-					AZ(req->ws->r);
-					AZ(wrk->aws->r);
+					AZ(WS_Reservation(req->ws));
+					AZ(WS_Reservation(wrk->aws));
 					http1_setstate(sp, H1CLEANUP);
 					continue;
 				}
@@ -370,8 +370,8 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 			if (i) {
 				assert(req->doclose > 0);
 				SES_Close(req->sp, req->doclose);
-				AZ(req->ws->r);
-				AZ(wrk->aws->r);
+				AZ(WS_Reservation(req->ws));
+				AZ(WS_Reservation(wrk->aws));
 				http1_setstate(sp, H1CLEANUP);
 				continue;
 			}
@@ -405,13 +405,13 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 			AZ(req->top->vcl0);
 			req->task->func = NULL;
 			req->task->priv = NULL;
-			AZ(req->ws->r);
-			AZ(wrk->aws->r);
+			AZ(WS_Reservation(req->ws));
+			AZ(WS_Reservation(wrk->aws));
 			http1_setstate(sp, H1CLEANUP);
 		} else if (st == H1CLEANUP) {
 
-			AZ(wrk->aws->r);
-			AZ(req->ws->r);
+			AZ(WS_Reservation(wrk->aws));
+			AZ(WS_Reservation(req->ws));
 
 			if (sp->fd >= 0 && req->doclose != SC_NULL)
 				SES_Close(sp, req->doclose);

--- a/bin/varnishd/http1/cache_http1_line.c
+++ b/bin/varnishd/http1/cache_http1_line.c
@@ -112,7 +112,7 @@ V1L_Open(struct worker *wrk, struct ws *ws, int *fd, struct vsl_log *vsl,
 		u = IOV_MAX;
 	if (niov != 0 && u > niov)
 		u = niov;
-	v1l->iov = (void*)ws->f;
+	v1l->iov = WS_Reservation(ws);
 	v1l->siov = u;
 	v1l->ciov = u;
 	v1l->wfd = fd;

--- a/bin/varnishd/http1/cache_http1_line.c
+++ b/bin/varnishd/http1/cache_http1_line.c
@@ -137,7 +137,7 @@ V1L_Close(struct worker *wrk, uint64_t *cnt)
 	wrk->v1l = NULL;
 	CHECK_OBJ_NOTNULL(v1l, V1L_MAGIC);
 	*cnt = v1l->cnt;
-	if (v1l->ws->r)
+	if (WS_Reservation(v1l->ws))
 		WS_Release(v1l->ws, 0);
 	WS_Rollback(v1l->ws, v1l->res);
 	ZERO_OBJ(v1l, sizeof *v1l);

--- a/bin/varnishd/http1/cache_http1_proto.c
+++ b/bin/varnishd/http1/cache_http1_proto.c
@@ -70,9 +70,8 @@ HTTP1_Complete(struct http_conn *htc)
 	enum htc_status_e retval;
 
 	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
-
-	assert(htc->rxbuf_e >= htc->rxbuf_b);
-	assert(htc->rxbuf_e <= htc->ws->r);
+	AN(WS_Reservation(htc->ws));
+	assert(pdiff(htc->rxbuf_b, htc->rxbuf_e) <= WS_ReservationSize(htc->ws));
 
 	/* Skip any leading white space */
 	for (p = htc->rxbuf_b ; p < htc->rxbuf_e && vct_islws(*p); p++)

--- a/bin/varnishd/http2/cache_http2_hpack.c
+++ b/bin/varnishd/http2/cache_http2_hpack.c
@@ -183,7 +183,7 @@ h2h_decode_init(const struct h2_sess *h2)
 	 * space. Require non-zero size.
 	 */
 	XXXAN(d->out_l);
-	d->out = h2->new_req->http->ws->f;
+	d->out = WS_Reservation(h2->new_req->http->ws);
 	d->reset = d->out;
 }
 

--- a/bin/varnishd/http2/cache_http2_hpack.c
+++ b/bin/varnishd/http2/cache_http2_hpack.c
@@ -231,13 +231,16 @@ h2h_decode_bytes(struct h2_sess *h2, const uint8_t *in, size_t in_l)
 	struct http *hp;
 	struct h2h_decode *d;
 	size_t in_u = 0;
+	const char *r, *e;
 
 	CHECK_OBJ_NOTNULL(h2, H2_SESS_MAGIC);
 	CHECK_OBJ_NOTNULL(h2->new_req, REQ_MAGIC);
 	hp = h2->new_req->http;
 	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
 	CHECK_OBJ_NOTNULL(hp->ws, WS_MAGIC);
-	AN(hp->ws->r);
+	r = WS_Reservation(hp->ws);
+	AN(r);
+	e = r + WS_ReservationSize(hp->ws);
 	d = h2->decode;
 	CHECK_OBJ_NOTNULL(d, H2H_DECODE_MAGIC);
 
@@ -316,9 +319,9 @@ h2h_decode_bytes(struct h2_sess *h2, const uint8_t *in, size_t in_l)
 
 		if (d->error == H2SE_ENHANCE_YOUR_CALM) {
 			d->out = d->reset;
-			d->out_l = hp->ws->r - d->out;
+			d->out_l = e - d->out;
 			d->out_u = 0;
-			assert(d->out_u < d->out_l);
+			assert(d->out_l > 0);
 		} else if (d->error)
 			break;
 	}

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -184,7 +184,7 @@ h2_del_req(struct worker *wrk, const struct h2_req *r2)
 	/* XXX: PRIORITY reshuffle */
 	VTAILQ_REMOVE(&h2->streams, r2, list);
 	Lck_Unlock(&sp->mtx);
-	AZ(r2->req->ws->r);
+	AZ(WS_Reservation(r2->req->ws));
 	Req_Cleanup(sp, wrk, r2->req);
 	Req_Release(r2->req);
 }
@@ -532,7 +532,7 @@ h2_do_req(struct worker *wrk, void *priv)
 
 	wrk->stats->client_req++;
 	if (CNT_Request(req) != REQ_FSM_DISEMBARK) {
-		AZ(req->ws->r);
+		AZ(WS_Reservation(req->ws));
 		AZ(req->top->vcl0);
 		h2 = r2->h2sess;
 		CHECK_OBJ_NOTNULL(h2, H2_SESS_MAGIC);
@@ -563,7 +563,7 @@ h2_end_headers(struct worker *wrk, struct h2_sess *h2,
 		Lck_Lock(&h2->sess->mtx);
 		VSLb(h2->vsl, SLT_Debug, "HPACK/FINI %s", h2e->name);
 		Lck_Unlock(&h2->sess->mtx);
-		AZ(r2->req->ws->r);
+		AZ(WS_Reservation(r2->req->ws));
 		h2_del_req(wrk, r2);
 		return (h2e);
 	}
@@ -685,7 +685,7 @@ h2_rx_headers(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 		VSLb(h2->vsl, SLT_Debug, "HPACK(hdr) %s", h2e->name);
 		Lck_Unlock(&h2->sess->mtx);
 		(void)h2h_decode_fini(h2);
-		AZ(r2->req->ws->r);
+		AZ(WS_Reservation(r2->req->ws));
 		h2_del_req(wrk, r2);
 		return (h2e);
 	}
@@ -720,7 +720,7 @@ h2_rx_continuation(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 		VSLb(h2->vsl, SLT_Debug, "HPACK(cont) %s", h2e->name);
 		Lck_Unlock(&h2->sess->mtx);
 		(void)h2h_decode_fini(h2);
-		AZ(r2->req->ws->r);
+		AZ(WS_Reservation(r2->req->ws));
 		h2_del_req(wrk, r2);
 		return (h2e);
 	}

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -148,7 +148,7 @@ h2_del_sess(struct worker *wrk, struct h2_sess *h2, enum sess_close reason)
 	VHT_Fini(h2->dectbl);
 	AZ(pthread_cond_destroy(h2->winupd_cond));
 	TAKE_OBJ_NOTNULL(req, &h2->srq, REQ_MAGIC);
-	AZ(req->ws->r);
+	AZ(WS_Reservation(req->ws));
 	sp = h2->sess;
 	Req_Cleanup(sp, wrk, req);
 	Req_Release(req);
@@ -367,21 +367,21 @@ h2_new_session(struct worker *wrk, void *arg)
 	HTC_RxPipeline(h2->htc, h2->htc->rxbuf_b + sizeof(H2_prism));
 	WS_Rollback(h2->ws, 0);
 	HTC_RxInit(h2->htc, h2->ws);
-	AN(h2->ws->r);
+	AN(WS_Reservation(h2->ws));
 	VSLb(h2->vsl, SLT_Debug, "H2: Got pu PRISM");
 
 	THR_SetRequest(h2->srq);
-	AN(h2->ws->r);
+	AN(WS_Reservation(h2->ws));
 
 	l = h2_enc_settings(&h2->local_settings, settings, sizeof (settings));
-	AN(h2->ws->r);
+	AN(WS_Reservation(h2->ws));
 	H2_Send_Get(wrk, h2, h2->req0);
-	AN(h2->ws->r);
+	AN(WS_Reservation(h2->ws));
 	H2_Send_Frame(wrk, h2,
 	    H2_F_SETTINGS, H2FF_NONE, l, 0, settings);
-	AN(h2->ws->r);
+	AN(WS_Reservation(h2->ws));
 	H2_Send_Rel(h2, h2->req0);
-	AN(h2->ws->r);
+	AN(WS_Reservation(h2->ws));
 
 	/* and off we go... */
 	h2->cond = &wrk->cond;
@@ -394,7 +394,7 @@ h2_new_session(struct worker *wrk, void *arg)
 			h2->error = H2CE_INTERNAL_ERROR;
 			break;
 		}
-		AN(h2->ws->r);
+		AN(WS_Reservation(h2->ws));
 	}
 
 	AN(h2->error);

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -480,9 +480,8 @@ vpx_complete(struct http_conn *htc)
 	char *p, *q;
 
 	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
-
-	assert(htc->rxbuf_e >= htc->rxbuf_b);
-	assert(htc->rxbuf_e <= htc->ws->r);
+	AN(WS_Reservation(htc->ws));
+	assert(pdiff(htc->rxbuf_b, htc->rxbuf_e) <= WS_ReservationSize(htc->ws));
 
 	l = htc->rxbuf_e - htc->rxbuf_b;
 	p = htc->rxbuf_b;

--- a/bin/varnishtest/tests/r03319.vtc
+++ b/bin/varnishtest/tests/r03319.vtc
@@ -1,0 +1,21 @@
+varnishtest "Vary handling out of workspace"
+
+varnish v1 -vcl {
+	import vtc;
+
+	backend be none;
+
+	sub vcl_recv {
+		vtc.workspace_alloc(client, vtc.workspace_free(client));
+	}
+
+	sub vcl_backend_fetch {
+		return (error(200));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 500
+} -run

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -56,6 +56,7 @@
  *	Added VRT_DirectorResolve()
  *	Added VCL_STRING VRT_BLOB_string(VRT_CTX, VCL_BLOB)
  *	[cache.h] WS_Reserve() removed
+ *	[cache.h] WS_Printf() changed
  * 11.0 (2020-03-16)
  *	Changed type of vsa_suckaddr_len from int to size_t
  *	New prefix_{ptr|len} fields in vrt_backend

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -55,6 +55,7 @@
  * NEXT (2020-09-15)
  *	Added VRT_DirectorResolve()
  *	Added VCL_STRING VRT_BLOB_string(VRT_CTX, VCL_BLOB)
+ *	[cache.h] WS_Reserve() removed
  * 11.0 (2020-03-16)
  *	Changed type of vsa_suckaddr_len from int to size_t
  *	New prefix_{ptr|len} fields in vrt_backend

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -57,6 +57,8 @@
  *	Added VCL_STRING VRT_BLOB_string(VRT_CTX, VCL_BLOB)
  *	[cache.h] WS_Reserve() removed
  *	[cache.h] WS_Printf() changed
+ *	[cache.h] WS_ReservationSize() added
+ *	[cache.h] WS_Front() replaced by WS_Reservation()
  * 11.0 (2020-03-16)
  *	Changed type of vsa_suckaddr_len from int to size_t
  *	New prefix_{ptr|len} fields in vrt_backend

--- a/lib/libvmod_blob/vmod_blob.c
+++ b/lib/libvmod_blob/vmod_blob.c
@@ -341,7 +341,7 @@ vmod_decode(VRT_CTX, VCL_ENUM decs, VCL_INT length, VCL_STRANDS strings)
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 
 	space = WS_ReserveAll(ctx->ws);
-	buf = WS_Front(ctx->ws);
+	buf = WS_Reservation(ctx->ws);
 
 	if (length <= 0)
 		length = -1;
@@ -378,7 +378,7 @@ encode(VRT_CTX, enum encoding enc, enum case_e kase, VCL_BLOB b)
 
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 	space = WS_ReserveAll(ctx->ws);
-	buf = WS_Front(ctx->ws);
+	buf = WS_Reservation(ctx->ws);
 
 	len = func[enc].encode(enc, kase, buf, space, b->blob, b->len);
 

--- a/lib/libvmod_blob/vmod_blob.c
+++ b/lib/libvmod_blob/vmod_blob.c
@@ -369,7 +369,6 @@ encode(VRT_CTX, enum encoding enc, enum case_e kase, VCL_BLOB b)
 {
 	ssize_t len;
 	char *buf;
-	uintptr_t snap;
 	unsigned space;
 
 	AENC(enc);
@@ -378,7 +377,6 @@ encode(VRT_CTX, enum encoding enc, enum case_e kase, VCL_BLOB b)
 		return (NULL);
 
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
-	snap = WS_Snapshot(ctx->ws);
 	space = WS_ReserveAll(ctx->ws);
 	buf = WS_Front(ctx->ws);
 
@@ -387,12 +385,10 @@ encode(VRT_CTX, enum encoding enc, enum case_e kase, VCL_BLOB b)
 	if (len == -1) {
 		ERRNOMEM(ctx, "cannot encode");
 		WS_Release(ctx->ws, 0);
-		WS_Reset(ctx->ws, snap);
 		return (NULL);
 	}
 	if (len == 0) {
 		WS_Release(ctx->ws, 0);
-		WS_Reset(ctx->ws, snap);
 		return ("");
 	}
 	buf[len] = '\0';

--- a/lib/libvmod_blob/vmod_blob.c
+++ b/lib/libvmod_blob/vmod_blob.c
@@ -340,8 +340,8 @@ vmod_decode(VRT_CTX, VCL_ENUM decs, VCL_INT length, VCL_STRANDS strings)
 	AN(strings);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 
-	buf = WS_Front(ctx->ws);
 	space = WS_ReserveAll(ctx->ws);
+	buf = WS_Front(ctx->ws);
 
 	if (length <= 0)
 		length = -1;
@@ -379,8 +379,8 @@ encode(VRT_CTX, enum encoding enc, enum case_e kase, VCL_BLOB b)
 
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 	snap = WS_Snapshot(ctx->ws);
-	buf = WS_Front(ctx->ws);
 	space = WS_ReserveAll(ctx->ws);
+	buf = WS_Front(ctx->ws);
 
 	len = func[enc].encode(enc, kase, buf, space, b->blob, b->len);
 

--- a/lib/libvmod_cookie/vmod_cookie.c
+++ b/lib/libvmod_cookie/vmod_cookie.c
@@ -58,8 +58,8 @@ static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
 struct cookie {
 	unsigned		magic;
 #define VMOD_COOKIE_ENTRY_MAGIC	0x3BB41543
-	char			*name;
-	char			*value;
+	const char		*name;
+	const char		*value;
 	VTAILQ_ENTRY(cookie)	list;
 };
 
@@ -163,7 +163,7 @@ vmod_set(VRT_CTX, struct vmod_priv *priv, VCL_STRING name, VCL_STRING value)
 {
 	struct vmod_cookie *vcp = cobj_get(priv);
 	struct cookie *cookie;
-	char *p;
+	const char *p;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);

--- a/lib/libvmod_std/vmod_std.c
+++ b/lib/libvmod_std/vmod_std.c
@@ -76,7 +76,7 @@ vmod_updown(VRT_CTX, int up, VCL_STRANDS s)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	u = WS_ReserveAll(ctx->ws);
-	e = b = ctx->ws->f;
+	e = b = WS_Reservation(ctx->ws);
 	e += u;
 	for (i = 0; i < s->n && b < e; i++) {
 		p = s->p[i];
@@ -96,7 +96,7 @@ vmod_updown(VRT_CTX, int up, VCL_STRANDS s)
 		return (NULL);
 	} else {
 		e = b;
-		b = ctx->ws->f;
+		b = WS_Reservation(ctx->ws);
 		WS_Release(ctx->ws, e - b);
 		return (b);
 	}

--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -195,6 +195,7 @@ vmod_integer(VRT_CTX, struct VARGS(integer) *a)
 VCL_IP
 vmod_ip(VRT_CTX, struct VARGS(ip) *a)
 {
+	uintptr_t sn;
 	void *p;
 	VCL_IP retval = NULL;
 
@@ -202,6 +203,7 @@ vmod_ip(VRT_CTX, struct VARGS(ip) *a)
 	if (a->valid_fallback)
 		assert(VSA_Sane(a->fallback));
 
+	sn = WS_Snapshot(ctx->ws);
 	p = WS_Alloc(ctx->ws, vsa_suckaddr_len);
 	if (p == NULL) {
 		VRT_fail(ctx, "std.ip: insufficient workspace");
@@ -217,7 +219,7 @@ vmod_ip(VRT_CTX, struct VARGS(ip) *a)
 	if (retval != NULL)
 		return (retval);
 
-	WS_Reset(ctx->ws, (uintptr_t)p);
+	WS_Reset(ctx->ws, sn);
 
 	if (a->valid_fallback)
 		return (a->fallback);

--- a/lib/libvmod_std/vmod_std_querysort.c
+++ b/lib/libvmod_std/vmod_std_querysort.c
@@ -81,7 +81,7 @@ vmod_querysort(VRT_CTX, VCL_STRING url)
 		return (url);
 
 	u = WS_ReserveLumps(ctx->ws, sizeof(const char **));
-	pp = (const char**)(void*)(ctx->ws->f);
+	pp = WS_Reservation(ctx->ws);
 	if (u < 4) {
 		WS_Release(ctx->ws, 0);
 		WS_MarkOverflow(ctx->ws);


### PR DESCRIPTION
As request by @bsdphk and @nigoroll this pull request is a series of cherry-picks from #3320 containing everything except wssan itself.

Most changes are small, larger changes are mostly mechanical.

API changes from #3320:

Avoiding direct field access was in some cases trivial, for example `ws->f` could be replaced with `WS_Front(ws)` and in other instances we needed new APIs to support "exotic" use cases.

- removed `WS_Front()`, it never makes sense, except during a reservation
- added `WS_Reservation()`, similar to `WS_Front()` but returns `NULL` outside of a reservation
- added `WS_Reserved()`, needed by the HTTP/1 pipelining code
- ~changed `WS_ReserveSize()` to reserve exactly what was requested or nothing~
- changed `WS_Copy()`, it returns `const void *`
  - only `std.querysort()` makes in-place modifications inside the copy
- changed `WS_Printf()`, it returns `const char *`
- added `WS_ReservationOffset()` and `WS_AtOffset()`
  - needed by the session attributes

We also have an inconsistent use of `unsigned` and `size_t` in the workspace API and since we are making breaking changes it might be the occasion to standardize on one type.

The `WS_ReserveSize()` change is really driven by wssan and did not happen in this branch. Once this is hopefully merged, I can either update #3220 or open a new pull request.