### PR TITLE
Various VSC consistency improvements

### DIFF
--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -477,6 +477,7 @@ void VMOD_Panic(struct vsb *);
 
 /* cache_wrk.c */
 void WRK_Init(void);
+void WRK_AddStat(struct worker *);
 
 /* cache_ws.c */
 void WS_Id(const struct ws *ws, char *id);

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -169,6 +169,25 @@ pool_addstat(struct VSC_main_wrk *dst, struct VSC_main_wrk *src)
 	memset(src, 0, sizeof *src);
 }
 
+void
+WRK_AddStat(struct worker *wrk)
+{
+	struct pool *pp;
+
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	pp = wrk->pool;
+	CHECK_OBJ_NOTNULL(pp, POOL_MAGIC);
+	if (++wrk->stats->summs >= cache_param->wthread_stats_rate) {
+		Lck_Lock(&pp->mtx);
+		pool_addstat(pp->a_stat, wrk->stats);
+		Lck_Unlock(&pp->mtx);
+	}
+}
+
+/*--------------------------------------------------------------------
+ * Pool reserve calculation
+ */
+
 static unsigned
 pool_reserve(void)
 {

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -389,7 +389,17 @@ Pool_Work_Thread(struct pool *pp, struct worker *wrk)
 			pp->nidle++;
 			do {
 				// see signaling_note at the top for explanation
-				if (wrk->vcl == NULL)
+				if (DO_DEBUG(DBG_VCLREL) &&
+				    pp->b_stat == NULL && pp->a_stat->summs)
+					/* We've released the VCL, but
+					 * there are pool stats not pushed
+					 * to the global stats and some
+					 * thread is busy pushing
+					 * stats. Set a 1 second timeout
+					 * so that we'll wake up and get a
+					 * chance to push stats. */
+					tmo = wrk->lastused + 1.;
+				else if (wrk->vcl == NULL)
 					tmo = 0;
 				else if (DO_DEBUG(DBG_VTC_MODE))
 					tmo =  wrk->lastused+1.;

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -426,6 +426,8 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 			HTC_RxInit(req->htc, req->ws);
 			if (req->htc->rxbuf_e != req->htc->rxbuf_b)
 				wrk->stats->sess_readahead++;
+			if (FEATURE(FEATURE_BUSY_STATS_RATE))
+				WRK_AddStat(wrk);
 			http1_setstate(sp, H1NEWREQ);
 		} else {
 			WRONG("Wrong H1 session state");

--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -67,7 +67,7 @@ do_xml_cb(void *priv, const struct VSC_point * const pt)
 	if (pt == NULL)
 		return (0);
 	AZ(strcmp(pt->ctype, "uint64_t"));
-	val = *(const volatile uint64_t*)pt->ptr;
+	val = VSC_Value(pt);
 
 	printf("\t<stat>\n");
 	printf("\t\t<name>%s</name>\n", pt->name);
@@ -106,7 +106,7 @@ do_json_cb(void *priv, const struct VSC_point * const pt)
 		return (0);
 
 	AZ(strcmp(pt->ctype, "uint64_t"));
-	val = (uintmax_t)*(const volatile uint64_t*)pt->ptr;
+	val = (uintmax_t)VSC_Value(pt);
 
 	sep = priv;
 
@@ -167,7 +167,7 @@ do_once_cb_first(void *priv, const struct VSC_point * const pt)
 	AZ(strcmp(pt->ctype, "uint64_t"));
 	if (strcmp(pt->name, "MAIN.uptime"))
 		return (0);
-	val = *(const volatile uint64_t*)pt->ptr;
+	val = VSC_Value(pt);
 	op->up = (double)val;
 	return (1);
 }
@@ -183,7 +183,7 @@ do_once_cb(void *priv, const struct VSC_point * const pt)
 		return (0);
 	op = priv;
 	AZ(strcmp(pt->ctype, "uint64_t"));
-	val = *(const volatile uint64_t*)pt->ptr;
+	val = VSC_Value(pt);
 	i = 0;
 	i += printf("%s", pt->name);
 	if (i >= op->pad)

--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -315,6 +315,9 @@ main(int argc, char * const *argv)
 			AN(VSC_Arg(vsc, opt, optarg));
 			has_f = 1;
 			break;
+		case 'r':
+			AN(VSC_Arg(vsc, opt, optarg));
+			break;
 		case 'V':
 			AN(VUT_Arg(vut, opt, optarg));
 			break;

--- a/bin/varnishstat/varnishstat_bindings.h
+++ b/bin/varnishstat/varnishstat_bindings.h
@@ -72,6 +72,14 @@ BINDING(UNSEEN,
     "\tof varnishstat. Defaults to hide unseen counters."
 )
 
+BINDING_KEY('r', "r",)
+BINDING(RAW,
+    "\tToggle between showing raw and adjusted gauges. When a gauge\n"
+    "\tis decremented faster than it is incremented, it may appear as\n"
+    "\ta large integer with its most significant bit set. By default\n"
+    "\tsuch values are adjusted to zero."
+)
+
 BINDING_KEY('e', "e",)
 BINDING(SCALE, "\tToggle scaling of values.")
 

--- a/bin/varnishstat/varnishstat_curses.c
+++ b/bin/varnishstat/varnishstat_curses.c
@@ -256,7 +256,7 @@ sample_points(void)
 	VTAILQ_FOREACH(pt, &ptlist, list) {
 		AN(pt->vpt);
 		AN(pt->vpt->ptr);
-		v = *pt->vpt->ptr;
+		v = VSC_Value(pt->vpt);
 		if (v == 0 && !pt->seen)
 			continue;
 		if (!pt->seen) {
@@ -1104,7 +1104,7 @@ newpt(void *priv, const struct VSC_point *const vpt)
 	rebuild |= REBUILD_NEXT;
 	AN(pt);
 	pt->vpt = vpt;
-	pt->last = *pt->vpt->ptr;
+	pt->last = VSC_Value(vpt);
 	pt->ma_10.nmax = 10;
 	pt->ma_100.nmax = 100;
 	pt->ma_1000.nmax = 1000;

--- a/bin/varnishstat/varnishstat_curses.c
+++ b/bin/varnishstat/varnishstat_curses.c
@@ -935,7 +935,7 @@ handle_common_keypress(enum kb_e kb)
 }
 
 static void
-handle_points_keypress(enum kb_e kb)
+handle_points_keypress(struct vsc *vsc, enum kb_e kb)
 {
 
 	switch (kb) {
@@ -971,6 +971,10 @@ handle_points_keypress(enum kb_e kb)
 		break;
 	case KB_UNSEEN:
 		hide_unseen = 1 - hide_unseen;
+		rebuild = REBUILD_NEXT;
+		break;
+	case KB_RAW:
+		VSC_Arg(vsc, 'r', NULL);
 		rebuild = REBUILD_NEXT;
 		break;
 	case KB_SCALE:
@@ -1046,6 +1050,7 @@ handle_help_keypress(enum kb_e kb)
 		help_line = bindings_help_len;
 		break;
 	case KB_UNSEEN:
+	case KB_RAW:
 	case KB_SCALE:
 	case KB_ACCEL:
 	case KB_DECEL:
@@ -1072,7 +1077,7 @@ handle_help_keypress(enum kb_e kb)
 }
 
 static void
-handle_keypress(int ch)
+handle_keypress(struct vsc *vsc, int ch)
 {
 	enum kb_e kb;
 
@@ -1091,7 +1096,7 @@ handle_keypress(int ch)
 	if (show_help)
 		handle_help_keypress(kb);
 	else
-		handle_points_keypress(kb);
+		handle_points_keypress(vsc, kb);
 }
 
 static void * v_matchproto_(VSC_new_f)
@@ -1201,7 +1206,7 @@ do_curses(struct vsm *vsm, struct vsc *vsc)
 			break;
 #endif
 		default:
-			handle_keypress(ch);
+			handle_keypress(vsc, ch);
 			break;
 		}
 	}

--- a/bin/varnishstat/varnishstat_curses.c
+++ b/bin/varnishstat/varnishstat_curses.c
@@ -123,6 +123,7 @@ static int show_help = 0;
 static int help_line = 0;
 static int keep_running = 1;
 static int hide_unseen = 1;
+static int raw_vsc = 0;
 static int page_start = 0;
 static int current = 0;
 static int rebuild = 0;
@@ -869,8 +870,12 @@ draw_bar_b(void)
 		    verbosity->label);
 		X -= strlen(verbosity->label) + 2;
 	}
