### PR TITLE
refactoring to prepare for working with vcl sets more

### DIFF
--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -113,6 +113,18 @@ vclset_free(struct vclset **setp)
 	free(set);
 }
 
+static int
+vclset_contains(const struct vclset *set, struct vclprog *vp)
+{
+	unsigned u;
+
+	for (u = 0; u < set->n; u++)
+		if (set->a[u] == vp)
+			return (1);
+
+	return (0);
+}
+
 /*--------------------------------------------------------------------*/
 
 
@@ -802,13 +814,9 @@ mgt_vcl_discard_depcheck(struct cli *cli, const char * const *names)
 		vp = set->a[i];
 		if (vp == NULL || VTAILQ_EMPTY(&vp->dto))
 			continue;
-		VTAILQ_FOREACH(vd, &vp->dto, lto) {
-			for (j = 0; j < set->n; j++)
-				if (set->a[j] == vd->from)
-					break;
-			if (j == set->n)
+		VTAILQ_FOREACH(vd, &vp->dto, lto)
+			if (! vclset_contains(set, vd->from))
 				break;
-		}
 		if (vd != NULL)
 			break;
 	}

--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -799,9 +799,10 @@ mgt_vcl_discard_depcheck(struct cli *cli, const char * const *names)
 	 * indirect dependent VCLs also belong.
 	 */
 	for (i = 0; i < set->n; i++) {
-		if (set->a[i] == NULL || VTAILQ_EMPTY(&set->a[i]->dto))
+		vp = set->a[i];
+		if (vp == NULL || VTAILQ_EMPTY(&vp->dto))
 			continue;
-		VTAILQ_FOREACH(vd, &set->a[i]->dto, lto) {
+		VTAILQ_FOREACH(vd, &vp->dto, lto) {
 			for (j = 0; j < set->n; j++)
 				if (set->a[j] == vd->from)
 					break;
@@ -813,7 +814,7 @@ mgt_vcl_discard_depcheck(struct cli *cli, const char * const *names)
 	}
 
 	if (i < set->n) {
-		mgt_vcl_discard_depfail(cli, set->a[i]);
+		mgt_vcl_discard_depfail(cli, vp);
 		vclset_free(&set);
 		return (NULL);
 	}

--- a/include/vav.h
+++ b/include/vav.h
@@ -34,6 +34,8 @@ void VAV_Free(char **argv);
 char **VAV_Parse(const char *s, int *argc, int flag);
 char *VAV_BackSlashDecode(const char *s, const char *e);
 int VAV_BackSlash(const char *s, char *res);
+unsigned VAV_Count(const char * const *av);
+
 #define ARGV_COMMENT	(1 << 0)
 #define ARGV_COMMA	(1 << 1)
 #define ARGV_NOESC	(1 << 2)

--- a/lib/libvarnish/vav.c
+++ b/lib/libvarnish/vav.c
@@ -224,6 +224,17 @@ VAV_Free(char **argv)
 	free(argv);
 }
 
+unsigned
+VAV_Count(const char * const *av)
+{
+	unsigned n = 0;
+
+	for (; *av != NULL; av++)
+		n++;
+
+	return (n);
+}
+
 #ifdef TESTPROG
 
 #include <printf.h>


### PR DESCRIPTION
@Dridi would this work for you?

This is to facilitate things like
* `vcl.discard *glob*`
* `vcl.discard -a` # all available vcls
* `vcl.discard -k <n>` # keep <n> vcls
