### PR TITLE
vmod: Objects can have methods named like constructors

### DIFF
--- a/bin/varnishtest/tests/m00000.vtc
+++ b/bin/varnishtest/tests/m00000.vtc
@@ -36,6 +36,7 @@ varnish v1 -vcl+backend {
 
 	sub vcl_init {
 		new objx = dbg.obj();
+		objx.obj();
 		dbg.vsc_new();
 		call log;
 	}

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -211,6 +211,13 @@ after the instantiation)::
 		foo.method(...);
 	}
 
+Nothing prevents a method to be named like the constructor and the
+meaning of such a method is up to the vmod author::
+
+	$Object foo(...)
+	$Method .bar(...)
+	$Method .foo(...)
+
 Object instances are represented as pointers to vmod-implemented C
 structs. Varnish only provides space to store the address of object
 instances and ensures that the right object address gets passed to C

--- a/lib/libvmod_debug/vmod_debug.vcc
+++ b/lib/libvmod_debug/vmod_debug.vcc
@@ -74,6 +74,10 @@ $Method VOID .enum(ENUM { phk, des, kristian, mithrandir, martin })
 Testing that enums work as part of object and that the parser isn't
 (too) buggy.
 
+$Method VOID .obj()
+
+Covering the fact that a method can be named like the constructor.
+
 $Method STRING .string()
 
 getter for string

--- a/lib/libvmod_debug/vmod_debug_obj.c
+++ b/lib/libvmod_debug/vmod_debug_obj.c
@@ -82,6 +82,14 @@ xyzzy_obj_enum(VRT_CTX, struct xyzzy_debug_obj *o, VCL_ENUM e)
 	assert(!strcmp(e, "martin"));
 }
 
+VCL_VOID v_matchproto_(td_xyzzy_obj_enum)
+xyzzy_obj_obj(VRT_CTX, struct xyzzy_debug_obj *o)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(o, VMOD_DEBUG_OBJ_MAGIC);
+}
+
 VCL_STRING v_matchproto_()
 xyzzy_obj_foo(VRT_CTX, struct xyzzy_debug_obj *o, VCL_STRING s)
 {


### PR DESCRIPTION
I came across a VMOD that has a method named like the constructor to
conceptually reinitialize the object's state. That's an implementation
detail of the VMOD in question and arguably undefined behavior in
Varnish.

In order to not accidentally break this assumption, add some test
coverage and document this possibility.