### PR TITLE
VRB_Free() refcount checking

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -1028,9 +1028,6 @@ vbf_fetch_thread(struct worker *wrk, void *priv)
 	VCL_TaskLeave(bo->privs);
 	http_Teardown(bo->bereq);
 	http_Teardown(bo->beresp);
-	// XXX after 6.4 release:
-	// bereq_body should have 0 or 1 references remaining,
-	// see VRB_Free() for the other end
 	if (bo->bereq_body != NULL)
 		(void) HSH_DerefObjCore(bo->wrk, &bo->bereq_body, 0);
 

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -259,17 +259,12 @@ VRB_Ignore(struct req *req)
 void
 VRB_Free(struct req *req)
 {
-	int r;
-
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 
 	if (req->body_oc == NULL)
 		return;
 
-	r = HSH_DerefObjCore(req->wrk, &req->body_oc, 0);
-
-	// a busyobj may have gained a reference
-	assert (r == 0 || r == 1);
+	(void) HSH_DerefObjCore(req->wrk, &req->body_oc, 0);
 }
 
 /*----------------------------------------------------------------------

--- a/bin/varnishtest/tests/r03433.vtc
+++ b/bin/varnishtest/tests/r03433.vtc
@@ -1,0 +1,41 @@
+varnishtest "req.body and restarts"
+
+server s1 -repeat 4 {
+	rxreq
+	txresp -bodylen 1000
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+	import vtc;
+
+	sub vcl_recv {
+		std.cache_req_body(1MB);
+		return (hash);
+	}
+
+	sub vcl_backend_response {
+		set beresp.ttl = 0.1s;
+	}
+
+	sub vcl_deliver {
+		if (!req.restarts) {
+			set req.url = "/2";
+			return (restart);
+		}
+	}
+} -start
+
+client c1 {
+	txreq -req PUT -url /1 -bodylen 250000
+	rxresp
+	expect resp.status == 200
+
+	delay 0.2
+
+	txreq -req PUT -url /1 -bodylen 250000
+	rxresp
+	expect resp.status == 200
+} -run
+
+delay 0.2


### PR DESCRIPTION
We can't really assume any refcount value in VRB_Free(). In theory, it can be any number from 0 to 1 + number of restarts.

Fixes #3433