### PR TITLE
Strip Keep-Alive header from any backend response when the client is …

### DIFF
--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -109,6 +109,12 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+    # Some misbehaving backends force Keep-Alive header which breaks
+    # clients like Safari and Curl.
+    if (req.proto ~ "HTTP/1") {
+        unset resp.http.keep-alive;
+    }
+
     return (deliver);
 }
 


### PR DESCRIPTION
…using HTTP/2.0