### PR TITLE
Introduce VCL_SUB and VCL_SUB_DYNAMIC

### DIFF
--- a/bin/varnishtest/tests/m00053.vtc
+++ b/bin/varnishtest/tests/m00053.vtc
@@ -1,4 +1,4 @@
-varnishtest "VCL_SUB type basics"
+varnishtest "VCL_SUB_DYNAMIC type basics"
 
 varnish v1 -vcl {
 	import std;
@@ -13,16 +13,16 @@ varnish v1 -vcl {
 		set beresp.http.it = "works";
 	}
 	sub indirect {
-		debug.call(foo);
+		debug.call_dynamic(foo);
 	}
 	sub direct {
 		call foo;
 	}
 	sub recursive {
-		debug.call(recursive);
+		debug.call_dynamic(recursive);
 	}
 	sub recursive_indirect {
-		debug.call(recursive_indirect);
+		debug.call_dynamic(recursive_indirect);
 	}
 	sub rollback {
 		std.rollback(req);
@@ -30,10 +30,10 @@ varnish v1 -vcl {
 
 	sub vcl_recv {
 		if (req.url == "/wrong") {
-			debug.call(foo);
+			debug.call_dynamic(foo);
 		}
 		if (req.url == "/recursive") {
-			debug.call(recursive);
+			debug.call_dynamic(recursive);
 		}
 		if (req.url == "/recursive_indirect") {
 			call recursive_indirect;
@@ -42,20 +42,20 @@ varnish v1 -vcl {
 	}
 	sub vcl_synth {
 		if (req.url == "/foo") {
-			debug.call(foo);
+			debug.call_dynamic(foo);
 		} else if (req.url == "/direct") {
-			debug.call(direct);
+			debug.call_dynamic(direct);
 		} else if (req.url == "/indirect") {
-			debug.call(indirect);
+			debug.call_dynamic(indirect);
 		} else if (req.url == "/rollback") {
-			debug.call(rollback);
+			debug.call_dynamic(rollback);
 		} else if (req.url == "/callthenrollback") {
-			debug.call(foo);
+			debug.call_dynamic(foo);
 			call rollback;
 			if (! resp.http.it) {
 				set resp.http.rolledback = true;
 			}
-			debug.call(foo);
+			debug.call_dynamic(foo);
 		} else if (req.url == "/checkwrong") {
 			synthetic(debug.check_call(bar));
 			set resp.status = 500;
@@ -123,7 +123,7 @@ varnish v1 -errvcl {Impossible Subroutine('<vcl.inline>' Line 8 Pos 13)} {
 	}
 	sub vcl_recv {
 		if (req.url == "/impossible") {
-			debug.call(impossible);
+			debug.call_dynamic(impossible);
 		}
 	}
 }

--- a/bin/varnishtest/tests/m00053.vtc
+++ b/bin/varnishtest/tests/m00053.vtc
@@ -9,6 +9,9 @@ varnish v1 -vcl {
 	sub foo {
 		set resp.http.it = "works";
 	}
+	sub bar {
+		set beresp.http.it = "works";
+	}
 	sub indirect {
 		debug.call(foo);
 	}
@@ -53,6 +56,9 @@ varnish v1 -vcl {
 				set resp.http.rolledback = true;
 			}
 			debug.call(foo);
+		} else if (req.url == "/checkwrong") {
+			synthetic(debug.check_call(bar));
+			set resp.status = 500;
 		}
 		return (deliver);
 	}
@@ -99,6 +105,12 @@ client c4 {
 	rxresp
 	expect resp.status == 200
 } -start
+client c5 {
+	txreq -url "/checkwrong"
+	rxresp
+	expect resp.status == 500
+	expect resp.body == {Dynamic call to "sub bar{}" not allowed from here}
+} -start
 
 varnish v1 -errvcl {Impossible Subroutine('<vcl.inline>' Line 8 Pos 13)} {
 	import std;
@@ -120,3 +132,4 @@ client c1 -wait
 client c2 -wait
 client c3 -wait
 client c4 -wait
+client c5 -wait

--- a/bin/varnishtest/tests/m00053.vtc
+++ b/bin/varnishtest/tests/m00053.vtc
@@ -6,9 +6,6 @@ varnish v1 -vcl {
 
 	backend dummy None;
 
-	sub impossible {
-		set req.http.impossible = beresp.reason;
-	}
 	sub foo {
 		set resp.http.it = "works";
 	}
@@ -29,9 +26,6 @@ varnish v1 -vcl {
 	}
 
 	sub vcl_recv {
-		if (req.url == "/impossible") {
-			debug.call(impossible);
-		}
 		if (req.url == "/wrong") {
 			debug.call(foo);
 		}
@@ -101,17 +95,28 @@ client c3 {
 	expect resp.status == 503
 } -start
 client c4 {
-	txreq -url "/impossible"
-	rxresp
-	expect resp.status == 503
-} -start
-client c5 {
 	txreq -url "/rollback"
 	rxresp
 	expect resp.status == 200
 } -start
+
+varnish v1 -errvcl {Impossible Subroutine('<vcl.inline>' Line 8 Pos 13)} {
+	import std;
+	import debug;
+
+	backend dummy None;
+
+	sub impossible {
+		set req.http.impossible = beresp.reason;
+	}
+	sub vcl_recv {
+		if (req.url == "/impossible") {
+			debug.call(impossible);
+		}
+	}
+}
+
 client c1 -wait
 client c2 -wait
 client c3 -wait
 client c4 -wait
-client c5 -wait

--- a/bin/varnishtest/tests/m00053.vtc
+++ b/bin/varnishtest/tests/m00053.vtc
@@ -1,0 +1,117 @@
+varnishtest "VCL_SUB type basics"
+
+varnish v1 -vcl {
+	import std;
+	import debug;
+
+	backend dummy None;
+
+	sub impossible {
+		set req.http.impossible = beresp.reason;
+	}
+	sub foo {
+		set resp.http.it = "works";
+	}
+	sub indirect {
+		debug.call(foo);
+	}
+	sub direct {
+		call foo;
+	}
+	sub recursive {
+		debug.call(recursive);
+	}
+	sub recursive_indirect {
+		debug.call(recursive_indirect);
+	}
+	sub rollback {
+		std.rollback(req);
+	}
+
+	sub vcl_recv {
+		if (req.url == "/impossible") {
+			debug.call(impossible);
+		}
+		if (req.url == "/wrong") {
+			debug.call(foo);
+		}
+		if (req.url == "/recursive") {
+			debug.call(recursive);
+		}
+		if (req.url == "/recursive_indirect") {
+			call recursive_indirect;
+		}
+		return (synth(200));
+	}
+	sub vcl_synth {
+		if (req.url == "/foo") {
+			debug.call(foo);
+		} else if (req.url == "/direct") {
+			debug.call(direct);
+		} else if (req.url == "/indirect") {
+			debug.call(indirect);
+		} else if (req.url == "/rollback") {
+			debug.call(rollback);
+		} else if (req.url == "/callthenrollback") {
+			debug.call(foo);
+			call rollback;
+			if (! resp.http.it) {
+				set resp.http.rolledback = true;
+			}
+			debug.call(foo);
+		}
+		return (deliver);
+	}
+} -start
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.it == "works"
+
+	txreq -url "/direct"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.it == "works"
+
+	txreq -url "/indirect"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.it == "works"
+
+	txreq -url "/callthenrollback"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.rolledback == "true"
+	expect resp.http.it == "works"
+
+	txreq -url "/wrong"
+	rxresp
+	expect resp.status == 503
+} -start
+client c2 {
+	txreq -url "/recursive"
+	rxresp
+	expect resp.status == 503
+} -start
+client c3 {
+	txreq -url "/recursive_indirect"
+	rxresp
+	expect resp.status == 503
+} -start
+client c4 {
+	txreq -url "/impossible"
+	rxresp
+	expect resp.status == 503
+} -start
+client c5 {
+	txreq -url "/rollback"
+	rxresp
+	expect resp.status == 200
+} -start
+client c1 -wait
+client c2 -wait
+client c3 -wait
+client c4 -wait
+client c5 -wait

--- a/bin/varnishtest/tests/m00054.vtc
+++ b/bin/varnishtest/tests/m00054.vtc
@@ -19,7 +19,7 @@ varnish v1 -vcl {
 	backend dummy None;
 
 	sub vcl_recv {
-		debug.call(debug.total_recall());
+		debug.call_dynamic(debug.total_recall());
 	}
 
 }

--- a/bin/varnishtest/tests/m00054.vtc
+++ b/bin/varnishtest/tests/m00054.vtc
@@ -1,0 +1,34 @@
+varnishtest "VCL_SUB wrong vmod behavior"
+
+varnish v1 -arg "-p feature=+no_coredump" -vcl {
+	import debug;
+
+	backend dummy None;
+
+	sub foo {
+		set resp.http.it = "works";
+	}
+
+	sub vcl_init {
+		debug.bad_memory(foo);
+	}
+} -start
+
+varnish v1 -vcl {
+	import debug;
+	backend dummy None;
+
+	sub vcl_recv {
+		debug.call(debug.total_recall());
+	}
+
+}
+
+client c1 {
+	txreq -url "/foo"
+	expect_close
+} -run
+
+varnish v1 -cliexpect "Assert error in VRT_call" "panic.show"
+varnish v1 -cliok "panic.clear"
+varnish v1 -expectexit 0x40

--- a/bin/varnishtest/tests/m00054.vtc
+++ b/bin/varnishtest/tests/m00054.vtc
@@ -29,6 +29,6 @@ client c1 {
 	expect_close
 } -run
 
-varnish v1 -cliexpect "Assert error in VRT_call" "panic.show"
+varnish v1 -cliexpect "Assert error in VRT_check_call" "panic.show"
 varnish v1 -cliok "panic.clear"
 varnish v1 -expectexit 0x40

--- a/bin/varnishtest/tests/m00055.vtc
+++ b/bin/varnishtest/tests/m00055.vtc
@@ -1,0 +1,53 @@
+varnishtest "VCL_SUB and compile time checking"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import debug;
+
+	sub foo {
+		set req.http.test = "works";
+	}
+
+	sub vcl_recv {
+		debug.call(foo);
+	}
+
+	sub vcl_deliver {
+		set resp.http.test = req.http.test;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.test == "works"
+	expect resp.status == 200
+} -run
+
+varnish v1 -errvcl {Cannot be set from subroutine 'vcl_recv'} {
+	import debug;
+
+	backend default none;
+
+	sub foo {
+		set bereq.http.test = "bereq is a compile time error here";
+	}
+
+	sub vcl_recv {
+		debug.call(foo);
+	}
+}
+
+varnish v1 -errvcl {Expression has type SUB_DYNAMIC, expected SUB} {
+	import debug;
+
+	backend default none;
+
+	sub vcl_recv {
+		debug.call(debug.total_recall());
+	}
+}

--- a/bin/varnishtest/tests/v00020.vtc
+++ b/bin/varnishtest/tests/v00020.vtc
@@ -246,6 +246,17 @@ varnish v1 -errvcl {Not available in subroutine 'vcl_recv'.} {
 	}
 }
 
+varnish v1 -cliok "param.set vcc_err_unref off"
+
+varnish v1 -errvcl {Impossible Subroutine} {
+	backend b { .host = "127.0.0.1"; }
+	sub foo {
+		set req.http.foo = 100 + beresp.status;
+	}
+}
+
+varnish v1 -cliok "param.set vcc_err_unref on"
+
 varnish v1 -errvcl {
 ('<vcl.inline>' Line 4 Pos 44) -- (Pos 49)
         sub foo { set req.http.foo = 100 + beresp.status; }

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -56,6 +56,16 @@ Varnish Cache Next (2021-03-15)
 * All shard ``Error`` and ``Notice`` messages now use the unified
   prefix ``vmod_directors: shard %s``.
 
+* The ``VCL_SUB`` data type is now supported for VMODs to save
+  references to subroutines to be called later using
+  ``VRT_call()``. Calls from a wrong context (e.g. calling a
+  subroutine accessing ``req`` from the backend side) and recursive
+  calls fail the VCL.
+
+  Note that, for performance reasons, recursive call detection only
+  happens for the second dynamic call. This implementation detail is
+  subject to change and must not be relied on.
+
 ================================
 Varnish Cache 6.5.1 (2020-09-25)
 ================================

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -66,6 +66,13 @@ Varnish Cache Next (2021-03-15)
   happens for the second dynamic call. This implementation detail is
   subject to change and must not be relied on.
 
+* ``VRT_check_call()`` can be used to check if a ``VRT_call()`` would
+  succeed in order to avoid the potential VCL failure in case it would
+  not.
+
+  It returns ``NULL`` if ``VRT_call()`` would make the call or an
+  error string why not.
+
 ================================
 Varnish Cache 6.5.1 (2020-09-25)
 ================================

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -56,8 +56,8 @@ Varnish Cache Next (2021-03-15)
 * All shard ``Error`` and ``Notice`` messages now use the unified
   prefix ``vmod_directors: shard %s``.
 
-* The ``VCL_SUB`` data type is now supported for VMODs to save
-  references to subroutines to be called later using
+* The ``VCL_SUB`` and ``VCL_SUB_DYNAMIC`` data types are now supported
+  for VMODs to use references to subroutines to be called using
   ``VRT_call()``. Calls from a wrong context (e.g. calling a
   subroutine accessing ``req`` from the backend side) and recursive
   calls fail the VCL.

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -460,6 +460,29 @@ TIME
 
 	An absolute time, as in 1284401161.
 
+VCL_SUB
+	C-type: ``const struct vcl_sub *``
+
+	Opaque handle on a VCL subroutine.
+
+	References to subroutines can be passed into VMODs as
+	arguments and called later through ``VRT_call()``. The scope
+	strictly is the VCL: vmods must ensure that ``VCL_SUB``
+	references never be called from a different VCL.
+
+	``VRT_call()`` fails the VCL for recursive calls and when the
+	``VCL_SUB`` can not be called from the current context
+	(e.g. calling a subroutine accessing ``req`` from the backend
+	side). Note that, for performance reasons, recursive call
+	detection only happens for the second dynamic call. This
+	implementation detail is subject to change and must not be
+	relied on.
+
+	``VRT_check_call()`` can be used to check if a ``VRT_call()``
+	would succeed in order to avoid the potential VCL failure.  It
+	returns ``NULL`` if ``VRT_call()`` would make the call or an
+	error string why not.
+
 VOID
 	C-type: ``void``
 

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -463,10 +463,11 @@ TIME
 VCL_SUB
 	C-type: ``const struct vcl_sub *``
 
-	Opaque handle on a VCL subroutine.
+	Opaque handle to a VCL subroutine with both compile time
+	and runtime context checking.
 
 	References to subroutines can be passed into VMODs as
-	arguments and called later through ``VRT_call()``. The scope
+	arguments and called through ``VRT_call()``. The scope
 	strictly is the VCL: vmods must ensure that ``VCL_SUB``
 	references never be called from a different VCL.
 
@@ -482,6 +483,19 @@ VCL_SUB
 	would succeed in order to avoid the potential VCL failure.  It
 	returns ``NULL`` if ``VRT_call()`` would make the call or an
 	error string why not.
+
+	This type can only be used when referencing an actual VCL based
+	``sub``. Cannot be used as a VMOD return type.
+
+	This type can automatically cast into a ``VCL_SUB_DYNAMIC``.
+
+VCL_SUB_DYNAMIC
+	C-type: ``const struct vcl_sub *``
+
+	Opaque handle to a VCL subroutine with only runtime context
+	checking. Interchangable with ``VCL_SUB`` when used in a ``VRT_*``
+	call. Can be used as a VMOD return type. This type cannot cast
+	into a ``VCL_SUB``.
 
 VOID
 	C-type: ``void``

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -77,7 +77,7 @@ struct vpi_ii {
 void VPI_re_init(struct vre **, const char *);
 void VPI_re_fini(struct vre *);
 
-/* VCL_SUB type */
+/* VCL_SUB and VCL_SUB_DYNAMIC types */
 
 struct vcl_sub {
 	unsigned		magic;

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -76,3 +76,15 @@ struct vpi_ii {
 
 void VPI_re_init(struct vre **, const char *);
 void VPI_re_fini(struct vre *);
+
+/* VCL_SUB type */
+
+struct vcl_sub {
+	unsigned		magic;
+#define VCL_SUB_MAGIC		0x12c1750b
+	const unsigned		methods;	// ok &= ctx->method
+	const char * const	name;
+	const struct VCL_conf	*vcl_conf;
+	vcl_func_f		*func;
+	unsigned		n;
+};

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -66,6 +66,7 @@
  *	VRT_re_match signature changed
  *	VRT_regsub signature changed
  *	VRT_call() added
+ *	VRT_check_call() added
  * 12.0 (2020-09-15)
  *	Added VRT_DirectorResolve()
  *	Added VCL_STRING VRT_BLOB_string(VRT_CTX, VCL_BLOB)
@@ -656,4 +657,5 @@ void VRT_VCL_Allow_Discard(struct vclref **);
 
 /* VCL_SUB */
 
+VCL_STRING VRT_check_call(VRT_CTX, VCL_SUB);
 VCL_VOID VRT_call(VRT_CTX, VCL_SUB);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -65,6 +65,7 @@
  *	VRT_re_fini removed
  *	VRT_re_match signature changed
  *	VRT_regsub signature changed
+ *	VRT_call() added
  * 12.0 (2020-09-15)
  *	Added VRT_DirectorResolve()
  *	Added VCL_STRING VRT_BLOB_string(VRT_CTX, VCL_BLOB)
@@ -344,6 +345,8 @@ struct vrt_ctx {
 	 *    synth+error:	struct vsb *
 	 */
 	void				*specific;
+	/* if present, vbitmap of called subs */
+	void				*called;
 };
 
 #define VRT_CTX		const struct vrt_ctx *ctx
@@ -650,3 +653,7 @@ void VRT_VCL_Allow_Cold(struct vclref **);
 
 struct vclref * VRT_VCL_Prevent_Discard(VRT_CTX, const char *);
 void VRT_VCL_Allow_Discard(struct vclref **);
+
+/* VCL_SUB */
+
+VCL_VOID VRT_call(VRT_CTX, VCL_SUB);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -285,6 +285,7 @@ typedef const struct stevedore *		VCL_STEVEDORE;
 typedef const struct strands *			VCL_STRANDS;
 typedef const char *				VCL_STRING;
 typedef const struct vcl_sub *			VCL_SUB;
+typedef const struct vcl_sub *			VCL_SUB_DYNAMIC;
 typedef vtim_real				VCL_TIME;
 typedef struct vcl *				VCL_VCL;
 typedef void					VCL_VOID;

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -205,6 +205,7 @@ struct vsmw_cluster;
 struct vsl_log;
 struct ws;
 struct VSC_main;
+struct vcl_sub;
 
 /*
  * VCL_STRANDS:
@@ -281,6 +282,7 @@ typedef const struct vre *			VCL_REGEX;
 typedef const struct stevedore *		VCL_STEVEDORE;
 typedef const struct strands *			VCL_STRANDS;
 typedef const char *				VCL_STRING;
+typedef const struct vcl_sub *			VCL_SUB;
 typedef vtim_real				VCL_TIME;
 typedef struct vcl *				VCL_VCL;
 typedef void					VCL_VOID;
@@ -345,6 +347,8 @@ struct vrt_ctx {
 };
 
 #define VRT_CTX		const struct vrt_ctx *ctx
+
+typedef void vcl_func_f(VRT_CTX);
 
 /***********************************************************************
  * This is the interface structure to a compiled VMOD

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -644,7 +644,6 @@ fo.write("""
 typedef int vcl_event_f(VRT_CTX, enum vcl_event_e);
 typedef int vcl_init_f(VRT_CTX);
 typedef void vcl_fini_f(VRT_CTX);
-typedef void vcl_func_f(VRT_CTX);
 
 struct VCL_conf {
 	unsigned		magic;
@@ -657,6 +656,7 @@ struct VCL_conf {
 	const struct vpi_ref	*ref;
 
 	int			nsrc;
+	unsigned		nsub;
 	const char		**srcname;
 	const char		**srcbody;
 

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -53,7 +53,7 @@ vcc_act_call(struct vcc *tl, struct token *t, struct symbol *sym)
 	if (sym != NULL) {
 		vcc_AddCall(tl, t0, sym);
 		VCC_GlobalSymbol(sym, SUB, "VGC_function");
-		Fb(tl, 1, "%s(ctx);\n", sym->rname);
+		Fb(tl, 1, "%s(ctx);\n", sym->lname);
 		SkipToken(tl, ';');
 	}
 }

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -315,7 +315,7 @@ vcc_act_return_vcl(struct vcc *tl)
 static void v_matchproto_(sym_act_f)
 vcc_act_return(struct vcc *tl, struct token *t, struct symbol *sym)
 {
-	unsigned hand;
+	unsigned hand, mask;
 	const char *h;
 
 	(void)t;
@@ -335,6 +335,7 @@ vcc_act_return(struct vcc *tl, struct token *t, struct symbol *sym)
 		if (vcc_IdIs(tl->t, #l)) {		\
 			hand = VCL_RET_ ## U;		\
 			h = #U;				\
+			mask = B;			\
 		}
 #include "tbl/vcl_returns.h"
 	if (h == NULL) {
@@ -344,7 +345,7 @@ vcc_act_return(struct vcc *tl, struct token *t, struct symbol *sym)
 	}
 	assert(hand < VCL_RET_MAX);
 
-	vcc_ProcAction(tl->curproc, hand, tl->t);
+	vcc_ProcAction(tl->curproc, hand, mask, tl->t);
 	vcc_NextToken(tl);
 	if (tl->t->tok == '(') {
 		if (hand == VCL_RET_SYNTH || hand == VCL_RET_ERROR)

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -149,6 +149,7 @@ vcc_NewProc(struct vcc *tl, struct symbol *sym)
 static void
 vcc_EmitProc(struct vcc *tl, struct proc *p)
 {
+	AN(p->okmask);
 	AZ(VSB_finish(p->cname));
 	AZ(VSB_finish(p->prologue));
 	AZ(VSB_finish(p->body));

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -59,6 +59,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "vcc_compile.h"
 
@@ -140,6 +141,7 @@ vcc_NewProc(struct vcc *tl, struct symbol *sym)
 	AN(p->body);
 	p->cname = VSB_new_auto();
 	AN(p->cname);
+	p->okmask = UINT_MAX;
 	sym->proc = p;
 	return (p);
 }
@@ -151,6 +153,15 @@ vcc_EmitProc(struct vcc *tl, struct proc *p)
 	AZ(VSB_finish(p->prologue));
 	AZ(VSB_finish(p->body));
 	Fh(tl, 1, "vcl_func_f %s;\n", VSB_data(p->cname));
+	Fh(tl, 1, "const struct vcl_sub sub_%s[1] = {{\n",
+	   VSB_data(p->cname));
+	Fh(tl, 1, "\t.magic\t\t= VCL_SUB_MAGIC,\n");
+	Fh(tl, 1, "\t.methods\t= 0x%x,\n", p->okmask);
+	Fh(tl, 1, "\t.name\t\t= \"%.*s\",\n", PF(p->name));
+	Fh(tl, 1, "\t.vcl_conf\t= &VCL_conf,\n");
+	Fh(tl, 1, "\t.func\t\t= %s,\n", VSB_data(p->cname));
+	Fh(tl, 1, "\t.n\t\t= %d\n", tl->nsub++);
+	Fh(tl, 1, "}};\n");
 	/*
 	 * TODO: v_dont_optimize for custom subs called from vcl_init/fini only
 	 *
@@ -493,6 +504,7 @@ EmitStruct(const struct vcc *tl)
 	Fc(tl, 0, "\t.ref = VGC_ref,\n");
 	Fc(tl, 0, "\t.nref = VGC_NREFS,\n");
 	Fc(tl, 0, "\t.nsrc = VGC_NSRCS,\n");
+	Fc(tl, 0, "\t.nsub = %d,\n", tl->nsub);
 	Fc(tl, 0, "\t.srcname = srcname,\n");
 	Fc(tl, 0, "\t.srcbody = srcbody,\n");
 	Fc(tl, 0, "\t.nvmod = %u,\n", tl->vmod_count);

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -504,7 +504,7 @@ EmitStruct(const struct vcc *tl)
 	Fc(tl, 0, "\t.ref = VGC_ref,\n");
 	Fc(tl, 0, "\t.nref = VGC_NREFS,\n");
 	Fc(tl, 0, "\t.nsrc = VGC_NSRCS,\n");
-	Fc(tl, 0, "\t.nsub = %d,\n", tl->nsub);
+	Fc(tl, 0, "\t.nsub = %d,\n", tl->subref > 0 ? tl->nsub : 0);
 	Fc(tl, 0, "\t.srcname = srcname,\n");
 	Fc(tl, 0, "\t.srcbody = srcbody,\n");
 	Fc(tl, 0, "\t.nvmod = %u,\n", tl->vmod_count);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -211,6 +211,7 @@ struct proc {
 	unsigned		ret_bitmap;
 	unsigned		called;
 	unsigned		active;
+	unsigned		okmask;
 	struct token		*return_tok[VCL_RET_MAX];
 	struct vsb		*cname;
 	struct vsb		*prologue;
@@ -264,6 +265,7 @@ struct vcc {
 						 */
 	struct vsb		*sb;
 	int			err;
+	unsigned		nsub;
 	struct proc		*curproc;
 	VTAILQ_HEAD(, proc)	procs;
 
@@ -426,7 +428,7 @@ void VCC_InstanceInfo(struct vcc *tl);
 void VCC_XrefTable(struct vcc *);
 
 void vcc_AddCall(struct vcc *, struct token *, struct symbol *);
-void vcc_ProcAction(struct proc *p, unsigned action, struct token *t);
+void vcc_ProcAction(struct proc *, unsigned, unsigned, struct token *);
 int vcc_CheckAction(struct vcc *tl);
 
 

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -266,6 +266,7 @@ struct vcc {
 	struct vsb		*sb;
 	int			err;
 	unsigned		nsub;
+	unsigned		subref;	// SUB arguments present
 	struct proc		*curproc;
 	VTAILQ_HEAD(, proc)	procs;
 

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -740,6 +740,9 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 				vcc_expr_tostring(tl, e, STRINGS);
 				ERRCHK(tl);
 			}
+			if (fmt == SUB) {
+				vcc_AddCall(tl, tl->t, sym);
+			}
 			return;
 		}
 		VSB_printf(tl->sb,
@@ -1343,8 +1346,8 @@ vcc_expr0(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 	t1 = tl->t;
 	if (fmt->stringform)
 		vcc_expr_cor(tl, e, STRINGS);
-	else if (fmt == REGEX)
-		vcc_expr4(tl, e, REGEX);
+	else if (fmt == REGEX || fmt == SUB)
+		vcc_expr4(tl, e, fmt);
 	else
 		vcc_expr_cor(tl, e, fmt);
 	ERRCHK(tl);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -720,8 +720,10 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			(*e)->instance = sym;
 			return;
 		}
-		if (sym->kind == SYM_FUNC && sym->type == VOID) {
-			VSB_cat(tl->sb, "Function returns VOID:\n");
+		if (sym->kind == SYM_FUNC && (sym->type == VOID ||
+		    sym->type == SUB)) {
+			VSB_printf(tl->sb, "Function returns %s:\n",
+			    sym->type->name);
 			vcc_ErrWhere(tl, tl->t);
 			return;
 		}

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -445,7 +445,7 @@ vcc_do_arg(struct vcc *tl, struct func_arg *fa)
 		vcc_do_enum(tl, fa, PF(tl->t));
 		SkipToken(tl, ID);
 	} else {
-		if (fa->type == SUB)
+		if (fa->type == SUB || fa->type == SUB_DYNAMIC)
 			tl->subref++;
 		vcc_expr0(tl, &e2, fa->type);
 		ERRCHK(tl);
@@ -1382,6 +1382,9 @@ vcc_expr0(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		vcc_expr_tobool(tl, e);
 		ERRCHK(tl);
 	}
+
+	if ((*e)->fmt == SUB && fmt == SUB_DYNAMIC)
+		(*e)->fmt = SUB_DYNAMIC;
 
 	if (fmt != (*e)->fmt)  {
 		VSB_printf(tl->sb, "Expression has type %s, expected %s\n",

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -445,6 +445,8 @@ vcc_do_arg(struct vcc *tl, struct func_arg *fa)
 		vcc_do_enum(tl, fa, PF(tl->t));
 		SkipToken(tl, ID);
 	} else {
+		if (fa->type == SUB)
+			tl->subref++;
 		vcc_expr0(tl, &e2, fa->type);
 		ERRCHK(tl);
 		assert(e2->fmt == fa->type);

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -251,7 +251,7 @@ vcc_ParseFunction(struct vcc *tl)
 		VCC_GlobalSymbol(sym, SUB, "VGC_function");
 		p = vcc_NewProc(tl, sym);
 		p->name = t;
-		VSB_printf(p->cname, "%s", sym->rname);
+		VSB_printf(p->cname, "%s", sym->lname);
 	} else if (p->method == NULL) {
 		VSB_printf(tl->sb, "Subroutine '%s' redefined\n", sym->name);
 		vcc_ErrWhere(tl, t);

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -469,6 +469,14 @@ VCC_GlobalSymbol(struct symbol *sym, vcc_type_t type, const char *pfx)
 	VSB_printf(vsb, "%s_", pfx);
 	VCC_PrintCName(vsb, sym->name, NULL);
 	AZ(VSB_finish(vsb));
+	sym->lname = strdup(VSB_data(vsb));
+	if (type == SUB) {
+		VSB_destroy(&vsb);
+		vsb = VSB_new_auto();
+		AN(vsb);
+		VSB_printf(vsb, "sub_%s", sym->lname);
+		AZ(VSB_finish(vsb));
+	}
 	sym->rname = strdup(VSB_data(vsb));
 	AN(sym->rname);
 	VSB_destroy(&vsb);

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -470,7 +470,7 @@ VCC_GlobalSymbol(struct symbol *sym, vcc_type_t type, const char *pfx)
 	VCC_PrintCName(vsb, sym->name, NULL);
 	AZ(VSB_finish(vsb));
 	sym->lname = strdup(VSB_data(vsb));
-	if (type == SUB) {
+	if (type == SUB || type == SUB_DYNAMIC) {
 		VSB_destroy(&vsb);
 		vsb = VSB_new_auto();
 		AN(vsb);

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -209,6 +209,11 @@ const struct type SUB[1] = {{
 	.name =			"SUB",
 }};
 
+const struct type SUB_DYNAMIC[1] = {{
+	.magic =		TYPE_MAGIC,
+	.name =			"SUB_DYNAMIC",
+}};
+
 const struct type TIME[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"TIME",

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -161,11 +161,12 @@ vcc_AddCall(struct vcc *tl, struct token *t, struct symbol *sym)
 }
 
 void
-vcc_ProcAction(struct proc *p, unsigned returns, struct token *t)
+vcc_ProcAction(struct proc *p, unsigned returns, unsigned mask, struct token *t)
 {
 
 	assert(returns < VCL_RET_MAX);
 	p->ret_bitmap |= (1U << returns);
+	p->okmask &= mask;
 	/* Record the first instance of this return */
 	if (p->return_tok[returns] == NULL)
 		p->return_tok[returns] = t;
@@ -212,6 +213,7 @@ vcc_CheckActionRecurse(struct vcc *tl, struct proc *p, unsigned bitmap)
 			vcc_ErrWhere(tl, pc->t);
 			return (1);
 		}
+		p->okmask &= pc->sym->proc->okmask;
 	}
 	p->active = 0;
 	p->called++;
@@ -279,22 +281,27 @@ vcc_illegal_write(struct vcc *tl, struct procuse *pu, const struct method *m)
 }
 
 static struct procuse *
-vcc_FindIllegalUse(struct vcc *tl, const struct proc *p, const struct method *m)
+vcc_FindIllegalUse(struct vcc *tl, struct proc *p, const struct method *m)
 {
-	struct procuse *pu, *pw;
+	struct procuse *pu, *pw, *r = NULL;
 
 	VTAILQ_FOREACH(pu, &p->uses, list) {
+		p->okmask &= pu->mask;
+		if (m == NULL)
+			continue;
 		pw = vcc_illegal_write(tl, pu, m);
+		if (r != NULL)
+			continue;
 		if (tl->err)
-			return (pw);
-		if (!(pu->mask & m->bitval))
-			return (pu);
+			r = pw;
+		else if (!(pu->mask & m->bitval))
+			r = pu;
 	}
-	return (NULL);
+	return (r);
 }
 
 static int
-vcc_CheckUseRecurse(struct vcc *tl, const struct proc *p,
+vcc_CheckUseRecurse(struct vcc *tl, struct proc *p,
     const struct method *m)
 {
 	struct proccall *pc;
@@ -319,6 +326,7 @@ vcc_CheckUseRecurse(struct vcc *tl, const struct proc *p,
 			vcc_ErrWhere(tl, pc->t);
 			return (1);
 		}
+		p->okmask &= pc->sym->proc->okmask;
 	}
 	return (0);
 }
@@ -331,8 +339,6 @@ vcc_checkuses(struct vcc *tl, const struct symbol *sym)
 
 	p = sym->proc;
 	AN(p);
-	if (p->method == NULL)
-		return;
 	pu = vcc_FindIllegalUse(tl, p, p->method);
 	if (pu != NULL) {
 		vcc_ErrWhere2(tl, pu->t1, pu->t2);

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -115,6 +115,7 @@ CTYPES = {
     'STRANDS':     "VCL_STRANDS",
     'STRING':      "VCL_STRING",
     'STRING_LIST': "const char *, ...",
+    'SUB':         "VCL_SUB",
     'TIME':        "VCL_TIME",
     'VOID':        "VCL_VOID",
 }

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -116,6 +116,7 @@ CTYPES = {
     'STRING':      "VCL_STRING",
     'STRING_LIST': "const char *, ...",
     'SUB':         "VCL_SUB",
+    'SUB_DYNAMIC': "VCL_SUB_DYNAMIC",
     'TIME':        "VCL_TIME",
     'VOID':        "VCL_VOID",
 }

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -720,6 +720,9 @@ class FunctionStanza(Stanza):
 
     def parse(self):
         self.proto = ProtoType(self)
+        if self.proto.retval.vt == 'SUB':
+            err("SUB cannot be used as a return type, please use SUB_DYNAMIC",
+                warn=False)
         self.rstlbl = '%s.%s()' % (self.vcc.modname, self.proto.name)
         self.vcc.contents.append(self)
 

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1287,3 +1287,33 @@ xyzzy_just_return_regex(VRT_CTX, VCL_REGEX r)
 	AN(r);
 	return (r);
 }
+
+/*---------------------------------------------------------------------*/
+
+VCL_VOID v_matchproto_(td_xyzzy_call)
+xyzzy_call(VRT_CTX, VCL_SUB sub)
+{
+	VRT_call(ctx, sub);
+}
+
+/* the next two are to test WRONG vmod behavior:
+ * holding a VCL_SUB reference across vcls
+ */
+
+static VCL_SUB wrong = NULL;
+
+VCL_VOID v_matchproto_(td_xyzzy_bad_memory)
+xyzzy_bad_memory(VRT_CTX, VCL_SUB sub)
+{
+	(void) ctx;
+
+	wrong = sub;
+}
+
+VCL_SUB v_matchproto_(td_xyzzy_total_recall)
+xyzzy_total_recall(VRT_CTX)
+{
+	(void) ctx;
+
+	return (wrong);
+}

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1290,33 +1290,33 @@ xyzzy_just_return_regex(VRT_CTX, VCL_REGEX r)
 
 /*---------------------------------------------------------------------*/
 
-VCL_VOID v_matchproto_(td_xyzzy_call)
-xyzzy_call(VRT_CTX, VCL_SUB sub)
+VCL_VOID v_matchproto_(td_xyzzy_call_dynamic)
+xyzzy_call_dynamic(VRT_CTX, VCL_SUB_DYNAMIC sub)
 {
 	VRT_call(ctx, sub);
 }
 
 VCL_STRING v_matchproto_(td_xyzzy_check_call)
-xyzzy_check_call(VRT_CTX, VCL_SUB sub)
+xyzzy_check_call(VRT_CTX, VCL_SUB_DYNAMIC sub)
 {
 	return (VRT_check_call(ctx, sub));
 }
 
 /* the next two are to test WRONG vmod behavior:
- * holding a VCL_SUB reference across vcls
+ * holding a VCL_SUB_DYNAMIC reference across vcls
  */
 
 static VCL_SUB wrong = NULL;
 
 VCL_VOID v_matchproto_(td_xyzzy_bad_memory)
-xyzzy_bad_memory(VRT_CTX, VCL_SUB sub)
+xyzzy_bad_memory(VRT_CTX, VCL_SUB_DYNAMIC sub)
 {
 	(void) ctx;
 
 	wrong = sub;
 }
 
-VCL_SUB v_matchproto_(td_xyzzy_total_recall)
+VCL_SUB_DYNAMIC v_matchproto_(td_xyzzy_total_recall)
 xyzzy_total_recall(VRT_CTX)
 {
 	(void) ctx;

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1296,6 +1296,12 @@ xyzzy_call(VRT_CTX, VCL_SUB sub)
 	VRT_call(ctx, sub);
 }
 
+VCL_STRING v_matchproto_(td_xyzzy_check_call)
+xyzzy_check_call(VRT_CTX, VCL_SUB sub)
+{
+	return (VRT_check_call(ctx, sub));
+}
+
 /* the next two are to test WRONG vmod behavior:
  * holding a VCL_SUB reference across vcls
  */

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1296,6 +1296,12 @@ xyzzy_call_dynamic(VRT_CTX, VCL_SUB_DYNAMIC sub)
 	VRT_call(ctx, sub);
 }
 
+VCL_VOID v_matchproto_(td_xyzzy_call)
+xyzzy_call(VRT_CTX, VCL_SUB sub)
+{
+	VRT_call(ctx, sub);
+}
+
 VCL_STRING v_matchproto_(td_xyzzy_check_call)
 xyzzy_check_call(VRT_CTX, VCL_SUB_DYNAMIC sub)
 {

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -324,19 +324,19 @@ $Function REGEX just_return_regex(REGEX)
 
 Take a REGEX argument and return it.
 
-$Function STRING check_call(SUB)
+$Function STRING check_call(SUB_DYNAMIC)
 
 Check if a sub can be called. Returns the NULL string if yes, or a
 string saying why not.
 
-$Function VOID call(SUB)
+$Function VOID call_dynamic(SUB_DYNAMIC)
 
 Call a sub
 
-$Function VOID bad_memory(SUB)
+$Function VOID bad_memory(SUB_DYNAMIC)
 
 To test *WRONG* behavior
 
-$Function SUB total_recall()
+$Function SUB_DYNAMIC total_recall()
 
 To test *WRONG* behavior

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -324,6 +324,11 @@ $Function REGEX just_return_regex(REGEX)
 
 Take a REGEX argument and return it.
 
+$Function STRING check_call(SUB)
+
+Check if a sub can be called. Returns the NULL string if yes, or a
+string saying why not.
+
 $Function VOID call(SUB)
 
 Call a sub

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -331,6 +331,10 @@ string saying why not.
 
 $Function VOID call_dynamic(SUB_DYNAMIC)
 
+Call a dynamic sub
+
+$Function VOID call(SUB)
+
 Call a sub
 
 $Function VOID bad_memory(SUB_DYNAMIC)

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -323,3 +323,15 @@ Test if the argument is a valid header according to RFC7230 section 3.2.
 $Function REGEX just_return_regex(REGEX)
 
 Take a REGEX argument and return it.
+
+$Function VOID call(SUB)
+
+Call a sub
+
+$Function VOID bad_memory(SUB)
+
+To test *WRONG* behavior
+
+$Function SUB total_recall()
+
+To test *WRONG* behavior


### PR DESCRIPTION
This PR introduces `VCL_SUB` and `VCL_SUB_DYNAMIC`. Its based on #3163 and implements @Dridi's idea to split the type into 2 so we can have both compile time and runtime checking behavior. This is done as 3 additional commits to #3163. The usecases for these types range from function aliasing, dynamic calls, callbacks, and looping.

As I mentioned before, I believe that this split actually gives us a much stronger design than previously implemented. The best way to explain this is to address what this combined PR actually does:

* Adds a new `SUB` vmod type. This type is identical in behavior to the existing VCL based `sub`/`call` syntax. Touching a `sub` anywhere will result in a compile time context check. The usecase is that the `SUB` is immediately called by the vmod (callbacks and looping).
* Adds new `VRT_*` functions to support calling subs in vmod code. These functions have additional runtime checks, which add more safety. This comes directly from #3163.
* You **cannot** return a `SUB` from a vmod function. The `SUB` type is restricted to VCL based definitions that can be compile time checked. VMODs can only accept them, its a one way street.
* Introduces `SUB_DYNAMIC`. This is a completely new type which happens to share its C code core struct with `SUB`. This means the `VRT_*` functions with runtime checks work on both types since its the same C struct. However, VCC sees them as different animals. Because its a new type, existing compile time VCL checks simply don't exist and aren't done.
* Allow `SUB` types to be cast into `SUB_DYNAMIC`. This bridges the above VCC gap and allows VCL based subs to be inputted in as unchecked `SUB_DYNAMIC` vmod types. This solves the aliasing and dynamic call usecase.
* You **cannot** cast a `SUB_DYNAMIC` back to a `SUB`. The enforces the rule that all `SUB` types must be VCL based and compile time checked. Subs returned from vmods can be anything, so they can only be `SUB_DYNAMIC` (see previous point blocking `SUB` as a return type). If you want to pass a SUB between 2 vmods, `SUB_DYNAMIC` is how that is done.

To me, this is a very logical separation between the 2 types while sharing common behavior and code. The takeaway here is that all of the behavior from #3163 is maintained while adding a new type which brings back the existing compile time checking behavior.

As to why? I will try and keep this brief, but we (Varnish Software) have found that compile errors can be easily understood and remedied by Varnish users themselves (assuming the compiler messages are good). However, runtime errors usually require extra support from us or this project and can be labor intensive. Runtime errors require going thru logs and piecing together behavior, which seems to something not all users can do. This idea is echoed throughout the software project ecosystem where more and more compile time checks are being done to prevent runtime problems. The Rust language is an innovator in this space. I think we would all love to have our C bugs spotted ahead of time by the compiler than dealing with the aftermath here as a Github issue... This is the motivation for keeping the compile time checks for the VCL `SUB` type.