-	if (!hide_unseen)
+	if (!hide_unseen) {
 		mvwprintw(w_bar_b, 0, X - 6, "%s", "UNSEEN");
+		X -= 8;
+	}
+	if (raw_vsc)
+		mvwprintw(w_bar_b, 0, X - 3, "%s", "RAW");
 
 	wnoutrefresh(w_bar_b);
 }
@@ -975,6 +980,7 @@ handle_points_keypress(struct vsc *vsc, enum kb_e kb)
 		break;
 	case KB_RAW:
 		VSC_Arg(vsc, 'r', NULL);
+		raw_vsc = VSC_IsRaw(vsc);
 		rebuild = REBUILD_NEXT;
 		break;
 	case KB_SCALE:
@@ -1171,6 +1177,7 @@ do_curses(struct vsm *vsm, struct vsc *vsc)
 
 	VSC_State(vsc, newpt, delpt, NULL);
 
+	raw_vsc = VSC_IsRaw(vsc);
 	rebuild |= REBUILD_FIRST;
 	(void)VSC_Iter(vsc, vsm, NULL, NULL);
 	build_pt_array();

--- a/bin/varnishstat/varnishstat_options.h
+++ b/bin/varnishstat/varnishstat_options.h
@@ -47,6 +47,10 @@
 	    "Lists the available fields to use with the -f option",	\
 	    "Lists the available fields to use with the -f option."	\
 	)
