### PR TITLE
Missing newline character between the secret and the challenge

### DIFF
--- a/doc/sphinx/reference/varnish-cli.rst
+++ b/doc/sphinx/reference/varnish-cli.rst
@@ -382,10 +382,11 @@ The authenticator is calculated by applying the SHA256 function to the
 following byte sequence:
 
 * Challenge string
-* Newline (0x0a) character.
+* Newline (0x0a) character
 * Contents of the secret file
+* Newline (0x0a) character
 * Challenge string
-* Newline (0x0a) character.
+* Newline (0x0a) character
 
 and dumping the resulting digest in lower-case hex.
 


### PR DESCRIPTION
If you look at @bsdphk's example of how to compose the authentication string, you clearly see there's a newline between `foo` (the secret), and `ixslvvxrgkjptxmcgnnsdxsvdmvfympg` (the challenge):
```
   critter phk> cat > _
   ixslvvxrgkjptxmcgnnsdxsvdmvfympg
   foo
   ixslvvxrgkjptxmcgnnsdxsvdmvfympg
   ^D
   critter phk> hexdump -C _
   00000000  69 78 73 6c 76 76 78 72  67 6b 6a 70 74 78 6d 63  |ixslvvxrgkjptxmc|
   00000010  67 6e 6e 73 64 78 73 76  64 6d 76 66 79 6d 70 67  |gnnsdxsvdmvfympg|
   00000020  0a 66 6f 6f 0a 69 78 73  6c 76 76 78 72 67 6b 6a  |.foo.ixslvvxrgkj|
   00000030  70 74 78 6d 63 67 6e 6e  73 64 78 73 76 64 6d 76  |ptxmcgnnsdxsvdmv|
   00000040  66 79 6d 70 67 0a                                 |fympg.|
   00000046
   critter phk> sha256 _
   SHA256 (_) = 455ce847f0073c7ab3b1465f74507b75d3dc064c1e7de3b71e00de9092fdc89a
   critter phk> openssl dgst -sha256 < _
   455ce847f0073c7ab3b1465f74507b75d3dc064c1e7de3b71e00de9092fdc89a
```

This newline was apparently missing in the list.

I also remove the dots at the end of some of the lines.