### PR TITLE
VENC vs. vmod_blob

### DIFF
--- a/bin/varnishd/cache/cache_expire.c
+++ b/bin/varnishd/cache/cache_expire.c
@@ -208,6 +208,7 @@ EXP_Insert(struct worker *wrk, struct objcore *oc)
 	if (remove_race) {
 		ObjSendEvent(wrk, oc, OEV_EXPIRE);
 		tmpoc = oc;
+		assert(oc->refcnt >= 2); /* Silence coverity */
 		(void)HSH_DerefObjCore(wrk, &tmpoc, 0);
 		AZ(tmpoc);
 		assert(oc->refcnt >= 1); /* Silence coverity */

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -738,7 +738,7 @@ MCF_ParamConf(enum mcf_which_e which, const char * const param,
 	va_end(ap);
 	AZ(VSB_finish(vsb));
 	mcf_dyn_vsb(which, pp, vsb);
-	VSB_delete(vsb);
+	VSB_destroy(&vsb);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -755,7 +755,7 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 	    version == 2 ? VSB_QUOTE_HEX : 0);
 	AZ(VSB_finish(vsb2));
 	VSL(SLT_Debug, 999, "PROXY_HDR %s", VSB_data(vsb2));
-	VSB_delete(vsb2);
+	VSB_destroy(&vsb2);
 	return (r);
 }
 

--- a/bin/varnishtest/tests/i00000.vtc
+++ b/bin/varnishtest/tests/i00000.vtc
@@ -1,10 +1,22 @@
-varnishtest "SF-blob parsing in VCL"
+varnishtest "SF-binary/BLOB parsing in VCL"
 
-varnish v1 -errvcl "BLOB must have n*3 base64 characters" { sub vcl_recv { :a: } }
-varnish v2 -errvcl "BLOB must have n*3 base64 characters" { sub vcl_recv { :aa: } }
-varnish v3 -errvcl "Illegal BLOB character:" { sub vcl_recv { :aa?: } }
-varnish v4 -errvcl "BLOB must have n*3 base64 characters" { sub vcl_recv { :aaaa: } }
-varnish v5 -errvcl "Wrong padding ('=') in BLOB" { sub vcl_recv { :aaa=aa: } }
-varnish v6 -errvcl "Wrong padding ('=') in BLOB" { sub vcl_recv { :aaa==a: } }
-varnish v7 -errvcl "Wrong padding ('=') in BLOB" { sub vcl_recv { :aaaa=a: } }
-varnish v8 -errvcl "BLOB is not supported yet" { sub vcl_recv { :aaaa==: } }
+varnish v1 -errvcl "BLOB must have n*4 base64 characters" { sub vcl_recv { :a: } }
+varnish v1 -errvcl "BLOB must have n*4 base64 characters" { sub vcl_recv { :bbbbaa: } }
+varnish v1 -errvcl "BLOB must have n*4 base64 characters" { sub vcl_recv { :bbbbccccaaa: } }
+varnish v1 -errvcl "Illegal BLOB character:" { sub vcl_recv { :aa?: } }
+varnish v1 -errvcl "Wrong padding ('=') in BLOB" { sub vcl_recv { :aaaa=aa: } }
+varnish v1 -errvcl "Wrong padding ('=') in BLOB" { sub vcl_recv { :aaaa==a: } }
+varnish v1 -errvcl "Wrong padding ('=') in BLOB" { sub vcl_recv { :aaaaa=a: } }
+varnish v1 -errvcl "Missing colon at end of BLOB" " sub vcl_recv { :aaaa"
+varnish v1 -errvcl "Missing colon at end of BLOB" " sub vcl_recv { :"
+
+# hint: the 'B' leaves bits in the second output byte
+varnish v1 -errvcl "Illegal BLOB character:" { sub vcl_recv { :AB==: } }
+
+varnish v1 -errvcl "BLOB is not supported yet:" {
+	import blob;
+
+	sub vcl_deliver {
+		set resp.http.foo = blob.encode(BASE64, blob=:AAAAAA==:);
+	}
+}

