### PR TITLE
vbf: Prevent pooling of a Connection:close beresp

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -452,6 +452,10 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 
 	VCL_backend_response_method(bo->vcl, wrk, NULL, bo, NULL);
 
+	if (bo->htc != NULL && bo->htc->doclose == SC_NULL &&
+	    http_GetHdrField(bo->beresp, H_Connection, "close", NULL))
+		bo->htc->doclose = SC_RESP_CLOSE;
+
 	if (wrk->handling == VCL_RET_ABANDON || wrk->handling == VCL_RET_FAIL ||
 	    wrk->handling == VCL_RET_ERROR) {
 		/* do not count deliberately ending the backend connection as

--- a/bin/varnishtest/tests/b00073.vtc
+++ b/bin/varnishtest/tests/b00073.vtc
@@ -1,0 +1,39 @@
+varnishtest "backend connection close"
+
+server s1 {
+	rxreq
+	expect req.http.beresp-connection ~ close
+	txresp
+	expect_close
+
+	accept
+	rxreq
+	expect req.http.beresp-connection !~ close
+	txresp -hdr "connection: close"
+	expect_close
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pass);
+	}
+	sub vcl_backend_response {
+		# NB: this overrides unconditionally on purpose
+		set beresp.http.connection = bereq.http.beresp-connection;
+	}
+} -start
+
+client c1 {
+	txreq -hdr "beresp-connection: close, x-varnish"
+	rxresp
+	expect resp.status == 200
+
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+server s1 -wait
+
+varnish v1 -expect MAIN.backend_recycle == 0
+varnish v1 -expect VBE.vcl1.s1.conn == 0

--- a/doc/sphinx/whats-new/changes-trunk.rst
+++ b/doc/sphinx/whats-new/changes-trunk.rst
@@ -34,6 +34,25 @@ Changes to VCL
 VCL variables
 ~~~~~~~~~~~~~
 
+It is now possible to manually set a ``Connection: close`` header in
+``beresp`` to signal that the backend connection shouldn't be recycled.
+This might help dealing with backends that would under certain circumstances
+have trouble managing their end of the connection, for example for certain
+kinds of resources.
+
+Care should be taken to preserve other headers listed in the connection
+header::
+
+    sub vcl_backend_response {
+        if (beresp.backend == faulty_backend) {
+            if (beresp.http.Connection) {
+                set beresp.http.Connection += ", close";
+            } else {
+                set beresp.http.Connection = "close";
+            }
+        }
+    }
+
 **XXX new, deprecated or removed variables, or changed semantics**
 
 Other changes to VCL


### PR DESCRIPTION
Whether the header was set by the backend or directly in VCL, it is now
possible to signal that a backend connection should not be added back to
the pool after a successful fetch with a Connection:close header.

Pooling such a connection would be counter-productive if closing the
session was requested by the backend itself, because it would then be
likely that reusing the connection would result in busting the extra
chance.

Setting the Connection:close directly in VCL can help mitigating against
a misbehaving backend.

Refs #3400

---

Split in two commits to ease back-ports.