### PR TITLE
fix signal handling in VUT

### DIFF
--- a/lib/libvarnishapi/vut.c
+++ b/lib/libvarnishapi/vut.c
@@ -454,7 +454,9 @@ VUT_Main(struct VUT *vut)
 
 		do
 			i = VSLQ_Dispatch(vut->vslq, vut_dispatch, vut);
-		while (i == vsl_more && !VSIG_hup && !VSIG_usr1);
+		while (i == vsl_more &&
+		       VSIG_usr1 == vut->last_sigusr1 &&
+		       VSIG_hup == vut->last_sighup);
 
 		if (i == vsl_more)
 			continue;


### PR DESCRIPTION
55995ab0f96c458b1b585afe49c3af737e363205 turned the `VSIG_*` flags into counters, and changed the top of the `VUT_Main()` accordingly.

We need to reflect the change also further down in the tight loop calling `VSLQ_Dispatch()`.

Fixes #3436

system call count for the test case from the issue with this patch applied:
```
$ ab -kn 100000 http://localhost:8888/ & timeout 10 strace -c /tmp/bin/varnishncsa >/dev/null & sleep 1 ; pkill -USR1 varnishncsa
...
Completed 60000 requests
Completed 70000 requests
strace: Process 20860 detached
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    0.000007           0      3304           newfstatat
  0.00    0.000000           0      1665           read
  0.00    0.000000           0      2412           write
  0.00    0.000000           0        18         7 open
  0.00    0.000000           0        10           close
  0.00    0.000000           0         3         3 stat
...
```