### PR TITLE
vsb: Harden destroy and fini operations

### DIFF
--- a/lib/libvarnish/vsb.c
+++ b/lib/libvarnish/vsb.c
@@ -529,6 +529,7 @@ VSB_fini(struct vsb *s)
 
 	assert_VSB_integrity(s);
 	assert(!VSB_ISDYNAMIC(s));
+	assert(!VSB_ISDYNSTRUCT(s));
 	memset(s, 0, sizeof(*s));
 }
 
@@ -539,6 +540,7 @@ VSB_destroy(struct vsb **s)
 	AN(s);
 	assert_VSB_integrity(*s);
 	assert(VSB_ISDYNAMIC(*s));
+	assert(VSB_ISDYNSTRUCT(*s));
 	SBFREE((*s)->s_buf);
 	memset(*s, 0, sizeof(**s));
 	SBFREE(*s);


### PR DESCRIPTION
They either take both a dynamic struct and buffer, or both are static.

We can also use macros from miniobj to tidy the functions and try to
ensure that memset() is not optimized away.

---

I'm wondering whether it makes sense to keep some of the macros
from sbuf and not go straight for miniobj, vas and stdlib facilities. We
already diverged a lot with sbuf, both in terms of downstream changes
and lagging behind upstream.