### PR TITLE
vsl: New Timestamp records for backend tasks

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -168,6 +168,7 @@ vbe_dir_getfd(VRT_CTX, struct worker *wrk, struct backend *bp,
 		return (NULL);
 	}
 
+	VSLb_ts_busyobj(bo, "Connected", W_TIM_real(wrk));
 	fdp = PFD_Fd(pfd);
 	AN(fdp);
 	assert(*fdp >= 0);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -395,6 +395,7 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 	if (wrk->handling == VCL_RET_ERROR)
 		return (F_STP_ERROR);
 
+	VSLb_ts_busyobj(bo, "Fetch", W_TIM_real(wrk));
 	i = VDI_GetHdr(bo);
 
 	now = W_TIM_real(wrk);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -493,6 +493,7 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 		return (F_STP_ERROR);
 	}
 
+	VSLb_ts_busyobj(bo, "Process", W_TIM_real(wrk));
 	assert(oc->boc->state <= BOS_REQ_DONE);
 	if (oc->boc->state != BOS_REQ_DONE) {
 		bo->req = NULL;

--- a/bin/varnishtest/tests/c00036.vtc
+++ b/bin/varnishtest/tests/c00036.vtc
@@ -20,6 +20,7 @@ varnish v1 -vcl+backend {
 
 logexpect l1 -v v1 -q "vxid == 1004" {
 	expect * 1004 VCL_return      {^fetch}
+	expect 0 1004 Timestamp       {^Fetch:}
 	expect 0 1004 Timestamp       {^Connected:}
 	expect 0 1004 BackendOpen     {^\d+ s1}
 	expect 0 1004 Timestamp       {^Bereq:}

--- a/bin/varnishtest/tests/c00036.vtc
+++ b/bin/varnishtest/tests/c00036.vtc
@@ -20,6 +20,7 @@ varnish v1 -vcl+backend {
 
 logexpect l1 -v v1 -q "vxid == 1004" {
 	expect * 1004 VCL_return      {^fetch}
+	expect 0 1004 Timestamp       {^Connected:}
 	expect 0 1004 BackendOpen     {^\d+ s1}
 	expect 0 1004 Timestamp       {^Bereq:}
 
@@ -27,6 +28,7 @@ logexpect l1 -v v1 -q "vxid == 1004" {
 	# backend goes away on a keepalive TCP connection:
 	expect 0 1004 FetchError      {^HTC eof .-1.}
 	expect 0 1004 BackendClose    {^\d+ s1}
+	expect 0 1004 Timestamp       {^Connected:}
 	expect 0 1004 BackendOpen     {^\d+ s1}
 
 	expect 0 1004 Timestamp       {^Bereq:}

--- a/doc/sphinx/reference/vsl.rst
+++ b/doc/sphinx/reference/vsl.rst
@@ -86,6 +86,9 @@ Backend fetch timestamps
 Start
 	Start of the backend fetch processing.
 
+Fetch
+	Came off vcl_backend_fetch ready to send the backend request.
+
 Connected
 	Successfully established or reused a backend connection.
 

--- a/doc/sphinx/reference/vsl.rst
+++ b/doc/sphinx/reference/vsl.rst
@@ -98,6 +98,9 @@ Bereq
 Beresp
 	Backend response headers received.
 
+Process
+	Processing finished, ready to fetch the response body.
+
 BerespBody
 	Backend response body received.
 

--- a/doc/sphinx/reference/vsl.rst
+++ b/doc/sphinx/reference/vsl.rst
@@ -86,6 +86,9 @@ Backend fetch timestamps
 Start
 	Start of the backend fetch processing.
 
+Connected
+	Successfully established or reused a backend connection.
+
 Bereq
 	Backend request sent.
 


### PR DESCRIPTION
Unlike client transactions where it's usually easy to attribute latency, we lack some serious insights on the backend side. I had a hard time finding names and eventually gave up on the idea not to collide with client timestamps, but client and backend tasks already share Timestamp:Start so maybe it's fine to actually repurpose some?