### PR TITLE
vbe: Don't recycle Connection:close sessions

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -235,7 +235,9 @@ vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 	if (PFD_State(pfd) != PFD_STATE_USED)
 		assert(bo->htc->doclose == SC_TX_PIPE ||
 		    bo->htc->doclose == SC_RX_TIMEOUT);
-	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0) {
+	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0 ||
+	    http_GetHdrField(bo->bereq, H_Connection, "close", NULL) ||
+	    http_GetHdrField(bo->beresp, H_Connection, "close", NULL)) {
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s close", *PFD_Fd(pfd),
 		    VRT_BACKEND_string(bp->director));
 		VTP_Close(&pfd);

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -235,8 +235,7 @@ vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 	if (PFD_State(pfd) != PFD_STATE_USED)
 		assert(bo->htc->doclose == SC_TX_PIPE ||
 		    bo->htc->doclose == SC_RX_TIMEOUT);
-	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0 ||
-	    http_GetHdrField(bo->beresp, H_Connection, "close", NULL)) {
+	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0) {
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s close", *PFD_Fd(pfd),
 		    VRT_BACKEND_string(bp->director));
 		VTP_Close(&pfd);

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -236,7 +236,6 @@ vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 		assert(bo->htc->doclose == SC_TX_PIPE ||
 		    bo->htc->doclose == SC_RX_TIMEOUT);
 	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0 ||
-	    http_GetHdrField(bo->bereq, H_Connection, "close", NULL) ||
 	    http_GetHdrField(bo->beresp, H_Connection, "close", NULL)) {
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s close", *PFD_Fd(pfd),
 		    VRT_BACKEND_string(bp->director));

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -450,6 +450,10 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 	if (http_IsStatus(bo->beresp, 304) && vbf_304_logic(bo) < 0)
 		return (F_STP_ERROR);
 
+	if (bo->htc->doclose == SC_NULL &&
+	    http_GetHdrField(bo->bereq, H_Connection, "close", NULL))
+		bo->htc->doclose = SC_REQ_CLOSE;
+
 	VCL_backend_response_method(bo->vcl, wrk, NULL, bo, NULL);
 
 	if (wrk->handling == VCL_RET_ABANDON || wrk->handling == VCL_RET_FAIL ||

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -456,6 +456,10 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 
 	VCL_backend_response_method(bo->vcl, wrk, NULL, bo, NULL);
 
+	if (bo->htc != NULL && bo->htc->doclose == SC_NULL &&
+	    http_GetHdrField(bo->beresp, H_Connection, "close", NULL))
+		bo->htc->doclose = SC_RESP_CLOSE;
+
 	if (wrk->handling == VCL_RET_ABANDON || wrk->handling == VCL_RET_FAIL ||
 	    wrk->handling == VCL_RET_ERROR) {
 		/* do not count deliberately ending the backend connection as

--- a/bin/varnishtest/tests/b00073.vtc
+++ b/bin/varnishtest/tests/b00073.vtc
@@ -3,42 +3,62 @@ varnishtest "backend connection close"
 server s1 {
 	rxreq
 	expect req.http.connection ~ close
+	expect req.http.beresp-connection !~ close
 	txresp
 	expect_close
 
 	accept
 	rxreq
 	expect req.http.connection !~ close
+	expect req.http.beresp-connection ~ close
 	txresp
 	expect_close
 
 	accept
 	rxreq
 	expect req.http.connection !~ close
+	expect req.http.beresp-connection !~ close
 	txresp -hdr "connection: close"
+	expect_close
+
+	accept
+	rxreq
+	expect req.http.connection ~ close
+	expect req.http.unset-connection == true
+	txresp
 	expect_close
 } -start
 
 varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pass);
+	}
 	sub vcl_backend_fetch {
 		set bereq.http.connection = bereq.http.bereq-connection;
 	}
 	sub vcl_backend_response {
+		if (bereq.http.unset-connection) {
+			unset bereq.http.connection;
+		}
 		# NB: this overrides unconditionally on purpose
 		set beresp.http.connection = bereq.http.beresp-connection;
 	}
 } -start
 
 client c1 {
-	txreq -url "/1" -hdr "bereq-connection: close, x-varnish"
+	txreq -hdr "bereq-connection: close, x-varnish"
 	rxresp
 	expect resp.status == 200
 
-	txreq -url "/2" -hdr "beresp-connection: close, x-varnish"
+	txreq -hdr "beresp-connection: close, x-varnish"
 	rxresp
 	expect resp.status == 200
 
-	txreq -url "/3"
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "bereq-connection: close" -hdr "unset-connection: true"
 	rxresp
 	expect resp.status == 200
 } -run

--- a/bin/varnishtest/tests/b00073.vtc
+++ b/bin/varnishtest/tests/b00073.vtc
@@ -1,0 +1,49 @@
+varnishtest "backend connection close"
+
+server s1 {
+	rxreq
+	expect req.http.connection ~ close
+	txresp
+	expect_close
+
+	accept
+	rxreq
+	expect req.http.connection !~ close
+	txresp
+	expect_close
+
+	accept
+	rxreq
+	expect req.http.connection !~ close
+	txresp -hdr "connection: close"
+	expect_close
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_backend_fetch {
+		set bereq.http.connection = bereq.http.bereq-connection;
+	}
+	sub vcl_backend_response {
+		# NB: this overrides unconditionally on purpose
+		set beresp.http.connection = bereq.http.beresp-connection;
+	}
+} -start
+
+client c1 {
+	txreq -url "/1" -hdr "bereq-connection: close, x-varnish"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/2" -hdr "beresp-connection: close, x-varnish"
+	rxresp
+	expect resp.status == 200
+
+	txreq -url "/3"
+	rxresp
+	expect resp.status == 200
+} -run
+
+server s1 -wait
+
+varnish v1 -expect MAIN.backend_recycle == 0
+varnish v1 -expect VBE.vcl1.s1.conn == 0


### PR DESCRIPTION
When a user adds a Connection:close header to the bereq, we end up
recycling the session and relying solely on the backend to close
it. This is not ideal when we deal with a misbehaving backend.

Conversely, if a backend replies with a Connection:close header,
or if a user manually adds it to the beresp, we should also not be
recycling sessions.