### PR TITLE
add `std.ban()` for vcl access to ban errors

### DIFF
--- a/bin/varnishtest/tests/v00009.vtc
+++ b/bin/varnishtest/tests/v00009.vtc
@@ -1,0 +1,104 @@
+varnishtest "Test std.ban()"
+
+# see also v00011.vtc
+
+server s1 {
+	rxreq
+	txresp -body "foo"
+
+	rxreq
+	txresp -body "foo"
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_synth {
+		set resp.http.b1 = std.ban(req.http.doesntexist);
+		set resp.http.b1e = std.ban_error();
+		set resp.http.b2 = std.ban("");
+		set resp.http.b2e = std.ban_error();
+		set resp.http.b3 = std.ban("req.url");
+		set resp.http.b3e = std.ban_error();
+		set resp.http.b4 = std.ban("req.url //");
+		set resp.http.b4e = std.ban_error();
+		set resp.http.b5 = std.ban("req.url // bar");
+		set resp.http.b5e = std.ban_error();
+		set resp.http.b6 = std.ban("req.url == bar //");
+		set resp.http.b6e = std.ban_error();
+		set resp.http.b7 = std.ban("foo == bar //");
+		set resp.http.b7e = std.ban_error();
+		set resp.http.b8 = std.ban("obj.age == 4");
+		set resp.http.b8e = std.ban_error();
+		set resp.http.b9 = std.ban("obj.age // 4d");
+		set resp.http.b9e = std.ban_error();
+		set resp.http.b10 = std.ban("obj.http.foo > 4d");
+		set resp.http.b10e = std.ban_error();
+		set resp.http.b11 = std.ban("req.url ~ ^/$");
+		set resp.http.b11e = std.ban_error();
+	}
+	sub vcl_recv {
+		if (req.method == "BAN") {
+			return (synth(209,"foo"));
+		}
+	}
+
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.X-Varnish == "1001"
+} -run
+
+logexpect l1 -v v1 -d 1 -g vxid {
+	expect * 1004	VCL_Error {ban[(][)]: Null argument}
+	expect * 1004	VCL_Error {ban[(][)]: No ban conditions found[.]}
+	expect * 1004	VCL_Error {ban[(][)]: Expected comparison operator[.]}
+	expect * 1004	VCL_Error {ban[(][)]: Expected second operand[.]}
+	expect * 1004	VCL_Error {ban[(][)]: expected conditional [(]==, !=, ~ or !~[)] got "//"}
+	expect * 1004	VCL_Error {ban[(][)]: Expected && between conditions, found "//"}
+	expect * 1004	VCL_Error {ban[(][)]: Unknown or unsupported field "foo"}
+	expect * 1004	VCL_Error {ban[(][)]: expected duration <n.nn>.ms|s|m|h|d|w|y. got "4"}
+	expect * 1004	VCL_Error {ban[(][)]: expected conditional [(]==, !=, >, >=, < or <=[)] got "//"}
+	expect * 1004	VCL_Error {ban[(][)]: expected conditional [(]==, !=, ~ or !~[)] got ">"}
+
+
+} -start
+
+client c1 {
+	txreq -req "BAN"
+	rxresp
+	expect resp.http.X-Varnish == "1004"
+	expect resp.status == 209
+	expect resp.http.b1 == false
+	expect resp.http.b1e == {Null argument}
+	expect resp.http.b2 == false
+	expect resp.http.b2e == {No ban conditions found.}
+	expect resp.http.b3 == false
+	expect resp.http.b3e == {Expected comparison operator.}
+	expect resp.http.b4 == false
+	expect resp.http.b4e == {Expected second operand.}
+	expect resp.http.b5 == false
+	expect resp.http.b5e == {expected conditional (==, !=, ~ or !~) got "//"}
+	expect resp.http.b6 == false
+	expect resp.http.b6e == {Expected && between conditions, found "//"}
+	expect resp.http.b7 == false
+	expect resp.http.b7e == {Unknown or unsupported field "foo"}
+	expect resp.http.b8 == false
+	expect resp.http.b8e == {expected duration <n.nn>[ms|s|m|h|d|w|y] got "4"}
+	expect resp.http.b9 == false
+	expect resp.http.b9e == {expected conditional (==, !=, >, >=, < or <=) got "//"}
+	expect resp.http.b10 == false
+	expect resp.http.b10e == {expected conditional (==, !=, ~ or !~) got ">"}
+	expect resp.http.b11 == true
+	expect resp.http.b11e == {}
+} -run
+
+logexpect l1 -wait
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.X-Varnish == "1006"
+} -run

