### PR TITLE
h2: Add a sess_close reason to h2 connection errors

### DIFF
--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -44,15 +44,15 @@ struct h2_error_s {
 	uint32_t			val;
 	int				stream;
 	int				connection;
+	enum sess_close			reason;
 };
 
 typedef const struct h2_error_s *h2_error;
 
-#define H2EC0(U,v,d)
-#define H2EC1(U,v,d) extern const struct h2_error_s H2CE_##U[1];
-#define H2EC2(U,v,d) extern const struct h2_error_s H2SE_##U[1];
-#define H2EC3(U,v,d) H2EC1(U,v,d) H2EC2(U,v,d)
-#define H2_ERROR(NAME, val, sc, desc) H2EC##sc(NAME, val, desc)
+#define H2EC1(U,v,r,d) extern const struct h2_error_s H2CE_##U[1];
+#define H2EC2(U,v,r,d) extern const struct h2_error_s H2SE_##U[1];
+#define H2EC3(U,v,r,d) H2EC1(U,v,r,d) H2EC2(U,v,r,d)
+#define H2_ERROR(NAME, val, sc, reason, desc) H2EC##sc(NAME, val, reason, desc)
 #include "tbl/h2_error.h"
 #undef H2EC1
 #undef H2EC2

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -45,10 +45,10 @@
 #include "vtcp.h"
 #include "vtim.h"
 
-#define H2EC1(U,v,d) const struct h2_error_s H2CE_##U[1] = {{#U,d,v,0,1}};
-#define H2EC2(U,v,d) const struct h2_error_s H2SE_##U[1] = {{#U,d,v,1,0}};
-#define H2EC3(U,v,d) H2EC1(U,v,d) H2EC2(U,v,d)
-#define H2_ERROR(NAME, val, sc, desc) H2EC##sc(NAME, val, desc)
+#define H2EC1(U,v,r,d) const struct h2_error_s H2CE_##U[1] = {{#U,d,v,0,1,r}};
+#define H2EC2(U,v,r,d) const struct h2_error_s H2SE_##U[1] = {{#U,d,v,1,0,r}};
+#define H2EC3(U,v,r,d) H2EC1(U,v,r,d) H2EC2(U,v,r,d)
+#define H2_ERROR(NAME, val, sc, reason, desc) H2EC##sc(NAME, val, reason, desc)
 #include "tbl/h2_error.h"
 #undef H2EC1
 #undef H2EC2
