### PR TITLE
Add VSA_getsockname()

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -315,8 +315,6 @@ vca_mk_tcp(const struct wrk_accept *wa,
     struct sess *sp, char *laddr, char *lport, char *raddr, char *rport)
 {
 	struct suckaddr *sa;
-	struct sockaddr_storage ss;
-	socklen_t sl;
 
 	AN(SES_Reserve_remote_addr(sp, &sa));
 	AN(VSA_Build(sa, &wa->acceptaddr, wa->acceptaddrlen));
@@ -326,10 +324,9 @@ vca_mk_tcp(const struct wrk_accept *wa,
 	AN(SES_Set_String_Attr(sp, SA_CLIENT_IP, raddr));
 	AN(SES_Set_String_Attr(sp, SA_CLIENT_PORT, rport));
 
-	sl = sizeof ss;
-	AZ(getsockname(sp->fd, (void*)&ss, &sl));
+
 	AN(SES_Reserve_local_addr(sp, &sa));
-	AN(VSA_Build(sa, &ss, sl));
+	AN(VSA_getsockname(sp->fd, sa, vsa_suckaddr_len));
 	sp->sattr[SA_SERVER_ADDR] = sp->sattr[SA_LOCAL_ADDR];
 	VTCP_name(sa, laddr, VTCP_ADDRBUFSIZE, lport, VTCP_PORTBUFSIZE);
 }

--- a/include/vsa.h
+++ b/include/vsa.h
@@ -42,6 +42,7 @@ unsigned VSA_Port(const struct suckaddr *);
 int VSA_Compare(const struct suckaddr *, const struct suckaddr *);
 int VSA_Compare_IP(const struct suckaddr *, const struct suckaddr *);
 struct suckaddr *VSA_Clone(const struct suckaddr *sua);
+struct suckaddr *VSA_getsockname(int, void *, size_t);
 
 const void *VSA_Get_Sockaddr(const struct suckaddr *, socklen_t *sl);
 int VSA_Get_Proto(const struct suckaddr *);

--- a/lib/libvarnish/vsa.c
+++ b/lib/libvarnish/vsa.c
@@ -418,3 +418,26 @@ VSA_Port(const struct suckaddr *sua)
 		return (0);
 	}
 }
+
+/* VSA_Build from socket name of a file descriptor */
+struct suckaddr *
+VSA_getsockname(int fd, void *d, size_t l)
+{
+	struct suckaddr *sua;
+	socklen_t sl;
+	int r;
+
+	AN(d);
+	if (l != vsa_suckaddr_len) {
+		errno = EINVAL;
+		return (NULL);
+	}
+
+	sua = d;
+
+	INIT_OBJ(sua, SUCKADDR_MAGIC);
+	sl = sizeof(sua->sa);
+	r = getsockname(fd, &sua->sa, &sl);
+
+	return (r == 0 ? sua : NULL);
+}


### PR DESCRIPTION
Flexelint on Linux exhibits exactly the problem described by @bsdphk  in his rant at the top of `vsa.c`, quote:

> Do I need to tell you that static code analysis tools have a really hard time coping with (struct suckaddr_storage), and that they give a lot of false negatives which confuse people ?

One instance of this issue:

```
--- Module:   cache/cache_acceptor.c (C)
                                               _
#... _assert(!!((getsockname(sp->fd, (void*)&ss, &sl)) == 0)) /*lint -restore *
#... getsockname(sp->fd, (void*)&ss, &sl)) == 0); } while (0)
	AZ(getsockname(sp->fd, (void*)&ss, &sl));
cache/cache_acceptor.c  330  Error 64: Type mismatch (arg. no. 2) (union
    __SOCKADDR_ARG = void *)
                                 _
#... SA_Build(sa, &ss, sl)) != 0); } while (0)
	AN(VSA_Build(sa, &ss, sl));
cache/cache_acceptor.c  332  Warning 603: Symbol 'ss' (line 318) not
    initialized
cache/cache_acceptor.c  318  Info 830: Location cited in prior message
                                                                  _
			i = accept(ls->sock, (void*)&wa.acceptaddr,
cache/cache_acceptor.c  458  Error 64: Type mismatch (arg. no. 2) (union
    __SOCKADDR_ARG = void *)
```

There is one more in `cache/cache_backend_probe.c`

As the purpose of VSA is to avoid exactly this kind of trouble, we provide a VSA-wrapper for `getsockname()`.