### PR TITLE
vcl: Add support for vcl.discard glob patterns

### DIFF
--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -33,6 +33,7 @@
 
 #include "config.h"
 
+#include <fnmatch.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -686,13 +687,13 @@ mgt_vcl_discard(struct cli *cli, struct vclproghead *vh, struct vclprog *vp)
 }
 
 static int
-mgt_vcl_discard_mark(struct cli *cli, struct vclproghead *vh, const char *name)
+mgt_vcl_discard_mark(struct cli *cli, struct vclproghead *vh, const char *glob)
 {
 	struct vclprog *vp;
 	unsigned marked = 0;
 
 	VTAILQ_FOREACH(vp, &vclhead, list) {
-		if (strcmp(name, vp->name))
+		if (fnmatch(glob, vp->name, 0))
 			continue;
 		if (vp == active_vcl) {
 			VCLI_SetResult(cli, CLIS_CANT);
@@ -708,7 +709,7 @@ mgt_vcl_discard_mark(struct cli *cli, struct vclproghead *vh, const char *name)
 
 	if (marked == 0) {
 		VCLI_SetResult(cli, CLIS_PARAM);
-		VCLI_Out(cli, "No VCL named %s known\n", name);
+		VCLI_Out(cli, "No VCL name matches %s\n", glob);
 	}
 
 	return (marked);

--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -777,10 +777,14 @@ mgt_vcl_discard_clear(void)
 static void v_matchproto_(cli_func_t)
 mcf_vcl_discard(struct cli *cli, const char * const *av, void *priv)
 {
+	const struct vclprog *vp;
 
 	(void)priv;
 
 	assert(VTAILQ_EMPTY(&discardhead));
+	VTAILQ_FOREACH(vp, &vclhead, list)
+		AZ(vp->discard);
+
 	for (av += 2; *av != NULL; av++) {
 		if (mgt_vcl_discard_mark(cli, *av) <= 0) {
 			mgt_vcl_discard_clear();

--- a/bin/varnishd/mgt/mgt_vcl.h
+++ b/bin/varnishd/mgt/mgt_vcl.h
@@ -68,6 +68,8 @@ struct vclprog {
 	int			nto;
 	int			loaded;
 	VTAILQ_HEAD(, vmoddep)	vmods;
+	unsigned		discard;
+	VTAILQ_ENTRY(vclprog)	discard_list;
 };
 
 struct vmodfile {

--- a/bin/varnishtest/tests/c00077.vtc
+++ b/bin/varnishtest/tests/c00077.vtc
@@ -66,4 +66,4 @@ varnish v1 -cliok "vcl.symtab"
 
 varnish v1 -clierr 300 "vcl.discard vcl*"
 varnish v1 -clierr 300 "vcl.discard vcl[1-7]"
-varnish v1 -cliok "vcl.discard vcl[1-7A-B]"
+varnish v1 -cliok "vcl.discard vcl[1-7] vcl[A-B]"

--- a/bin/varnishtest/tests/c00077.vtc
+++ b/bin/varnishtest/tests/c00077.vtc
@@ -64,5 +64,6 @@ varnish v1 -clierr 106 "vcl.label vclA vcl3"
 
 varnish v1 -cliok "vcl.symtab"
 
-varnish v1 -clierr 300 "vcl.discard vcl1 vcl2 vcl3 vcl4 vcl5 vcl6 vcl7"
-varnish v1 -cliok "vcl.discard vcl1 vcl2 vcl3 vcl4 vcl5 vcl6 vcl7 vclA vclB"
+varnish v1 -clierr 300 "vcl.discard vcl*"
+varnish v1 -clierr 300 "vcl.discard vcl[1-7]"
+varnish v1 -cliok "vcl.discard vcl[1-7A-B]"

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -99,13 +99,16 @@ CLI_CMD(VCL_STATE,
 
 CLI_CMD(VCL_DISCARD,
 	"vcl.discard",
-	"vcl.discard <configname|label>...",
-	"Unload the named configurations (if possible).",
-	"The configname or label arguments are matched as glob patterns."
-	" If more than one configuration matches patterns the command"
-	" is equivalent to individual commands in the right order with"
-	" respect to configurations dependencies."
-	" All individual patterns must match at least one configuration.",
+	"vcl.discard <name_pattern>...",
+	"Unload the named configurations (when possible).",
+	"Unload the named configurations and labels matching at least"
+	" one name pattern. All matching configurations and labels"
+	" are discarded in the correct order with respect to potential"
+	" dependencies. If one configuration or label could not be"
+	" discarded because one of its dependencies would remain,"
+	" nothing is discarded."
+	" Each individual name pattern must match at least one named"
+	" configuration or label.",
 	1, -1
 )
 

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -99,11 +99,13 @@ CLI_CMD(VCL_STATE,
 
 CLI_CMD(VCL_DISCARD,
 	"vcl.discard",
-	"vcl.discard <configname|label>...", /* XXX: allow globs */
+	"vcl.discard <configname|label>...",
 	"Unload the named configurations (if possible).",
-	" If more than one named configuration is specified the command"
+	"The configname or label arguments are matched as glob patterns."
+	" If more than one configuration matches patterns the command"
 	" is equivalent to individual commands in the right order with"
-	" respect to configurations dependencies.",
+	" respect to configurations dependencies."
+	" All individual patterns must match at least one configuration.",
 	1, -1
 )
 


### PR DESCRIPTION
This replaces the previous mapping of VCLs to discard with a mark and
sweep operation where a different head is used to track matching VCLs.

To discard VCLs in topological order, we can simply discard dependencies
recursively before discarding a given VCL.

It then becomes trivial to switch to glob patterns.