### PR TITLE
Count ESI subrequests

### DIFF
--- a/bin/varnishd/VSC_main.vsc
+++ b/bin/varnishd/VSC_main.vsc
@@ -97,6 +97,12 @@
 
 	The count of parseable client requests seen.
 
+.. varnish_vsc:: esi_req
+	:group: wrk
+	:oneliner:	ESI subrequests
+
+	Number of ESI subrequests made.
+
 .. varnish_vsc:: cache_hit
 	:group: wrk
 	:oneliner:	Cache hits

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -139,6 +139,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 
 	VSLb_ts_req(req, "Start", W_TIM_real(wrk));
 
+	wrk->stats->esi_req++;
 	req->esi_level = preq->esi_level + 1;
 
 	memset(req->top, 0, sizeof *req->top);

--- a/bin/varnishtest/tests/e00003.vtc
+++ b/bin/varnishtest/tests/e00003.vtc
@@ -83,6 +83,7 @@ client c1 {
 }
 
 client c1 -run
+varnish v1 -expect esi_req == 2
 varnish v1 -expect esi_errors == 0
 varnish v1 -expect MAIN.s_resp_bodybytes == 150
 


### PR DESCRIPTION
This has been on my TODO for many years, finally got around to making the PR. The problem is that when you make an ESI subrequest, its not considered a `client_req`. However, it gets accounted for in all the other counters like `cache_hit`, `cache_miss`, etc. This leads to situations where you can see way more hits and misses than requests, which is confusing. Adding this counter will bring these counts back into equilibrium.