--- a/bin/varnishtest/tests/v00011.vtc
+++ b/bin/varnishtest/tests/v00011.vtc
@@ -1,5 +1,7 @@
 varnishtest "Test vcl ban()"
 
+# see also v00009.vtc
+
 server s1 {
 	rxreq
 	txresp -body "foo"

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -58,6 +58,7 @@
  *	struct vmod_priv_methods added
  *	struct vmod_priv free member replaced with methods
  *	VRT_CTX_Assert() added
+ *	VRT_ban_string() signature changed
  * 12.0 (2020-09-15)
  *	Added VRT_DirectorResolve()
  *	Added VCL_STRING VRT_BLOB_string(VRT_CTX, VCL_BLOB)
@@ -494,7 +495,7 @@ VCL_BYTES VRT_CacheReqBody(VRT_CTX, VCL_BYTES maxsize);
 /* Regexp related */
 
 const char *VRT_regsub(VRT_CTX, int all, const char *, void *, const char *);
-VCL_VOID VRT_ban_string(VRT_CTX, VCL_STRING);
+VCL_STRING VRT_ban_string(VRT_CTX, VCL_STRING);
 VCL_INT VRT_purge(VRT_CTX, VCL_DURATION, VCL_DURATION, VCL_DURATION);
 VCL_VOID VRT_synth(VRT_CTX, VCL_INT, VCL_STRING);
 VCL_VOID VRT_hit_for_pass(VRT_CTX, VCL_DURATION);

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -187,7 +187,7 @@ vcc_act_ban(struct vcc *tl, struct token *t, struct symbol *sym)
 	ExpectErr(tl, '(');
 	vcc_NextToken(tl);
 
-	Fb(tl, 1, "VRT_ban_string(ctx, \n");
+	Fb(tl, 1, "(void) VRT_ban_string(ctx, \n");
 	tl->indent += INDENT;
 	vcc_Expr(tl, STRING);
 	tl->indent -= INDENT;

--- a/lib/libvmod_std/vmod_std.vcc
+++ b/lib/libvmod_std/vmod_std.vcc
@@ -561,6 +561,16 @@ Example::
 
 	std.rollback(bereq);
 
+$Function BOOL ban(STRING)
+
+Same as :ref:`vcl(7)_ban`, but returns true if the ban succeeded and
+false otherwise.
+
+$Function STRING ban_error()
+
+Returns a textual error description of the last `std.ban()`_ call from
+the same task or the empty string if there either was no error or no
+`std.ban()`_ call.
 
 DEPRECATED functions
 ====================
@@ -629,8 +639,6 @@ be returned.
 Example::
 
 	set req.http.real = std.time2real(now, 1.0);
-
-
 
 SEE ALSO
 ========


### PR DESCRIPTION
The `ban()` vcl action adds bans like the `ban` CLI command, but has no facility for in-band error reporting. Errors are only reported to VSL.

We add `std.ban()` as a replacement for `ban()` with identical semantics, but error reporting added.

We add `v00009.vtc` mirroring `v00011.vtc`, but with `std.ban()` replacing `ban()`. The test number was chosen to fill a gap close to `v00011.vtc`.

Implementation:

We change `VRT_ban_string()` to return any error. Where the error is not a constant string, we need to format it on the workspace. For workspace overflows, we need to fall back to canned constant error strings to ensure that the error case never appears as success.