### PR TITLE
Change CCI behaviour for the release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
     default: "HEAD"
   pkg-commit:
     type: string
-    default: "master"
+    default: "6.5"
 jobs:
   dist:
     description: Builds varnish-x.y.z.tar.gz that is used later for the packaging jobs
@@ -252,43 +252,7 @@ jobs:
 
 workflows:
   version: 2
-  commit:
-    jobs:
-      - dist
-      - distcheck:
-          name: distcheck_centos_7
-          dist: centos
-          release: "7"
-          requires:
-            - dist
-      - distcheck:
-          name: distcheck_centos_8
-          dist: centos
-          release: "8"
-          requires:
-            - dist
-      - distcheck:
-          name: distcheck_debian_buster
-          dist: debian
-          release: buster
-          extra_conf: --enable-asan --enable-ubsan
-          requires:
-            - dist
-      - distcheck:
-          name: distcheck_alpine
-          dist: alpine
-          release: "latest"
-          #extra_conf: --without-jemalloc
-          requires:
-            - dist
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 4 * * *"
-          filters:
-            branches:
-              only:
-                - master
+  release:
     jobs:
       - dist
       - tar_pkg_tools


### PR DESCRIPTION
This changes the .circleci/config.yaml for the release branch. This accomplishes two things:

The nightly "build packages" behaviour is now for all commits to the release branch, so no need to wait for the nightly cron trigger to get a package building type of build initiated by circleci.

It uses the 6.5 branch of pkg-varnish-cache, which was forked off of the master pkg-varnish-cache for this release. This makes it so that any future changes to pkg-varnish-cache won't influence the building of the release branch. This will be very useful if there ever is a need to make another point release on the release branch.