### PR TITLE
vsc: Add an 'R' argument for required fields (back-port)

### DIFF
--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -319,10 +319,10 @@ main(int argc, char * const *argv)
 
 	if (curses) {
 		if (has_f) {
-			AN(VSC_Arg(vsc, 'f', "MGT.uptime"));
-			AN(VSC_Arg(vsc, 'f', "MAIN.uptime"));
-			AN(VSC_Arg(vsc, 'f', "MAIN.cache_hit"));
-			AN(VSC_Arg(vsc, 'f', "MAIN.cache_miss"));
+			AN(VSC_Arg(vsc, 'R', "MGT.uptime"));
+			AN(VSC_Arg(vsc, 'R', "MAIN.uptime"));
+			AN(VSC_Arg(vsc, 'R', "MAIN.cache_hit"));
+			AN(VSC_Arg(vsc, 'R', "MAIN.cache_miss"));
 		}
 		do_curses(vd, vsc);
 	}

--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -335,7 +335,7 @@ main(int argc, char * const *argv)
 	else if (f_list)
 		list_fields(vd, vsc);
 	else
-		assert(0);
+		WRONG("undefined varnishstat mode");
 
 	exit(0);
 }

--- a/bin/varnishstat/varnishstat_options.h
+++ b/bin/varnishstat/varnishstat_options.h
@@ -36,14 +36,6 @@
 	    "Instead of presenting a continuously updated display,"	\
 	    " print the statistics to stdout."				\
 	)
-#define STAT_OPT_f							\
-	VOPT("f:", "[-f <glob>]", "Field inclusion glob",		\
-	    "Field inclusion glob."					\
-	    " Use backslash to escape characters. If the argument"	\
-	    " starts with '^' it is used as an exclusive glob."		\
-	    " Multiple -f arguments may be given. Inclusive globs"	\
-	    " are accumulative and are run before exclusive ones."	\
-	)
 #define STAT_OPT_j							\
 	VOPT("j", "[-j]", "Print statistics to stdout as JSON",		\
 	    "Print statistics to stdout as JSON."			\
@@ -59,7 +51,7 @@
 	)
 
 STAT_OPT_1
-STAT_OPT_f
+VSC_OPT_f
 VUT_OPT_h
 STAT_OPT_j
 STAT_OPT_l

--- a/bin/varnishtest/tests/r03394.vtc
+++ b/bin/varnishtest/tests/r03394.vtc
@@ -1,0 +1,9 @@
+varnishtest "varnishstat curses field exclusion"
+
+server s1 -start
+
+varnish v1 -vcl+backend "" -start
+
+process p1 -dump {varnishstat -n ${v1_name}} -start
+process p1 -expect-text 0 0 "MAIN.pools"
+process p1 -screen_dump -write q -wait

--- a/include/vapi/vapi_options.h
+++ b/include/vapi/vapi_options.h
@@ -122,3 +122,14 @@
 	    " taglist and regular expression. Applies to any tag if"	\
 	    " taglist is absent. Multiple -X options may be given.\n"	\
 	)
+
+/* VSC options */
+
+#define VSC_OPT_f							\
+	VOPT("f:", "[-f <glob>]", "Field inclusion glob",		\
+	    "Field inclusion glob."					\
+	    " Use backslash to escape characters. If the argument"	\
+	    " starts with '^' it is used as an exclusive glob."		\
+	    " Multiple -f arguments may be given. Inclusive globs"	\
+	    " are accumulative and are run before exclusive ones."	\
+	)

--- a/include/vapi/vsc.h
+++ b/include/vapi/vsc.h
@@ -112,10 +112,11 @@ void VSC_Destroy(struct vsc **, struct vsm *);
 int VSC_Arg(struct vsc *, char arg, const char *opt);
 	/*
 	 * Handle standard stat-presenter arguments
-	 *	'f' - filter
+	 *	'f' - filter fields (include or exclude)
+	 *	'R' - require fields (include only)
 	 *
 	 * Return:
-	 *	-1 error, VSM_Error() returns diagnostic string
+	 *	-1 error
 	 *	 0 not handled
 	 *	 1 Handled.
 	 */

--- a/lib/libvarnishapi/vsc.c
+++ b/lib/libvarnishapi/vsc.c
@@ -132,18 +132,17 @@ vsc_f_arg(struct vsc *vsc, const char *opt)
 	struct vsc_sf *sf;
 	unsigned exclude = 0;
 
+	CHECK_OBJ_NOTNULL(vsc, VSC_MAGIC);
 	AN(opt);
-
-	ALLOC_OBJ(sf, VSC_SF_MAGIC);
-	AN(sf);
 
 	if (opt[0] == '^') {
 		exclude = 1;
 		opt++;
 	}
 
-	sf->pattern = strdup(opt);
-	AN(sf->pattern);
+	ALLOC_OBJ(sf, VSC_SF_MAGIC);
+	AN(sf);
+	REPLACE(sf->pattern, opt);
 
 	if (exclude)
 		VTAILQ_INSERT_TAIL(&vsc->sf_list_exclude, sf, list);


### PR DESCRIPTION
This is a 6.0 variant of #3395 that addressed #3394 for the master branch without breaking any prior behavior, but using the same VSC argument as #3396 instead.

Fixes #3394