### PR TITLE
Get rid of the malloc'ed VSB for synth bodies

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -266,9 +266,7 @@ cnt_vclfail(const struct worker *wrk, struct req *req)
 static enum req_fsm_nxt
 cnt_synth(struct worker *wrk, struct req *req)
 {
-	struct vsb *synth_body;
-	ssize_t sz, szl;
-	uint8_t *ptr;
+	struct http_body *hb;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
@@ -284,17 +282,13 @@ cnt_synth(struct worker *wrk, struct req *req)
 	Resp_Setup_Synth(req);
 
 	req->filter_list = NULL;
-	synth_body = VSB_new_auto();
-	AN(synth_body);
+	hb = VRB_Alloc_Body(req->ws);
+	if (hb != NULL) {
+		VCL_synth_method(req->vcl, wrk, req, NULL, hb);
+		VSLb_ts_req(req, "Process", W_TIM_real(wrk));
+	}
 
-	VCL_synth_method(req->vcl, wrk, req, NULL, synth_body);
-
-	AZ(VSB_finish(synth_body));
-
-	VSLb_ts_req(req, "Process", W_TIM_real(wrk));
-
-	if (wrk->handling == VCL_RET_FAIL) {
-		VSB_destroy(&synth_body);
+	if (hb == NULL || wrk->handling == VCL_RET_FAIL) {
 		req->doclose = SC_VCL_FAILURE;
 		VSLb_ts_req(req, "Resp", W_TIM_real(wrk));
 		http_Teardown(req->resp);
@@ -311,15 +305,10 @@ cnt_synth(struct worker *wrk, struct req *req)
 		 * XXX: If so, to what ?
 		 */
 		HTTP_Setup(req->resp, req->ws, req->vsl, SLT_RespMethod);
-		VSB_destroy(&synth_body);
 		req->req_step = R_STP_RESTART;
 		return (REQ_FSM_MORE);
 	}
 	assert(wrk->handling == VCL_RET_DELIVER);
-
-	http_Unset(req->resp, H_Content_Length);
-	http_PrintfHeader(req->resp, "Content-Length: %zd",
-	    VSB_len(synth_body));
 
 	if (!req->doclose && http_HdrIs(req->resp, H_Connection, "close"))
 		req->doclose = SC_RESP_CLOSE;
@@ -329,36 +318,24 @@ cnt_synth(struct worker *wrk, struct req *req)
 
 	req->objcore = HSH_Private(wrk);
 	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
-	szl = -1;
 	if (STV_NewObject(wrk, req->objcore, stv_transient, 1024)) {
-		szl = VSB_len(synth_body);
-		assert(szl >= 0);
-		sz = szl;
-		if (sz > 0 &&
-		    ObjGetSpace(wrk, req->objcore, &sz, &ptr) && sz >= szl) {
-			memcpy(ptr, VSB_data(synth_body), szl);
-			ObjExtend(wrk, req->objcore, szl);
-		} else if (sz > 0) {
-			szl = -1;
+		if (VRB_Copy_To_ObjCore(wrk, hb, req->objcore) >= 0) {
+			VRB_Free_Body(hb);
+			HSH_DerefBoc(wrk, req->objcore);
+			req->req_step = R_STP_TRANSMIT;
+			return (REQ_FSM_MORE);
 		}
 	}
 
-	if (szl >= 0)
-		AZ(ObjSetU64(wrk, req->objcore, OA_LEN, szl));
+	VRB_Free_Body(hb);
 	HSH_DerefBoc(wrk, req->objcore);
-	VSB_destroy(&synth_body);
 
-	if (szl < 0) {
-		VSLb(req->vsl, SLT_Error, "Could not get storage");
-		req->doclose = SC_OVERLOAD;
-		VSLb_ts_req(req, "Resp", W_TIM_real(wrk));
-		(void)HSH_DerefObjCore(wrk, &req->objcore, 1);
-		http_Teardown(req->resp);
-		return (REQ_FSM_DONE);
-	}
-
-	req->req_step = R_STP_TRANSMIT;
-	return (REQ_FSM_MORE);
+	VSLb(req->vsl, SLT_Error, "Could not get storage");
+	req->doclose = SC_OVERLOAD;
+	VSLb_ts_req(req, "Resp", W_TIM_real(wrk));
+	(void)HSH_DerefObjCore(wrk, &req->objcore, 1);
+	http_Teardown(req->resp);
+	return (REQ_FSM_DONE);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -123,6 +123,43 @@ struct vcf {
 	void			*priv;
 };
 
+/* HTTP bodies -------------------------------------------------------*/
+
+struct http_body_part;
+typedef int http_body_part_store_f(struct worker *, struct objcore *, void *);
+typedef void http_body_part_free_f(const struct http_body_part*);
+
+struct http_body_part_methods {
+	unsigned				magic;
+#define HTTP_BODY_PART_METHODS_MAGIC		0x6f7e9c53
+	http_body_part_store_f			*store;
+	http_body_part_free_f			*free;
+};
+
+struct http_body_part {
+	unsigned				magic;
+#define HTTP_BODY_PART_MAGIC			0x9cc6293d
+	void					*priv;
+	VTAILQ_ENTRY(http_body_part)		list;
+	const struct http_body_part_methods	*methods;
+};
+
+struct http_body {
+	unsigned				magic;
+#define HTTP_BODY_MAGIC				0x7e1c42e1
+	struct ws				*ws;
+	VTAILQ_HEAD(, http_body_part)		parts;
+};
+
+struct http_body *VRB_Alloc_Body(struct ws *);
+void VRB_Free_Body(struct http_body *);
+
+void VRB_Add_String(struct http_body *, const char *);
+void VRB_Add_Strands(struct http_body *, VCL_STRANDS);
+
+
+int VRB_Copy_To_ObjCore(struct worker *, struct http_body *, struct objcore *);
+
 /* Prototypes etc ----------------------------------------------------*/
 
 /* cache_acceptor.c */

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -801,24 +801,6 @@ VRT_Rollback(VRT_CTX, VCL_HTTP hp)
 /*--------------------------------------------------------------------*/
 
 VCL_VOID
-VRT_synth_page(VRT_CTX, VCL_STRANDS s)
-{
-	struct vsb *vsb;
-	int i;
-
-	CAST_OBJ_NOTNULL(vsb, ctx->specific, VSB_MAGIC);
-	AN(s);
-	for (i = 0; i < s->n; i++) {
-		if (s->p[i] != NULL)
-			VSB_cat(vsb, s->p[i]);
-		else
-			VSB_cat(vsb, "(null)");
-	}
-}
-
-/*--------------------------------------------------------------------*/
-
-VCL_VOID
 VRT_ban_string(VRT_CTX, VCL_STRING str)
 {
 	char *a1, *a2, *a3;

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -936,35 +936,6 @@ VRT_r_resp_do_esi(VRT_CTX)
 
 /*--------------------------------------------------------------------*/
 
-#define VRT_BODY_L(which)					\
-VCL_VOID							\
-VRT_l_##which##_body(VRT_CTX, enum lbody_e type,		\
-    const char *str, ...)					\
-{								\
-	va_list ap;						\
-	const char *p;						\
-	struct vsb *vsb;					\
-								\
-	CAST_OBJ_NOTNULL(vsb, ctx->specific, VSB_MAGIC);	\
-	assert(type == LBODY_SET || type == LBODY_ADD);		\
-	if (type == LBODY_SET)					\
-		VSB_clear(vsb);					\
-	va_start(ap, str);					\
-	p = str;						\
-	while (p != vrt_magic_string_end) {			\
-		if (p == NULL)					\
-			p = "(null)";				\
-		VSB_cat(vsb, p);				\
-		p = va_arg(ap, const char *);			\
-	}							\
-	va_end(ap);						\
-}
-
-VRT_BODY_L(beresp)
-VRT_BODY_L(resp)
-
-/*--------------------------------------------------------------------*/
-
 			/* digest */
 #define BLOB_HASH_TYPE 0x00d16357
 


### PR DESCRIPTION
This is a PR for discussion purposes relative to making *.body able to ingest BLOBs (ie: #3123 bis)

I'm not entirely happy with the gains of this patch.

There are also a couple of error conditions which seems to fall through the cracks.