### PR TITLE
Methods for vmod_priv

### DIFF
--- a/include/vrt.h
+++ b/include/vrt.h
@@ -55,6 +55,8 @@
  * 13.0 (2021-03-15)
  *	Calling convention for VDP implementation changed
  *	Added VRT_ValidHdr()
+ *	struct vmod_priv_methods added
+ *	struct vmod_priv free member replaced with methods
  * 12.0 (2020-09-15)
  *	Added VRT_DirectorResolve()
  *	Added VCL_STRING VRT_BLOB_string(VRT_CTX, VCL_BLOB)
@@ -583,11 +585,20 @@ void VRT_Format_Proxy(struct vsb *, VCL_INT, VCL_IP, VCL_IP, VCL_STRING);
 
 typedef int vmod_event_f(VRT_CTX, struct vmod_priv *, enum vcl_event_e);
 
-typedef void vmod_priv_free_f(void *);
+/* vmod_priv related */
+typedef void vmod_priv_fini_f(void *);
+
+struct vmod_priv_methods {
+	unsigned			magic;
+#define VMOD_PRIV_METHODS_MAGIC	0xcea5ff99
+	const char			*type;
+	vmod_priv_fini_f		*fini;
+};
+
 struct vmod_priv {
-	void			*priv;
-	long			len;
-	vmod_priv_free_f	*free;
+	void				*priv;
+	long				len;
+	const struct vmod_priv_methods	*methods;
 };
 
 void VRT_priv_fini(const struct vmod_priv *p);

--- a/lib/libvmod_cookie/vmod_cookie.c
+++ b/lib/libvmod_cookie/vmod_cookie.c
@@ -84,6 +84,12 @@ cobj_free(void *p)
 	FREE_OBJ(vcp);
 }
 
+static const struct vmod_priv_methods cookie_cobj_priv_methods[1] = {{
+		.magic = VMOD_PRIV_METHODS_MAGIC,
+		.type = "vmod_cookie_cobj",
+		.fini = cobj_free
+}};
+
 static struct vmod_cookie *
 cobj_get(struct vmod_priv *priv)
 {
@@ -94,7 +100,7 @@ cobj_get(struct vmod_priv *priv)
 		AN(vcp);
 		VTAILQ_INIT(&vcp->cookielist);
 		priv->priv = vcp;
-		priv->free = cobj_free;
+		priv->methods = cookie_cobj_priv_methods;
 	} else
 		CAST_OBJ_NOTNULL(vcp, priv->priv, VMOD_COOKIE_MAGIC);
 
@@ -258,6 +264,12 @@ free_re(void *priv)
 	AZ(vre);
 }
 
+static const struct vmod_priv_methods cookie_re_priv_methods[1] = {{
+		.magic = VMOD_PRIV_METHODS_MAGIC,
+		.type = "vmod_cookie_re",
+		.fini = free_re
+}};
+
 VCL_STRING
 vmod_get_re(VRT_CTX, struct vmod_priv *priv, struct vmod_priv *priv_call,
     VCL_STRING expression)
@@ -281,7 +293,7 @@ vmod_get_re(VRT_CTX, struct vmod_priv *priv, struct vmod_priv *priv_call,
 		}
 
 		priv_call->priv = vre;
-		priv_call->free = free_re;
+		priv_call->methods = cookie_re_priv_methods;
 		AZ(pthread_mutex_unlock(&mtx));
 	}
 
@@ -431,7 +443,7 @@ re_filter(VRT_CTX, struct vmod_priv *priv, struct vmod_priv *priv_call,
 		}
 
 		priv_call->priv = vre;
-		priv_call->free = free_re;
+		priv_call->methods = cookie_re_priv_methods;
 		AZ(pthread_mutex_unlock(&mtx));
 	}
 

--- a/lib/libvmod_directors/shard_cfg.c
+++ b/lib/libvmod_directors/shard_cfg.c
@@ -86,7 +86,7 @@ change_reconfigure(struct shard_change *change, VCL_INT replicas);
  * a PRIV_TASK state, which we work in reconfigure.
  */
 
-static void v_matchproto_(vmod_priv_free_f)
+static void v_matchproto_(vmod_priv_fini_f)
 shard_change_fini(void * priv)
 {
 	struct shard_change *change;
@@ -98,6 +98,12 @@ shard_change_fini(void * priv)
 
 	(void) change_reconfigure(change, 67);
 }
+
+static const struct vmod_priv_methods shard_change_priv_methods[1] = {{
+		.magic = VMOD_PRIV_METHODS_MAGIC,
+		.type = "vmod_directors_shard_cfg",
+		.fini = shard_change_fini
+}};
 
 static struct shard_change *
 shard_change_get(VRT_CTX, struct sharddir * const shardd)
@@ -132,7 +138,7 @@ shard_change_get(VRT_CTX, struct sharddir * const shardd)
 	change->shardd = shardd;
 	VSTAILQ_INIT(&change->tasks);
 	task->priv = change;
-	task->free = shard_change_fini;
+	task->methods = shard_change_priv_methods;
 
 	return (change);
 }

--- a/lib/libvmod_std/vmod_std_fileread.c
+++ b/lib/libvmod_std/vmod_std_fileread.c
@@ -83,6 +83,12 @@ free_frfile(void *ptr)
 	}
 }
 
+static const struct vmod_priv_methods frfile_methods[1] = {{
+		.magic = VMOD_PRIV_METHODS_MAGIC,
+		.type = "vmod_std_fileread",
+		.fini = free_frfile
+}};
+
 static struct frfile *
 find_frfile(struct vmod_priv *priv, VCL_STRING file_name)
 {
@@ -112,7 +118,7 @@ find_frfile(struct vmod_priv *priv, VCL_STRING file_name)
 	}
 	AZ(pthread_mutex_unlock(&frmtx));
 	if (frf != NULL) {
-		priv->free = free_frfile;
+		priv->methods = frfile_methods;
 		priv->priv = frf;
 		return (frf);
 	}
@@ -127,7 +133,7 @@ find_frfile(struct vmod_priv *priv, VCL_STRING file_name)
 		frf->contents = s;
 		frf->blob->blob = s;
 		frf->blob->len = (size_t)sz;
-		priv->free = free_frfile;
+		priv->methods = frfile_methods;
 		priv->priv = frf;
 		AZ(pthread_mutex_lock(&frmtx));
 		VTAILQ_INSERT_HEAD(&frlist, frf, list);


### PR DESCRIPTION
This is the refactoring we agreed on to enable an alternative implementation of #3454. This PR does not yet introduce the copy callback needed to add the functionality suggested in #3454.

We replace the `.free` pointer of `struct vmod_priv` with a pointer to a methods struct with callbacks. As of this commit, it only contains the former `.free` callback renamed to `.fini`. The purpose of the refactoring is to allow addition of more callbacks later.

The new `struct vmod_priv_methods` also contains a `.type` member pointing to a string to contain an arbitrary description of the type of data any priv holds which uses these methods.

Implementation:

relevant changes are in `cache_vrt_priv.c` and `vrt.h`, other changes are to the documentation and bundled vmods.

The implementation is a simple refactoring for indirection of the call to the `.fini` callback via the methods structure.