### PR TITLE
Backend connection reuse logging (v2)

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -242,7 +242,7 @@ vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 		Lck_Lock(&bp->mtx);
 	} else {
 		assert (PFD_State(pfd) == PFD_STATE_USED);
-		VSLb(bo->vsl, SLT_BackendReuse, "%d %s", *PFD_Fd(pfd),
+		VSLb(bo->vsl, SLT_BackendClose, "%d %s", *PFD_Fd(pfd),
 		    VRT_BACKEND_string(bp->director));
 		Lck_Lock(&bp->mtx);
 		VSC_C_main->backend_recycle++;

--- a/bin/varnishtest/tests/b00060.vtc
+++ b/bin/varnishtest/tests/b00060.vtc
@@ -24,5 +24,5 @@ logexpect l2 -v v1 -d 1 -g vxid {
 
 logexpect l3 -v v1 -d 1 -g vxid {
 	expect * *	Begin		^bereq
-	expect * =	BackendOpen	"0.0.0.0 0 0.0.0.0 0$"
+	expect * =	BackendOpen	"0.0.0.0 0 0.0.0.0 0 connect$"
 } -run

--- a/bin/varnishtest/tests/e00008.vtc
+++ b/bin/varnishtest/tests/e00008.vtc
@@ -83,19 +83,19 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^ERR after 665 ESI 1.0 </esi:include> illegal end-tag$}
 	expect 0 = ESI_xmlerror {^ERR after 767 XML 1.0 Missing end attribute delimiter$}
 	expect 0 = ESI_xmlerror {^ERR after 843 ESI 1.0 <esi:include> has whitespace in src= attribute$}
-	expect 0 = BackendReuse
+	expect 0 = BackendClose
 } -start
 
 logexpect l2 -v v1 -g vxid {
 	expect * * BereqURL	{^/body$}
 	expect * = ESI_xmlerror {^ERR after 30 VEP ended inside a tag$}
-	expect 0 = BackendReuse
+	expect 0 = BackendClose
 } -start
 
 logexpect l3 -v v1 -g vxid {
 	expect * * BereqURL	{^/body2$}
 	expect * = ESI_xmlerror {^ERR after 39 VEP ended inside a tag$}
-	expect 0 = BackendReuse
+	expect 0 = BackendClose
 } -start
 
 varnish v1 -cliok "param.set debug +esi_chop"

--- a/bin/varnishtest/tests/e00019.vtc
+++ b/bin/varnishtest/tests/e00019.vtc
@@ -63,7 +63,7 @@ logexpect l1 -v v1 -g vxid -q "vxid == 1002" {
 	expect 0 = ESI_xmlerror {^WARN after 107 ESI 1.0 <esi:include> lacks final '/'$}
 	expect 0 = ESI_xmlerror {^ERR after 130 ESI 1.0 <esi:bogus> element$}
 	expect 0 = ESI_xmlerror {^ERR after 131837 VEP ended inside a tag$}
-	expect 0 = BackendReuse
+	expect 0 = BackendClose
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/e00020.vtc
+++ b/bin/varnishtest/tests/e00020.vtc
@@ -27,7 +27,7 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^ERR after 3 ESI 1.0 <esi:include> element nested in <esi:remove>$}
 	expect 0 = ESI_xmlerror {^ERR after 3 ESI 1.0 Nested <!--esi element in <esi:remove>$}
 	expect 0 = Gzip         {^U}
-	expect 0 = BackendReuse
+	expect 0 = BackendClose
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/e00022.vtc
+++ b/bin/varnishtest/tests/e00022.vtc
@@ -33,7 +33,7 @@ logexpect l1 -v v1 -g vxid {
 	expect 0 = ESI_xmlerror {^ERR after 24 ESI 1.0 Nested <!--esi element in <esi:remove>$}
 	expect 0 = Gzip         {^G}
 	expect 0 = Gzip         {^U}
-	expect 0 = BackendReuse
+	expect 0 = BackendClose
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/r00894.vtc
+++ b/bin/varnishtest/tests/r00894.vtc
@@ -14,7 +14,7 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g raw {
 	expect * * Fetch_Body
 	expect 0 = ESI_xmlerror {^ERR after 5 ESI 1.0 <esi:include> has multiple src= attributes$}
-	expect 0 = BackendReuse
+	expect 0 = BackendClose
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/r01092.vtc
+++ b/bin/varnishtest/tests/r01092.vtc
@@ -27,7 +27,7 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g raw {
 	expect * * Fetch_Body
 	expect 0 * ESI_xmlerror {^ERR after 66 ESI 1.0 Nested <!--esi element in <esi:remove>$}
-	expect 0 = BackendReuse
+	expect 0 = BackendClose
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/r01355.vtc
+++ b/bin/varnishtest/tests/r01355.vtc
@@ -24,11 +24,11 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g raw {
 	expect * * Fetch_Body
 	expect 0 = ESI_xmlerror {^No ESI processing, first char not '<' but BOM. .See feature esi_remove_bom.$}
-	expect 0 = BackendReuse
+	expect 0 = BackendClose
 # XXX another logexpect weirdness - why can't we catch the second occurrence?
 #	expect * * Fetch_Body
 #	expect 0 = ESI_xmlerror {^No ESI processing, first char not '<' but BOM. .See feature esi_remove_bom.$}
-#	expect 0 = BackendReuse
+#	expect 0 = BackendClose
 } -start
 
 client c1 {

--- a/include/tbl/vsl_tags.h
+++ b/include/tbl/vsl_tags.h
@@ -126,6 +126,7 @@ SLTM(BackendReuse, 0, "Backend connection put up for reuse",
 	"\t|  +- Backend display name\n"
 	"\t+---- Connection file descriptor\n"
 	"\n"
+	NOSUP_NOTICE
 )
 
 SLTM(BackendClose, 0, "Backend connection closed",

--- a/include/tbl/vsl_tags.h
+++ b/include/tbl/vsl_tags.h
@@ -106,14 +106,15 @@ SLTM(SessClose, 0, "Client connection closed",
 SLTM(BackendOpen, 0, "Backend connection opened",
 	"Logged when a new backend connection is opened.\n\n"
 	"The format is::\n\n"
-	"\t%d %s %s %s %s %s\n"
-	"\t|  |  |  |  |  |\n"
-	"\t|  |  |  |  |  +- Local port\n"
-	"\t|  |  |  |  +---- Local address\n"
-	"\t|  |  |  +------- Remote port\n"
-	"\t|  |  +---------- Remote address\n"
-	"\t|  +------------- Backend display name\n"
-	"\t+---------------- Connection file descriptor\n"
+	"\t%d %s %s %s %s %s %s\n"
+	"\t|  |  |  |  |  |  |\n"
+	"\t|  |  |  |  |  |  +- \"connect\" or \"reuse\"\n"
+	"\t|  |  |  |  |  +---- Local port\n"
+	"\t|  |  |  |  +------- Local address\n"
+	"\t|  |  |  +---------- Remote port\n"
+	"\t|  |  +------------- Remote address\n"
+	"\t|  +---------------- Backend display name\n"
+	"\t+------------------- Connection file descriptor\n"
 	"\n"
 )
 
@@ -132,11 +133,12 @@ SLTM(BackendReuse, 0, "Backend connection put up for reuse",
 SLTM(BackendClose, 0, "Backend connection closed",
 	"Logged when a backend connection is closed.\n\n"
 	"The format is::\n\n"
-	"\t%d %s [ %s ]\n"
-	"\t|  |    |\n"
-	"\t|  |    +- Optional reason\n"
-	"\t|  +------ Backend display name\n"
-	"\t+--------- Connection file descriptor\n"
+	"\t%d %s %s [ %s ]\n"
+	"\t|  |  |    |\n"
+	"\t|  |  |    +- Optional reason\n"
+	"\t|  |  +------ \"close\" or \"recycle\"\n"
+	"\t|  +--------- Backend display name\n"
+	"\t+------------ Connection file descriptor\n"
 	"\n"
 )
 


### PR DESCRIPTION
This is a followup to https://github.com/varnishcache/varnish-cache/pull/3288. As discussed:

* Deprecate `BackendReuse` in favor of `BackendClose`
* Add a connection status field to `BackendOpen` and `BackendClose` which states if the connection is new, reused, recycled, or closed.