--- a/bin/varnishtest/tests/m00037.vtc
+++ b/bin/varnishtest/tests/m00037.vtc
@@ -269,7 +269,7 @@ client c1 {
 
 # Decode failures
 
-server s1 -repeat 3 {
+server s1 -repeat 4 {
 	rxreq
 	txresp
 } -start
@@ -279,7 +279,11 @@ varnish v1 -vcl+backend {
 
 	sub vcl_deliver {
 	  set req.http.foo = "AAA=";
-	  if (req.url == "/base64") {
+	  if (req.url == "/dribble-bits") {
+		set resp.http.dribble-bits = blob.encode(HEX,
+		    blob=blob.decode(BASE64, encoded="VB=="));
+	  }
+	  elsif (req.url == "/base64") {
 		set resp.http.bad64 = blob.encode(IDENTITY,
 		    blob=blob.decode(BASE64, encoded="-_-_" + req.http.foo));
 	  }
@@ -294,6 +298,14 @@ varnish v1 -vcl+backend {
 	  }
 	}
 }
+
+client c1 {
+	txreq -url /dribble-bits
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
+	expect resp.http.driblle-bits == <undef>
+} -run
 
 client c1 {
 	txreq -url /base64

--- a/bin/varnishtest/tests/m00042.vtc
+++ b/bin/varnishtest/tests/m00042.vtc
@@ -225,10 +225,12 @@ varnish v1 -vcl {
 				   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"
 				   + "ghijklmnopqrstuvwxyz0123456789+/");
 
+/*
 	  set resp.http.b64url2b64url =
 	    blob.transcode(BASE64URL, BASE64URL, length=34, encoded=
 				 "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"
 				 + "ghijklmnopqrstuvwxyz0123456789-_");
+*/
 
 	  set resp.http.b64urlnopad2b64urlnopad =
 	    blob.transcode(BASE64URLNOPAD, BASE64URLNOPAD, length=34, encoded=
@@ -263,7 +265,7 @@ client c1 {
 	expect resp.http.hexmix2hexlc == resp.http.hexmix2hex
 	expect resp.http.hexparam == "0123456789"
 	expect resp.http.b642b64 == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
-	expect resp.http.b64url2b64url == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefeQ=="
+#	expect resp.http.b64url2b64url == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefeQ=="
 	expect resp.http.b64urlnopad2b64urlnopad == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgg"
 } -run
 

--- a/bin/varnishtest/vtc_barrier.c
+++ b/bin/varnishtest/vtc_barrier.c
@@ -306,7 +306,7 @@ barrier_sock_sync(struct barrier *b, struct vtclog *vl)
 		vtc_fatal(vl, "Barrier(%s) connection failed: %s",
 		    b->name, err);
 
-	VSB_delete(vsb);
+	VSB_destroy(&vsb);
 
 	/* emulate pthread_cond_wait's behavior */
 	AZ(pthread_mutex_unlock(&b->mtx));

--- a/bin/varnishtest/vtc_client.c
+++ b/bin/varnishtest/vtc_client.c
@@ -225,7 +225,7 @@ client_thread(void *priv)
 	vsb = macro_expand(vl, c->connect);
 	AN(vsb);
 #if !defined(__sun)
-	pthread_cleanup_push((void (*)(void *))VSB_delete, vsb);
+	pthread_cleanup_push((void (*)(void *))VSB_destroy, &vsb);
 #endif
 	c->addr = VSB_data(vsb);
 
@@ -252,7 +252,7 @@ client_thread(void *priv)
 	pthread_cleanup_pop(0);
 #endif
 	pthread_cleanup_pop(0);
-	VSB_delete(vsb);
+	VSB_destroy(&vsb);
 	vtc_logclose(vl);
 	return (NULL);
 }

--- a/bin/varnishtest/vtc_proxy.c
+++ b/bin/varnishtest/vtc_proxy.c
@@ -129,6 +129,6 @@ vtc_send_proxy(int fd, int version, const struct suckaddr *sac,
 
 	AZ(VSB_finish(vsb));
 	i = VSB_tofile(vsb, fd);
-	VSB_delete(vsb);
+	VSB_destroy(&vsb);
 	return (i);
 }

--- a/doc/sphinx/reference/vtla.rst
+++ b/doc/sphinx/reference/vtla.rst
@@ -45,6 +45,12 @@ VDD
     Varnish (Core) Developer Day -- Quarterly invite-only meeting strictly
     for Varnish core (C) developers, packagers and VMOD hackers.
 
+VENC
+    Varnish ENCoding -- functions to decode and encode in formats such as base64.
+
+VEND
+    Varnish ENDian -- functions to encode and decode data in specified endianess
+
 VEV
     Varnish EVent -- library functions to implement a simple event-dispatcher.
 

--- a/flint.lnt
+++ b/flint.lnt
@@ -185,7 +185,6 @@
 -esym(765, VSB_*)		// extern could be made static
 -esym(714, VSB_*)		// symb not ref
 -sem(VSB_new, @p == (1p ? 1p : malloc(1)))
--sem(VSB_delete, custodial(1))
 
 // ignore retval
 -esym(534, VSB_cat)

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -90,6 +90,7 @@ nobase_noinst_HEADERS = \
 	vcs_version.h \
 	vct.h \
 	vcurses.h \
+	venc.h \
 	vend.h \
 	vev.h \
 	vfil.h \

--- a/include/venc.h
+++ b/include/venc.h
@@ -1,0 +1,34 @@
+/*-
+ * Copyright (c) 2020 Varnish Software AS
+ * All rights reserved.
+ *
+ * Author: Poul-Henning Kamp <phk@phk.freebsd.dk>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+struct vsb;
+
+const char *VENC_Decode_Base64(struct vsb *, const char *, const char *);

--- a/include/venc.h
+++ b/include/venc.h
@@ -32,3 +32,7 @@
 struct vsb;
 
 const char *VENC_Decode_Base64(struct vsb *, const char *, const char *);
+
+int VENC_Decode_Base64_Strands(struct vsb *dst, VCL_STRANDS input, ssize_t ilen);
+int VENC_Decode_Base64URL_Strands(struct vsb *dst, VCL_STRANDS input, ssize_t ilen, int pad);
+

--- a/include/vsb.h
+++ b/include/vsb.h
@@ -48,9 +48,9 @@ struct vsb {
 #define	VSB_USRFLAGMSK	0x0000ffff	/* mask of flags the user may specify */
 #define	VSB_DYNAMIC	0x00010000	/* s_buf must be freed */
 #define	VSB_FINISHED	0x00020000	/* set by VSB_finish() */
-#define	VSB_DYNSTRUCT	0x00080000	/* vsb must be freed */
 	int		 s_flags;	/* flags */
 	int		 s_indent;	/* Ident level */
+	void		*s_alloced;	/* Ptr to free, if vsb is malloced */
 };
 
 #ifdef __cplusplus

--- a/lib/libvarnish/Makefile.am
+++ b/lib/libvarnish/Makefile.am
@@ -21,6 +21,7 @@ libvarnish_la_SOURCES = \
 	vcli_proto.c \
 	vcli_serve.c \
 	vct.c \
+	venc.c \
 	verrno.c \
 	version.c \
 	vev.c \

--- a/lib/libvarnish/venc.c
+++ b/lib/libvarnish/venc.c
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <limits.h>
+#include <sys/types.h>
 
 #include "vdef.h"
 #include "vas.h"

--- a/lib/libvarnish/venc.c
+++ b/lib/libvarnish/venc.c
@@ -1,0 +1,152 @@
+/*-
+ * Copyright (c) 2020 Varnish Software AS
+ * All rights reserved.
+ *
+ * Author: Poul-Henning Kamp <phk@phk.freebsd.dk>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "config.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <limits.h>
+
+#include "vdef.h"
+#include "vas.h"
+#include "vrt.h"
+#include "venc.h"
+
+#include "vsb.h"
+
+#define BV 64
+
+static const uint8_t base64_dec[256] = {
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, 62, BV, BV, BV, 63,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, BV, BV, BV,  0, BV, BV,
+    BV,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, BV, BV, BV, BV, BV,
+    BV, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV,
+    BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV, BV
+};
+
+struct venc_state {
+	unsigned		n;
+	unsigned		f;
+	uint8_t			w;
+	struct vsb		*vsb;
+	const uint8_t		*tbl;
+};
+
+static const char *
+venc_decode_base64(struct venc_state *ves, const char *b, const char *e)
+{
+	unsigned i;
+
+	AN(ves);
+	AN(ves->vsb);
+	AN(ves->tbl);
+
+	AN(b);
+	if (e == NULL)
+		e = strchr(b, '\0');
+	assert(e >= b);
+
+	for (; b < e; b++) {
+		i = ves->tbl[*(const uint8_t*)b];
+		if (i == BV)
+			return (b);
+		if (*b == '=' && ves->n < 2)
+			return (b);
+		else if (*b == '=')
+			ves->f++;
+		else if (ves->f)
+			return (b - 1);
+		if (ves->f && ves->w)
+			return (b - 1);
+		switch(++ves->n) {
+		case 1:
+			ves->w = i << 2;
+			break;
+		case 2:
+			ves->w |= i >> 4;
+			VSB_putc(ves->vsb, ves->w);
+			ves->w = i << 4;
+			break;
+		case 3:
+			ves->w |= i >> 2;
+			if (!ves->f)
+				VSB_putc(ves->vsb, ves->w);
+			ves->w = i << 6;
+			break;
+		case 4:
+			ves->w |= i;
+			if (!ves->f)
+				VSB_putc(ves->vsb, ves->w);
+			ves->w = 0;
+			ves->n = 0;
+			break;
+		default:
+			WRONG("Wrong turn in venc_decode_base64()");
+		}
+	}
+	return (NULL);
+}
+
+/*
+ * Decode base64 (RFC4648 section 4) into VSB.
+ *
+ * Returns NULL on success.
+ * Returns pointer to offending input character on failure.
+ */
+
+const char *
+VENC_Decode_Base64(struct vsb *dst, const char *b, const char *e)
+{
+	struct venc_state ves;
+	const char *rv;
+
+	memset(&ves, 0, sizeof ves);
+	ves.vsb = dst;
+	ves.tbl = base64_dec;
+
+	rv = venc_decode_base64(&ves, b, e);
+	if (rv)
+		return (rv);
+	if (ves.n)
+		return (e);
+	return (NULL);
+}

--- a/lib/libvarnish/vsb.c
+++ b/lib/libvarnish/vsb.c
@@ -51,8 +51,7 @@ __FBSDID("$FreeBSD: head/sys/kern/subr_vsb.c 222004 2011-05-17 06:36:32Z phk $")
 /*
  * Predicates
  */
-#define	VSB_ISDYNAMIC(s)	((s)->s_flags & VSB_DYNAMIC)
-#define	VSB_ISDYNSTRUCT(s)	((s)->s_flags & VSB_DYNSTRUCT)
+#define VSB_ISDYNAMIC(s)	((s)->s_flags & VSB_DYNAMIC)
 #define	VSB_HASROOM(s)		((s)->s_len < (s)->s_size - 1L)
 #define	VSB_FREESPACE(s)	((s)->s_size - ((s)->s_len + 1L))
 #define	VSB_CANEXTEND(s)	((s)->s_flags & VSB_AUTOEXTEND)
@@ -232,7 +231,7 @@ VSB_new(struct vsb *s, char *buf, int length, int flags)
 		SBFREE(s);
 		return (NULL);
 	}
-	VSB_SETFLAG(s, VSB_DYNSTRUCT);
+	s->s_alloced = s;
 	return (s);
 }
 
@@ -480,17 +479,17 @@ VSB_len(const struct vsb *s)
 void
 VSB_delete(struct vsb *s)
 {
-	int isdyn;
+	void *p;
 
 	assert_VSB_integrity(s);
 	/* don't care if it's finished or not */
 
 	if (VSB_ISDYNAMIC(s))
 		SBFREE(s->s_buf);
-	isdyn = VSB_ISDYNSTRUCT(s);
+	p = s->s_alloced;
 	memset(s, 0, sizeof(*s));
-	if (isdyn)
-		SBFREE(s);
+	if (p != NULL)
+		SBFREE(p);
 }
 
 void

--- a/lib/libvarnish/vsb_test.c
+++ b/lib/libvarnish/vsb_test.c
@@ -44,7 +44,7 @@ main(int argc, char *argv[])
 		printf("\n");
 		VSB_clear(vsb);
 	}
