### PR TITLE
add a VRT_CTX argument to the vmod_priv fini function

### DIFF
--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -190,11 +190,17 @@ Req_Release(struct req *req)
  */
 
 void
-Req_Rollback(struct req *req)
+Req_Rollback(VRT_CTX)
 {
+	struct req *req;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	req = ctx->req;
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+
 	if (IS_TOPREQ(req))
-		VCL_TaskLeave(req->top->privs);
-	VCL_TaskLeave(req->privs);
+		VCL_TaskLeave(ctx, req->top->privs);
+	VCL_TaskLeave(ctx, req->privs);
 	VCL_TaskEnter(req->privs);
 	if (IS_TOPREQ(req))
 		VCL_TaskEnter(req->top->privs);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -255,7 +255,7 @@ enum vbf_fetch_mode_e {
 void VBF_Fetch(struct worker *wrk, struct req *req,
     struct objcore *oc, struct objcore *oldoc, enum vbf_fetch_mode_e);
 const char *VBF_Get_Filter_List(struct busyobj *);
-void Bereq_Rollback(struct busyobj *);
+void Bereq_Rollback(VRT_CTX);
 
 /* cache_fetch_proc.c */
 void VFP_Init(void);
@@ -362,7 +362,7 @@ void pan_pool(struct vsb *);
 /* cache_req.c */
 struct req *Req_New(const struct worker *, struct sess *);
 void Req_Release(struct req *);
-void Req_Rollback(struct req *req);
+void Req_Rollback(VRT_CTX);
 void Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req);
 void Req_Fail(struct req *req, enum sess_close reason);
 void Req_AcctLogCharge(struct VSC_main_wrk *, struct req *);
@@ -473,7 +473,7 @@ const struct vrt_backend_probe *VCL_DefaultProbe(const struct vcl *);
 /* cache_vrt_priv.c */
 extern struct vrt_privs cli_task_privs[1];
 void VCL_TaskEnter(struct vrt_privs *);
-void VCL_TaskLeave(struct vrt_privs *);
+void VCL_TaskLeave(VRT_CTX, struct vrt_privs *);
 
 /* cache_vrt_vmod.c */
 void VMOD_Init(void);

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -215,7 +215,7 @@ vcl_send_event(struct vcl *vcl, enum vcl_event_e ev, struct vsb **msg)
 
 	VCL_TaskEnter(cli_task_privs);
 	r = ctx->vcl->conf->event_vcl(ctx, ev);
-	VCL_TaskLeave(cli_task_privs);
+	VCL_TaskLeave(ctx, cli_task_privs);
 
 	/* if the warm event did not get to vcl_init, vcl_fini
 	 * won't be run, so handling may be zero */

--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -101,7 +101,7 @@ VPI_vcl_select(VRT_CTX, VCL_VCL vcl)
 	if (! IS_TOPREQ(req))
 		assert(req->vcl == req->top->vcl0);
 
-	Req_Rollback(req);
+	Req_Rollback(ctx);
 
 	if (IS_TOPREQ(req)) {
 		AN(req->top);

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -801,14 +801,13 @@ VRT_Rollback(VRT_CTX, VCL_HTTP hp)
 	}
 	if (hp == ctx->http_req) {
 		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
-		Req_Rollback(ctx->req);
+		Req_Rollback(ctx);
 		if (ctx->method & VCL_MET_DELIVER)
 			XXXAZ(Resp_Setup_Deliver(ctx->req));
 		if (ctx->method & VCL_MET_SYNTH)
 			Resp_Setup_Synth(ctx->req);
 	} else if (hp == ctx->http_bereq) {
-		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
-		Bereq_Rollback(ctx->bo);
+		Bereq_Rollback(ctx);
 	} else
 		WRONG("VRT_Rollback 'hp' invalid");
 }

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -273,6 +273,9 @@ VRT_priv_fini(VRT_CTX, const struct vmod_priv *p)
 	if (p->priv == NULL || m->fini == NULL)
 		return;
 
+	// XXX remove me after soak in
+	VRT_CTX_Assert(ctx);
+
 	m->fini(ctx, p->priv);
 }
 

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -259,9 +259,11 @@ VRT_priv_top(VRT_CTX, const void *vmod_id)
  */
 
 void
-VRT_priv_fini(const struct vmod_priv *p)
+VRT_priv_fini(VRT_CTX, const struct vmod_priv *p)
 {
 	const struct vmod_priv_methods *m;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
 	m = p->methods;
 	if (m == NULL)
@@ -271,7 +273,7 @@ VRT_priv_fini(const struct vmod_priv *p)
 	if (p->priv == NULL || m->fini == NULL)
 		return;
 
-	m->fini(p->priv);
+	m->fini(ctx, p->priv);
 }
 
 /*--------------------------------------------------------------------*/
