### PR TITLE
VMB: renovation (re: #3316)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,9 @@ AC_SUBST(NET_LIBS, "${SOCKET_LIBS} ${NSL_LIBS}")
 # Userland slab allocator from Solaris, ported to other systems
 AC_CHECK_HEADERS([umem.h])
 
+# More portable vmb.h
+AC_CHECK_HEADERS([stdatomic.h])
+
 # XXX: This _may_ be for OS/X
 AC_CHECK_LIBM
 AC_SUBST(LIBM)

--- a/include/vmb.h
+++ b/include/vmb.h
@@ -29,60 +29,38 @@
  *
  * Memory barriers
  *
- * XXX: It is utterly braindamaged, that no standard facility for this
- * XXX: is available.  The "just use pthreads locking" excuse does not
- * XXX: make sense, and does not apply to two unthreaded programs sharing
- * XXX: a memory segment.
  */
 
 #ifndef VMB_H_INCLUDED
 #define VMB_H_INCLUDED
 
-#if defined(__FreeBSD__)
-#include <sys/param.h>
-#endif
+#if defined(HAVE_STDATOMIC_H)
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800058
-
-#include <sys/types.h>
-#include <machine/atomic.h>
-#define VMB()	mb()
-#define VWMB()	wmb()
-#define VRMB()	rmb()
+#  include <stdatomic.h>
+#  define VWMB()	atomic_thread_fence(memory_order_release)
+#  define VRMB()	atomic_thread_fence(memory_order_acquire)
 
 #elif defined(__amd64__) && defined(__GNUC__)
 
-#define VMB()	__asm __volatile("mfence;" : : : "memory")
-#define VWMB()	__asm __volatile("sfence;" : : : "memory")
-#define VRMB()	__asm __volatile("lfence;" : : : "memory")
-
-#elif defined(__arm__)
-
-#define VMB()
-#define VWMB()
-#define VRMB()
+#  define VWMB()	__asm __volatile("sfence;" : : : "memory")
+#  define VRMB()	__asm __volatile("lfence;" : : : "memory")
 
 #elif defined(__i386__) && defined(__GNUC__)
 
-#define VMB()	__asm __volatile("lock; addl $0,(%%esp)" : : : "memory")
-#define VWMB()	__asm __volatile("lock; addl $0,(%%esp)" : : : "memory")
-#define VRMB()	__asm __volatile("lock; addl $0,(%%esp)" : : : "memory")
+#  define VWMB()	__asm __volatile("lock; addl $0,(%%esp)" : : : "memory")
+#  define VRMB()	__asm __volatile("lock; addl $0,(%%esp)" : : : "memory")
 
 #elif defined(__sparc64__) && defined(__GNUC__)
 
-#define VMB()	__asm__ __volatile__ ("membar #MemIssue": : :"memory")
-#define VWMB()	VMB()
-#define VRMB()	VMB()
+#  define VWMB()	__asm__ __volatile__ ("membar #MemIssue": : :"memory")
+#  define VRMB()	__asm__ __volatile__ ("membar #MemIssue": : :"memory")
 
 #else
 
-#define VMB_NEEDS_PTHREAD_WORKAROUND_THIS_IS_BAD_FOR_PERFORMANCE 1
-
-void vmb_pthread(void);
-
-#define VMB()	vmb_pthread()
-#define VWMB()	vmb_pthread()
-#define VRMB()	vmb_pthread()
+#  define VMB_NEEDS_PTHREAD_WORKAROUND_THIS_IS_BAD_FOR_PERFORMANCE 1
+   void vmb_pthread(void);
+#  define VWMB()	vmb_pthread()
+#  define VRMB()	vmb_pthread()
 
 #endif
 


### PR DESCRIPTION
Use <stdatomic.h> if we have it.

Let Ancient FreeBSD without `<stdatomic.h>` fall back to the `__GNUCC_` inline assy.