### PR TITLE
VCL_REGEX

### DIFF
--- a/bin/varnishtest/tests/c00103.vtc
+++ b/bin/varnishtest/tests/c00103.vtc
@@ -1,0 +1,32 @@
+varnishtest "REGEX expressions in VCL"
+
+varnish v1 -vcl {
+	import debug;
+	backend be none;
+	sub vcl_recv {
+		# NB: the REGEX expression below is needlessly complicated
+		# on purpose to ensure we don't treat REGEX expressions
+		# differently.
+		if (req.url ~ (debug.just_return_regex(
+		    debug.just_return_regex("hello")))) {
+			return (synth(200));
+		}
+		return (synth(500));
+	}
+	sub vcl_synth {
+		set resp.reason = regsub(resp.reason,
+		    debug.just_return_regex("OK"), "world");
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 500
+	expect resp.reason == "Internal Server Error"
+
+	txreq -url "/hello"
+	rxresp
+	expect resp.status == 200
+	expect resp.reason == world
+} -run

--- a/bin/varnishtest/tests/r00409.vtc
+++ b/bin/varnishtest/tests/r00409.vtc
@@ -1,10 +1,28 @@
 varnishtest "Regression test for ticket 409"
 
-varnish v1 -errvcl {Expected CSTR got '!'} {
-	backend b { .host = "${localhost}"; }
+varnish v1 -errvcl {Unknown token '!' when looking for REGEX} {
+	backend be none;
 	sub vcl_recv {
 		if ( req.url ~ ! "\.(png|jpg|gif|js|css)$" ) {
 			return (pass);
 		}
+	}
+}
+
+varnish v1 -errvcl {Expression has type STRING, expected REGEX} {
+	backend be none;
+	sub vcl_recv {
+		set req.http.regex = "\.(png|jpg|gif|js|css)$";
+		if (req.url ~ req.http.regex) {
+			return (pass);
+		}
+	}
+}
+
+varnish v1 -errvcl {Expression has type STRING, expected REGEX} {
+	backend be none;
+	sub vcl_recv {
+		set req.http.regex = "\?.*";
+		set req.url = regsub(req.url, req.http.regex, "");
 	}
 }

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -385,6 +385,9 @@ REGEX
 	C-type: ``const struct vre *``
 
 	This is an opaque type for regular expressions with a VCL scope.
+	The REGEX type is only meant for regular expression literals
+	managed by the VCL compiler. For dynamic regular expressions or
+	complex usage see the API from the ``include/vre.h`` file.
 
 STRING
 	C-type: ``const char *``

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -381,6 +381,11 @@ REAL
 
 	A floating point value.
 
+REGEX
+	C-type: ``const struct vre *``
+
+	This is an opaque type for regular expressions with a VCL scope.
+
 STRING
 	C-type: ``const char *``
 

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -71,3 +71,8 @@ struct vpi_ii {
 	const void *			p;
 	const char * const		name;
 };
+
+/* Compile time regexp */
+
+void VPI_re_init(struct vre **, const char *);
+void VPI_re_fini(struct vre *);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -273,6 +273,7 @@ typedef int64_t					VCL_INT;
 typedef const struct suckaddr *			VCL_IP;
 typedef const struct vrt_backend_probe *	VCL_PROBE;
 typedef double					VCL_REAL;
+typedef const struct vre *			VCL_REGEX;
 typedef const struct stevedore *		VCL_STEVEDORE;
 typedef const struct strands *			VCL_STRANDS;
 typedef const char *				VCL_STRING;

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -61,6 +61,10 @@
  *	VRT_ban_string() signature changed
  *	VRT_priv_task_get() added
  *	VRT_priv_top_get() added
+ *	VRT_re_init removed
+ *	VRT_re_fini removed
+ *	VRT_re_match signature changed
+ *	VRT_regsub signature changed
  * 12.0 (2020-09-15)
  *	Added VRT_DirectorResolve()
  *	Added VCL_STRING VRT_BLOB_string(VRT_CTX, VCL_BLOB)
@@ -459,14 +463,6 @@ void VRT_acl_log(VRT_CTX, const char *);
 int VRT_acl_match(VRT_CTX, VCL_ACL, VCL_IP);
 
 /***********************************************************************
- * Compile time regexp
- */
-
-void VRT_re_init(void **, const char *);
-void VRT_re_fini(void *);
-int VRT_re_match(VRT_CTX, const char *, void *);
-
-/***********************************************************************
  * Getting hold of the various struct http
  */
 
@@ -495,7 +491,8 @@ VCL_BYTES VRT_CacheReqBody(VRT_CTX, VCL_BYTES maxsize);
 
 /* Regexp related */
 
-const char *VRT_regsub(VRT_CTX, int all, const char *, void *, const char *);
+VCL_BOOL VRT_re_match(VRT_CTX, VCL_STRING, VCL_REGEX);
+VCL_STRING VRT_regsub(VRT_CTX, int all, VCL_STRING, VCL_REGEX, VCL_STRING);
 VCL_STRING VRT_ban_string(VRT_CTX, VCL_STRING);
 VCL_INT VRT_purge(VRT_CTX, VCL_DURATION, VCL_DURATION, VCL_DURATION);
 VCL_VOID VRT_synth(VRT_CTX, VCL_INT, VCL_STRING);

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -151,6 +151,11 @@ const struct type REAL[1] = {{
 	.multype =		REAL,
 }};
 
+const struct type REGEX[1] = {{
+	.magic =		TYPE_MAGIC,
+	.name =			"REGEX",
+}};
+
 static const struct vcc_method stevedore_methods[] = {
 #define VRTSTVVAR(nm, vtype, ctype, dval) \
 	{ VCC_METHOD_MAGIC, vtype, #nm, "VRT_stevedore_" #nm "(\v1)", 0},

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -71,12 +71,12 @@ vcc_regexp(struct vcc *tl, struct vsb *vgc_name)
 	if (vgc_name)
 		VSB_cat(vgc_name, buf);
 
-	Fh(tl, 0, "static void *%s;\n", buf);
+	Fh(tl, 0, "static struct vre *%s;\n", buf);
 	ifp = New_IniFin(tl);
-	VSB_printf(ifp->ini, "\tVRT_re_init(&%s, ",buf);
+	VSB_printf(ifp->ini, "\tVPI_re_init(&%s, ",buf);
 	EncToken(ifp->ini, tl->t);
 	VSB_cat(ifp->ini, ");");
-	VSB_printf(ifp->fin, "\t\tVRT_re_fini(%s);", buf);
+	VSB_printf(ifp->fin, "\t\tVPI_re_fini(%s);", buf);
 }
 
 /*

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -57,9 +57,8 @@ vcc_regexp(struct vcc *tl, struct vsb *vgc_name)
 	int erroroffset;
 	struct inifin *ifp;
 
-	Expect(tl, CSTR);
-	if (tl->err)
-		return;
+	assert(tl->t->tok == CSTR);
+
 	t = VRE_compile(tl->t->dec, 0, &error, &erroroffset);
 	if (t == NULL) {
 		VSB_printf(tl->sb,
@@ -78,7 +77,6 @@ vcc_regexp(struct vcc *tl, struct vsb *vgc_name)
 	EncToken(ifp->ini, tl->t);
 	VSB_cat(ifp->ini, ");");
 	VSB_printf(ifp->fin, "\t\tVRT_re_fini(%s);", buf);
-	vcc_NextToken(tl);
 }
 
 /*

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -110,6 +110,7 @@ CTYPES = {
     'IP':          "VCL_IP",
     'PROBE':       "VCL_PROBE",
     'REAL':        "VCL_REAL",
+    'REGEX':       "VCL_REGEX",
     'STEVEDORE':   "VCL_STEVEDORE",
     'STRANDS':     "VCL_STRANDS",
     'STRING':      "VCL_STRING",

--- a/vmod/vmod_cookie.vcc
+++ b/vmod/vmod_cookie.vcc
@@ -81,7 +81,7 @@ Example::
 	}
 
 
-$Function VOID filter_re(PRIV_TASK, PRIV_CALL, STRING expression)
+$Function VOID filter_re(PRIV_TASK, REGEX expression)
 
 Delete all cookies from internal vmod storage that matches the
 regular expression ``expression``.
@@ -109,7 +109,7 @@ Example::
 	    # "cookie1: value1; cookie2: value2;";
 	}
 
-$Function VOID keep_re(PRIV_TASK, PRIV_CALL, STRING expression)
+$Function VOID keep_re(PRIV_TASK, REGEX expression)
 
 Delete all cookies from internal vmod storage that does not match
 expression ``expression``.
@@ -155,7 +155,7 @@ Example::
 	    std.log("cookie1 value is: " + cookie.get("cookie1"));
 	}
 
-$Function STRING get_re(PRIV_TASK, PRIV_CALL, STRING expression)
+$Function STRING get_re(PRIV_TASK, REGEX expression)
 
 Get the value of the first cookie in internal vmod storage that matches
 regular expression ``expression``. If nothing matches, an empty string

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1278,3 +1278,12 @@ xyzzy_validhdr(VRT_CTX, VCL_STRANDS s)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	return (VRT_ValidHdr(ctx, s));
 }
+
+VCL_REGEX v_matchproto_(td_xyzzy_regex)
+xyzzy_just_return_regex(VRT_CTX, VCL_REGEX r)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(r);
+	return (r);
+}

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -319,3 +319,7 @@ A function mixing a named PRIV_TASK with optional parameters.
 $Function BOOL validhdr(STRANDS)
 
 Test if the argument is a valid header according to RFC7230 section 3.2.
+
+$Function REGEX just_return_regex(REGEX)
+
+Take a REGEX argument and return it.


### PR DESCRIPTION
I wrote this patch myself, ended up not reviewing a previous submission.

There are open questions in VRT where part of the API uses `VCL_REGEX` and others use `void *`.