### PR TITLE
Add PAN_dump_oneline() ?

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -848,9 +848,12 @@ Tlen(const txt t)
  */
 #define W_TIM_real(w) ((w)->lastused = VTIM_real())
 
-int PAN_dump_struct2(struct vsb *vsb, const void *ptr,
+int PAN_dump_struct2(struct vsb *vsb, int block, const void *ptr,
     const char *smagic, unsigned magic, const char *fmt, ...)
-    v_printflike_(5,6);
+    v_printflike_(6,7);
 
-#define PAN_dump_struct(vsb, ptr, magic, ...) \
-    PAN_dump_struct2(vsb, ptr, #magic, magic, __VA_ARGS__)
+#define PAN_dump_struct(vsb, ptr, magic, ...)		\
+    PAN_dump_struct2(vsb, 1, ptr, #magic, magic, __VA_ARGS__)
+
+#define PAN_dump_oneline(vsb, ptr, magic, ...)		\
+    PAN_dump_struct2(vsb, 0, ptr, #magic, magic, __VA_ARGS__)

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -110,7 +110,7 @@ static const void *already_list[N_ALREADY];
 static int already_idx;
 
 int
-PAN_dump_struct2(struct vsb *vsb, const void *ptr,
+PAN_dump_struct2(struct vsb *vsb, int block, const void *ptr,
     const char *smagic, unsigned magic, const char *fmt, ...)
 {
 	va_list ap;
@@ -125,10 +125,14 @@ PAN_dump_struct2(struct vsb *vsb, const void *ptr,
 		VSB_printf(vsb, " = NULL\n");
 		return (-1);
 	}
-	VSB_printf(vsb, " = %p {\n", ptr);
+	VSB_printf(vsb, " = %p {", ptr);
+	if (block)
+		VSB_putc(vsb, '\n');
 	for (i = 0; i < already_idx; i++) {
 		if (already_list[i] == ptr) {
-			VSB_cat(vsb, "  [Already dumped, see above]\n");
+			VSB_cat(vsb, "  [Already dumped, see above]");
+			if (block)
+				VSB_putc(vsb, '\n');
 			VSB_cat(vsb, "},\n");
 			return (-2);
 		}
@@ -138,11 +142,14 @@ PAN_dump_struct2(struct vsb *vsb, const void *ptr,
 	uptr = ptr;
 	if (*uptr != magic) {
 		VSB_printf(vsb, "  .magic = 0x%08x", *uptr);
-		VSB_printf(vsb, " EXPECTED: %s=0x%08x\n", smagic, magic);
+		VSB_printf(vsb, " EXPECTED: %s=0x%08x", smagic, magic);
+		if (block)
+			VSB_putc(vsb, '\n');
 		VSB_printf(vsb, "}\n");
 		return (-3);
 	}
-	VSB_indent(vsb, 2);
+	if (block)
+		VSB_indent(vsb, 2);
 	return (0);
 }
 

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -71,25 +71,23 @@ pan_privs(struct vsb *vsb, const struct vrt_privs *privs)
 	VSB_printf(vsb, "privs = %p {\n", privs);
 	VSB_indent(vsb, 2);
 	VRBT_FOREACH(vp, vrt_privs, privs) {
-		if (PAN_dump_struct(vsb, vp, VRT_PRIV_MAGIC, "priv"))
+		if (PAN_dump_oneline(vsb, vp, VRT_PRIV_MAGIC, "priv"))
 			continue;
 		p = vp->priv;
 		//lint -e{774}
 		if (p == NULL) {
 			// should never happen
-			VSB_printf(vsb, "NULL vmod %jx\n",
+			VSB_printf(vsb, "NULL vmod %jx},\n",
 			    (uintmax_t)vp->vmod_id);
-		} else {
-			m = p->methods;
-			VSB_printf(vsb,
-			    "{p %p l %ld m %p t \"%s\"} vmod %jx\n",
-			    p->priv, p->len, m,
-			    m != NULL ? m->type : "",
-			    (uintmax_t)vp->vmod_id
-			);
+			continue;
 		}
-		VSB_indent(vsb, -2);
-		VSB_cat(vsb, "},\n");
+		m = p->methods;
+		VSB_printf(vsb,
+		    "{p %p l %ld m %p t \"%s\"} vmod %jx},\n",
+		    p->priv, p->len, m,
+		    m != NULL ? m->type : "",
+		    (uintmax_t)vp->vmod_id
+		);
 	}
 	VSB_indent(vsb, -2);
 	VSB_cat(vsb, "},\n");


### PR DESCRIPTION
Very minor, utterly insignificant suggestion which I am just not sure about:

This adds a variant of `PAN_dump_struct()` which does not start a new indentation level on a new line.

For example, privs panic:

* before:
```
***  v1    debug|  privs = 0x7ff354c96200 {
***  v1    debug|    priv = 0x7ff354c98198 {
***  v1    debug|      {p (nil) l 0 m (nil) t \"\"} vmod 7ff35a7fc260
***  v1    debug|    },
***  v1    debug|  },
```
* after:
```
***  v1    debug|  privs = 0x7f0674096200 {
***  v1    debug|    priv = 0x7f0674098198 {{p (nil) l 0 m (nil) t \"\"} vmod 7f06793fd260},
***  v1    debug|  },
```

Obviously, this makes more of a difference for iterations over many objects