### PR TITLE
vsc: New 'F' argument to force field inclusion

### DIFF
--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -165,8 +165,7 @@ do_once_cb_first(void *priv, const struct VSC_point * const pt)
 		return (0);
 	op = priv;
 	AZ(strcmp(pt->ctype, "uint64_t"));
-	if (strcmp(pt->name, "MAIN.uptime"))
-		return (0);
+	AZ(strcmp(pt->name, "MAIN.uptime"));
 	val = *(const volatile uint64_t*)pt->ptr;
 	op->up = (double)val;
 	return (1);

--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -336,10 +336,10 @@ main(int argc, char * const *argv)
 
 	if (curses) {
 		if (has_f) {
-			AN(VSC_Arg(vsc, 'f', "MGT.uptime"));
-			AN(VSC_Arg(vsc, 'f', "MAIN.uptime"));
-			AN(VSC_Arg(vsc, 'f', "MAIN.cache_hit"));
-			AN(VSC_Arg(vsc, 'f', "MAIN.cache_miss"));
+			AN(VSC_Arg(vsc, 'F', "MGT.uptime"));
+			AN(VSC_Arg(vsc, 'F', "MAIN.uptime"));
+			AN(VSC_Arg(vsc, 'F', "MAIN.cache_hit"));
+			AN(VSC_Arg(vsc, 'F', "MAIN.cache_miss"));
 		}
 		do_curses(vd, vsc);
 	}

--- a/bin/varnishtest/tests/r03394.vtc
+++ b/bin/varnishtest/tests/r03394.vtc
@@ -6,4 +6,4 @@ varnish v1 -vcl+backend "" -start
 
 process p1 -dump {varnishstat -n ${v1_name}} -start
 process p1 -expect-text 0 0 "MAIN.pools"
-process p1 -screen_dump
+process p1 -screen_dump -write q -wait

--- a/bin/varnishtest/tests/r03394.vtc
+++ b/bin/varnishtest/tests/r03394.vtc
@@ -1,0 +1,9 @@
+varnishtest "varnishstat curses field exclusion"
+
+server s1 -start
+
+varnish v1 -vcl+backend "" -start
+
+process p1 -dump {varnishstat -n ${v1_name}} -start
+process p1 -expect-text 0 0 "MAIN.pools"
+process p1 -screen_dump

--- a/include/vapi/vsc.h
+++ b/include/vapi/vsc.h
@@ -114,7 +114,8 @@ void VSC_Destroy(struct vsc **, struct vsm *);
 int VSC_Arg(struct vsc *, char arg, const char *opt);
 	/*
 	 * Handle standard stat-presenter arguments
-	 *	'f' - filter
+	 *	'f' - filter fields (include or exclude)
+	 *	'F' - force fields (include only)
 	 *
 	 * Return:
 	 *	-1 error, VSM_Error() returns diagnostic string

--- a/lib/libvarnishapi/vsc.c
+++ b/lib/libvarnishapi/vsc.c
@@ -85,6 +85,7 @@ struct vsc {
 	unsigned		magic;
 #define VSC_MAGIC		0x3373554a
 
+	struct vsc_sf_head	sf_list_force;
 	struct vsc_sf_head	sf_list_include;
 	struct vsc_sf_head	sf_list_exclude;
 	VTAILQ_HEAD(,vsc_seg)	segs;
@@ -120,6 +121,7 @@ VSC_New(void)
 	ALLOC_OBJ(vsc, VSC_MAGIC);
 	if (vsc == NULL)
 		return (vsc);
+	VTAILQ_INIT(&vsc->sf_list_force);
 	VTAILQ_INIT(&vsc->sf_list_include);
 	VTAILQ_INIT(&vsc->sf_list_exclude);
 	VTAILQ_INIT(&vsc->segs);
@@ -129,7 +131,7 @@ VSC_New(void)
 /*--------------------------------------------------------------------*/
 
 static int
-vsc_f_arg(struct vsc *vsc, const char *opt)
+vsc_f_arg(struct vsc *vsc, const char *opt, unsigned force)
 {
 	struct vsc_sf *sf;
 	unsigned exclude = 0;
@@ -142,11 +144,18 @@ vsc_f_arg(struct vsc *vsc, const char *opt)
 		opt++;
 	}
 
+	if (force && exclude) {
+		INCOMPL(); /* XXX: we lack access to vsm_diag() */
+		return (-1);
+	}
+
 	ALLOC_OBJ(sf, VSC_SF_MAGIC);
 	AN(sf);
 	REPLACE(sf->pattern, opt);
 
-	if (exclude)
+	if (force)
+		VTAILQ_INSERT_TAIL(&vsc->sf_list_force, sf, list);
+	else if (exclude)
 		VTAILQ_INSERT_TAIL(&vsc->sf_list_exclude, sf, list);
 	else
 		VTAILQ_INSERT_TAIL(&vsc->sf_list_include, sf, list);
