### PR TITLE
vslc: New mmap cursor type for regular files

### DIFF
--- a/lib/libvarnishapi/vsl_cursor.c
+++ b/lib/libvarnishapi/vsl_cursor.c
@@ -456,10 +456,14 @@ static enum vsl_check v_matchproto_(vslc_check_f)
 vslc_mmap_check(const struct VSL_cursor *cursor, const struct VSLC_ptr *ptr)
 {
 	struct vslc_mmap *c;
+	const char *t;
 
 	CAST_OBJ_NOTNULL(c, cursor->priv_data, VSLC_MMAP_MAGIC);
 	assert(&c->cursor == cursor);
 	AN(ptr->ptr);
+	t = TRUST_ME(ptr->ptr);
+	assert(t > c->b);
+	assert(t <= c->e);
 	return (vsl_check_valid);
 }
 


### PR DESCRIPTION
This cursor is the simplest of all as of now, and also the fastest way
to skim through a -r input when it's a regular file. This is essentially
a file cursor with much less memory churn.

On a 13GB log dump captured during a performance benchmark varnishlog
takes around 6m15s to print all the transactions to /dev/null but the
mmap cursor consistently reduces this time to around 1m01s.

This is particularly useful to audit logs at rest, be it error logs
after an incident or transactions captured during a benchmark-type
scenario.