### PR TITLE
Add """ ... """ as a long string format in VCL

### DIFF
--- a/bin/varnishtest/tests/v00019.vtc
+++ b/bin/varnishtest/tests/v00019.vtc
@@ -18,6 +18,11 @@ varnish v1 -errvcl {Unterminated long-string, starting at} {
 	{" }
 }
 
+varnish v1 -errvcl {Unterminated long-string, starting at} {
+	backend b { .host = "127.0.0.1"; }
+	""" ""
+}
+
 varnish v1 -errvcl {Unterminated string at} {
 	backend b { .host = "127.0.0.1"; }
 	"

--- a/bin/varnishtest/tests/v00066.vtc
+++ b/bin/varnishtest/tests/v00066.vtc
@@ -1,0 +1,22 @@
+varnishtest "long string coverage"
+
+varnish v1 -vcl {
+	backend default none;
+
+	sub vcl_recv {
+		return (synth(200));
+	}
+
+	sub vcl_synth {
+                set resp.body = """{"key":"value"}""";
+                return (deliver);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+        expect resp.bodylen == 15
+	expect resp.body == {{"key":"value"}}
+} -run

--- a/doc/sphinx/reference/vcl.rst
+++ b/doc/sphinx/reference/vcl.rst
@@ -84,7 +84,7 @@ Strings
 
 Basic strings are enclosed in double quotes ``"``\ *...*\ ``"``, and
 may not contain newlines. Long strings are enclosed in
-``{"``\ *...*\ ``"}``. They may contain any character including single
+``{"``\ *...*\ ``"}`` or ``"""``\ *...*\ ``"""``. They may contain any character including single
 double quotes ``"``, newline and other control characters except for the
 *NUL* (0x00) character.
 
@@ -511,7 +511,7 @@ ban(STRING)
 
       Either a literal string or a regular expression. Note that
       *<arg>* does not use any of the string delimiters like ``"`` or
-      ``{"``\ *...*\ ``"}`` used elsewhere in varnish. To match
+      ``{"``\ *...*\ ``"}`` or ``"""``\ *...*\ ``"""`` used elsewhere in varnish. To match
       against strings containing whitespace, regular expressions
       containing ``\s`` can be used.
 

--- a/doc/sphinx/users-guide/vcl-syntax.rst
+++ b/doc/sphinx/users-guide/vcl-syntax.rst
@@ -23,7 +23,7 @@ to do the "count-the-backslashes" polka::
 
   regsub("barf", "(b)(a)(r)(f)", "\4\3\2p") -> "frap"
 
-Long strings are enclosed in {" ... "}. They may contain any character
+Long strings are enclosed in {" ... "} or """ ... """. They may contain any character
 including ", newline and other control characters except for the NUL
 (0x00) character. If you really want NUL characters in a string there
 is a VMOD that makes it possible to create such strings.


### PR DESCRIPTION
This PR adds """ ... """ as a long string format to VCL. The purpose of this is to allow JSON to be more easily written in VCL as the current string format(s) in VCL heavily conflict with JSON. While I wanted to use backticks (`) @bsdphk said we should go with triple double quotes to keep in line with borrowing things from python. 