### PR TITLE
 Generalize type methods (take 3)

### DIFF
--- a/bin/varnishtest/tests/v00018.vtc
+++ b/bin/varnishtest/tests/v00018.vtc
@@ -147,3 +147,11 @@ varnish v1 -errvcl {Syntax error} {
 		directors.round_robin.backend();
 	}
 }
+
+varnish v1 -errvcl {Expected '.' got ';'} {
+	import directors;
+	sub vcl_init {
+		new rr = directors.round_robin();
+		rr;
+	}
+}

--- a/bin/varnishtest/tests/v00018.vtc
+++ b/bin/varnishtest/tests/v00018.vtc
@@ -133,3 +133,17 @@ varnish v1 -syntax 4.0 -errvcl {Symbol not found:} {
 		return (vcl(vcl_recv));
 	}
 }
+
+varnish v1 -errvcl {Syntax error} {
+	import directors;
+	sub vcl_recv {
+		set req.backend_hint = directors.round_robin.backend();
+	}
+}
+
+varnish v1 -errvcl {Syntax error} {
+	import directors;
+	sub vcl_recv {
+		directors.round_robin.backend();
+	}
+}

--- a/lib/libvcc/Makefile.am
+++ b/lib/libvcc/Makefile.am
@@ -13,6 +13,7 @@ libvcc_a_CFLAGS = \
 
 libvcc_a_SOURCES = \
 	vcc_compile.h \
+	vcc_namespace.h \
 	vcc_token_defs.h \
 	vcc_acl.c \
 	vcc_action.c \

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -184,7 +184,7 @@ class vardef(object):
         ctyp = vcltypes[self.typ]
 
         # fo.write("\t{ \"%s\", %s,\n" % (nm, self.typ))
-        fo.write("\tsym = VCC_MkSym(tl, \"%s\", " % self.nam)
+        fo.write("\tsym = VCC_MkSym(tl, \"%s\", SYM_MAIN," % self.nam)
         if self.typ == "HEADER":
             fo.write(" SYM_NONE, %d, %d);\n" % (self.vlo, self.vhi))
             fo.write("\tAN(sym);\n")

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -49,7 +49,7 @@ vcc_act_call(struct vcc *tl, struct token *t, struct symbol *sym)
 	(void)t;
 	ExpectErr(tl, ID);
 	t0 = tl->t;
-	sym = VCC_SymbolGet(tl, SYM_SUB, SYMTAB_CREATE, XREF_REF);
+	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_SUB, SYMTAB_CREATE, XREF_REF);
 	if (sym != NULL) {
 		vcc_AddCall(tl, t0, sym);
 		VCC_GlobalSymbol(sym, SUB, "VGC_function");
@@ -124,7 +124,7 @@ vcc_act_set(struct vcc *tl, struct token *t, struct symbol *sym)
 	(void)t;
 	ExpectErr(tl, ID);
 	t = tl->t;
-	sym = VCC_SymbolGet(tl, SYM_VAR, SYMTAB_EXISTING, XREF_NONE);
+	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_VAR, SYMTAB_EXISTING, XREF_NONE);
 	ERRCHK(tl);
 	AN(sym);
 	vcc_AddUses(tl, t, tl->t, sym, XREF_WRITE);
@@ -162,7 +162,7 @@ vcc_act_unset(struct vcc *tl, struct token *t, struct symbol *sym)
 	/* XXX: Wrong, should use VCC_Expr(HEADER) */
 	ExpectErr(tl, ID);
 	t = tl->t;
