### PR TITLE
client.ip equals remote.ip, not local.ip

### DIFF
--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -110,7 +110,7 @@ client.ip
 	Readable from: client, backend
 
 
-	The client's IP address, either the same as ``local.ip``
+	The client's IP address, either the same as ``remote.ip``
 	or what the PROXY protocol told us.
 
 client.identity


### PR DESCRIPTION
If *PROXY protocol* is not used, the value of `client.ip` will be the same as `remote.ip`, not `local.ip` as mentioned in the docs.