### PR TITLE
assert() for VGC and arm assertions on ctx->method

### DIFF
--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -133,3 +133,10 @@ VPI_vcl_select(VRT_CTX, VCL_VCL vcl)
 	VSLb(ctx->req->vsl, SLT_VCL_use, "%s via %s",
 	    req->vcl->loaded_name, vcl->loaded_name);
 }
+
+void v_noreturn_
+VPI_Fail(const char *func, const char *file, int line,
+    const char *cond)
+{
+	VAS_Fail(func, file, line, cond, VAS_ASSERT);
+}

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -83,6 +83,7 @@ nobase_noinst_HEADERS = \
 	compat/daemon.h \
 	vfl.h \
 	libvcc.h \
+	vcc_assert.h \
 	vcc_interface.h \
 	vcli_serve.h \
 	vcs_version.h \
@@ -109,6 +110,7 @@ nobase_noinst_HEADERS = \
 ## keep in sync with lib/libvcc/Makefile.am
 vcl.h: \
 	    $(top_srcdir)/lib/libvcc/generate.py \
+	    $(top_srcdir)/include/vcc_assert.h \
 	    $(top_srcdir)/include/vcc_interface.h \
 	    $(top_srcdir)/include/vdef.h \
 	    $(top_srcdir)/include/vrt.h \

--- a/include/vcc_assert.h
+++ b/include/vcc_assert.h
@@ -1,0 +1,6 @@
+#define assert(e)							\
+do {									\
+	if (!(e)) {							\
+		VPI_Fail(__func__, __FILE__, __LINE__, #e);		\
+	}								\
+} while (0)

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -38,6 +38,8 @@
 VCL_VCL VPI_vcl_get(VRT_CTX, const char *);
 void VPI_vcl_rel(VRT_CTX, VCL_VCL);
 void VPI_vcl_select(VRT_CTX, VCL_VCL);
+void v_noreturn_ VPI_Fail(const char *func, const char *file, int line,
+    const char *cond);
 
 /***********************************************************************
  * VPI_count() refers to this structure for coordinates into the VCL source.

--- a/lib/libvcc/Makefile.am
+++ b/lib/libvcc/Makefile.am
@@ -44,6 +44,7 @@ dist_pkgdata_SCRIPTS = \
 ## keep in sync with include/Makefile.am
 vcc_obj.c: \
 	    $(top_srcdir)/lib/libvcc/generate.py \
+	    $(top_srcdir)/include/vcc_assert.h \
 	    $(top_srcdir)/include/vcc_interface.h \
 	    $(top_srcdir)/include/vdef.h \
 	    $(top_srcdir)/include/vrt.h \

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -788,6 +788,7 @@ emit_file(fo, srcroot, "include/vrt.h")
 emit_file(fo, buildroot, "include/vcl.h")
 emit_file(fo, buildroot, "include/vrt_obj.h")
 emit_file(fo, srcroot, "include/vcc_interface.h")
+emit_file(fo, srcroot, "include/vcc_assert.h")
 
 fo.write("\n}\n")
 fo.close()

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -189,7 +189,7 @@ vcc_EmitProc(struct vcc *tl, struct proc *p)
 		AN(vsbm);
 		vcc_vcl_met2c(vsbm, p->method->bitval);
 		AZ(VSB_finish(vsbm));
-		Fc(tl, 1, "  // assert(ctx->method == (%s));\n",
+		Fc(tl, 1, "  assert(ctx->method == (%s));\n",
 		   VSB_data(vsbm));
 		VSB_destroy(&vsbm);
 	}


### PR DESCRIPTION
We wrap `VAS_Fail()` as `VPI_Fail()` and add an `assert()` macro to the Varnish Generated C (VGC) code. This `assert()` definition is basically a copy of that in `vas.h`, but deliberately added to a source file which is only used by `generate.py` for VGC, such that this slightly different definition be only visible to VGC.

I also pondered the option to include VCL source information in `VPI_Fail()`: By using the information updated by `VPI_count()`, we could have that, but as the assert is, for now, intended only to ensure correctness of VCC and core VRT code, I decided against this complication.

With `assert()` in place for VGC, we arm the assertions from 75acb5cc7aa73fcd22b150dd1a3b899c6ec9bc44