### PR TITLE
synth: Don't close the connection upon VCL failure

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -295,7 +295,9 @@ cnt_synth(struct worker *wrk, struct req *req)
 
 	if (wrk->handling == VCL_RET_FAIL) {
 		VSB_destroy(&synth_body);
-		req->doclose = SC_VCL_FAILURE;
+		(void)VRB_Ignore(req);
+		if (req->transport->minimal_response(req, 500))
+			req->doclose = SC_VCL_FAILURE;
 		VSLb_ts_req(req, "Resp", W_TIM_real(wrk));
 		http_Teardown(req->resp);
 		return (REQ_FSM_DONE);

--- a/bin/varnishtest/tests/b00074.vtc
+++ b/bin/varnishtest/tests/b00074.vtc
@@ -1,0 +1,65 @@
+varnishtest "failure in vcl_synth"
+
+barrier b1 sock 2 -cyclic
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -vcl {
+	import vtc;
+
+	backend be none;
+
+	sub vcl_recv {
+		if (req.method == "FAIL") {
+			return (synth(501));
+		}
+		return (synth(200));
+	}
+
+	sub vcl_synth {
+		if (req.method == "FAIL") {
+			vtc.barrier_sync("${b1_sock}");
+			return (fail);
+		}
+	}
+} -start
+
+client c1 {
+	txreq -method FAIL
+	barrier b1 sync
+	rxresp
+	expect resp.status == 500
+
+	txreq -method FAIL -hdr "Transfer-Encoding: chunked"
+	barrier b1 sync
+	delay 0.1
+	chunkedlen 1024
+	chunkedlen 0
+	rxresp
+	expect resp.status == 500
+
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+client c2 {
+	stream 1 {
+		txreq -method FAIL
+		barrier b1 sync
+		rxresp
+		expect resp.status == 500
+	} -run
+	stream 3 {
+		txreq -method FAIL -hdr content-length 1024 -nostrend
+		barrier b1 sync
+		delay 0.1
+		txdata -datalen 1024
+		rxresp
+		expect resp.status == 500
+	} -run
+	stream 5 {
+		txreq
+		rxresp
+		expect resp.status == 200
+	} -run
+} -run

--- a/bin/varnishtest/tests/r02339.vtc
+++ b/bin/varnishtest/tests/r02339.vtc
@@ -152,6 +152,8 @@ client c1 {
 
 client c1 {
 	txreq -url synth
+	rxresp
+	expect resp.status == 500
 	expect_close
 } -run
 

--- a/bin/varnishtest/tests/r02488.vtc
+++ b/bin/varnishtest/tests/r02488.vtc
@@ -35,7 +35,8 @@ client c1 {
 	expect resp.http.bar == "bar"
 
 	txreq -url "/empty"
-	expect_close
+	rxresp
+	expect resp.status == 500
 } -run
 
 logexpect l1 -wait

--- a/bin/varnishtest/tests/v00051.vtc
+++ b/bin/varnishtest/tests/v00051.vtc
@@ -92,11 +92,12 @@ logexpect l1 -v v1 -g raw {
 
 client c1 {
 	txreq -hdr "foo: synth"
-	expect_close
+	rxresp
+	expect resp.status == 500
 } -run
 
 varnish v1 -expect vcl_fail == 3
-varnish v1 -expect sc_vcl_failure == 3
+varnish v1 -expect sc_vcl_failure == 2
 
 logexpect l1 -wait
 
@@ -127,7 +128,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 4
-varnish v1 -expect sc_vcl_failure == 4
+varnish v1 -expect sc_vcl_failure == 3
 
 logexpect l1 -wait
 
@@ -162,7 +163,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 5
-varnish v1 -expect sc_vcl_failure == 5
+varnish v1 -expect sc_vcl_failure == 4
 
 logexpect l1 -wait
 
@@ -196,7 +197,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 6
-varnish v1 -expect sc_vcl_failure == 6
+varnish v1 -expect sc_vcl_failure == 5
 
 logexpect l1 -wait
 
@@ -230,7 +231,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 7
-varnish v1 -expect sc_vcl_failure == 7
+varnish v1 -expect sc_vcl_failure == 6
 
 logexpect l1 -wait
 
@@ -261,7 +262,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 8
-varnish v1 -expect sc_vcl_failure == 8
+varnish v1 -expect sc_vcl_failure == 7
 
 logexpect l1 -wait
 
@@ -292,7 +293,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 9
-varnish v1 -expect sc_vcl_failure == 9
+varnish v1 -expect sc_vcl_failure == 8
 
 logexpect l1 -wait
 
@@ -323,7 +324,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 10
-varnish v1 -expect sc_vcl_failure == 10
+varnish v1 -expect sc_vcl_failure == 9
 
 logexpect l1 -wait
 
@@ -352,7 +353,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 11
-varnish v1 -expect sc_vcl_failure == 10
+varnish v1 -expect sc_vcl_failure == 9
 
 logexpect l1 -wait
 
@@ -386,7 +387,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 12
-varnish v1 -expect sc_vcl_failure == 10
+varnish v1 -expect sc_vcl_failure == 9
 
 logexpect l1 -wait
 
@@ -421,7 +422,7 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 13
-varnish v1 -expect sc_vcl_failure == 10
+varnish v1 -expect sc_vcl_failure == 9
 
 logexpect l1 -wait
 
@@ -451,6 +452,6 @@ client c1 {
 } -run
 
 varnish v1 -expect vcl_fail == 14
-varnish v1 -expect sc_vcl_failure == 11
+varnish v1 -expect sc_vcl_failure == 10
 
 logexpect l1 -wait


### PR DESCRIPTION
Before that, try to send a minimal 500 response and see whether we can
avoid losing the session, especially for h2 connections.