### PR TITLE
plug VSB leak

### DIFF
--- a/lib/libvarnish/vsb.c
+++ b/lib/libvarnish/vsb.c
@@ -539,6 +539,7 @@ VSB_destroy(struct vsb **s)
 	AN(s);
 	assert_VSB_integrity(*s);
 	assert(VSB_ISDYNAMIC(*s));
+	SBFREE((*s)->s_buf);
 	memset(*s, 0, sizeof(**s));
 	SBFREE(*s);
 	*s = NULL;


### PR DESCRIPTION
`cci` has been complaining about a leak, but only for `debian:buster`:
```
Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f871d0f4330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x5574f9341a25 in VSB_newbuf /workspace/lib/libvarnish/vsb.c:203
    #2 0x5574f9341eb2 in VSB_new_auto /workspace/lib/libvarnish/vsb.c:261
    #3 0x5574f91ed833 in MCF_ParamConf mgt/mgt_param.c:737
    #4 0x5574f91f08fe in tcp_probe mgt/mgt_param_tcp.c:65
    #5 0x5574f91f0c9f in tcp_keep_probes mgt/mgt_param_tcp.c:78
    #6 0x5574f91f0ead in MCF_TcpParams mgt/mgt_param_tcp.c:89
    #7 0x5574f91ed09f in MCF_InitParams mgt/mgt_param.c:664
    #8 0x5574f91de52f in mgt_initialize mgt/mgt_main.c:289
    #9 0x5574f91e05bb in main mgt/mgt_main.c:497
    #10 0x7f871be2e09a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)
```

If I understand 904659a1475a395c9972626670abbf0d2e4222f4 correctly, we should free the `s_buf` field in `VSB_destroy`