### PR TITLE
Consistent use of VTCP_Assert

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -229,6 +229,7 @@ vbp_write(struct vbp_target *vt, int *sock, const void *buf, size_t len)
 	int i;
 
 	i = write(*sock, buf, len);
+	VTCP_Assert(i);
 	if (i != len) {
 		if (i < 0) {
 			vt->err_xmit |= 1;
@@ -371,6 +372,7 @@ vbp_poke(struct vbp_target *vt)
 			    sizeof vt->resp_buf - rlen);
 		else
 			i = read(s, buf, sizeof buf);
+		VTCP_Assert(i);
 		if (i <= 0) {
 			if (i < 0)
 				bprintf(vt->resp_buf, "Read error %d (%s)",

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -35,6 +35,8 @@
 #include "cache/cache_filter.h"
 #include "cache_http1.h"
 
+#include "vtcp.h"
+
 /*--------------------------------------------------------------------*/
 
 static int v_matchproto_(vdp_bytes_f)
@@ -76,7 +78,7 @@ v1d_error(struct req *req, const char *msg)
 	VSLb(req->vsl, SLT_RespReason, "Internal Server Error");
 
 	req->wrk->stats->client_resp_500++;
-	(void)write(req->sp->fd, r_500, sizeof r_500 - 1);
+	VTCP_Assert(write(req->sp->fd, r_500, sizeof r_500 - 1));
 	req->doclose = SC_TX_EOF;
 }
 

--- a/bin/varnishd/http1/cache_http1_pipe.c
+++ b/bin/varnishd/http1/cache_http1_pipe.c
@@ -39,6 +39,7 @@
 #include <stdio.h>
 
 #include "cache_http1.h"
+#include "vtcp.h"
 
 #include "VSC_vbe.h"
 
@@ -51,10 +52,12 @@ rdf(int fd0, int fd1, uint64_t *pcnt)
 	char buf[BUFSIZ], *p;
 
 	i = read(fd0, buf, sizeof buf);
+	VTCP_Assert(i);
 	if (i <= 0)
 		return (1);
 	for (p = buf; i > 0; i -= j, p += j) {
 		j = write(fd1, p, i);
+		VTCP_Assert(j);
 		if (j <= 0)
 			return (1);
 		*pcnt += j;
@@ -123,6 +126,7 @@ V1P_Process(const struct req *req, int fd, struct v1p_acct *v1a)
 	if (req->htc->pipeline_b != NULL) {
 		j = write(fd,  req->htc->pipeline_b,
 		    req->htc->pipeline_e - req->htc->pipeline_b);
+		VTCP_Assert(j);
 		if (j < 0)
 			return;
 		req->htc->pipeline_b = NULL;

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -44,6 +44,7 @@
 #include "cache_http1.h"
 
 #include "vct.h"
+#include "vtcp.h"
 
 /*--------------------------------------------------------------------
  * Read up to len bytes, returning pipelined data first.
@@ -76,7 +77,7 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 	if (len > 0) {
 		i = read(*htc->rfd, p, len);
 		if (i < 0) {
-			// XXX: VTCP_Assert(i); // but also: EAGAIN
+			VTCP_Assert(i);
 			VSLb(vc->wrk->vsl, SLT_FetchError,
 			    "%s", vstrerror(errno));
 			return (i);

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -40,6 +40,7 @@
 
 #include "vend.h"
 #include "vtim.h"
+#include "vtcp.h"
 
 static const char h2_resp_101[] =
 	"HTTP/1.1 101 Switching Protocols\r\n"
@@ -255,6 +256,7 @@ h2_ou_session(struct worker *wrk, struct h2_sess *h2,
 	}
 
 	sz = write(h2->sess->fd, h2_resp_101, strlen(h2_resp_101));
+	VTCP_Assert(sz);
 	if (sz != strlen(h2_resp_101)) {
 		VSLb(h2->vsl, SLT_Debug, "H2: Upgrade: Error writing 101"
 		    " response: %s\n", vstrerror(errno));

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -744,6 +744,7 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 		WRONG("Wrong proxy version");
 
 	r = write(fd, VSB_data(vsb), VSB_len(vsb));
+	VTCP_Assert(r);
 
 	if (!DO_DEBUG(DBG_PROTOCOL))
 		return (r);

--- a/include/vtcp.h
+++ b/include/vtcp.h
@@ -37,7 +37,7 @@ struct suckaddr;
 #define VTCP_ADDRBUFSIZE		64
 #define VTCP_PORTBUFSIZE		16
 
-int VTCP_Check(int a);
+int VTCP_Check(ssize_t a);
 #define VTCP_Assert(a) assert(VTCP_Check(a))
 
 struct suckaddr *VTCP_my_suckaddr(int sock);

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -562,6 +562,8 @@ VTCP_Check(ssize_t a)
 {
 	if (a == 0)
 		return (1);
+	if (a > 0)
+		return (1);
 	if (errno == ECONNRESET || errno == ENOTCONN || errno == EPIPE)
 		return (1);
 	/* Accept EAGAIN (and EWOULDBLOCK in case they are not the same)

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -558,7 +558,7 @@ VTCP_check_hup(int sock)
  */
 
 int
-VTCP_Check(int a)
+VTCP_Check(ssize_t a)
 {
 	if (a == 0)
 		return (1);

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -344,7 +344,7 @@ VTCP_close(int *s)
 
 	i = close(*s);
 
-	assert(VTCP_Check(i));
+	VTCP_Assert(i);
 	*s = -1;
 }
 

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -564,6 +564,14 @@ VTCP_Check(int a)
 		return (1);
 	if (errno == ECONNRESET || errno == ENOTCONN || errno == EPIPE)
 		return (1);
+	/* Accept EAGAIN (and EWOULDBLOCK in case they are not the same)
+	 * as errno values. Even though our sockets are all non-blocking,
+	 * when a SO_{SND|RCV}TIMEO expires, read() or write() on the
+	 * socket will return (-1) and errno set to EAGAIN. (This is not
+	 * documented in the read(2) and write(2) manpages, but is
+	 * described in the socket(7) manpage.) */
+	if (errno == EAGAIN || errno == EWOULDBLOCK)
+		return (1);
 #if (defined (__SVR4) && defined (__sun))
 	if (errno == EPROTO)
 		return (1);

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -619,5 +619,6 @@ VTCP_read(int fd, void *ptr, size_t len, vtim_dur tmo)
 			return (-2);
 	}
 	i = read(fd, ptr, len);
+	VTCP_Assert(i);
 	return (i < 0 ? -1 : i);
 }


### PR DESCRIPTION
This PR adds EAGAIN/EWOULDBLOCK as an accepted errno for operations on sockets. This fixes #3415.

It also adds VTCP_Assert around other operations on sockets throughout the code. This is for consistency.
