### PR TITLE
a compromise on workspace / priv handling of vcl_pipe

### DIFF
--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -206,9 +206,8 @@ VDI_Http1Pipe(struct req *req, struct busyobj *bo)
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 	INIT_OBJ(ctx, VRT_CTX_MAGIC);
-	VCL_Req2Ctx(ctx, req);
 	VCL_Bo2Ctx(ctx, bo);
-	ctx->ws = req->ws;
+	VCL_Req2Ctx(ctx, req);
 
 	d = VDI_Resolve(ctx);
 	if (d == NULL || d->vdir->methods->http1pipe == NULL) {

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -208,6 +208,7 @@ VDI_Http1Pipe(struct req *req, struct busyobj *bo)
 	INIT_OBJ(ctx, VRT_CTX_MAGIC);
 	VCL_Req2Ctx(ctx, req);
 	VCL_Bo2Ctx(ctx, bo);
+	ctx->ws = req->ws;
 
 	d = VDI_Resolve(ctx);
 	if (d == NULL || d->vdir->methods->http1pipe == NULL) {

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -745,7 +745,7 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	bo->sp = req->sp;
 	SES_Ref(bo->sp);
 
-	HTTP_Setup(bo->bereq, bo->ws, bo->vsl, SLT_BereqMethod);
+	HTTP_Setup(bo->bereq, req->ws, bo->vsl, SLT_BereqMethod);
 	http_FilterReq(bo->bereq, req->http, 0);	// XXX: 0 ?
 	http_PrintfHeader(bo->bereq, "X-Varnish: %u", VXID(req->vsl->wid));
 	http_ForceHeader(bo->bereq, H_Connection, "close");
@@ -756,7 +756,10 @@ cnt_pipe(struct worker *wrk, struct req *req)
 	}
 
 	bo->wrk = wrk;
-	VCL_pipe_method(req->vcl, wrk, req, bo, NULL);
+	if (WS_Overflowed(req->ws))
+		wrk->handling = VCL_RET_FAIL;
+	else
+		VCL_pipe_method(req->vcl, wrk, req, bo, NULL);
 
 	switch (wrk->handling) {
 	case VCL_RET_SYNTH:

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -795,6 +795,10 @@ VRT_Rollback(VRT_CTX, VCL_HTTP hp)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
+	if (ctx->method & VCL_MET_PIPE) {
+		VRT_fail(ctx, "Cannot rollback in vcl_pipe {}");
+		return;
+	}
 	if (hp == ctx->http_req) {
 		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
 		Req_Rollback(ctx->req);

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -144,12 +144,8 @@ vrt_priv_task_context(VRT_CTX)
 {
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	/*
-	 * XXX when coming from VRT_DirectorResolve() in pipe mode
-	 * (ctx->method == 0), both req and bo are set.
-	 * see #3329 #3330: we should make up our mind where
-	 * pipe objects live
-	 */
+
+	/* In pipe mode, both req and bo are set. We use req */
 
 	assert(ctx->req == NULL || ctx->bo == NULL ||
 	    ctx->method == VCL_MET_PIPE || ctx->method == 0);

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -238,7 +238,9 @@ VCL_TaskLeave(struct vrt_privs *privs)
 	 * a costly operation. Instead we safely walk the whole tree and clear
 	 * the head at the very end.
 	 */
-	VRBT_FOREACH_SAFE(vp, vrt_privs, privs, vp1)
+	VRBT_FOREACH_SAFE(vp, vrt_privs, privs, vp1) {
+		CHECK_OBJ(vp, VRT_PRIV_MAGIC);
 		VRT_priv_fini(vp->priv);
+	}
 	ZERO_OBJ(privs, sizeof *privs);
 }

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -451,21 +451,19 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	INIT_OBJ(&ctx, VRT_CTX_MAGIC);
+	if (bo != NULL) {
+		CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
+		CHECK_OBJ_NOTNULL(bo->vcl, VCL_MAGIC);
+		VCL_Bo2Ctx(&ctx, bo);
+	}
 	if (req != NULL) {
+		if (bo != NULL)
+			assert(method == VCL_MET_PIPE);
 		CHECK_OBJ(req, REQ_MAGIC);
 		CHECK_OBJ_NOTNULL(req->sp, SESS_MAGIC);
 		CHECK_OBJ_NOTNULL(req->vcl, VCL_MAGIC);
 		CHECK_OBJ_NOTNULL(req->top, REQTOP_MAGIC);
 		VCL_Req2Ctx(&ctx, req);
-	}
-	if (bo != NULL) {
-		CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
-		CHECK_OBJ_NOTNULL(bo->vcl, VCL_MAGIC);
-		VCL_Bo2Ctx(&ctx, bo);
-		if (req) {
-			assert(method == VCL_MET_PIPE);
-			ctx.ws = req->ws;
-		}
 	}
 	assert(ctx.now != 0);
 	ctx.specific = specific;

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -459,11 +459,13 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 		VCL_Req2Ctx(&ctx, req);
 	}
 	if (bo != NULL) {
-		if (req)
-			assert(method == VCL_MET_PIPE);
 		CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 		CHECK_OBJ_NOTNULL(bo->vcl, VCL_MAGIC);
 		VCL_Bo2Ctx(&ctx, bo);
+		if (req) {
+			assert(method == VCL_MET_PIPE);
+			ctx.ws = req->ws;
+		}
 	}
 	assert(ctx.now != 0);
 	ctx.specific = specific;

--- a/bin/varnishtest/tests/b00001.vtc
+++ b/bin/varnishtest/tests/b00001.vtc
@@ -20,6 +20,7 @@ varnish v1 -vcl+backend {
 		if (req.url == "/2") {
 			set bereq.http.connection = req.http.connection;
 		}
+		set bereq.http.xid = bereq.xid;
 	}
 } -start
 

--- a/bin/varnishtest/tests/m00017.vtc
+++ b/bin/varnishtest/tests/m00017.vtc
@@ -3,6 +3,8 @@ varnishtest "Test std.rollback"
 # bug regressions:
 # - #3009
 # - #3083
+# - #3329
+# - #3385
 
 server s1 {
 	rxreq
@@ -335,3 +337,40 @@ client c6 {
 } -run
 
 server s1 -wait
+
+# this could work, but would need additional coding to save
+# the right snapshot of the bereq on the req ws
+varnish v1 -errvcl {Not available in subroutine 'vcl_pipe'} {
+	import std;
+
+	backend proforma None;
+
+	sub vcl_pipe {
+		std.rollback(bereq);
+	}
+}
+
+# vcl_pipe { std.rollback(req); } cannot work unless it also implied
+# rolling back the bereq first.
+# We would want to remove req from vcl_pipe, but that could break
+# vmods, so we fail specifically at runtime
+
+varnish v1 -vcl {
+	import std;
+
+	backend proforma None;
+
+	sub vcl_recv {
+		return (pipe);
+	}
+	sub vcl_pipe {
+		std.rollback(req);
+	}
+}
+
+client c7 {
+	txreq -url /
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "VCL failed"
+} -run

--- a/bin/varnishtest/tests/r03329.vtc
+++ b/bin/varnishtest/tests/r03329.vtc
@@ -1,0 +1,18 @@
+varnishtest "Lost reason from pipe to synth"
+
+server s1 {} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pipe);
+	}
+	sub vcl_pipe {
+		return (synth(505, req.http.foo + "/bar"));
+	}
+} -start
+
+client c1 {
+	txreq -hdr "foo: foo"
+	rxresp
+	expect resp.reason == "foo/bar"
+} -run

