### PR TITLE
Introduce req.hash_always_pass

### DIFF
--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -246,6 +246,7 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 	req->req_body_status = NULL;
 
 	req->hash_always_miss = 0;
+	req->hash_always_pass = 0;
 	req->hash_ignore_busy = 0;
 	req->esi_level = 0;
 	req->is_hit = 0;

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -855,6 +855,7 @@ cnt_recv_prep(struct req *req, const char *ci)
 		req->d_grace = -1;
 		req->disable_esi = 0;
 		req->hash_always_miss = 0;
+		req->hash_always_pass = 0;
 		req->hash_ignore_busy = 0;
 		req->client_identity = NULL;
 		req->storage = NULL;
@@ -933,6 +934,10 @@ cnt_recv(struct worker *wrk, struct req *req)
 	if (req->req_body_status == BS_ERROR) {
 		req->doclose = SC_RX_BODY;
 		return (REQ_FSM_DONE);
+	}
+
+	if (wrk->handling == VCL_RET_HASH && req->hash_always_pass) {
+		wrk->handling = VCL_RET_PASS;
 	}
 
 	recv_handling = wrk->handling;

--- a/bin/varnishtest/tests/c00102.vtc
+++ b/bin/varnishtest/tests/c00102.vtc
@@ -1,0 +1,47 @@
+varnishtest "hash_always_pass"
+
+server s1 {
+	rxreq
+	txresp -body "1"
+
+	rxreq
+	txresp -body "2"
+
+	rxreq
+	txresp -body "3"
+} -start
+
+varnish v1 -syntax 4.0 -arg "-smysteve=malloc,1m" -vcl+backend {
+	sub vcl_recv {
+		if (req.http.hap) {
+			set req.hash_always_pass = true;
+		}
+	}
+} -start
+
+client c1 {
+	# insert object in cache
+	txreq
+	rxresp
+	expect resp.body == "1"
+
+	# hit the cached object
+	txreq
+	rxresp
+	expect resp.body == "1"
+
+	# bypass the cache
+	txreq -hdr "hap: true"
+	rxresp
+	expect resp.body == "2"
+
+	# again
+	txreq -hdr "hap: true"
+	rxresp
+	expect resp.body == "3"
+
+	# hit the cached object
+	txreq
+	rxresp
+	expect resp.body == "1"
+} -run

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -391,6 +391,22 @@ req.hash_always_miss
 	This is useful to force-update the cache without invalidating
 	existing entries in case the fetch fails.
 
+req.hash_always_pass
+
+	Type: BOOL
+
+	Readable from: client
+
+	Writable from: client
+
+	Default: ``false``.
+
+	Force a cache pass for this request, even if perfectly
+	good matching objects are in the cache.
+
+        This allows to flag a request as uncacheable in ``vcl_recv`` without
+        immediately returning from the subroutine.
+
 req.is_hitmiss
 
 	Type: BOOL

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -35,6 +35,7 @@
 REQ_FLAG(disable_esi,		0, 0, "")
 REQ_FLAG(hash_ignore_busy,	1, 1, "")
 REQ_FLAG(hash_always_miss,	1, 1, "")
+REQ_FLAG(hash_always_pass,	1, 1, "")
 REQ_FLAG(is_hit,		0, 0, "")
 REQ_FLAG(is_hitmiss,		1, 0, "")
 REQ_FLAG(is_hitpass,		1, 0, "")


### PR DESCRIPTION
The current way to bypass the cache is to either `return(pass)` in
`vcl_recv` or to trigger an HfP/HfM on the backend side.

The former forces you to interrupt the request processing, such as
header normalization, or to set a variable/header to remember your
choice so that you can return `pass` once processing is done.

The latter is nicer but has to deal with request coalescing and it
doesn't really make sense to wait that long before make this decision.

`req.hash_always_pass` mirrors `req.hash_always_miss` but really just
transforms a `return(hash)` into a `return(pass)`. This means that it
has priority over `req.hash_always_miss` but also operate slightly
earlier, at the end of vcl_recv` rather than at the end of `vcl_hash`

`req.uncacheable` might be a better fit, not sure.