### PR TITLE
clarify first byte timeout FetchError message

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -301,7 +301,7 @@ vbe_dir_gethdrs(VRT_CTX, VCL_BACKEND d)
 			    bo->htc->first_byte_timeout) != 0) {
 				bo->htc->doclose = SC_RX_TIMEOUT;
 				VSLb(bo->vsl, SLT_FetchError,
-				     "Timed out reusing backend connection");
+				     "first byte timeout (reused connection)");
 				extrachance = 0;
 			}
 		}


### PR DESCRIPTION
For a first byte timeout on a new connection, we emit

	FetchError: first byte timeout

For a first byte timeout being reached on a recycled connection, we
should keep the error message similar.

Ref eecd409d13f145765de3aeee4984179e0ae008b5