@@ -284,7 +286,7 @@ VCL_TaskEnter(struct vrt_privs *privs)
 }
 
 void
-VCL_TaskLeave(struct vrt_privs *privs)
+VCL_TaskLeave(VRT_CTX, struct vrt_privs *privs)
 {
 	struct vrt_priv *vp, *vp1;
 
@@ -295,7 +297,7 @@ VCL_TaskLeave(struct vrt_privs *privs)
 	 */
 	VRBT_FOREACH_SAFE(vp, vrt_privs, privs, vp1) {
 		CHECK_OBJ(vp, VRT_PRIV_MAGIC);
-		VRT_priv_fini(vp->priv);
+		VRT_priv_fini(ctx, vp->priv);
 	}
 	ZERO_OBJ(privs, sizeof *privs);
 }

--- a/bin/varnishd/cache/cache_vrt_vmod.c
+++ b/bin/varnishd/cache/cache_vrt_vmod.c
@@ -165,7 +165,7 @@ VPI_Vmod_Init(VRT_CTX, struct vmod **hdl, unsigned nbr, void *ptr, int len,
 }
 
 void
-VPI_Vmod_Unload(struct vmod **hdl)
+VPI_Vmod_Unload(VRT_CTX, struct vmod **hdl)
 {
 	struct vmod *v;
 
@@ -173,7 +173,7 @@ VPI_Vmod_Unload(struct vmod **hdl)
 
 	TAKE_OBJ_NOTNULL(v, hdl, VMOD_MAGIC);
 
-	VCL_TaskLeave(cli_task_privs);
+	VCL_TaskLeave(ctx, cli_task_privs);
 	VCL_TaskEnter(cli_task_privs);
 
 #ifndef DONT_DLCLOSE_VMODS

--- a/bin/varnishtest/tests/v00041.vtc
+++ b/bin/varnishtest/tests/v00041.vtc
@@ -131,15 +131,8 @@ logexpect l0 -v v1 -g raw -d 1 -m -q "vxid == 0" {
 	expect 0 =    CLI               {^Rd debug.listen_address}
 	expect 0 =    CLI               {^Wr 200}
 
-	# 1001/1002
-	expect ? =    Debug		{^priv_task_fini}
-	expect ? =    Debug		{^obj_priv_task_fini.*"r1002"}
-	expect ? =    Debug		{^priv_task_fini}
-	expect ? =    Debug		{^obj_priv_task_fini.*"d1001"}
-
 	# ...
 	# 1006 pipe
-	expect * =    Debug		{^obj_priv_task_fini.*"p1006"}
 
 	# vcl_fini
 	expect * =    Debug		{^vcl1: VCL_EVENT_COLD}
@@ -179,6 +172,9 @@ logexpect l1001 -v v1 -g vxid -q "vxid == 1001" {
 	expect 0 =    Debug		{^objc.priv_task.. =.*"d1001".}
 	expect 0 =    RespHeader	{^objc: d1001}
 	expect 0 =    VCL_return	{^deliver}
+	expect 9 =    Timestamp	{^Resp}
+	expect ? =    Debug		{^priv_task_fini}
+	expect ? =    Debug		{^obj_priv_task_fini.*"d1001"}
 } -start
 
 logexpect l1002 -v v1 -g vxid -q "vxid == 1002" {
@@ -205,6 +201,9 @@ logexpect l1002 -v v1 -g vxid -q "vxid == 1002" {
 	expect 0 =    Debug		{^objb.priv_task.. =.*"r1002".}
 	expect 0 =    BerespHeader	{^objb: r1002}
 	expect 0 =    VCL_return	{^deliver}
+	expect 9 =    Timestamp	{^BerespBody}
+	expect ? =    Debug		{^priv_task_fini}
+	expect ? =    Debug		{^obj_priv_task_fini.*"r1002"}
 } -start
 
 logexpect l1006 -v v1 -g vxid -q "vxid == 1006" {
@@ -236,6 +235,9 @@ logexpect l1006 -v v1 -g vxid -q "vxid == 1006" {
 	expect 0 =    ReqHeader		{^x0: /pipe bazz /pipe}
 	expect 0 =    Debug		{^test_priv_task.*update.$}
 	expect 0 =    VCL_return	{^pipe}
+	expect 4 =    PipeAcct
+	expect ? =    Debug		{^priv_task_fini}
+	expect ? =    Debug		{^obj_priv_task_fini.*"p1006"}
 } -start
 
 client c1 {

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -528,7 +528,7 @@ code wants to use them for.
 
 ``.methods`` can be an optional pointer to a struct of callbacks::
 
-	typedef void vmod_priv_fini_f(void *);
+	typedef void vmod_priv_fini_f(VRT_CTX, void *);
 
 	struct vmod_priv_methods {
 		unsigned			magic;
@@ -542,15 +542,22 @@ help debugging.
 
 ``.fini`` will be called for a non-NULL ``.priv`` of the ``struct
 vmod_priv`` when the scope ends with that ``.priv`` pointer as its
-only argument.
+second argument besides a ``VRT_CTX``.
 
 The common case where a private data structure is allocated with
 malloc(3) would look like this::
 
+	static void
+	myfree(VRT_CTX, void *p)
+	{
+		CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+		free (p);
+	}
+
 	static const struct vmod_priv_methods mymethods[1] = {{
 		.magic = VMOD_PRIV_METHODS_MAGIC,
 		.type = "mystate",
-		.fini = free	/* free(3) */
+		.fini = myfree
 	}};
 
 	// ....

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -55,7 +55,7 @@ void VPI_count(VRT_CTX, unsigned);
 
 int VPI_Vmod_Init(VRT_CTX, struct vmod **hdl, unsigned nbr, void *ptr, int len,
     const char *nm, const char *path, const char *file_id, const char *backup);
-void VPI_Vmod_Unload(struct vmod **hdl);
+void VPI_Vmod_Unload(VRT_CTX, struct vmod **hdl);
 
 typedef int acl_match_f(VRT_CTX, const VCL_IP);
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -580,7 +580,7 @@ void VRT_Format_Proxy(struct vsb *, VCL_INT, VCL_IP, VCL_IP, VCL_STRING);
 typedef int vmod_event_f(VRT_CTX, struct vmod_priv *, enum vcl_event_e);
 
 /* vmod_priv related */
-typedef void vmod_priv_fini_f(void *);
+typedef void vmod_priv_fini_f(VRT_CTX, void *);
 
 struct vmod_priv_methods {
 	unsigned			magic;
@@ -595,7 +595,7 @@ struct vmod_priv {
 	const struct vmod_priv_methods	*methods;
 };
 
-void VRT_priv_fini(const struct vmod_priv *p);
+void VRT_priv_fini(VRT_CTX, const struct vmod_priv *p);
 struct vmod_priv *VRT_priv_task(VRT_CTX, const void *vmod_id);
 struct vmod_priv *VRT_priv_task_get(VRT_CTX, const void *vmod_id);
 struct vmod_priv *VRT_priv_top(VRT_CTX, const void *vmod_id);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -368,7 +368,7 @@ vcc_priv_arg(struct vcc *tl, const char *p, const struct symbol *sym)
 		bprintf(buf, "vmod_priv_%u", tl->unique++);
 		ifp = New_IniFin(tl);
 		Fh(tl, 0, "static struct vmod_priv %s;\n", buf);
-		VSB_printf(ifp->fin, "\tVRT_priv_fini(&%s);", buf);
+		VSB_printf(ifp->fin, "\tVRT_priv_fini(ctx, &%s);", buf);
 		return (vcc_mk_expr(VOID, "&%s", buf));
 	}
 

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -436,8 +436,8 @@ vcc_ParseImport(struct vcc *tl)
 	VSB_cat(tl->symtab, "    }");
 
 	/* XXX: zero the function pointer structure ?*/
-	VSB_printf(ifp->fin, "\t\tVRT_priv_fini(&vmod_priv_%.*s);", PF(mod));
-	VSB_printf(ifp->final, "\t\tVPI_Vmod_Unload(&VGC_vmod_%.*s);", PF(mod));
+	VSB_printf(ifp->fin, "\t\tVRT_priv_fini(ctx, &vmod_priv_%.*s);", PF(mod));
+	VSB_printf(ifp->final, "\t\tVPI_Vmod_Unload(ctx, &VGC_vmod_%.*s);", PF(mod));
 
 	vj = vjsn_parse(vmd->json, &p);
 	XXXAZ(p);

--- a/vmod/vmod_cookie.c
+++ b/vmod/vmod_cookie.c
@@ -71,10 +71,11 @@ struct vmod_cookie {
 };
 
 static void
-cobj_free(void *p)
+cobj_free(VRT_CTX, void *p)
 {
 	struct vmod_cookie *vcp;
 
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CAST_OBJ_NOTNULL(vcp, p, VMOD_COOKIE_MAGIC);
 	FREE_OBJ(vcp);
 }

--- a/vmod/vmod_debug_obj.c
+++ b/vmod/vmod_debug_obj.c
@@ -155,12 +155,13 @@ xyzzy_obj_test_priv_vcl(VRT_CTX,
 
 #define PRIV_FINI(name)						\
 static void v_matchproto_(vmod_priv_fini_f)				\
-obj_priv_ ## name ## _fini(void *ptr)					\
+obj_priv_ ## name ## _fini(VRT_CTX, void *ptr)				\
 {									\
 	const char * const fmt = "obj_priv_" #name "_fini(%p = \"%s\")"; \
 									\
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);				\
 	AN(ptr);							\
-	VSL(SLT_Debug, 0, fmt, ptr, (char *)ptr);			\
+	mylog(ctx->vsl, SLT_Debug, fmt, ptr, (char *)ptr);		\
 }									\
 									\
 static const struct vmod_priv_methods					\

--- a/vmod/vmod_directors_shard_cfg.c
+++ b/vmod/vmod_directors_shard_cfg.c
@@ -76,7 +76,7 @@ struct backend_reconfig {
 
 /* forward decl */
 static VCL_BOOL
-change_reconfigure(struct shard_change *change, VCL_INT replicas);
+change_reconfigure(VRT_CTX, struct shard_change *change, VCL_INT replicas);
 
 /*
  * ============================================================
@@ -87,7 +87,7 @@ change_reconfigure(struct shard_change *change, VCL_INT replicas);
  */
 
 static void v_matchproto_(vmod_priv_fini_f)
-shard_change_fini(void * priv)
+shard_change_fini(VRT_CTX, void * priv)
 {
 	struct shard_change *change;
 
@@ -96,7 +96,7 @@ shard_change_fini(void * priv)
 
 	CAST_OBJ_NOTNULL(change, priv, SHARD_CHANGE_MAGIC);
 
-	(void) change_reconfigure(change, 67);
+	(void) change_reconfigure(ctx, change, 67);
 }
 
 static const struct vmod_priv_methods shard_change_priv_methods[1] = {{
@@ -632,7 +632,7 @@ shardcfg_apply_change(struct vsl_log *vsl, struct sharddir *shardd,
  */
 
 static VCL_BOOL
-change_reconfigure(struct shard_change *change, VCL_INT replicas)
+change_reconfigure(VRT_CTX, struct shard_change *change, VCL_INT replicas)
 {
 	struct sharddir *shardd;
 
@@ -646,7 +646,7 @@ change_reconfigure(struct shard_change *change, VCL_INT replicas)
 
 	sharddir_wrlock(shardd);
 
-	shardcfg_apply_change(change->vsl, shardd, change, replicas);
+	shardcfg_apply_change(ctx->vsl, shardd, change, replicas);
 	shard_change_finish(change);
 
 	if (shardd->hashcircle)
@@ -654,7 +654,7 @@ change_reconfigure(struct shard_change *change, VCL_INT replicas)
 	shardd->hashcircle = NULL;
 
 	if (shardd->n_backend == 0) {
-		shard_err0(change->vsl, shardd->name,
+		shard_err0(ctx->vsl, shardd->name,
 		    ".reconfigure() no backends");
 		sharddir_unlock(shardd);
 		return (0);
@@ -681,7 +681,7 @@ shardcfg_reconfigure(VRT_CTX, struct sharddir *shardd, VCL_INT replicas)
 	if (change == NULL)
 		return (0);
 
-	return (change_reconfigure(change, replicas));
+	return (change_reconfigure(ctx, change, replicas));
 }
 
 /*

--- a/vmod/vmod_std_fileread.c
+++ b/vmod/vmod_std_fileread.c
@@ -64,10 +64,11 @@ static VTAILQ_HEAD(, frfile)	frlist = VTAILQ_HEAD_INITIALIZER(frlist);
 static pthread_mutex_t		frmtx = PTHREAD_MUTEX_INITIALIZER;
 
 static void
-free_frfile(void *ptr)
+fini_frfile(VRT_CTX, void *ptr)
 {
 	struct frfile *frf;
 
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CAST_OBJ_NOTNULL(frf, ptr, CACHED_FILE_MAGIC);
 
 	AZ(pthread_mutex_lock(&frmtx));
@@ -86,7 +87,7 @@ free_frfile(void *ptr)
 static const struct vmod_priv_methods frfile_methods[1] = {{
 		.magic = VMOD_PRIV_METHODS_MAGIC,
 		.type = "vmod_std_fileread",
-		.fini = free_frfile
+		.fini = fini_frfile
 }};
 
 static struct frfile *


### PR DESCRIPTION
Continuation of #3464:

we take the chance of the breaking change in the previous commit to also add a `VRT_CTX` argument to `vmod_priv_fini_f`. This allows a `vmod_priv` fini function, for example, access to the request or simpler and better logging (because the task's vsl buffer can be used where otherwise only unbuffered vsl was possible).

Implementation:

The meat of this commit really only is the change to the `vmod_priv_fini_f` typedef and `VRT_priv_fini()`.

All other changes are either to bundled vmods or the straight forward infrastructure to make available a ctx to `VRT_priv_fini()`, which, for client and backend context, is called via `VCL_TaskLeave()`.

Consequently, it made sense to also change the signature `Req_Rollback()` and `Bereq_Rollback()`.