--- a/bin/varnishtest/tests/r03329.vtc
+++ b/bin/varnishtest/tests/r03329.vtc
@@ -3,11 +3,20 @@ varnishtest "Lost reason from pipe to synth"
 server s1 {} -start
 
 varnish v1 -vcl+backend {
+	import vtc;
 	sub vcl_recv {
+		if (req.http.workspace) {
+			vtc.workspace_alloc(client, -10);
+		}
 		return (pipe);
 	}
 	sub vcl_pipe {
-		return (synth(505, req.http.foo + "/bar"));
+		if (req.http.foo) {
+			return (synth(505, req.http.foo + "/bar"));
+		} else {
+			set bereq.http.baz = "baz";
+			return (synth(505, bereq.http.baz));
+		}
 	}
 } -start
 
@@ -15,4 +24,12 @@ client c1 {
 	txreq -hdr "foo: foo"
 	rxresp
 	expect resp.reason == "foo/bar"
+
+	txreq
+	rxresp
+	expect resp.reason == "baz"
+
+	txreq -hdr "workspace: true"
+	rxresp
+	expect resp.status == 503
 } -run

--- a/bin/varnishtest/tests/r03385.vtc
+++ b/bin/varnishtest/tests/r03385.vtc
@@ -1,0 +1,23 @@
+varnishtest "Use a priv in vcl_pipe"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import debug;
+
+	sub vcl_recv {
+		return (pipe);
+	}
+
+	sub vcl_pipe {
+		debug.test_priv_task();
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run

--- a/bin/varnishtest/tests/v00051.vtc
+++ b/bin/varnishtest/tests/v00051.vtc
@@ -158,9 +158,6 @@ logexpect l2 -v v1 -g vxid -q "vxid == 1012" {
 	expect 0 =	BereqHeader	{^X-Forwarded-For: }
 	expect 0 =	BereqHeader	{^X-Varnish: 1011}
 	expect 0 =	BereqHeader	{^Connection: close}
-	expect 0 =	VCL_call	{^PIPE}
-	expect 0 =	VCL_Error	{^Forced failure}
-	expect 0 =	VCL_return	{^fail}
 	expect 0 =	BereqAcct	{^0 0 0 0 0 0}
 	expect 0 =	End
 } -start
@@ -182,6 +179,9 @@ logexpect l3 -v v1 -g vxid -q "vxid == 1011" {
 	expect 0 =	VCL_call        {^HASH}
 	expect 0 =	VCL_return      {^lookup}
 	expect 0 =	Link            {^bereq 1012 pipe}
+	expect 0 =	VCL_call	{^PIPE}
+	expect 0 =	VCL_Error	{^Forced failure}
+	expect 0 =	VCL_return	{^fail}
 	expect 0 =	RespProtocol    {^HTTP/1.1}
 	expect 0 =	RespStatus      {^503}
 	expect 0 =	RespReason      {^VCL failed}

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -480,7 +480,7 @@ bereq.xid
 
 	Type: STRING
 
-	Readable from: backend
+	Readable from: vcl_pipe, backend
 
 	Unique ID of this request.
 


### PR DESCRIPTION
This is a follow-up  to #3408 because I accidentally pushed 5cbb3586649839b83438bd99f557cf30c9c78a66 while working on #3464. This also exposed #3385. (the reason for my accidental push was that, unfortunately, I looked at an old `make check` before pushing - my apologies).
At any rate, this has made me re-iterate over #3329, #3385 and #3408 :
So far my position has been [that we need to make vcl_pipe {} live either on the client, or the backend side](https://github.com/varnishcache/varnish-cache/pull/3330#issuecomment-654346165) but not both, which, while it formally is client side, is currently indirectly implied by the availability of symbols like `bereq.http` and `bereq.backend` and the fact that `ctx->ws` is the backend workspace (which is also the cause for #3385 )
While I stand by my point that the backend side would be the right place for clarity, I partly surrender my position in order to solve the currently open bugs for the existing `vcl_pipe {}`, in the hope that we will replace it with something better and cleaner soon.
This basically boils down to making the decision I asked for as _client side_.
I want to emphasize though that I _still fear we might be overlooking something important_ even with this PR: Along this path, we need to always consider `vcl_pipe {}` specifically. As an example, if, hypothetically, in `VRT_r_client_identity()`, `ctx->bo->client_identity` was considered first, we could easily leak backend workspace to the client side again.

But I also do not want to see us starve locked into a corner.

So, why this PR?

I went through the patches from #3408, which basically move all of `vcl_pipe {}` processing to the client side, and made some changes:
* https://github.com/varnishcache/varnish-cache/pull/3408/commits/fd0b1135b11332f6b9fd691d093779a4fe1d957c I did not pick, because it points in the wrong direction. We hand out task privs via `VRT_priv_task()` and as long as that always prefers the `req` privs, it is cleaner if privs do not even exist on the busyobj
* https://github.com/varnishcache/varnish-cache/pull/3408/commits/4caad2c1858afb399f75230916183d31f57fc908 is not a good idea. We do not want to remove objects from an rbtree which we are about to destroy.
* https://github.com/varnishcache/varnish-cache/pull/3408/commits/76e09408a5cda6416e980f102daa615257d8926a and https://github.com/varnishcache/varnish-cache/pull/3408/commits/48911e9efe50a719d383221f885537ad04e0b2bd make `ctx.ws` the client workspace. I have added a commit achieving the same, but in a different way: by simply calling `Req2Ctx()` last such that its changes win.
* https://github.com/varnishcache/varnish-cache/pull/3408/commits/810e06998a4c47082f9248a59a7a4f4feb0c80fb is important to ensure the bereq's `http->ws` points to the client workspace.
* I added a patch to fail `std.rollback(req)`, which would break things big time when the bereq lives on the client workspace. See the last commit for details, we could also solve this in VCC if we accepted potentially breaking vmod functions taking a `req` argument.
