### PR TITLE
vbf: Prevent pooling of a Connection:close bereq

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -451,6 +451,10 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 	if (http_IsStatus(bo->beresp, 304) && vbf_304_logic(bo) < 0)
 		return (F_STP_ERROR);
 
+	if (bo->htc->doclose == SC_NULL &&
+	    http_GetHdrField(bo->bereq, H_Connection, "close", NULL))
+		bo->htc->doclose = SC_REQ_CLOSE;
+
 	VCL_backend_response_method(bo->vcl, wrk, NULL, bo, NULL);
 
 	if (bo->htc != NULL && bo->htc->doclose == SC_NULL &&

--- a/bin/varnishtest/tests/b00073.vtc
+++ b/bin/varnishtest/tests/b00073.vtc
@@ -2,14 +2,30 @@ varnishtest "backend connection close"
 
 server s1 {
 	rxreq
+	expect req.http.connection ~ close
+	expect req.http.beresp-connection !~ close
+	txresp
+	expect_close
+
+	accept
+	rxreq
+	expect req.http.connection !~ close
 	expect req.http.beresp-connection ~ close
 	txresp
 	expect_close
 
 	accept
 	rxreq
+	expect req.http.connection !~ close
 	expect req.http.beresp-connection !~ close
 	txresp -hdr "connection: close"
+	expect_close
+
+	accept
+	rxreq
+	expect req.http.connection ~ close
+	expect req.http.unset-connection == true
+	txresp
 	expect_close
 } -start
 
@@ -17,18 +33,32 @@ varnish v1 -vcl+backend {
 	sub vcl_recv {
 		return (pass);
 	}
+	sub vcl_backend_fetch {
+		set bereq.http.connection = bereq.http.bereq-connection;
+	}
 	sub vcl_backend_response {
+		if (bereq.http.unset-connection) {
+			unset bereq.http.connection;
+		}
 		# NB: this overrides unconditionally on purpose
 		set beresp.http.connection = bereq.http.beresp-connection;
 	}
 } -start
 
 client c1 {
+	txreq -hdr "bereq-connection: close, x-varnish"
+	rxresp
+	expect resp.status == 200
+
 	txreq -hdr "beresp-connection: close, x-varnish"
 	rxresp
 	expect resp.status == 200
 
 	txreq
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "bereq-connection: close" -hdr "unset-connection: true"
 	rxresp
 	expect resp.status == 200
 } -run


### PR DESCRIPTION
Once we ask the backend to close the connection after a given request
there is no benefit from putting the backend connection back in the
pool. It's actually a surefire way to force a subsequent backend fetch
to fail its first attempt and go straight to its extra chance.

Since we try to maximize connection reuse this would have to come from
VCL and a user asking for the backend to close the connection should
have a good reason to do so, for example when the backend is known to
misbehave under certain circumstances.

Closes #3400
Refs #3405