### PR TITLE
vbe: Update the poll timeout before polling-reading in backend probes

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -348,6 +348,7 @@ vbp_poke(struct vbp_target *vt)
 	while (1) {
 		pfd->events = POLLIN;
 		pfd->revents = 0;
+		t_now = VTIM_real();
 		tmo = (int)round((t_end - t_now) * 1e3);
 		if (tmo <= 0) {
 			bprintf(vt->resp_buf,


### PR DESCRIPTION
Varnish uses a global per-probe timeout for backend probes. When reading
the backend response, Varnish tries to poll and read in a loop, until a
poll timeouts, the streams EOFs or there is an error.

The poll is supposed to timeout when the per-probe timeout ends. This is
currently setup so that `t_end` is the deadline for the probe, set when
the function starts, then the poll waits until `t_end`.

Previously, the poll timeout was never updated, and was always set to
`t_end - t_now` without updating `t_now`, which means that it was
effectively a between-bytes timeout instead of a proper per-probe
timeout.

This fixes this issue by updating `t_now` before updating the
`t_end - t_now` timeout so that the timeout passed to poll effectively
corresponds to a deadline of `t_end`.

See the issue fixed by this commit for more details.

Fixes: #3402