### PR TITLE
cli: Teach vcl.discard to operate on multiple VCLs

### DIFF
--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -128,7 +128,7 @@ mcf_find_vcl(struct cli *cli, const char *name)
 	vp = mcf_vcl_byname(name);
 	if (vp == NULL) {
 		VCLI_SetResult(cli, CLIS_PARAM);
-		VCLI_Out(cli, "No VCL named %s known.", name);
+		VCLI_Out(cli, "No VCL named %s known\n", name);
 	}
 	return (vp);
 }
@@ -694,7 +694,8 @@ mgt_vcl_can_discard(struct cli *cli, const char * const *av)
 		return (NULL);
 	if (vp == active_vcl) {
 		VCLI_SetResult(cli, CLIS_CANT);
-		VCLI_Out(cli, "Cannot discard active VCL program\n");
+		VCLI_Out(cli, "Cannot discard active VCL program %s\n",
+		    vp->name);
 		return (NULL);
 	}
 	if (VTAILQ_EMPTY(&vp->dto))
@@ -703,11 +704,12 @@ mgt_vcl_can_discard(struct cli *cli, const char * const *av)
 	VCLI_SetResult(cli, CLIS_CANT);
 	AN(vp->warm);
 	if (!mcf_is_label(vp))
-		VCLI_Out(cli, "Cannot discard labeled VCL program.\n");
+		VCLI_Out(cli, "Cannot discard labeled VCL program %s:\n",
+		    vp->name);
 	else
 		VCLI_Out(cli,
-		    "Cannot discard this VCL label, "
-		    "other VCLs depend on it.\n");
+		    "Cannot discard VCL label %s, other VCLs depend on it:\n",
+		    vp->name);
 	n = 0;
 	VTAILQ_FOREACH(vd, &vp->dto, lto) {
 		if (n++ == 5) {

--- a/bin/varnishtest/tests/c00077.vtc
+++ b/bin/varnishtest/tests/c00077.vtc
@@ -64,15 +64,5 @@ varnish v1 -clierr 106 "vcl.label vclA vcl3"
 
 varnish v1 -cliok "vcl.symtab"
 
-varnish v1 -cliok "vcl.discard vcl3"
-varnish v1 -cliok "vcl.discard vcl4"
-varnish v1 -cliok "vcl.discard vcl5"
-varnish v1 -cliok "vcl.discard vcl6"
-varnish v1 -cliok "vcl.discard vcl7"
-
-varnish v1 -cliok "vcl.discard vclB"
-varnish v1 -cliok "vcl.discard vcl2"
-varnish v1 -cliok "vcl.discard vclA"
-varnish v1 -cliok "vcl.discard vcl1"
-
-
+varnish v1 -clierr 300 "vcl.discard vcl1 vcl2 vcl3 vcl4 vcl5 vcl6 vcl7"
+varnish v1 -cliok "vcl.discard vcl1 vcl2 vcl3 vcl4 vcl5 vcl6 vcl7 vclA vclB"

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -125,6 +125,20 @@ CLI_CMD(VCL_LIST,
 	0, 0
 )
 
+CLI_CMD(VCL_DEPS,
+	"vcl.deps",
+	"vcl.deps [-j]",
+	"List all loaded configuration and their dependencies.",
+	"  Unless ``-j`` is specified for JSON output, the"
+	" output format is up to two columns of dynamic width"
+	" separated by white space with the fields:\n\n"
+	"  * VCL: a VCL program\n\n"
+	"  * Dependency: another VCL program it depends on\n\n"
+	"Only direct dependencies are listed, and VCLs with"
+	" multiple dependencies are listed multiple times.",
+	0, 0
+)
+
 CLI_CMD(VCL_SHOW,
 	"vcl.show",
 	"vcl.show [-v] <configname>",

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -99,10 +99,12 @@ CLI_CMD(VCL_STATE,
 
 CLI_CMD(VCL_DISCARD,
 	"vcl.discard",
-	"vcl.discard <configname|label>",
-	"Unload the named configuration (when possible).",
-	"",
-	1, 1
+	"vcl.discard <configname|label>...", /* XXX: allow globs */
+	"Unload the named configurations (if possible).",
+	" If more than one named configuration is specified the command"
+	" is equivalent to individual commands in the right order with"
+	" respect to configurations dependencies.",
+	1, -1
 )
 
 CLI_CMD(VCL_LIST,


### PR DESCRIPTION
To put it simply, let's take a simple CLI script:

    vcl.discard vcl1
    vcl.discard vcl2
    [...]
    vcl.discard vclX

We can now achieve the same with a single command:

    vcl.discard vcl1 vcl2 ... vclX

But there is slighty more to it, because vcl.discard operates on both
VCLs and VCL labels, and dependencies can exist between both. So in
addition to operate on multiple VCLs it also does so in the correct
order.