### PR TITLE
feature: Transit buffer

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -286,7 +286,9 @@ struct boc {
 	void			*stevedore_priv;
 	enum boc_state_e	state;
 	uint8_t			*vary;
-	uint64_t		len_so_far;
+	uint64_t		fetched_so_far;
+	uint64_t		delivered_so_far;
+	uint64_t		pass_prefetch;
 };
 
 /* Object core structure ---------------------------------------------

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -297,6 +297,36 @@ VRT_r_beresp_uncacheable(VRT_CTX)
 
 /*--------------------------------------------------------------------*/
 
+VCL_BYTES
+VRT_r_beresp_pass_prefetch(VRT_CTX)
+{
+    struct objcore *oc;
+
+    CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+    CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+
+    oc = ctx->bo->fetch_objcore;
+    CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+
+    return oc->boc->pass_prefetch;
+}
+
+VCL_VOID
+VRT_l_beresp_pass_prefetch(VRT_CTX, VCL_BYTES value)
+{
+    struct objcore *oc;
+
+    CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+    CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+
+    oc = ctx->bo->fetch_objcore;
+    CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+
+    oc->boc->pass_prefetch = value;
+}
+
+/*--------------------------------------------------------------------*/
+
 VCL_STRING
 VRT_r_client_identity(VRT_CTX)
 {

--- a/bin/varnishtest/tests/v00067.vtc
+++ b/bin/varnishtest/tests/v00067.vtc
@@ -1,0 +1,26 @@
+varnishtest "Pass buffering normal operation"
+
+server s1 {
+	rxreq
+	txresp -bodylen 2000000
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pass);
+	}
+	sub vcl_backend_response {
+		set beresp.pass_prefetch = 1KB;
+	}
+} -start
+
+client c1 -connect "${v1_sock}" {
+	txreq
+	rxresp
+	expect resp.bodylen == 2000000
+} -start
+
+varnish v1 -expect VBE.vcl1.s1.beresp_bodybytes < 100000
+
+# Make sure request finishes OK
+client c1 -wait

--- a/bin/varnishtest/tests/v00068.vtc
+++ b/bin/varnishtest/tests/v00068.vtc
@@ -1,0 +1,31 @@
+varnishtest "Pass buffering with early close"
+barrier b1 cond 2
+
+server s1 {
+	non_fatal
+	rxreq
+	txresp -bodylen 2000000
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		set req.backend_hint = s1;
+		return (pass);
+	}
+	sub vcl_backend_response {
+		set beresp.pass_prefetch = 1KB;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresphdrs
+	expect resp.status == 200
+	recv 100
+	barrier b1 sync
+	recv 200000
+} -start
+
+barrier b1 sync
+varnish v1 -expect VBE.vcl1.s1.conn == 0
+varnish v1 -expect VBE.vcl1.s1.busy == 0

--- a/bin/varnishtest/tests/v00069.vtc
+++ b/bin/varnishtest/tests/v00069.vtc
@@ -1,0 +1,42 @@
+varnishtest "Pass buffering deadlock test"
+
+server s1 {
+	rxreq
+	txresp -status 404
+} -start
+
+server s2 {
+	non_fatal
+	rxreq
+	txresp -bodylen 2000000
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		set req.backend_hint = s2;
+		if (req.restarts == 1) {
+			set req.backend_hint = s1;
+		}
+		return (pass);
+	}
+	sub vcl_deliver {
+		if (req.restarts < 1) {
+			return (restart);
+		}
+	}
+	sub vcl_backend_response {
+		set beresp.pass_prefetch = 1KB;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.bodylen == 0
+	expect resp.status == 404
+} -run
+
+varnish v1 -expect VBE.vcl1.s1.conn == 0
+varnish v1 -expect VBE.vcl1.s1.busy == 0
+varnish v1 -expect VBE.vcl1.s2.conn == 0
+varnish v1 -expect VBE.vcl1.s2.busy == 0

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1024,6 +1024,18 @@ beresp.filters
 	After beresp.filters is set, using any of the beforementioned
 	``beresp.do_*`` switches is a VCL error.
 
+beresp.pass_prefetch
+
+	Type: BYTES
+
+	Readable from: vcl_backend_response
+
+	Writable from: vcl_backend_response
+
+	Set the maximum number of bytes the client can be ahead of the
+	backend during a streaming pass.
+
+
 obj
 ~~~
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -465,6 +465,19 @@ PARAM_SIMPLE(
 )
 
 PARAM_SIMPLE(
+	/* name */	pass_prefetch,
+	/* type */	bytes,
+	/* min */	"4k",
+	/* max */	NULL,
+	/* def */	"1M",
+	/* units */	"bytes",
+	/* descr */
+	"The default prefetch amount used during a single private transaction.\n"
+	"Enabling this will prevent running out of memory when "
+	"there are big streaming transfers going on."
+)
+
+PARAM_SIMPLE(
 	/* name */	gzip_buffer,
 	/* type */	bytes_u,
 	/* min */	"2k",


### PR DESCRIPTION
See: https://github.com/varnishcache/varnish-cache/wiki/VIP-26%3A-limit-private-prefetch

Ended up using beresp.pass_prefetch as the only difference.
