### PR TITLE
directors: Optional weight in hash::add_backend()

### DIFF
--- a/bin/varnishtest/tests/d00003.vtc
+++ b/bin/varnishtest/tests/d00003.vtc
@@ -26,7 +26,7 @@ varnish v1 -vcl+backend {
 
 	sub vcl_init {
 		new h1 = directors.hash();
-		h1.add_backend(s1, 1);
+		h1.add_backend(s1);
 		h1.add_backend(s2, 1);
 	}
 

--- a/lib/libvmod_directors/vmod_directors.vcc
+++ b/lib/libvmod_directors/vmod_directors.vcc
@@ -201,23 +201,24 @@ Example::
 
 	new vdir = directors.hash();
 
-$Method VOID .add_backend(BACKEND, REAL)
+$Method VOID .add_backend(BACKEND, REAL weight = 1.0)
 
 Add a backend to the director with a certain weight.
 
-Weight is used as in the random director. Recommended value is 1.0
-unless you have special needs.
+Weight is used as in the random director. Recommended and default value
+is 1.0 unless you have special needs.
 
 Example::
 
-	vdir.add_backend(backend1, 1.0);
+	vdir.add_backend(normal_backend);
+	vdir.add_backend(larger_backend, 1.5);
 
 $Method VOID .remove_backend(BACKEND)
 
 Remove a backend from the director.
 
 Example::
-	vdir.remove_backend(backend1);
+	vdir.remove_backend(larger_backend);
 
 $Method BACKEND .backend(STRANDS)
 


### PR DESCRIPTION
It makes it easier to substitute the hash director with say, the round robin director, when weight is not a concern.

---

Why not use the shard director you ask? Because in some cases the hash director fits better, mainly for its simplicity.