### PR TITLE
Clear vut->sighup even if sighup_f is not defined

### DIFF
--- a/lib/libvarnishapi/vut.c
+++ b/lib/libvarnishapi/vut.c
@@ -364,12 +364,15 @@ VUT_Main(struct VUT *vut)
 	AN(vut->vslq);
 
 	while (!vut->sigint) {
-		if (vut->sighup && vut->sighup_f) {
-			/* sighup callback */
+		if (vut->sighup) {
 			vut->sighup = 0;
-			i = vut->sighup_f(vut);
-			if (i)
-				break;
+
+			if (vut->sighup_f) {
+				/* sighup callback */
+				i = vut->sighup_f(vut);
+				if (i)
+					break;
+			}
 		}
 
 		if (vut->sigusr1) {


### PR DESCRIPTION
Fixes #3437