+#define STAT_OPT_r							\
+	VOPT("r", "[-r]", "Toggle raw or adjusted gauges",		\
+	    "Toggle raw or adjusted gauges, adjusted is the default."	\
+	)
 #define STAT_OPT_x							\
 	VOPT("x", "[-x]", "Print statistics to stdout as XML",		\
 	    "Print statistics to stdout as XML."			\
@@ -59,6 +63,7 @@ VSC_OPT_I
 STAT_OPT_j
 STAT_OPT_l
 VUT_OPT_n
+STAT_OPT_r
 VUT_OPT_t
 VUT_GLOBAL_OPT_V
 VSC_OPT_X

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -862,7 +862,7 @@ do_stat_dump_cb(void *priv, const struct VSC_point * const pt)
 
 	if (strcmp(pt->ctype, "uint64_t"))
 		return (0);
-	u = *pt->ptr;
+	u = VSC_Value(pt);
 
 	if (strcmp(dp->arg, "*")) {
 		if (fnmatch(dp->arg, pt->name, 0))
@@ -924,7 +924,7 @@ do_expect_cb(void *priv, const struct VSC_point * const pt)
 	if (!sp->lhs.good && stat_match(sp->lhs.pattern, pt->name) == 0) {
 		AZ(strcmp(pt->ctype, "uint64_t"));
 		AN(pt->ptr);
-		sp->lhs.val = *pt->ptr;
+		sp->lhs.val = VSC_Value(pt);
 		sp->lhs.good = 1;
 	}
 
@@ -934,7 +934,7 @@ do_expect_cb(void *priv, const struct VSC_point * const pt)
 	    stat_match(sp->rhs.pattern, pt->name) == 0) {
 		AZ(strcmp(pt->ctype, "uint64_t"));
 		AN(pt->ptr);
-		sp->rhs.val = *pt->ptr;
+		sp->rhs.val = VSC_Value(pt);
 		sp->rhs.good = 1;
 	}
 

--- a/include/tbl/feature_bits.h
+++ b/include/tbl/feature_bits.h
@@ -78,6 +78,10 @@ FEATURE_BIT(VALIDATE_HEADERS,		validate_headers,
     "Validate all header set operations to conform to RFC7230."
 )
 
+FEATURE_BIT(BUSY_STATS_RATE,	busy_stats_rate,
+    "Make busy workers comply with thread_stats_rate."
+)
+
 #undef FEATURE_BIT
 
 /*lint -restore */

--- a/include/vapi/vsc.h
+++ b/include/vapi/vsc.h
@@ -159,4 +159,15 @@ const struct VSC_level_desc *VSC_ChangeLevel(const struct VSC_level_desc*, int);
 	 * Change a level up or down.
 	 */
 
+static inline uint64_t
+VSC_Value(const struct VSC_point * const pt)
+{
+	uint64_t val;
+
+	val = *pt->ptr;
+	if (pt->semantics == 'g' && val > INT64_MAX)
+		val = 0;
+	return (val);
+}
+
 #endif /* VAPI_VSC_H_INCLUDED */

--- a/include/vapi/vsc.h
+++ b/include/vapi/vsc.h
@@ -161,6 +161,11 @@ const struct VSC_level_desc *VSC_ChangeLevel(const struct VSC_level_desc*, int);
 	 * Change a level up or down.
 	 */
 
+unsigned VSC_IsRaw(const struct vsc *);
+	/*
+	 * Returns zero if gauges are adjusted by VSC_Value().
+	 */
+
 static inline uint64_t
 VSC_Value(const struct VSC_point * const pt)
 {

--- a/include/vapi/vsc.h
+++ b/include/vapi/vsc.h
@@ -69,6 +69,7 @@ struct VSC_point {
 	const char *sdesc;		/* short description		*/
 	const char *ldesc;		/* long description		*/
 	void *priv;			/* return val from VSC_new_f	*/
+	unsigned raw;			/* adjusted or raw value	*/
 };
 
 /*---------------------------------------------------------------------
@@ -118,6 +119,7 @@ int VSC_Arg(struct vsc *, char arg, const char *opt);
 	 *	'X' - field exclusion glob
 	 *	'R' - required field glob
 	 *	'f' - legacy field filter glob (deprecated)
+	 *	'r' - toggle raw gauges
 	 *
 	 * Return:
 	 *	-1 error, VSM_Error() returns diagnostic string
@@ -165,7 +167,7 @@ VSC_Value(const struct VSC_point * const pt)
 	uint64_t val;
 
 	val = *pt->ptr;
-	if (pt->semantics == 'g' && val > INT64_MAX)
+	if (!pt->raw && pt->semantics == 'g' && val > INT64_MAX)
 		val = 0;
 	return (val);
 }

--- a/lib/libvarnishapi/libvarnishapi.map
+++ b/lib/libvarnishapi/libvarnishapi.map
@@ -195,3 +195,11 @@ LIBVARNISHAPI_2.5 {	/* 2020-09-15 release */
     local:
 	*;
 };
+
+LIBVARNISHAPI_2.6 {	/* 2020-03-15 release */
+    global:
+	# vsc.c
+	VSC_IsRaw;
+    local:
+	*;
+};

--- a/lib/libvarnishapi/vsc.c
+++ b/lib/libvarnishapi/vsc.c
@@ -191,6 +191,13 @@ VSC_Arg(struct vsc *vsc, char arg, const char *opt)
 	}
 }
 
