### PR TITLE
Add counters: beresp_uncacheable, beresp_shortlived

### DIFF
--- a/bin/varnishd/VSC_main.vsc
+++ b/bin/varnishd/VSC_main.vsc
@@ -137,6 +137,19 @@
 	Count of misses. A cache miss indicates the object was fetched from
 	the backend before delivering it to the client.
 
+.. varnish_vsc:: beresp_uncacheable
+   :group: wrk
+   :oneliner: Uncacheable backend responses
+
+   Count of backend responses considered uncacheable.
+
+.. varnish_vsc:: beresp_shortlived
+   :group: wrk
+   :oneliner: Shortlived objects
+
+   Count of objects created with ttl+grace+keep shorter than the 'shortlived'
+   runtime parameter.
+
 .. varnish_vsc:: backend_conn
 	:oneliner:	Backend conn. success
 

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -58,8 +58,14 @@ vbf_allocobj(struct busyobj *bo, unsigned l)
 
 	lifetime = oc->ttl + oc->grace + oc->keep;
 
-	if (bo->uncacheable || lifetime < cache_param->shortlived)
+	if (bo->uncacheable) {
 		stv = stv_transient;
+		bo->wrk->stats->beresp_uncacheable++;
+	}
+	else if (lifetime < cache_param->shortlived) {
+		stv = stv_transient;
+		bo->wrk->stats->beresp_shortlived++;
+	}
 	else
 		stv = bo->storage;
 

--- a/bin/varnishtest/tests/b00066.vtc
+++ b/bin/varnishtest/tests/b00066.vtc
@@ -100,3 +100,5 @@ client c1 {
 
 
 varnish v1 -expect *.s1.req == 12
+varnish v1 -expect beresp_uncacheable == 12
+varnish v1 -expect beresp_shortlived == 0

--- a/bin/varnishtest/tests/s00007.vtc
+++ b/bin/varnishtest/tests/s00007.vtc
@@ -40,3 +40,4 @@ client c1 {
 	expect resp.body == "foo"
 } -run
 
+varnish v1 -expect beresp_shortlived == 1


### PR DESCRIPTION
Uncacheable and shortlived objects end up in transient memory. Add two
counters to track both type of responses separately.