### PR TITLE
vcc: Pass literal VCL_STRANDS arguments

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -223,27 +223,6 @@ VRT_AllocStrandsWS(struct ws *ws, int n)
 }
 
 /*--------------------------------------------------------------------
- * Build STRANDS from what is essentially a STRING_LIST
- */
-
-VCL_STRANDS
-VPI_BundleStrands(int n, struct strands *s, char const **d, const char *f, ...)
-{
-	va_list ap;
-
-	assert(n > 0);
-	s->n = n;
-	s->p = d;
-	*d++ = f;
-	va_start(ap, f);
-	while(--n)
-		*d++ = va_arg(ap, const char *);
-	assert(va_arg(ap, const char *) == vrt_magic_string_end);
-	va_end(ap);
-	return (s);
-}
-
-/*--------------------------------------------------------------------
  * Compare two STRANDS
  */
 

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -71,6 +71,3 @@ struct vpi_ii {
 	const void *			p;
 	const char * const		name;
 };
-
-VCL_STRANDS VPI_BundleStrands(int, struct strands *, char const **,
-    const char *f, ...);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -153,6 +153,8 @@ vcc_expr_edit(struct vcc *tl, vcc_type_t fmt, const char *p, struct expr *e1,
 	struct expr *e, *e3;
 	int nl = 1;
 
+	(void) tl;
+
 	AN(e1);
 	e = vcc_new_expr(fmt);
 	while (*p != '\0') {
@@ -184,16 +186,10 @@ vcc_expr_edit(struct vcc *tl, vcc_type_t fmt, const char *p, struct expr *e1,
 		case 't':
 			e3 = (*p == 'T' ? e1 : e2);
 			AN(e3);
-			VSB_printf(tl->curproc->prologue,
-			    "  struct strands strs_%u_a;\n"
-			    "  const char * strs_%u_s[%d];\n",
-			    tl->unique, tl->unique, e3->nstr);
 			VSB_printf(e->vsb,
-			    "VPI_BundleStrands(%d, &strs_%u_a, strs_%u_s,"
-			    "\v+\n%s,\nvrt_magic_string_end\v-\n)",
-			    e3->nstr, tl->unique, tl->unique,
-			VSB_data(e3->vsb));
-			tl->unique++;
+			    "&(struct strands){.n = %d, .p = "
+			    "(const char *[%d]){\n%s\n}}",
+			    e3->nstr, e3->nstr, VSB_data(e3->vsb));
 			break;
 		case '1':
 			VSB_cat(e->vsb, VSB_data(e1->vsb));


### PR DESCRIPTION
avoiding local variables and `VPI_BundleStrands()`

DRAFT, TODO: Might need polishing, check suncc, definitely needs some benchmarking.

Fixes #3392