-	sym = VCC_SymbolGet(tl, SYM_VAR, SYMTAB_EXISTING, XREF_NONE);
+	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_VAR, SYMTAB_EXISTING, XREF_NONE);
 	ERRCHK(tl);
 	AN(sym);
 	if (sym->u_methods == 0) {
@@ -281,7 +281,7 @@ vcc_act_return_vcl(struct vcc *tl)
 
 	SkipToken(tl, '(');
 	ExpectErr(tl, ID);
-	sym = VCC_SymbolGet(tl, SYM_VCL, SYMTAB_EXISTING, XREF_NONE);
+	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_VCL, SYMTAB_EXISTING, XREF_NONE);
 	ERRCHK(tl);
 	AN(sym);
 	if (sym->eval_priv == NULL) {
@@ -402,7 +402,8 @@ vcc_act_synthetic(struct vcc *tl, struct token *t, struct symbol *sym)
 #define ACT(name, func, mask)						\
 	do {								\
 		const char pp[] = #name;				\
-		sym = VCC_MkSym(tl, pp, SYM_ACTION, VCL_LOW, VCL_HIGH);	\
+		sym = VCC_MkSym(tl, pp, SYM_MAIN, SYM_ACTION, VCL_LOW,	\
+		    VCL_HIGH);						\
 		AN(sym);						\
 		sym->action = func;					\
 		sym->action_mask = (mask);				\

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -444,7 +444,7 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 				vcc_NextToken(tl);
 				(void)vcc_default_probe(tl);
 			} else {
-				pb = VCC_SymbolGet(tl, SYM_PROBE,
+				pb = VCC_SymbolGet(tl, SYM_MAIN, SYM_PROBE,
 				    SYMTAB_EXISTING, XREF_REF);
 				ERRCHK(tl);
 				AN(pb);

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -839,7 +839,7 @@ VCC_New(void)
 
 	for (i = 1; i < VCL_MET_MAX; i++) {
 		sym = VCC_MkSym(tl, method_tab[i].name,
-		    SYM_SUB, VCL_LOW, VCL_HIGH);
+		    SYM_MAIN, SYM_SUB, VCL_LOW, VCL_HIGH);
 		p = vcc_NewProc(tl, sym);
 		p->method = &method_tab[i];
 		VSB_printf(p->cname, "VGC_function_%s", p->method->name);
@@ -906,7 +906,7 @@ vcc_predef_vcl(struct vcc *vcc, const char *name)
 {
 	struct symbol *sym;
 
-	sym = VCC_MkSym(vcc, name, SYM_VCL, VCL_LOW, VCL_HIGH);
+	sym = VCC_MkSym(vcc, name, SYM_MAIN, SYM_VCL, VCL_LOW, VCL_HIGH);
 	AN(sym);
 	sym->type = VCL;
 	sym->r_methods = VCL_MET_RECV;

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -826,6 +826,7 @@ VCC_New(void)
 	VTAILQ_INIT(&tl->procs);
 	VTAILQ_INIT(&tl->sym_objects);
 	VTAILQ_INIT(&tl->sym_vmods);
+	VTAILQ_INIT(&tl->vmod_objects);
 
 	tl->nsources = 0;
 

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -647,6 +647,8 @@ vcc_CompileSource(struct vcc *tl, struct source *sp, const char *jfile)
 
 	vcc_Var_Init(tl);
 
+	vcc_Type_Init(tl);
+
 	Fh(tl, 0, "\nextern const struct VCL_conf VCL_conf;\n");
 
 	/* Register and lex the main source */

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -76,6 +76,7 @@ struct expr;
 struct vcc;
 struct vjsn_val;
 struct symbol;
+struct vmod_obj;
 
 struct source {
 	VTAILQ_ENTRY(source)	list;
@@ -276,6 +277,7 @@ struct vcc {
 
 	VTAILQ_HEAD(, symbol)	sym_objects;
 	VTAILQ_HEAD(, symbol)	sym_vmods;
+	VTAILQ_HEAD(, vmod_obj)	vmod_objects;
 
 	unsigned		unique;
 	unsigned		vmod_count;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -402,6 +402,8 @@ extern const struct symmode SYMTAB_PARTIAL[1];
 struct symbol *VCC_SymbolGet(struct vcc *, vcc_ns_t, vcc_kind_t,
     const struct symmode *, const struct symxref *);
 
+struct symbol *VCC_TypeSymbol(struct vcc *, vcc_kind_t, vcc_type_t);
+
 typedef void symwalk_f(struct vcc *tl, const struct symbol *s);
 void VCC_WalkSymbols(struct vcc *tl, symwalk_f *func, vcc_ns_t, vcc_kind_t);
 

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -110,6 +110,8 @@ typedef const struct type	*vcc_type_t;
  * XXX: type methods might move in a more comprehensive direction.
  */
 struct vcc_method {
+	unsigned		magic;
+#define VCC_METHOD_MAGIC	0x594108cd
 	vcc_type_t		type;
 	const char		*name;
 	const char		*impl;
@@ -423,6 +425,7 @@ void vcc_AddToken(struct vcc *tl, unsigned tok, const char *b,
 
 /* vcc_types.c */
 vcc_type_t VCC_Type(const char *p);
+void vcc_Type_Init(struct vcc *tl);
 
 /* vcc_var.c */
 sym_wildcard_t vcc_Var_Wildcard;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -100,6 +100,15 @@ struct token {
 
 typedef const struct type	*vcc_type_t;
 
+/*
+ * A type attribute is information already existing, requiring no processing
+ * or resource usage.
+ *
+ * A type method is a call and may do significant processing, change things,
+ * eat workspace etc.
+ *
+ * XXX: type methods might move in a more comprehensive direction.
+ */
 struct vcc_method {
 	vcc_type_t		type;
 	const char		*name;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -100,24 +100,6 @@ struct token {
 
 typedef const struct type	*vcc_type_t;
 
-/*
- * A type attribute is information already existing, requiring no processing
- * or resource usage.
- *
- * A type method is a call and may do significant processing, change things,
- * eat workspace etc.
- *
- * XXX: type methods might move in a more comprehensive direction.
- */
-struct vcc_method {
-	unsigned		magic;
-#define VCC_METHOD_MAGIC	0x594108cd
-	vcc_type_t		type;
-	const char		*name;
-	const char		*impl;
-	int			func;
-};
-
 struct type {
 	unsigned		magic;
 #define TYPE_MAGIC		0xfae932d9
@@ -353,6 +335,7 @@ void vcc_Expr_Init(struct vcc *tl);
 sym_expr_t vcc_Eval_Var;
 sym_expr_t vcc_Eval_Handle;
 sym_expr_t vcc_Eval_SymFunc;
+sym_expr_t vcc_Eval_TypeMethod;
 void vcc_Eval_Func(struct vcc *, const struct vjsn_val *,
     const char *, const struct symbol *);
 void VCC_GlobalSymbol(struct symbol *, vcc_type_t fmt, const char *pfx);
@@ -427,6 +410,7 @@ void vcc_AddToken(struct vcc *tl, unsigned tok, const char *b,
 
 /* vcc_types.c */
 vcc_type_t VCC_Type(const char *p);
+const char * VCC_Type_EvalMethod(struct vcc *, const struct symbol *);
 void vcc_Type_Init(struct vcc *tl);
 
 /* vcc_var.c */

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -333,6 +333,7 @@ char *TlDup(struct vcc *tl, const char *s);
 /* vcc_expr.c */
 void vcc_Expr(struct vcc *tl, vcc_type_t typ);
 sym_act_f vcc_Act_Call;
+sym_act_f vcc_Act_Obj;
 void vcc_Expr_Init(struct vcc *tl);
 sym_expr_t vcc_Eval_Var;
 sym_expr_t vcc_Eval_Handle;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -97,13 +97,23 @@ struct token {
 };
 
 /*---------------------------------------------------------------------*/
+
 typedef const struct type	*vcc_type_t;
+
+struct vcc_method {
+	vcc_type_t		type;
+	const char		*name;
+	const char		*impl;
+	int			func;
+};
 
 struct type {
 	unsigned		magic;
 #define TYPE_MAGIC		0xfae932d9
 
 	const char		*name;
+	const struct vcc_method	*methods;
+
 	const char		*tostring;
 	vcc_type_t		multype;
 	int			stringform;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -132,6 +132,7 @@ struct type {
 #include "tbl/vcc_types.h"
 
 /*---------------------------------------------------------------------*/
+
 typedef const struct kind	*vcc_kind_t;
 
 struct kind {
@@ -143,6 +144,19 @@ struct kind {
 
 #define VCC_KIND(U,l)	extern const struct kind SYM_##U[1];
 #include "tbl/symbol_kind.h"
+
+/*---------------------------------------------------------------------*/
+
+typedef const struct vcc_namespace *const vcc_ns_t;
+
+#define VCC_NAMESPACE(U, l)	extern vcc_ns_t SYM_##U;
+#include "vcc_namespace.h"
+
+enum vcc_namespace_e {
+#define VCC_NAMESPACE(U, l)	VCC_NAMESPACE_##U,
+#include "vcc_namespace.h"
+	VCC_NAMESPACE__MAX
+};
 
 /*---------------------------------------------------------------------*/
 
@@ -241,7 +255,7 @@ struct vcc {
 #define MGT_VCC(t, n, cc) t n;
 #include <tbl/mgt_vcc.h>
 
-	struct symtab		*syms;
+	struct symtab		*syms[VCC_NAMESPACE__MAX];
 
 	struct inifinhead	inifin;
 	unsigned		ninifin;
@@ -369,7 +383,8 @@ void vcc_stevedore(struct vcc *vcc, const char *stv_name);
 
 /* vcc_symb.c */
 void VCC_PrintCName(struct vsb *vsb, const char *b, const char *e);
-struct symbol *VCC_MkSym(struct vcc *tl, const char *b, vcc_kind_t, int, int);
+struct symbol *VCC_MkSym(struct vcc *tl, const char *b, vcc_ns_t, vcc_kind_t,
+    int, int);
 
 struct symxref { const char *name; };
 extern const struct symxref XREF_NONE[1];
@@ -382,11 +397,11 @@ extern const struct symmode SYMTAB_CREATE[1];
 extern const struct symmode SYMTAB_EXISTING[1];
 extern const struct symmode SYMTAB_PARTIAL[1];
 
-struct symbol *VCC_SymbolGet(struct vcc *, vcc_kind_t,
+struct symbol *VCC_SymbolGet(struct vcc *, vcc_ns_t, vcc_kind_t,
     const struct symmode *, const struct symxref *);
 
 typedef void symwalk_f(struct vcc *tl, const struct symbol *s);
-void VCC_WalkSymbols(struct vcc *tl, symwalk_f *func, vcc_kind_t);
+void VCC_WalkSymbols(struct vcc *tl, symwalk_f *func, vcc_ns_t, vcc_kind_t);
 
 /* vcc_token.c */
 void vcc_Coord(const struct vcc *tl, struct vsb *vsb,

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -823,6 +823,7 @@ static void
 vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 {
 	const struct vcc_method *vm;
+	const struct symbol *sym;
 
 	*e = NULL;
 	vcc_expr5(tl, e, fmt);
@@ -832,14 +833,8 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		vcc_NextToken(tl);
 		ExpectErr(tl, ID);
 
-		vm = (*e)->fmt->methods;
-		while (vm != NULL && vm->type != NULL) {
-			if (vcc_IdIs(tl->t, vm->name))
-				break;
-			vm++;
-		}
-
-		if (vm == NULL || vm->type == NULL) {
+		sym = VCC_TypeSymbol(tl, SYM_METHOD, (*e)->fmt);
+		if (sym == NULL) {
 			VSB_cat(tl->sb, "Unknown property ");
 			vcc_ErrToken(tl, tl->t);
 			VSB_printf(tl->sb,
@@ -847,6 +842,8 @@ vcc_expr4(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			vcc_ErrWhere(tl, tl->t);
 			return;
 		}
+		CAST_OBJ_NOTNULL(vm, sym->eval_priv, VCC_METHOD_MAGIC);
+
 		vcc_NextToken(tl);
 		*e = vcc_expr_edit(tl, vm->type, vm->impl, *e, NULL);
 		ERRCHK(tl);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -697,7 +697,8 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 	switch (tl->t->tok) {
 	case ID:
 		t = tl->t;
-		sym = VCC_SymbolGet(tl, SYM_NONE, SYMTAB_PARTIAL, XREF_REF);
+		sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_NONE, SYMTAB_PARTIAL,
+		    XREF_REF);
 		ERRCHK(tl);
 		AN(sym);
 		if (sym->kind == SYM_FUNC && sym->type == VOID) {
@@ -1070,7 +1071,7 @@ cmp_acl(struct vcc *tl, struct expr **e, const struct cmps *cp)
 
 	vcc_NextToken(tl);
 	vcc_ExpectVid(tl, "ACL");
-	sym = VCC_SymbolGet(tl, SYM_ACL, SYMTAB_CREATE, XREF_REF);
+	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_ACL, SYMTAB_CREATE, XREF_REF);
 	ERRCHK(tl);
 	AN(sym);
 	VCC_GlobalSymbol(sym, ACL, ACL_SYMBOL_PREFIX);
@@ -1483,31 +1484,31 @@ vcc_Expr_Init(struct vcc *tl)
 {
 	struct symbol *sym;
 
-	sym = VCC_MkSym(tl, "regsub", SYM_FUNC, VCL_LOW, VCL_HIGH);
+	sym = VCC_MkSym(tl, "regsub", SYM_MAIN, SYM_FUNC, VCL_LOW, VCL_HIGH);
 	AN(sym);
 	sym->type = STRING;
 	sym->eval = vcc_Eval_Regsub;
 	sym->eval_priv = NULL;
 
-	sym = VCC_MkSym(tl, "regsuball", SYM_FUNC, VCL_LOW, VCL_HIGH);
+	sym = VCC_MkSym(tl, "regsuball", SYM_MAIN, SYM_FUNC, VCL_LOW, VCL_HIGH);
 	AN(sym);
 	sym->type = STRING;
 	sym->eval = vcc_Eval_Regsub;
 	sym->eval_priv = sym;
 
-	sym = VCC_MkSym(tl, "true", SYM_FUNC, VCL_LOW, VCL_HIGH);
+	sym = VCC_MkSym(tl, "true", SYM_MAIN, SYM_FUNC, VCL_LOW, VCL_HIGH);
 	AN(sym);
 	sym->type = BOOL;
 	sym->eval = vcc_Eval_BoolConst;
 	sym->eval_priv = sym;
 
-	sym = VCC_MkSym(tl, "false", SYM_FUNC, VCL_LOW, VCL_HIGH);
+	sym = VCC_MkSym(tl, "false", SYM_MAIN, SYM_FUNC, VCL_LOW, VCL_HIGH);
 	AN(sym);
 	sym->type = BOOL;
 	sym->eval = vcc_Eval_BoolConst;
 	sym->eval_priv = NULL;
 
-	sym = VCC_MkSym(tl, "default", SYM_FUNC, VCL_LOW, VCL_HIGH);
+	sym = VCC_MkSym(tl, "default", SYM_MAIN, SYM_FUNC, VCL_LOW, VCL_HIGH);
 	AN(sym);
 	sym->type = BACKEND;	// ... can also (sometimes) deliver PROBE
 	sym->eval = vcc_Eval_Default;

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1431,6 +1431,7 @@ vcc_Act_Obj(struct vcc *tl, struct token *t, struct symbol *sym)
 	struct expr *e = NULL;
 
 	assert(sym->kind == SYM_INSTANCE);
+	ExpectErr(tl, '.');
 	tl->t = t;
 	vcc_expr4(tl, &e, sym->type);
 	ERRCHK(tl);

--- a/lib/libvcc/vcc_namespace.h
+++ b/lib/libvcc/vcc_namespace.h
@@ -1,0 +1,38 @@
+/*-
+ * Copyright (c) 2020 Varnish Software AS
+ * All rights reserved.
+ *
+ * Author: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/*lint -save -e525 -e539 */
+
+VCC_NAMESPACE(MAIN, main)
+VCC_NAMESPACE(TYPE, type)
+#undef VCC_NAMESPACE
+
+/*lint -restore */

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -182,8 +182,8 @@ vcc_Compound(struct vcc *tl)
 			tl->err = 1;
 			return;
 		case ID:
-			sym = VCC_SymbolGet(tl, SYM_NONE, SYMTAB_NOERR,
-			    XREF_NONE);
+			sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_NONE,
+			    SYMTAB_NOERR, XREF_NONE);
 			if (sym == NULL) {
 				VSB_printf(tl->sb, "Symbol not found.\n");
 				vcc_ErrWhere(tl, tl->t);
@@ -228,7 +228,7 @@ vcc_ParseFunction(struct vcc *tl)
 	ERRCHK(tl);
 
 	t = tl->t;
-	sym = VCC_SymbolGet(tl, SYM_SUB, SYMTAB_CREATE, XREF_DEF);
+	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_SUB, SYMTAB_CREATE, XREF_DEF);
 	ERRCHK(tl);
 	AN(sym);
 	p = sym->proc;
@@ -432,5 +432,6 @@ vcc_Parse_Init(struct vcc *tl)
 	struct toplev *tp;
 
 	for (tp = toplev; tp->name != NULL; tp++)
-		AN(VCC_MkSym(tl, tp->name, SYM_RESERVED, tp->vcllo, tp->vclhi));
+		AN(VCC_MkSym(tl, tp->name, SYM_MAIN, SYM_RESERVED,
+		    tp->vcllo, tp->vclhi));
 }

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -183,7 +183,7 @@ vcc_Compound(struct vcc *tl)
 			return;
 		case ID:
 			sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_NONE,
-			    SYMTAB_NOERR, XREF_NONE);
+			    SYMTAB_PARTIAL, XREF_NONE);
 			if (sym == NULL) {
 				VSB_printf(tl->sb, "Symbol not found.\n");
 				vcc_ErrWhere(tl, tl->t);

--- a/lib/libvcc/vcc_storage.c
+++ b/lib/libvcc/vcc_storage.c
@@ -70,7 +70,7 @@ vcc_stevedore(struct vcc *vcc, const char *stv_name)
 
 	CHECK_OBJ_NOTNULL(vcc, VCC_MAGIC);
 	bprintf(buf, "storage.%s", stv_name);
-	sym = VCC_MkSym(vcc, buf, SYM_VAR, VCL_LOW, VCL_41);
+	sym = VCC_MkSym(vcc, buf, SYM_MAIN, SYM_VAR, VCL_LOW, VCL_41);
 	AN(sym);
 	sym->type = STEVEDORE;
 	sym->eval = vcc_Eval_Var;

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -386,6 +386,7 @@ VCC_TypeSymbol(struct vcc *tl, vcc_kind_t kind, vcc_type_t type)
 	sym = VCC_SymbolGet(tl, SYM_TYPE, kind, SYMTAB_NOERR, XREF_NONE);
 	tl->t = t0;
 	VSB_destroy(&buf);
+
 	return (sym);
 }
 

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -365,6 +365,31 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 }
 
 struct symbol *
+VCC_TypeSymbol(struct vcc *tl, vcc_kind_t kind, vcc_type_t type)
+{
+	struct token t[1], *t0;
+	struct symbol *sym;
+	struct vsb *buf;
+
+	buf = VSB_new_auto();
+	AN(buf);
+	VSB_printf(buf, "%s.%.*s", type->name, PF(tl->t));
+	AZ(VSB_finish(buf));
+
+	/* NB: we create a fake token but errors are handled by the caller. */
+	memcpy(t, tl->t, sizeof *t);
+	t->b = VSB_data(buf);
+	t->e = t->b + VSB_len(buf);
+
+	t0 = tl->t;
+	tl->t = t;
+	sym = VCC_SymbolGet(tl, SYM_TYPE, kind, SYMTAB_NOERR, XREF_NONE);
+	tl->t = t0;
+	VSB_destroy(&buf);
+	return (sym);
+}
+
+struct symbol *
 VCC_MkSym(struct vcc *tl, const char *b, vcc_ns_t ns, vcc_kind_t kind,
     int vlo, int vhi)
 {

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -364,8 +364,8 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 	return (sym);
 }
 
-struct symbol *
-VCC_TypeSymbol(struct vcc *tl, vcc_kind_t kind, vcc_type_t type)
+static struct symbol *
+vcc_TypeSymbol(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind, vcc_type_t type)
 {
 	struct token t[1], *t0;
 	struct symbol *sym;
@@ -383,11 +383,22 @@ VCC_TypeSymbol(struct vcc *tl, vcc_kind_t kind, vcc_type_t type)
 
 	t0 = tl->t;
 	tl->t = t;
-	sym = VCC_SymbolGet(tl, SYM_TYPE, kind, SYMTAB_NOERR, XREF_NONE);
+	sym = VCC_SymbolGet(tl, ns, kind, SYMTAB_NOERR, XREF_NONE);
 	tl->t = t0;
 	VSB_destroy(&buf);
 
 	return (sym);
+}
+
+struct symbol *
+VCC_TypeSymbol(struct vcc *tl, vcc_kind_t kind, vcc_type_t type)
+{
+
+	if (strchr(type->name, '.') == NULL)
+		return (vcc_TypeSymbol(tl, SYM_TYPE, kind, type));
+
+	/* NB: type imported from a VMOD */
+	return (vcc_TypeSymbol(tl, SYM_MAIN, kind, type));
 }
 
 struct symbol *

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -43,8 +43,9 @@ const struct type ACL[1] = {{
 }};
 
 static const struct vcc_method backend_methods[] = {
-	{ BACKEND, "resolve", "VRT_DirectorResolve(ctx, \v1)", 1 },
-	{ NULL },
+	{ VCC_METHOD_MAGIC, BACKEND, "resolve",
+	    "VRT_DirectorResolve(ctx, \v1)", 1 },
+	{ VCC_METHOD_MAGIC, NULL },
 };
 
 const struct type BACKEND[1] = {{
@@ -133,9 +134,9 @@ const struct type REAL[1] = {{
 
 static const struct vcc_method stevedore_methods[] = {
 #define VRTSTVVAR(nm, vtype, ctype, dval) \
-	{ vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
+	{ VCC_METHOD_MAGIC, vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
 #include "tbl/vrt_stv_var.h"
-	{ NULL },
+	{ VCC_METHOD_MAGIC, NULL },
 };
 
 const struct type STEVEDORE[1] = {{
@@ -159,9 +160,11 @@ const struct type STRANDS[1] = {{
 }};
 
 static const struct vcc_method strings_methods[] = {
-	{ STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
-	{ STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
-	{ NULL },
+	{ VCC_METHOD_MAGIC, STRING, "upper",
+	    "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
+	{ VCC_METHOD_MAGIC, STRING, "lower",
+	    "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
+	{ VCC_METHOD_MAGIC, NULL },
 };
 
 const struct type STRINGS[1] = {{
@@ -207,3 +210,43 @@ VCC_Type(const char *p)
 	return (NULL);
 }
 
+static void
+vcc_type_init(struct vcc *tl, vcc_type_t type)
+{
+	const struct vcc_method *vm;
+	struct symbol *sym;
+	struct vsb *buf;
+
+	/* NB: Don't bother even creating a type symbol if there are no
+	 * methods attached to it.
+	 */
+	if (type->methods == NULL)
+		return;
+
+	buf = VSB_new_auto();
+	AN(buf);
+	AN(VCC_MkSym(tl, type->name, SYM_TYPE, SYM_NONE, VCL_LOW, VCL_HIGH));
+
+	for (vm = type->methods; vm->type != NULL; vm++) {
+		VSB_printf(buf, "%s.%s", type->name, vm->name);
+		AZ(VSB_finish(buf));
+		sym = VCC_MkSym(tl, VSB_data(buf), SYM_TYPE, SYM_METHOD,
+		    VCL_LOW, VCL_HIGH);
+		VSB_clear(buf);
+		if (tl->err)
+			break;
+		AN(sym);
+		sym->type = vm->type;
+		sym->eval_priv = vm;
+	}
+
+	VSB_destroy(&buf);
+}
+
+void
+vcc_Type_Init(struct vcc *tl)
+{
+
+#define VCC_TYPE(UC, lc)	vcc_type_init(tl, UC);
+#include "tbl/vcc_types.h"
+}

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -42,9 +42,15 @@ const struct type ACL[1] = {{
 	.tostring =		"((\v1)->name)",
 }};
 
+static const struct vcc_method backend_methods[] = {
+	{ BACKEND, "resolve", "VRT_VDI_Resolve(ctx, \v1)", 1 },
+	{ NULL },
+};
+
 const struct type BACKEND[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"BACKEND",
+	.methods =		backend_methods,
 	.tostring =		"VRT_BACKEND_string(\v1)",
 }};
 
@@ -125,9 +131,17 @@ const struct type REAL[1] = {{
 	.multype =		REAL,
 }};
 
+static const struct vcc_method stevedore_methods[] = {
+#define VRTSTVVAR(nm, vtype, ctype, dval) \
+	{ vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},
+#include "tbl/vrt_stv_var.h"
+	{ NULL },
+};
+
 const struct type STEVEDORE[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"STEVEDORE",
+	.methods =		stevedore_methods,
 	.tostring =		"VRT_STEVEDORE_string(\v1)",
 }};
 
@@ -144,9 +158,16 @@ const struct type STRANDS[1] = {{
 	.tostring =		"VRT_CollectStrands(ctx,\v+\n\v1\v-\n)",
 }};
 
+static const struct vcc_method strings_methods[] = {
+	{ STRING, "upper", "VRT_UpperLowerStrands(ctx, \vT, 1)", 1 },
+	{ STRING, "lower", "VRT_UpperLowerStrands(ctx, \vT, 0)", 1 },
+	{ NULL },
+};
+
 const struct type STRINGS[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"STRINGS",
+	.methods =		strings_methods,
 	.tostring =		"",
 }};
 

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -43,7 +43,7 @@ const struct type ACL[1] = {{
 }};
 
 static const struct vcc_method backend_methods[] = {
-	{ BACKEND, "resolve", "VRT_VDI_Resolve(ctx, \v1)", 1 },
+	{ BACKEND, "resolve", "VRT_DirectorResolve(ctx, \v1)", 1 },
 	{ NULL },
 };
 

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -497,6 +497,10 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 	    XREF_NONE);
 	ERRCHK(tl);
 	AN(osym);
+
+	/* Scratch the generic INSTANCE type */
+	isym->type = osym->type;
+
 	CAST_OBJ_NOTNULL(vv, osym->eval_priv, VJSN_VAL_MAGIC);
 	// vv = object name
 

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -252,7 +252,8 @@ vcc_VmodSymbols(struct vcc *tl, struct symbol *msym)
 		VSB_clear(buf);
 		VSB_printf(buf, "%s.%s", msym->name, vv2->value);
 		AZ(VSB_finish(buf));
-		fsym = VCC_MkSym(tl, VSB_data(buf), kind, VCL_LOW, VCL_HIGH);
+		fsym = VCC_MkSym(tl, VSB_data(buf), SYM_MAIN, kind,
+		    VCL_LOW, VCL_HIGH);
 		AN(fsym);
 
 		if (kind == SYM_FUNC) {
@@ -296,7 +297,7 @@ vcc_ParseImport(struct vcc *tl)
 	}
 	tmod = tl->t;
 
-	msym = VCC_SymbolGet(tl, SYM_VMOD, SYMTAB_CREATE, XREF_NONE);
+	msym = VCC_SymbolGet(tl, SYM_MAIN, SYM_VMOD, SYMTAB_CREATE, XREF_NONE);
 	ERRCHK(tl);
 	AN(msym);
 
@@ -454,7 +455,8 @@ vcc_Act_New(struct vcc *tl, struct token *t, struct symbol *sym)
 
 	SkipToken(tl, '=');
 	ExpectErr(tl, ID);
-	osym = VCC_SymbolGet(tl, SYM_OBJECT, SYMTAB_EXISTING, XREF_NONE);
+	osym = VCC_SymbolGet(tl, SYM_MAIN, SYM_OBJECT, SYMTAB_EXISTING,
+	    XREF_NONE);
 	ERRCHK(tl);
 	AN(osym);
 	CAST_OBJ_NOTNULL(vv, osym->eval_priv, VJSN_VAL_MAGIC);

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -95,7 +95,7 @@ int
 vcc_CheckReferences(struct vcc *tl)
 {
 
-	VCC_WalkSymbols(tl, vcc_checkref, SYM_NONE);
+	VCC_WalkSymbols(tl, vcc_checkref, SYM_MAIN, SYM_NONE);
 	return (tl->err);
 }
 
@@ -248,7 +248,7 @@ int
 vcc_CheckAction(struct vcc *tl)
 {
 
-	VCC_WalkSymbols(tl, vcc_checkaction, SYM_SUB);
+	VCC_WalkSymbols(tl, vcc_checkaction, SYM_MAIN, SYM_SUB);
 	return (tl->err);
 }
 
@@ -352,7 +352,7 @@ int
 vcc_CheckUses(struct vcc *tl)
 {
 
-	VCC_WalkSymbols(tl, vcc_checkuses, SYM_SUB);
+	VCC_WalkSymbols(tl, vcc_checkuses, SYM_MAIN, SYM_SUB);
 	return (tl->err);
 }
 
@@ -388,7 +388,7 @@ void
 VCC_InstanceInfo(struct vcc *tl)
 {
 	Fc(tl, 0, "\nconst struct vpi_ii VGC_instance_info[] = {\n");
-	VCC_WalkSymbols(tl, vcc_instance_info, SYM_INSTANCE);
+	VCC_WalkSymbols(tl, vcc_instance_info, SYM_MAIN, SYM_INSTANCE);
 	Fc(tl, 0, "\t{ .p = NULL, .name = \"\" }\n");
 	Fc(tl, 0, "};\n");
 }
@@ -414,8 +414,8 @@ VCC_XrefTable(struct vcc *tl)
 {
 
 	Fc(tl, 0, "\n/*\n * Symbol Table\n *\n");
-	VCC_WalkSymbols(tl, vcc_xreftable_len, SYM_NONE);
-	VCC_WalkSymbols(tl, vcc_xreftable, SYM_NONE);
+	VCC_WalkSymbols(tl, vcc_xreftable_len, SYM_MAIN, SYM_NONE);
+	VCC_WalkSymbols(tl, vcc_xreftable, SYM_MAIN, SYM_NONE);
 	Fc(tl, 0, "*/\n\n");
 }
 


### PR DESCRIPTION
The second iteration (#3158) of this change has been running in production successfully for months now (with I assume a variety of VMODs and a fair amount of VCL) but @bsdphk requested a third attempt.

The `_type` top-level symbol used to avoid conflicts was not as categorically rejected as the `::` hack from the first iteration and instead we decided to try with multiple symbol tables. This is what this patch series does.

This pull request is mostly composed of the exact same commits as #3158 (which I'm keeping open as requested by @nigoroll) and the main difference is the replacement of d5875b833cfeda80567d1c3a43be0c4efafc3c2a by e5a0cdc30 (with a few conflicts to resolve afterwards).

Again, like #3158 and #3147 this third installment does not change any VCL behavior, and only touches libvcc internals to accommodate future works around type methods.