+unsigned
+VSC_IsRaw(const struct vsc *vsc)
+{
+
+	CHECK_OBJ_NOTNULL(vsc, VSC_MAGIC);
+	return (vsc->raw);
+}
 
 /*--------------------------------------------------------------------
  */

--- a/lib/libvarnishapi/vsc.c
+++ b/lib/libvarnishapi/vsc.c
@@ -98,6 +98,7 @@ struct vsc {
 	unsigned		magic;
 #define VSC_MAGIC		0x3373554a
 
+	unsigned		raw;
 	struct vsc_sf_head	sf_list;
 	VTAILQ_HEAD(,vsc_seg)	segs;
 
@@ -185,6 +186,7 @@ VSC_Arg(struct vsc *vsc, char arg, const char *opt)
 	case 'X': return (vsc_sf_arg(vsc, opt, VSC_SF_EXCLUDE));
 	case 'R': return (vsc_sf_arg(vsc, opt, VSC_SF_REQUIRE));
 	case 'f': return (vsc_f_arg(vsc, opt));
+	case 'r': vsc->raw = !vsc->raw; return (1);
 	default: return (0);
 	}
 }
@@ -299,6 +301,7 @@ vsc_fill_point(const struct vsc *vsc, const struct vsc_seg *seg,
 	AN(vt);
 
 	point->point.ptr = (volatile void*)(seg->body + atoi(vt->value));
+	point->point.raw = vsc->raw;
 }
 
 static void


### PR DESCRIPTION
See the commit log for details:

* push stats in more relevant cases (by @mbgrydeland)
* adjust negative gauges to zero
  * add a 'r' control everywhere relevant
* push stats from the HTTP/1 session loop