@@ -59,7 +59,8 @@ static const struct h2_error_s H2NN_ERROR[1] = {{
 	"Unknown error number",
 	0xffffffff,
 	1,
-	1
+	1,
+	SC_RX_JUNK
 }};
 
 enum h2frame {
@@ -86,10 +87,10 @@ h2_framename(enum h2frame h2f)
  */
 
 static const h2_error stream_errors[] = {
-#define H2EC1(U,v,d)
-#define H2EC2(U,v,d) [v] = H2SE_##U,
-#define H2EC3(U,v,d) H2EC1(U,v,d) H2EC2(U,v,d)
-#define H2_ERROR(NAME, val, sc, desc) H2EC##sc(NAME, val, desc)
+#define H2EC1(U,v,r,d)
+#define H2EC2(U,v,r,d) [v] = H2SE_##U,
+#define H2EC3(U,v,r,d) H2EC1(U,v,r,d) H2EC2(U,v,r,d)
+#define H2_ERROR(NAME, val, sc, reason, desc) H2EC##sc(NAME, val, reason, desc)
 #include "tbl/h2_error.h"
 #undef H2EC1
 #undef H2EC2
@@ -111,10 +112,10 @@ h2_streamerror(uint32_t u)
  */
 
 static const h2_error conn_errors[] = {
-#define H2EC1(U,v,d) [v] = H2CE_##U,
-#define H2EC2(U,v,d)
-#define H2EC3(U,v,d) H2EC1(U,v,d) H2EC2(U,v,d)
-#define H2_ERROR(NAME, val, sc, desc) H2EC##sc(NAME, val, desc)
+#define H2EC1(U,v,r,d) [v] = H2CE_##U,
+#define H2EC2(U,v,r,d)
+#define H2EC3(U,v,r,d) H2EC1(U,v,r,d) H2EC2(U,v,r,d)
+#define H2_ERROR(NAME, val, sc, reason, desc) H2EC##sc(NAME, val, reason, desc)
 #include "tbl/h2_error.h"
 #undef H2EC1
 #undef H2EC2

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -145,6 +145,7 @@ h2_del_sess(struct worker *wrk, struct h2_sess *h2, enum sess_close reason)
 	CHECK_OBJ_NOTNULL(h2, H2_SESS_MAGIC);
 	AZ(h2->refcnt);
 	assert(VTAILQ_EMPTY(&h2->streams));
+	AN(reason);
 
 	VHT_Fini(h2->dectbl);
 	AZ(pthread_cond_destroy(h2->winupd_cond));
@@ -432,8 +433,7 @@ h2_new_session(struct worker *wrk, void *arg)
 	h2->cond = NULL;
 	assert(h2->refcnt == 1);
 	h2_del_req(wrk, h2->req0);
-	/* TODO: proper sess close reason */
-	h2_del_sess(wrk, h2, SC_RX_JUNK);
+	h2_del_sess(wrk, h2, h2->error->reason);
 }
 
 struct transport H2_transport = {

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -52,7 +52,7 @@
 #define BUF_SIZE	(1024*2048)
 
 static const char *const h2_errs[] = {
-#define H2_ERROR(n,v,sc,t) [v] = #n,
+#define H2_ERROR(n,v,sc,r,t) [v] = #n,
 #include <tbl/h2_error.h>
 	NULL
 };
@@ -1228,7 +1228,7 @@ cmd_var_resolve(const struct stream *s, const char *spec, char *buf)
 		else
 			return (NULL);
 	}
-#define H2_ERROR(U,v,sc,t) \
+#define H2_ERROR(U,v,sc,r,t) \
 	if (!strcmp(spec, #U)) { return (#v); }
 #include "tbl/h2_error.h"
 	return (spec);

--- a/include/tbl/h2_error.h
+++ b/include/tbl/h2_error.h
@@ -30,6 +30,7 @@
  * RFC7540 section 11.4
  *
  * Types: conn=1|stream=2
+ * Reason: enum sess_close
  */
 
 /*lint -save -e525 -e539 */
@@ -38,6 +39,7 @@ H2_ERROR(
 	/* name */	NO_ERROR,
 	/* val */	0,
 	/* types */	3,
+	/* reason */	SC_REM_CLOSE,
 	/* descr */	"Graceful shutdown"
 )
 
@@ -45,6 +47,7 @@ H2_ERROR(
 	/* name */	PROTOCOL_ERROR,
 	/* val */	1,
 	/* types */	3,
+	/* reason */	SC_RX_JUNK,
 	/* descr */	"Protocol error detected"
 )
 
@@ -52,6 +55,7 @@ H2_ERROR(
 	/* name */	INTERNAL_ERROR,
 	/* val */	2,
 	/* types */	3,
+	/* reason */	SC_VCL_FAILURE,
 	/* descr */	"Implementation fault"
 )
 
@@ -59,6 +63,7 @@ H2_ERROR(
 	/* name */	FLOW_CONTROL_ERROR,
 	/* val */	3,
 	/* types */	3,
+	/* reason */	SC_OVERLOAD,
 	/* descr */	"Flow-control limits exceeded"
 )
 
@@ -66,6 +71,7 @@ H2_ERROR(
 	/* name */	SETTINGS_TIMEOUT,
 	/* val */	4,
 	/* types */	1,
+	/* reason */	SC_RX_TIMEOUT,
 	/* descr */	"Settings not acknowledged"
 )
 
@@ -73,6 +79,7 @@ H2_ERROR(
 	/* name */	STREAM_CLOSED,
 	/* val */	5,
 	/* types */	2,
+	/* reason */	SC_NULL,
 	/* descr */	"Frame received for closed stream"
 )
 
@@ -80,6 +87,7 @@ H2_ERROR(
 	/* name */	FRAME_SIZE_ERROR,
 	/* val */	6,
 	/* types */	3,
+	/* reason */	SC_RX_JUNK,
 	/* descr */	"Frame size incorrect"
 )
 
@@ -87,6 +95,7 @@ H2_ERROR(
 	/* name */	REFUSED_STREAM,
 	/* val */	7,
 	/* types */	2,
+	/* reason */	SC_NULL,
 	/* descr */	"Stream not processed"
 )
 
@@ -94,6 +103,7 @@ H2_ERROR(
 	/* name */	CANCEL,
 	/* val */	8,
 	/* types */	2,
+	/* reason */	SC_NULL,
 	/* descr */	"Stream cancelled"
 )
 
@@ -101,6 +111,7 @@ H2_ERROR(
 	/* name */	COMPRESSION_ERROR,
 	/* val */	9,
 	/* types */	1,
+	/* reason */	SC_RX_JUNK,
 	/* descr */	"Compression state not updated"
 )
 
@@ -108,6 +119,7 @@ H2_ERROR(
 	/* name */	CONNECT_ERROR,
 	/* val */	10,
 	/* types */	2,
+	/* reason */	SC_NULL,
 	/* descr */	"TCP connection error for CONNECT method"
 )
 
@@ -115,6 +127,7 @@ H2_ERROR(
 	/* name */	ENHANCE_YOUR_CALM,
 	/* val */	11,
 	/* types */	3,
+	/* reason */	SC_OVERLOAD,
 	/* descr */	"Processing capacity exceeded"
 )
 
@@ -122,6 +135,7 @@ H2_ERROR(
 	/* name */	INADEQUATE_SECURITY,
 	/* val */	12,
 	/* types */	1,
+	/* reason */	SC_RX_JUNK,
 	/* descr */	"Negotiated TLS parameters not acceptable"
 )
 
@@ -129,6 +143,7 @@ H2_ERROR(
 	/* name */	HTTP_1_1_REQUIRED,
 	/* val */	13,
 	/* types */	1,
+	/* reason */	SC_REQ_HTTP20,
 	/* descr */	"Use HTTP/1.1 for the request"
 )
 

--- a/include/tbl/h2_error.h
+++ b/include/tbl/h2_error.h
@@ -29,25 +29,108 @@
  *
  * RFC7540 section 11.4
  *
- * Fields: Upper, value, conn=1|stream=2, description
+ * Types: conn=1|stream=2
  */
 
 /*lint -save -e525 -e539 */
 
-H2_ERROR(NO_ERROR,	       0,3, "Graceful shutdown")
-H2_ERROR(PROTOCOL_ERROR,       1,3, "Protocol error detected")
-H2_ERROR(INTERNAL_ERROR,       2,3, "Implementation fault")
-H2_ERROR(FLOW_CONTROL_ERROR,   3,3, "Flow-control limits exceeded")
-H2_ERROR(SETTINGS_TIMEOUT,     4,1, "Settings not acknowledged")
-H2_ERROR(STREAM_CLOSED,	       5,2, "Frame received for closed stream")
-H2_ERROR(FRAME_SIZE_ERROR,     6,3, "Frame size incorrect")
-H2_ERROR(REFUSED_STREAM,       7,2, "Stream not processed")
-H2_ERROR(CANCEL,	       8,2, "Stream cancelled")
-H2_ERROR(COMPRESSION_ERROR,    9,1, "Compression state not updated")
-H2_ERROR(CONNECT_ERROR,	      10,2, "TCP connection error for CONNECT method")
-H2_ERROR(ENHANCE_YOUR_CALM,   11,3, "Processing capacity exceeded")
-H2_ERROR(INADEQUATE_SECURITY, 12,1, "Negotiated TLS parameters not acceptable")
-H2_ERROR(HTTP_1_1_REQUIRED,   13,1, "Use HTTP/1.1 for the request")
-#undef H2_ERROR
+H2_ERROR(
+	/* name */	NO_ERROR,
+	/* val */	0,
+	/* types */	3,
+	/* descr */	"Graceful shutdown"
+)
 
+H2_ERROR(
+	/* name */	PROTOCOL_ERROR,
+	/* val */	1,
+	/* types */	3,
+	/* descr */	"Protocol error detected"
+)
+
+H2_ERROR(
+	/* name */	INTERNAL_ERROR,
+	/* val */	2,
+	/* types */	3,
+	/* descr */	"Implementation fault"
+)
+
+H2_ERROR(
+	/* name */	FLOW_CONTROL_ERROR,
+	/* val */	3,
+	/* types */	3,
+	/* descr */	"Flow-control limits exceeded"
+)
+
+H2_ERROR(
+	/* name */	SETTINGS_TIMEOUT,
+	/* val */	4,
+	/* types */	1,
+	/* descr */	"Settings not acknowledged"
+)
+
+H2_ERROR(
+	/* name */	STREAM_CLOSED,
+	/* val */	5,
+	/* types */	2,
+	/* descr */	"Frame received for closed stream"
+)
+
+H2_ERROR(
+	/* name */	FRAME_SIZE_ERROR,
+	/* val */	6,
+	/* types */	3,
+	/* descr */	"Frame size incorrect"
+)
+
+H2_ERROR(
+	/* name */	REFUSED_STREAM,
+	/* val */	7,
+	/* types */	2,
+	/* descr */	"Stream not processed"
+)
+
+H2_ERROR(
+	/* name */	CANCEL,
+	/* val */	8,
+	/* types */	2,
+	/* descr */	"Stream cancelled"
+)
+
+H2_ERROR(
+	/* name */	COMPRESSION_ERROR,
+	/* val */	9,
+	/* types */	1,
+	/* descr */	"Compression state not updated"
+)
+
+H2_ERROR(
+	/* name */	CONNECT_ERROR,
+	/* val */	10,
+	/* types */	2,
+	/* descr */	"TCP connection error for CONNECT method"
+)
+
+H2_ERROR(
+	/* name */	ENHANCE_YOUR_CALM,
+	/* val */	11,
+	/* types */	3,
+	/* descr */	"Processing capacity exceeded"
+)
+
+H2_ERROR(
+	/* name */	INADEQUATE_SECURITY,
+	/* val */	12,
+	/* types */	1,
+	/* descr */	"Negotiated TLS parameters not acceptable"
+)
+
+H2_ERROR(
+	/* name */	HTTP_1_1_REQUIRED,
+	/* val */	13,
+	/* types */	1,
+	/* descr */	"Use HTTP/1.1 for the request"
+)
+
+#undef H2_ERROR
 /*lint -restore */


### PR DESCRIPTION
And use that for logging purposes when a successfully opened h2 session
ends. RX_JUNK is still the default session close reason when existing
reasons aren't accurate enough.

Fixes #3393