@@ -163,8 +172,11 @@ VSC_Arg(struct vsc *vsc, char arg, const char *opt)
 	CHECK_OBJ_NOTNULL(vsc, VSC_MAGIC);
 
 	switch (arg) {
-	case 'f': return (vsc_f_arg(vsc, opt));
-	default: return (0);
+	case 'F':
+	case 'f':
+		return (vsc_f_arg(vsc, opt, arg == 'F'));
+	default:
+		  return (0);
 	}
 }
 
@@ -178,6 +190,9 @@ vsc_filter(const struct vsc *vsc, const char *nm)
 	struct vsc_sf *sf;
 
 	CHECK_OBJ_NOTNULL(vsc, VSC_MAGIC);
+	VTAILQ_FOREACH(sf, &vsc->sf_list_force, list)
+		if (!fnmatch(sf->pattern, nm, 0))
+			return (0);
 	VTAILQ_FOREACH(sf, &vsc->sf_list_exclude, list)
 		if (!fnmatch(sf->pattern, nm, 0))
 			return (1);
@@ -536,6 +551,7 @@ VSC_Destroy(struct vsc **vscp, struct vsm *vsm)
 	struct vsc_seg *sp, *sp2;
 
 	TAKE_OBJ_NOTNULL(vsc, vscp, VSC_MAGIC);
+	vsc_delete_sf_list(&vsc->sf_list_force);
 	vsc_delete_sf_list(&vsc->sf_list_include);
 	vsc_delete_sf_list(&vsc->sf_list_exclude);
 	VTAILQ_FOREACH_SAFE(sp, &vsc->segs, list, sp2) {

--- a/lib/libvarnishapi/vsc.c
+++ b/lib/libvarnishapi/vsc.c
@@ -134,18 +134,17 @@ vsc_f_arg(struct vsc *vsc, const char *opt)
 	struct vsc_sf *sf;
 	unsigned exclude = 0;
 
+	CHECK_OBJ_NOTNULL(vsc, VSC_MAGIC);
 	AN(opt);
-
-	ALLOC_OBJ(sf, VSC_SF_MAGIC);
-	AN(sf);
 
 	if (opt[0] == '^') {
 		exclude = 1;
 		opt++;
 	}
 
-	sf->pattern = strdup(opt);
-	AN(sf->pattern);
+	ALLOC_OBJ(sf, VSC_SF_MAGIC);
+	AN(sf);
+	REPLACE(sf->pattern, opt);
 
 	if (exclude)
 		VTAILQ_INSERT_TAIL(&vsc->sf_list_exclude, sf, list);


### PR DESCRIPTION
We need some fields to always be present in some cases with varnishstat
and as a result it disturbs end users settings. The new 'F' VSC argument
adds include patterns taking precedence over 'f' settings and is meant
for internal VUT usage.

Since varnishstat already needs to force some fields in curses mode, it's
the first consumer of the new argument.

Fixes #3394

---

The commits from this branch can be cleanly cherry-picked in the 6.0 branch as of the time of writing. This doesn't break the ABI and is therefore safe to back-port in the LTS branch. The test case fails in 6.0, but I don't understand why, yet:

```
*    top   1.7 RESETTING after bin/varnishtest/tests/r03394.vtc
**** p1    1.7 Sent signal 15
**** p1    1.7 stdout|\33[24;1H\33[?12l\33[?25h\33[?1049l\33[23;0;0t\r\33[?1l\33>
**** p1    1.7 stdout read -1
**** p1    1.7 stderr read 0
**   p1    1.7 WAIT4 pid=1223089 status=0x0100 (user 0.025696 sys 0.032119)
*    p1    1.7 Expected exit: 0x0 signal: 15 core: 0
---- p1    1.7 Bad exit status: 0x0100 exit 0x1 signal 0 core 0
---- p1    2.7 Failed to send signal 9 (No such process)
*    top   2.7 failure during reset
#    top  TEST bin/varnishtest/tests/r03394.vtc FAILED (2.696) exit=2
```

The error occurs after the test script succeeded, during the tear down phase.

This change is incomplete though, it lacks a bit of error handling where the `INCOMPL()` macro is used. Following the documentation I think we have a copy-pasta mistake:

```c
int VSC_Arg(struct vsc *, char arg, const char *opt);
        /*
         * Handle standard stat-presenter arguments
         *      'f' - filter
         *
         * Return:
         *      -1 error, VSM_Error() returns diagnostic string
         *       0 not handled
         *       1 Handled.
         */
```

There is no practical way to forward a diagnostic that will be output by `VSM_Error()` so I suspect it was meant to be `VSC_Error()` except that this function does not exist, probably because there was no diagnostic needed until now.

Adding the new function is kept outside of the scope of this PR because when I looked closer I realized that VSM and VSL code basically share the same diagnostic/error reporting code, and I don't think adding another copy in VSC code is the best way forward. Also, by keeping `VSC_Error()` separate we save ourselves ABI headaches in the 6.0 LTS branch where we can have this feature, and it is technically fine if a knob that is meant to only be used internally (not tainted by arbitrary input) to panic when misused.