-	VSB_delete(vsb);
+	VSB_destroy(&vsb);
 	printf("error is %i\n", err);
 	return (err);
 }

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -73,8 +73,9 @@ tokens = {
     "CNUM":     None,
     "FNUM":     None,
     "CSTR":     None,
-    "EOI":      None,
     "CSRC":     None,
+    "CBLOB":    None,
+    "EOI":      None,
 }
 
 #######################################################################

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -97,6 +97,7 @@ struct token {
 	VTAILQ_ENTRY(token)	list;
 	unsigned		cnt;
 	char			*dec;
+	struct vsb		*val;
 };
 
 /*---------------------------------------------------------------------*/

--- a/lib/libvcc/vcc_token.c
+++ b/lib/libvcc/vcc_token.c
@@ -36,7 +36,9 @@
 
 #include "vcc_compile.h"
 
+#include "venc.h"
 #include "vct.h"
+#include "vsb.h"
 
 /*--------------------------------------------------------------------*/
 
@@ -390,6 +392,7 @@ vcc_Lexer(struct vcc *tl, const struct source *sp, int eoi)
 {
 	const char *p, *q, *r;
 	unsigned u;
+	struct vsb *vsb;
 
 	for (p = sp->b; p < sp->e; ) {
 
@@ -485,45 +488,50 @@ vcc_Lexer(struct vcc *tl, const struct source *sp, int eoi)
 
 		/* Recognize BLOB (= SF-binary) */
 		if (*p == ':') {
-			r = NULL;
-			for (q = p + 1; q < sp->e && vct_isbase64(*q); q++) {
-				if (r == NULL && *q == '=')
-					r = q;
-			}
-			if (q == sp->e || *q != ':') {
-				VSB_cat(tl->sb,
-				    "Illegal BLOB character:\n");
-				vcc_addtoken(tl, EOI, sp, q, q+1);
-				vcc_ErrWhere(tl, tl->t);
-				return;
-			}
-			if ((q - p) % 3 != 1) {
-				u = ((q - 1) - p) / 3;
-				vcc_addtoken(tl, EOI, sp, p + u * 3 + 1, q);
-				VSB_cat(tl->sb,
-				    "BLOB must have n*3 base64 characters\n");
-				vcc_ErrWhere(tl, tl->t);
-				return;
-			}
+			vsb = VSB_new_auto();
+			AN(vsb);
+			q = sp->e;
+			q -= (q - (p + 1)) % 4;
+			assert(q > p);
+			r = VENC_Decode_Base64(vsb, p + 1, q);
 			if (r == NULL) {
-				/* No padding; */
-			} else if (r + 1 == q) {
-				/* One pad char */
-			} else if (r + 2 == q && r[1] == '=') {
-				/* Two (valid) pad chars */
-			} else {
+				vcc_addtoken(tl, CBLOB, sp, p, q + 1);
+				VSB_cat(tl->sb,
+				    "Missing colon at end of BLOB:\n");
+				vcc_ErrWhere(tl, tl->t);
+				VSB_destroy(&vsb);
+				return;
+			}
+			vcc_addtoken(tl, CBLOB, sp, p, r + 1);
+			if (*r == ':' && ((r - p) % 4) != 1) {
+				VSB_cat(tl->sb,
+				    "BLOB must have n*4 base64 characters\n");
+				vcc_ErrWhere(tl, tl->t);
+				VSB_destroy(&vsb);
+				return;
+			}
+			if (*r == '=') {
 				VSB_cat(tl->sb,
 				    "Wrong padding ('=') in BLOB:\n");
-				vcc_addtoken(tl, EOI, sp, r, r+1);
 				vcc_ErrWhere(tl, tl->t);
+				VSB_destroy(&vsb);
 				return;
 			}
-			p = q + 1;
-			vcc_addtoken(tl, EOI, sp, p, q);
-			VSB_cat(tl->sb,
-			    "BLOB is not supported yet.\n");
+			if (*r != ':') {
+				VSB_cat(tl->sb, "Illegal BLOB character:\n");
+				vcc_ErrWhere(tl, tl->t);
+				VSB_destroy(&vsb);
+				return;
+			}
+			r++;
+			vcc_addtoken(tl, CBLOB, sp, p, r);
+			AZ(VSB_finish(vsb));
+			tl->t->val = vsb;
+			vsb = NULL;
+			p = r;
+			VSB_cat(tl->sb, "BLOB is not supported yet:\n");
 			vcc_ErrWhere(tl, tl->t);
-			return;
+			continue;
 		}
 
 		/* Match for the fixed tokens (see generate.py) */

--- a/lib/libvmod_blob/vmod_blob.c
+++ b/lib/libvmod_blob/vmod_blob.c
@@ -213,7 +213,7 @@ vmod_blob__init(VRT_CTX, struct vmod_blob_blob **blobp, const char *vcl_name,
 
 	assert(len > 0);
 
-	buf = malloc(len);
+	buf = malloc(len + 1);
 	if (buf == NULL) {
 		VERRNOMEM(ctx, "cannot create blob %s", vcl_name);
 		return;
@@ -443,7 +443,7 @@ vmod_transcode(VRT_CTX, VCL_ENUM decs, VCL_ENUM encs, VCL_ENUM case_s,
 		return ("");
 
 	/* XXX: handle stack overflow? */
-	char buf[l];
+	char buf[l + 1];
 
 	if (length <= 0)
 		length = -1;

--- a/lib/libvmod_vtc/vmod_vtc.c
+++ b/lib/libvmod_vtc/vmod_vtc.c
@@ -362,7 +362,7 @@ vmod_proxy_header(VRT_CTX, VCL_ENUM venum, VCL_IP client, VCL_IP server,
 	VRT_Format_Proxy(vsb, version, client, server, authority);
 	l = VSB_len(vsb);
 	h = WS_Copy(ctx->ws, VSB_data(vsb), l);
-	VSB_delete(vsb);
+	VSB_destroy(&vsb);
 
 	if (h == NULL) {
 		VRT_fail(ctx, "proxy_header: out of workspace");


### PR DESCRIPTION
This PR is here so we can discuss if vmod_blob should be using systemwide base64 encoding functions or not.

The first two commits are part of the 'structured-fields' work in VCC, they lay the ground, but can otherwise be ignored.

The third commit adds functions so VENC can support vmod_blob

The fourth commit makes vmod_blob use VENC for base64 decoding, and it raises two questions:

1) Should we do this, or are there good reasons to let vmod_blob be self-contained (bugwards and backwards portability etc.)

2) I think there is a bug in the base64 decoding in vmod_blob today, which is not in the VENC code, and if we decide not to venc-ify vmod_blob, that should probably (unless bugwards compat ?) be fixed in vmod_blob.

The bug is exemplified by the base64 sequence `VB==`, which leaves "dribble-bits" after the payload bytes:

    V      B      =      =
    010101 000001 ------ ------
    01010100 0001---- --------

The addition to m00037 explictly tests for this, and if we do not venc-ify vmod_blob, I think this should be committed with a fix.

The test commented out in m00042 relies dribble-bits being ignored instead of rejected.  I cannot tell if the test can be removed or if it should be modified to fulfill other test-requirements.

Another important detail to note is that since the VENC functions uses VSB, and VSB always NUL-terminates, even for binary contents (it doesn't know it is binary) the buffer must be one byte larger for these decode functions, and the way I've done that now is only "proof-of-concept" quality.