### PR TITLE
fix round-robin race

### DIFF
--- a/lib/libvmod_directors/round_robin.c
+++ b/lib/libvmod_directors/round_robin.c
@@ -80,14 +80,16 @@ vmod_rr_resolve(VRT_CTX, VCL_BACKEND dir)
 	CHECK_OBJ_NOTNULL(dir, DIRECTOR_MAGIC);
 	CAST_OBJ_NOTNULL(rr, dir->priv, VMOD_DIRECTORS_ROUND_ROBIN_MAGIC);
 	vdir_rdlock(rr->vd);
+	nxt = rr->nxt;
 	for (u = 0; u < rr->vd->n_backend; u++) {
-		nxt = rr->nxt % rr->vd->n_backend;
-		rr->nxt = nxt + 1;
 		be = rr->vd->backend[nxt];
+		nxt++;
+		nxt %= rr->vd->n_backend;
 		CHECK_OBJ_NOTNULL(be, DIRECTOR_MAGIC);
 		if (VRT_Healthy(ctx, be, NULL))
 			break;
 	}
+	rr->nxt = nxt;
 	vdir_unlock(rr->vd);
 	if (u == rr->vd->n_backend)
 		be = NULL;


### PR DESCRIPTION
see https://github.com/varnishcache/varnish-cache/issues/3474#issuecomment-738012804 for discussion

When resolve requests race, we were not guaranteed to consider all backends because we updated a shared nxt variable.

Fixes #3474