### PR TITLE
vsl: Give up when it's too late to buffer records

### DIFF
--- a/lib/libvarnishapi/vsl_dispatch.c
+++ b/lib/libvarnishapi/vsl_dispatch.c
@@ -439,8 +439,7 @@ vtx_append(struct VSLQ *vslq, struct vtx *vtx, const struct VSLC_ptr *start,
 	enum vsl_check i;
 
 	AN(vtx);
-	if (len == 0)
-		return;
+	AN(len);
 	AN(start);
 
 	i = VSL_Check(vslq->c, start);


### PR DESCRIPTION
When a VUT is slow enough, it might very well be overrun while it is
scanning logs. For our built-in VUTs like varnishncsa or varnishlog
this can happen if writing the output can block waiting for IO ops
or when the output is piped to a slow consumer.

---

The assertion from 8a4e28f17c2ee39237a2c56fa0694f2f0b73e3f8 triggered in production.