### PR TITLE
Release Varnish Cache 6.5.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.59)
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
 Copyright (c) 2006-2020 Varnish Software])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [6.5.0], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [6.5.1], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -27,6 +27,14 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
+Varnish Cache 6.5.1 (2020-09-25)
+================================
+
+* Bump the VRT_MAJOR_VERSION from 11 to 12, to reflect the API changes
+  that went into the 6.5.0 release. This step was forgotten for that
+  release.
+
+================================
 Varnish Cache 6.5.0 (2020-09-15)
 ================================
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -26,9 +26,9 @@ http://varnish-cache.org/docs/trunk/whats-new/index.html and via
 individual releases. These documents are updated as part of the
 release process.
 
-===========================
-NEXT (scheduled 2020-09-15)
-===========================
+================================
+Varnish Cache 6.5.0 (2020-09-15)
+================================
 
 [ABI] marks potentially breaking changes to binary compatibility.
 

--- a/doc/sphinx/whats-new/upgrading-6.5.rst
+++ b/doc/sphinx/whats-new/upgrading-6.5.rst
@@ -92,4 +92,18 @@ needs some counters to be present the ``'R'`` argument takes a glob of
 required fields. Such counters are not affected by filtering from other
 ``VSC_Arg()`` arguments.
 
+Official Packages related changes
+=================================
+
+* The default systemd `varnish.service` unit file now sets `varnishd` to
+  listen for PROXY protocol connections on port 8443. This corresponds
+  with the Hitch default configuration, making it easier to set up Varnish
+  using TLS.
+
+* The default systemd `varnish.service` unit file now enables the HTTP/2
+  feature of `varnishd`. This corresponds with the default ALPN token
+  advertisement in the Hitch default configuration, making it easier to
+  enable HTTP/2 in Varnish setups.
+
+
 *eof*

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -166,7 +166,7 @@
  *	vrt_acl type added
  */
 
-#define VRT_MAJOR_VERSION	11U
+#define VRT_MAJOR_VERSION	12U
 
 #define VRT_MINOR_VERSION	0U
 


### PR DESCRIPTION
We need a new release in order to fix up the lack of bumping of VRT_MAJOR_VERSION in 6.5.0.