### PR TITLE
Conditional requests when there is no body

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -202,7 +202,7 @@ vbf_beresp2obj(struct busyobj *bo)
  */
 
 static enum fetch_step
-vbf_stp_mkbereq(struct worker *wrk, struct busyobj *bo)
+vbf_stp_mkbereq(const struct worker *wrk, struct busyobj *bo)
 {
 	const char *q;
 	struct objcore *oc;
@@ -231,8 +231,7 @@ vbf_stp_mkbereq(struct worker *wrk, struct busyobj *bo)
 	http_CopyHome(bo->bereq0);
 
 	if (bo->stale_oc != NULL &&
-	    ObjCheckFlag(bo->wrk, bo->stale_oc, OF_IMSCAND) &&
-	    (bo->stale_oc->boc != NULL || ObjGetLen(wrk, bo->stale_oc) != 0)) {
+	    ObjCheckFlag(bo->wrk, bo->stale_oc, OF_IMSCAND)) {
 		AZ(bo->stale_oc->flags & (OC_F_HFM|OC_F_PRIVATE));
 		q = HTTP_GetHdrPack(bo->wrk, bo->stale_oc, H_Last_Modified);
 		if (q != NULL)

--- a/bin/varnishtest/tests/r03341.vtc
+++ b/bin/varnishtest/tests/r03341.vtc
@@ -1,0 +1,33 @@
+varnishtest "Conditional fetch with no previous response body"
+
+server s1 {
+	rxreq
+	txresp -hdr "ETag: 1234" -hdr "Last-Modified: Wed, 10 Jun 2020 16:00:00 GMT"
+
+	rxreq
+	txresp -status 304
+	expect req.http.If-None-Match == "1234"
+	expect req.http.If-Modified-Since == "Wed, 10 Jun 2020 16:00:00 GMT"
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.ttl = 0.1s;
+		set beresp.grace = 0s;
+		set beresp.keep = 1h;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 0
+
+	delay 1.0
+
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 0
+} -run


### PR DESCRIPTION
This addresses https://github.com/varnishcache/varnish-cache/issues/3341. It reverts the change previously made to disable conditional requests when there is no body. I also add a regression VTC to cover this case.