### PR TITLE
Revert "Missing newline character between the secret and the challenge"

### DIFF
--- a/doc/sphinx/reference/varnish-cli.rst
+++ b/doc/sphinx/reference/varnish-cli.rst
@@ -382,11 +382,10 @@ The authenticator is calculated by applying the SHA256 function to the
 following byte sequence:
 
 * Challenge string
-* Newline (0x0a) character
+* Newline (0x0a) character.
 * Contents of the secret file
-* Newline (0x0a) character
 * Challenge string
-* Newline (0x0a) character
+* Newline (0x0a) character.
 
 and dumping the resulting digest in lower-case hex.
 


### PR DESCRIPTION
Reverts varnishcache/varnish-cache#3444 that was based on a shell
example that would mangle the secret file's last newline.