### PR TITLE
Pipe workspace and safety fixes

### DIFF
--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -208,6 +208,7 @@ VDI_Http1Pipe(struct req *req, struct busyobj *bo)
 	INIT_OBJ(ctx, VRT_CTX_MAGIC);
 	VCL_Req2Ctx(ctx, req);
 	VCL_Bo2Ctx(ctx, bo);
+	ctx->ws = req->ws;
 
 	d = VDI_Resolve(ctx);
 	if (d == NULL || d->vdir->methods->http1pipe == NULL) {

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -719,7 +719,7 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	SES_Ref(bo->sp);
 	VCL_TaskEnter(bo->privs);
 
-	HTTP_Setup(bo->bereq, bo->ws, bo->vsl, SLT_BereqMethod);
+	HTTP_Setup(bo->bereq, req->ws, bo->vsl, SLT_BereqMethod);
 	http_FilterReq(bo->bereq, req->http, 0);	// XXX: 0 ?
 	http_PrintfHeader(bo->bereq, "X-Varnish: %u", VXID(req->vsl->wid));
 	http_ForceHeader(bo->bereq, H_Connection, "close");
@@ -730,7 +730,10 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	}
 
 	bo->wrk = wrk;
-	VCL_pipe_method(req->vcl, wrk, req, bo, NULL);
+	if (WS_Overflowed(req->ws))
+		wrk->handling = VCL_RET_FAIL;
+	else
+		VCL_pipe_method(req->vcl, wrk, req, bo, NULL);
 
 	switch (wrk->handling) {
 	case VCL_RET_SYNTH:

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -717,6 +717,7 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	THR_SetBusyobj(bo);
 	bo->sp = req->sp;
 	SES_Ref(bo->sp);
+	VCL_TaskEnter(bo->privs);
 
 	HTTP_Setup(bo->bereq, bo->ws, bo->vsl, SLT_BereqMethod);
 	http_FilterReq(bo->bereq, req->http, 0);	// XXX: 0 ?
@@ -760,6 +761,7 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	}
 	http_Teardown(bo->bereq);
 	SES_Rel(bo->sp);
+	VCL_TaskLeave(bo->privs);
 	VBO_ReleaseBusyObj(wrk, &bo);
 	THR_SetBusyobj(NULL);
 	return (nxt);

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -220,12 +220,11 @@ VCL_TaskLeave(struct vrt_privs *privs)
 {
 	struct vrt_priv *vp, *vp1;
 
-	/*
-	 * NB: We don't bother removing entries as we finish them because it's
-	 * a costly operation. Instead we safely walk the whole tree and clear
-	 * the head at the very end.
-	 */
-	VRBT_FOREACH_SAFE(vp, vrt_privs, privs, vp1)
+	VRBT_FOREACH_SAFE(vp, vrt_privs, privs, vp1) {
+		CHECK_OBJ_NOTNULL(vp, VRT_PRIV_MAGIC);
+		VRBT_REMOVE(vrt_privs, privs, vp);
 		VRT_priv_fini(vp->priv);
+		ZERO_OBJ(vp, sizeof *vp);
+	}
 	ZERO_OBJ(privs, sizeof *privs);
 }

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -435,11 +435,13 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 		VCL_Req2Ctx(&ctx, req);
 	}
 	if (bo != NULL) {
-		if (req)
-			assert(method == VCL_MET_PIPE);
 		CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 		CHECK_OBJ_NOTNULL(bo->vcl, VCL_MAGIC);
 		VCL_Bo2Ctx(&ctx, bo);
+		if (req) {
+			assert(method == VCL_MET_PIPE);
+			ctx.ws = req->ws;
+		}
 	}
 	assert(ctx.now != 0);
 	ctx.specific = specific;

--- a/bin/varnishtest/tests/r03329.vtc
+++ b/bin/varnishtest/tests/r03329.vtc
@@ -1,0 +1,18 @@
+varnishtest "Lost reason from pipe to synth"
+
+server s1 {} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pipe);
+	}
+	sub vcl_pipe {
+		return (synth(505, req.http.foo + "/bar"));
+	}
+} -start
+
+client c1 {
+	txreq -hdr "foo: foo"
+	rxresp
+	expect resp.reason == "foo/bar"
+} -run

--- a/bin/varnishtest/tests/r03329.vtc
+++ b/bin/varnishtest/tests/r03329.vtc
@@ -3,11 +3,20 @@ varnishtest "Lost reason from pipe to synth"
 server s1 {} -start
 
 varnish v1 -vcl+backend {
+	import vtc;
 	sub vcl_recv {
+		if (req.http.workspace) {
+			vtc.workspace_alloc(client, -10);
+		}
 		return (pipe);
 	}
 	sub vcl_pipe {
-		return (synth(505, req.http.foo + "/bar"));
+		if (req.http.foo) {
+			return (synth(505, req.http.foo + "/bar"));
+		} else {
+			set bereq.http.baz = "baz";
+			return (synth(505, bereq.http.baz));
+		}
 	}
 } -start
 
@@ -15,4 +24,12 @@ client c1 {
 	txreq -hdr "foo: foo"
 	rxresp
 	expect resp.reason == "foo/bar"
+
+	txreq
+	rxresp
+	expect resp.reason == "baz"
+
+	txreq -hdr "workspace: true"
+	rxresp
+	expect resp.status == 503
 } -run

--- a/bin/varnishtest/tests/r03385.vtc
+++ b/bin/varnishtest/tests/r03385.vtc
@@ -1,0 +1,23 @@
+varnishtest "Use a priv in vcl_pipe"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import debug;
+
+	sub vcl_recv {
+		return (pipe);
+	}
+
+	sub vcl_pipe {
+		debug.test_priv_task();
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run


### PR DESCRIPTION
This fixes a handful of workspace and safety issues around `vcl_pipe` and privs. I will basically describe each commit and what it addresses:

fd0b113 - Task privs were never properly setup or free'ed in `vcl_pipe`. This leads to silently leaking privs. The setup just nulls a pointer, which was the case without this call.
ea511b0 - `vcl_pipe` has a special director resolve function which mixes `req` and `bo` workspaces.
4caad2c1858afb399f75230916183d31f57fc908 - Since `struct vrt_priv` is never magic checked, zero'ed, or removed, we can either double free or leak. This covered up a lot of unsafeness floating around. When I did a single step of zero'ing out the magic, I started getting a lot of VTC failures, so I went with full safety here. Given we are dealing with user memory, I think we need to be opting for safety over performance.
d239163 - Use `req->ws` as the `ctx` workspace. This is the safe choice since the req workspace outlives everything and we can jump back into client states.

Fixes #3329
Fixes #3385