### PR TITLE
Pipe workspace fix

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -768,6 +768,7 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	THR_SetBusyobj(bo);
 	bo->sp = req->sp;
 	SES_Ref(bo->sp);
+	VCL_TaskEnter(bo->vcl, bo->privs);
 
 	HTTP_Setup(bo->bereq, bo->ws, bo->vsl, SLT_BereqMethod);
 	http_FilterReq(bo->bereq, req->http, 0);	// XXX: 0 ?
@@ -802,6 +803,7 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	}
 	http_Teardown(bo->bereq);
 	SES_Rel(bo->sp);
+	VCL_TaskLeave(bo->vcl, bo->privs);
 	VBO_ReleaseBusyObj(wrk, &bo);
 	THR_SetBusyobj(NULL);
 	return (nxt);

--- a/bin/varnishd/cache/cache_vcl_vrt.c
+++ b/bin/varnishd/cache/cache_vcl_vrt.c
@@ -353,11 +353,13 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 		VCL_Req2Ctx(&ctx, req);
 	}
 	if (bo != NULL) {
-		if (req)
-			assert(method == VCL_MET_PIPE);
 		CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 		CHECK_OBJ_NOTNULL(bo->vcl, VCL_MAGIC);
 		VCL_Bo2Ctx(&ctx, bo);
+		if (req) {
+			assert(method == VCL_MET_PIPE);
+			ctx.ws = req->ws;
+		}
 	}
 	assert(ctx.now != 0);
 	ctx.syntax = ctx.vcl->conf->syntax;

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -197,7 +197,9 @@ VCL_TaskLeave(const struct vcl *vcl, struct vrt_privs *privs)
 	CHECK_OBJ_NOTNULL(privs, VRT_PRIVS_MAGIC);
 	VTAILQ_FOREACH_SAFE(vp, &privs->privs, list, vp1) {
 		VTAILQ_REMOVE(&privs->privs, vp, list);
+		CHECK_OBJ_NOTNULL(vp, VRT_PRIV_MAGIC);
 		VRT_priv_fini(vp->priv);
+		ZERO_OBJ(vp, sizeof *vp);
 	}
 	ZERO_OBJ(privs, sizeof *privs);
 }

--- a/bin/varnishtest/tests/r03329.vtc
+++ b/bin/varnishtest/tests/r03329.vtc
@@ -1,0 +1,18 @@
+varnishtest "Lost reason from pipe to synth"
+
+server s1 {} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pipe);
+	}
+	sub vcl_pipe {
+		return (synth(505, req.http.foo + "/bar"));
+	}
+} -start
+
+client c1 {
+	txreq -hdr "foo: foo"
+	rxresp
+	expect resp.reason == "foo/bar"
+} -run

--- a/bin/varnishtest/tests/r03385.vtc
+++ b/bin/varnishtest/tests/r03385.vtc
@@ -1,0 +1,23 @@
+varnishtest "Use a priv in vcl_pipe"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import debug;
+
+	sub vcl_recv {
+		return (pipe);
+	}
+
+	sub vcl_pipe {
+		debug.test_priv_task();
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run


### PR DESCRIPTION
This uses `req->ws` for `ctx->ws` when piping. Previously the `bo` workspace was used, which lead to privs being registered in the wrong context and client data being lost after the `bo` completes.

This is a 6.0 backport patch.

Fixes #3329
Fixes #3385