### PR TITLE
directors: Bring the client director back to life

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -441,6 +441,8 @@ struct busyobj {
 
 	uint16_t		err_code;
 	const char		*err_reason;
+
+	const char		*client_identity;
 };
 
 

--- a/bin/varnishd/cache/cache_busyobj.c
+++ b/bin/varnishd/cache/cache_busyobj.c
@@ -132,6 +132,11 @@ VBO_GetBusyObj(struct worker *wrk, const struct req *req)
 
 	bo->do_stream = 1;
 
+	if (req->client_identity != NULL) {
+		bo->client_identity = WS_Copy(bo->ws, req->client_identity, -1);
+		XXXAN(bo->client_identity);
+	}
+
 	bo->director_req = req->director_hint;
 	bo->vcl = req->vcl;
 	VCL_Ref(bo->vcl);

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -296,11 +296,19 @@ VRT_r_beresp_uncacheable(VRT_CTX)
 VCL_STRING
 VRT_r_client_identity(VRT_CTX)
 {
+	const char *id;
+
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
-	if (ctx->req->client_identity != NULL)
-		return (ctx->req->client_identity);
-	return (SES_Get_String_Attr(ctx->req->sp, SA_CLIENT_IP));
+	if (ctx->req != NULL) {
+		CHECK_OBJ(ctx->req, REQ_MAGIC);
+		id = ctx->req->client_identity;
+	} else {
+		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+		id = ctx->bo->client_identity;
+	}
+	if (id != NULL)
+		return (id);
+	return (SES_Get_String_Attr(ctx->sp, SA_CLIENT_IP));
 }
 
 VCL_VOID

--- a/bin/varnishtest/tests/v00025.vtc
+++ b/bin/varnishtest/tests/v00025.vtc
@@ -2,8 +2,10 @@ varnishtest "More VCL coverage"
 
 server s1 {
 	rxreq
+	expect req.http.c_id == "Samuel B. Nobody"
 	txresp
 	rxreq
+	expect req.http.c_id == ${localhost}
 	txresp
 } -start
 
@@ -85,6 +87,7 @@ varnish v1 -syntax 4.0 -vcl+backend {
 	}
 
 	sub vcl_backend_fetch {
+		set bereq.http.c_id = client.identity;
 		if (bereq.between_bytes_timeout < 10s) {
 			set bereq.http.quick = "please";
 		}
@@ -147,6 +150,10 @@ varnish v1 -syntax 4.0 -errvcl {Symbol not found: 'local.socket' (Only available
 }
 
 varnish v1 -syntax 4.1 -vcl+backend {
+	sub vcl_backend_fetch {
+		set bereq.http.c_id = client.identity;
+	}
+
 	sub vcl_backend_response {
 		set beresp.http.B-Sess-XID = sess.xid;
 		set beresp.http.B-Endpoint = local.endpoint;

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -117,7 +117,7 @@ client.identity
 
 	Type: STRING
 
-	Readable from: client
+	Readable from: client, backend
 
 	Writable from: client
 

--- a/lib/libvmod_directors/hash.c
+++ b/lib/libvmod_directors/hash.c
@@ -35,6 +35,7 @@
 
 #include "cache/cache.h"
 
+#include "vrt_obj.h"
 #include "vdir.h"
 
 #include "vcc_directors_if.h"
@@ -107,14 +108,28 @@ vmod_hash_remove_backend(VRT_CTX,
 }
 
 VCL_BACKEND v_matchproto_()
-vmod_hash_backend(VRT_CTX, struct vmod_directors_hash *rr, VCL_STRANDS s)
+vmod_hash_backend(VRT_CTX, struct vmod_directors_hash *rr,
+    struct VARGS(hash_backend) *args)
 {
 	VCL_BACKEND be;
+	VCL_STRANDS s;
+	struct strands t;
+	const char *p;
 	double r;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_ORNULL(ctx->bo, BUSYOBJ_MAGIC);
 	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_HASH_MAGIC);
+
+
+	if (args->valid_key) {
+		s = args->key;
+	} else {
+		p = VRT_r_client_identity(ctx);
+		t.n = 1;
+		t.p = &p;
+		s = &t;
+	}
 	AN(s);
 
 	r = VRT_HashStrands32(s);

--- a/lib/libvmod_directors/vmod_directors.vcc
+++ b/lib/libvmod_directors/vmod_directors.vcc
@@ -220,15 +220,19 @@ Remove a backend from the director.
 Example::
 	vdir.remove_backend(larger_backend);
 
-$Method BACKEND .backend(STRANDS)
+$Method BACKEND .backend([STRANDS key])
 
-Pick a backend from the backend director.
-
-Use the string or list of strings provided to pick the backend.
+Pick a backend from the hash director using the ``key`` string. When
+``key`` is omitted the ``client.identity`` variable is used instead,
+turning a hash director into a simple client director.
 
 Example::
 	# pick a backend based on the cookie header from the client
 	set req.backend_hint = vdir.backend(req.http.cookie);
+
+	# the same as above, but indirectly
+	set client.identity = req.http.cookie;
+	set req.backend_hint = vdir.backend();
 
 $Object shard()
 


### PR DESCRIPTION
Or almost: allow the hash director to not take a key and fall back to client.identity instead.

Refs #3276

---

If there's one thing I miss about the Varnish 3 days, it's the client director. It had an abstract ``client.identity`` placeholder with a sensible default value.