### PR TITLE
Formalize VCL Private data access via VRT_CTX / VCL line info in panics

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -244,7 +244,8 @@ struct worker {
 
 	unsigned		cur_method;
 	unsigned		seen_methods;
-	unsigned		handling;
+
+	struct wrk_vpi		*vpi;
 };
 
 /* Stored object -----------------------------------------------------

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -38,6 +38,7 @@
 #include "storage/storage.h"
 #include "vcl.h"
 #include "vtim.h"
+#include "vcc_interface.h"
 
 #define FETCH_STEPS \
 	FETCH_STEP(mkbereq,           MKBEREQ) \

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -297,11 +297,11 @@ pan_wrk(struct vsb *vsb, const struct worker *wrk)
 	else
 		VSB_printf(vsb, "0x%x,\n", m);
 
-	hand = VCL_Return_Name(wrk->handling);
+	hand = VCL_Return_Name(wrk->vpi->handling);
 	if (hand != NULL)
 		VSB_printf(vsb, "VCL::return = %s,\n", hand);
 	else
-		VSB_printf(vsb, "VCL::return = 0x%x,\n", wrk->handling);
+		VSB_printf(vsb, "VCL::return = 0x%x,\n", wrk->vpi->handling);
 	VSB_cat(vsb, "VCL::methods = {");
 	m = wrk->seen_methods;
 	p = "";

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -43,6 +43,7 @@
 
 #include "cache_varnishd.h"
 #include "cache_transport.h"
+#include "vcc_interface.h"
 
 #include "cache_filter.h"
 #include "common/heritage.h"

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -44,6 +44,7 @@
 #include "cache_filter.h"
 #include "cache_objhead.h"
 #include "cache_transport.h"
+#include "vcc_interface.h"
 
 #include "hash/hash_slinger.h"
 #include "http1/cache_http1.h"

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -239,12 +239,12 @@ cnt_deliver(struct worker *wrk, struct req *req)
 
 	assert(req->restarts <= cache_param->max_restarts);
 
-	if (wrk->handling != VCL_RET_DELIVER) {
+	if (wrk->vpi->handling != VCL_RET_DELIVER) {
 		HSH_Cancel(wrk, req->objcore, NULL);
 		(void)HSH_DerefObjCore(wrk, &req->objcore, HSH_RUSH_POLICY);
 		http_Teardown(req->resp);
 
-		switch (wrk->handling) {
+		switch (wrk->vpi->handling) {
 		case VCL_RET_RESTART:
 			req->req_step = R_STP_RESTART;
 			break;
@@ -261,7 +261,7 @@ cnt_deliver(struct worker *wrk, struct req *req)
 		return (REQ_FSM_MORE);
 	}
 
-	assert(wrk->handling == VCL_RET_DELIVER);
+	assert(wrk->vpi->handling == VCL_RET_DELIVER);
 
 	if (IS_TOPREQ(req) && RFC2616_Do_Cond(req))
 		http_PutResponse(req->resp, "HTTP/1.1", 304, NULL);
@@ -334,7 +334,7 @@ cnt_synth(struct worker *wrk, struct req *req)
 
 	VSLb_ts_req(req, "Process", W_TIM_real(wrk));
 
-	if (wrk->handling == VCL_RET_FAIL) {
+	if (wrk->vpi->handling == VCL_RET_FAIL) {
 		VSB_destroy(&synth_body);
 		(void)VRB_Ignore(req);
 		(void)req->transport->minimal_response(req, 500);
@@ -344,11 +344,11 @@ cnt_synth(struct worker *wrk, struct req *req)
 		return (REQ_FSM_DONE);
 	}
 
-	if (wrk->handling == VCL_RET_RESTART &&
+	if (wrk->vpi->handling == VCL_RET_RESTART &&
 	    req->restarts > cache_param->max_restarts)
-		wrk->handling = VCL_RET_DELIVER;
+		wrk->vpi->handling = VCL_RET_DELIVER;
 
-	if (wrk->handling == VCL_RET_RESTART) {
+	if (wrk->vpi->handling == VCL_RET_RESTART) {
 		/*
 		 * XXX: Should we reset req->doclose = SC_VCL_FAILURE
 		 * XXX: If so, to what ?
@@ -358,7 +358,7 @@ cnt_synth(struct worker *wrk, struct req *req)
 		req->req_step = R_STP_RESTART;
 		return (REQ_FSM_MORE);
 	}
-	assert(wrk->handling == VCL_RET_DELIVER);
+	assert(wrk->vpi->handling == VCL_RET_DELIVER);
 
 	http_Unset(req->resp, H_Content_Length);
 	http_PrintfHeader(req->resp, "Content-Length: %zd",
@@ -618,7 +618,7 @@ cnt_lookup(struct worker *wrk, struct req *req)
 
 	VCL_hit_method(req->vcl, wrk, req, NULL, NULL);
 
-	switch (wrk->handling) {
+	switch (wrk->vpi->handling) {
 	case VCL_RET_DELIVER:
 		if (busy != NULL) {
 			AZ(oc->flags & OC_F_HFM);
@@ -680,7 +680,7 @@ cnt_miss(struct worker *wrk, struct req *req)
 	CHECK_OBJ_ORNULL(req->stale_oc, OBJCORE_MAGIC);
 
 	VCL_miss_method(req->vcl, wrk, req, NULL, NULL);
-	switch (wrk->handling) {
+	switch (wrk->vpi->handling) {
 	case VCL_RET_FETCH:
 		wrk->stats->cache_miss++;
 		VBF_Fetch(wrk, req, req->objcore, req->stale_oc, VBF_NORMAL);
@@ -725,7 +725,7 @@ cnt_pass(struct worker *wrk, struct req *req)
 	AZ(req->stale_oc);
 
 	VCL_pass_method(req->vcl, wrk, req, NULL, NULL);
-	switch (wrk->handling) {
+	switch (wrk->vpi->handling) {
 	case VCL_RET_FAIL:
 		req->req_step = R_STP_VCLFAIL;
 		break;
@@ -786,11 +786,11 @@ cnt_pipe(struct worker *wrk, struct req *req)
 
 	bo->wrk = wrk;
 	if (WS_Overflowed(req->ws))
-		wrk->handling = VCL_RET_FAIL;
+		wrk->vpi->handling = VCL_RET_FAIL;
 	else
 		VCL_pipe_method(req->vcl, wrk, req, bo, NULL);
 
-	switch (wrk->handling) {
+	switch (wrk->vpi->handling) {
 	case VCL_RET_SYNTH:
 		req->req_step = R_STP_SYNTH;
 		nxt = REQ_FSM_MORE;
@@ -954,12 +954,12 @@ cnt_recv(struct worker *wrk, struct req *req)
 
 	VCL_recv_method(req->vcl, wrk, req, NULL, NULL);
 
-	if (wrk->handling == VCL_RET_FAIL) {
+	if (wrk->vpi->handling == VCL_RET_FAIL) {
 		req->req_step = R_STP_VCLFAIL;
 		return (REQ_FSM_MORE);
 	}
 
-	if (wrk->handling == VCL_RET_VCL && req->restarts == 0) {
+	if (wrk->vpi->handling == VCL_RET_VCL && req->restarts == 0) {
 		// Req_Rollback has happened in VPI_vcl_select
 		assert(WS_Snapshot(req->ws) == req->ws_req);
 		cnt_recv_prep(req, ci);
@@ -980,7 +980,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 		return (REQ_FSM_DONE);
 	}
 
-	recv_handling = wrk->handling;
+	recv_handling = wrk->vpi->handling;
 
 	/* We wash the A-E header here for the sake of VRY */
 	if (cache_param->http_gzip_support &&
@@ -995,10 +995,10 @@ cnt_recv(struct worker *wrk, struct req *req)
 
 	VSHA256_Init(&sha256ctx);
 	VCL_hash_method(req->vcl, wrk, req, NULL, &sha256ctx);
-	if (wrk->handling == VCL_RET_FAIL)
-		recv_handling = wrk->handling;
+	if (wrk->vpi->handling == VCL_RET_FAIL)
+		recv_handling = wrk->vpi->handling;
 	else
-		assert(wrk->handling == VCL_RET_LOOKUP);
+		assert(wrk->vpi->handling == VCL_RET_LOOKUP);
 	VSHA256_Final(req->digest, &sha256ctx);
 
 	switch (recv_handling) {
@@ -1083,7 +1083,7 @@ cnt_purge(struct worker *wrk, struct req *req)
 	AZ(HSH_DerefObjCore(wrk, &boc, 1));
 
 	VCL_purge_method(req->vcl, wrk, req, NULL, NULL);
-	switch (wrk->handling) {
+	switch (wrk->vpi->handling) {
 	case VCL_RET_RESTART:
 		req->req_step = R_STP_RESTART;
 		break;

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -524,6 +524,10 @@ void WRK_Init(void);
 void WRK_AddStat(const struct worker *);
 void WRK_Log(enum VSL_tag_e, const char *, ...);
 
+/* cache_vpi.c */
+extern const size_t vpi_wrk_len;
+void VPI_wrk_init(struct worker *, void *, size_t);
+
 /* cache_ws.c */
 void WS_Panic(struct vsb *, const struct ws *);
 static inline int

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -527,6 +527,7 @@ void WRK_Log(enum VSL_tag_e, const char *, ...);
 /* cache_vpi.c */
 extern const size_t vpi_wrk_len;
 void VPI_wrk_init(struct worker *, void *, size_t);
+void VPI_Panic(struct vsb *, const struct wrk_vpi *, const struct vcl *);
 
 /* cache_ws.c */
 void WS_Panic(struct vsb *, const struct ws *);

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -291,7 +291,7 @@ vcl_panic_conf(struct vsb *vsb, const struct VCL_conf *conf)
 	VSB_cat(vsb, "srcname = {\n");
 	VSB_indent(vsb, 2);
 	for (i = 0; i < conf->nsrc; ++i)
-		VSB_printf(vsb, "\"%s\",\n", conf->srcname[i]);
+		VSB_printf(vsb, "[%d] = \"%s\",\n", i, conf->srcname[i]);
 	VSB_indent(vsb, -2);
 	VSB_cat(vsb, "},\n");
 	VSB_cat(vsb, "instances = {\n");

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -68,7 +68,7 @@ struct lock		vcl_mtx;
 struct vcl		*vcl_active; /* protected by vcl_mtx */
 
 static struct vrt_ctx ctx_cli;
-static unsigned handling_cli;
+static struct wrk_vpi wrk_vpi_cli;
 static struct ws ws_cli;
 static uintptr_t ws_snapshot_cli;
 static struct vsl_log vsl_cli;
@@ -125,10 +125,9 @@ VCL_Get_CliCtx(int msg)
 {
 
 	ASSERT_CLI();
-	AZ(ctx_cli.handling);
 	INIT_OBJ(&ctx_cli, VRT_CTX_MAGIC);
-	handling_cli = 0;
-	ctx_cli.handling = &handling_cli;
+	INIT_OBJ(&wrk_vpi_cli, WRK_VPI_MAGIC);
+	ctx_cli.vpi = &wrk_vpi_cli;
 	ctx_cli.now = VTIM_real();
 	if (msg) {
 		ctx_cli.msg = VSB_new_auto();
@@ -156,7 +155,7 @@ VCL_Rel_CliCtx(struct vrt_ctx **ctx)
 
 	ASSERT_CLI();
 	assert(*ctx == &ctx_cli);
-	AN((*ctx)->handling);
+	AN((*ctx)->vpi);
 	if (ctx_cli.msg) {
 		TAKE_OBJ_NOTNULL(r, &ctx_cli.msg, VSB_MAGIC);
 		AZ(VSB_finish(r));

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -91,8 +91,8 @@ VCL_Bo2Ctx(struct vrt_ctx *ctx, struct busyobj *bo)
 	ctx->sp = bo->sp;
 	ctx->now = bo->t_prev;
 	ctx->ws = bo->ws;
-	ctx->handling = &bo->wrk->handling;
-	*ctx->handling = 0;
+	ctx->vpi = bo->wrk->vpi;
+	ctx->vpi->handling = 0;
 }
 
 void
@@ -114,8 +114,8 @@ VCL_Req2Ctx(struct vrt_ctx *ctx, struct req *req)
 	ctx->sp = req->sp;
 	ctx->now = req->t_prev;
 	ctx->ws = req->ws;
-	ctx->handling = &req->wrk->handling;
-	*ctx->handling = 0;
+	ctx->vpi = req->wrk->vpi;
+	ctx->vpi->handling = 0;
 }
 
 /*--------------------------------------------------------------------*/
@@ -186,10 +186,10 @@ vcl_event_handling(VRT_CTX)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
-	if (*ctx->handling == 0)
+	if (ctx->vpi->handling == 0)
 		return (0);
 
-	assert(*ctx->handling == VCL_RET_FAIL);
+	assert(ctx->vpi->handling == VCL_RET_FAIL);
 
 	if (ctx->method == VCL_MET_INIT)
 		return (1);
@@ -200,7 +200,7 @@ vcl_event_handling(VRT_CTX)
 	 */
 	assert(ctx->method == VCL_MET_FINI);
 
-	*ctx->handling = 0;
+	ctx->vpi->handling = 0;
 	VRT_fail(ctx, "VRT_fail() from vcl_fini{} has no effect");
 	return (0);
 }
@@ -239,8 +239,8 @@ vcl_send_event(struct vcl *vcl, enum vcl_event_e ev, struct vsb **msg)
 
 	ctx = VCL_Get_CliCtx(havemsg);
 
-	AN(ctx->handling);
-	AZ(*ctx->handling);
+	AN(ctx->vpi);
+	AZ(ctx->vpi->handling);
 	AN(ctx->ws);
 
 	ctx->vcl = vcl;

--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -67,6 +67,7 @@ VPI_count(VRT_CTX, unsigned u)
 	CHECK_OBJ_NOTNULL(ctx->vcl, VCL_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->vcl->conf, VCL_CONF_MAGIC);
 	assert(u < ctx->vcl->conf->nref);
+	ctx->vpi->ref = u;
 	if (ctx->vsl != NULL)
 		VSLb(ctx->vsl, SLT_VCL_trace, "%s %u %u.%u.%u",
 		    ctx->vcl->loaded_name, u, ctx->vcl->conf->ref[u].source,

--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -45,6 +45,20 @@
  * Private & exclusive interfaces between VCC and varnishd
  */
 
+const size_t vpi_wrk_len = sizeof(struct wrk_vpi);
+
+void
+VPI_wrk_init(struct worker *wrk, void *p, size_t spc)
+{
+	struct wrk_vpi *vpi = p;
+
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	AN(vpi);
+	assert(spc >= sizeof *vpi);
+	INIT_OBJ(vpi, WRK_VPI_MAGIC);
+	wrk->vpi = vpi;
+}
+
 void
 VPI_count(VRT_CTX, unsigned u)
 {

--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -89,12 +89,12 @@ void
 VPI_vcl_fini(VRT_CTX)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	AN(ctx->handling);
+	AN(ctx->vpi);
 
-	if (*ctx->handling == VCL_RET_FAIL)
+	if (ctx->vpi->handling == VCL_RET_FAIL)
 		return;
-	assert(*ctx->handling == VCL_RET_OK);
-	*ctx->handling = 0;
+	assert(ctx->vpi->handling == VCL_RET_OK);
+	ctx->vpi->handling = 0;
 }
 
 VCL_VCL

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -643,19 +643,19 @@ VRT_handling(VRT_CTX, unsigned hand)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	assert(hand != VCL_RET_FAIL);
-	AN(ctx->handling);
-	AZ(*ctx->handling);
+	AN(ctx->vpi);
+	AZ(ctx->vpi->handling);
 	assert(hand > 0);
 	assert(hand < VCL_RET_MAX);
-	*ctx->handling = hand;
+	ctx->vpi->handling = hand;
 }
 
 unsigned
 VRT_handled(VRT_CTX)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	AN(ctx->handling);
-	return (*ctx->handling);
+	AN(ctx->vpi);
+	return (ctx->vpi->handling);
 }
 
 /*--------------------------------------------------------------------*/
@@ -667,10 +667,10 @@ VRT_fail(VRT_CTX, const char *fmt, ...)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	assert(ctx->vsl != NULL || ctx->msg != NULL);
-	AN(ctx->handling);
-	if (*ctx->handling == VCL_RET_FAIL)
+	AN(ctx->vpi);
+	if (ctx->vpi->handling == VCL_RET_FAIL)
 		return;
-	AZ(*ctx->handling);
+	AZ(ctx->vpi->handling);
 	AN(fmt);
 	AZ(strchr(fmt, '\n'));
 	va_start(ap, fmt);
@@ -682,7 +682,7 @@ VRT_fail(VRT_CTX, const char *fmt, ...)
 		VSB_putc(ctx->msg, '\n');
 	}
 	va_end(ap);
-	*ctx->handling = VCL_RET_FAIL;
+	ctx->vpi->handling = VCL_RET_FAIL;
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -38,6 +38,7 @@
 
 #include "cache_varnishd.h"
 #include "vcl.h"
+#include "vcc_interface.h"
 
 struct vrt_priv {
 	unsigned			magic;

--- a/bin/varnishd/cache/cache_vrt_priv.c
+++ b/bin/varnishd/cache/cache_vrt_priv.c
@@ -280,7 +280,7 @@ VRT_priv_fini(VRT_CTX, const struct vmod_priv *p)
 	VRT_CTX_Assert(ctx);
 
 	m->fini(ctx, p->priv);
-	assert(*ctx->handling == 0 || *ctx->handling == VCL_RET_FAIL);
+	assert(ctx->vpi->handling == 0 || ctx->vpi->handling == VCL_RET_FAIL);
 }
 
 /*--------------------------------------------------------------------*/
@@ -298,8 +298,8 @@ VCL_TaskLeave(VRT_CTX, struct vrt_privs *privs)
 	struct vrt_priv *vp, *vp1;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	AN(ctx->handling);
-	assert(*ctx->handling == 0 || *ctx->handling == VCL_RET_FAIL);
+	AN(ctx->vpi);
+	assert(ctx->vpi->handling == 0 || ctx->vpi->handling == VCL_RET_FAIL);
 
 	/*
 	 * NB: We don't bother removing entries as we finish them because it's

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -558,9 +558,9 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 	VSLbs(ctx.vsl, SLT_VCL_call, TOSTRAND(VCL_Method_Name(method)));
 	func(&ctx, VSUB_STATIC, NULL);
 	VSLbs(ctx.vsl, SLT_VCL_return,
-	    TOSTRAND(VCL_Return_Name(wrk->handling)));
+	    TOSTRAND(VCL_Return_Name(wrk->vpi->handling)));
 	wrk->cur_method |= 1;		// Magic marker
-	if (wrk->handling == VCL_RET_FAIL)
+	if (wrk->vpi->handling == VCL_RET_FAIL)
 		wrk->stats->vcl_fail++;
 
 	/*

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -583,7 +583,7 @@ VCL_##func##_method(struct vcl *vcl, struct worker *wrk,		\
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);				\
 	vcl_call_method(wrk, req, bo, specific,				\
 	    VCL_MET_ ## upper, vcl->conf->func##_func, vcl->conf->nsub);\
-	AN((1U << wrk->handling) & bitmap);				\
+	AN((1U << wrk->vpi->handling) & bitmap);			\
 }
 
 #include "tbl/vcl_returns.h"

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -96,6 +96,7 @@ wrk_bgthread(void *arg)
 	INIT_OBJ(&wrk, WORKER_MAGIC);
 	INIT_OBJ(wpriv, WORKER_PRIV_MAGIC);
 	wrk.wpriv = wpriv;
+	// bgthreads do not have a vpi member
 	memset(&ds, 0, sizeof ds);
 	wrk.stats = &ds;
 
@@ -126,6 +127,7 @@ WRK_Thread(struct pool *qp, size_t stacksize, unsigned thread_workspace)
 	struct VSC_main_wrk ds;
 	unsigned char ws[thread_workspace];
 	struct worker_priv wpriv[1];
+	unsigned char vpi[vpi_wrk_len];
 
 	AN(qp);
 	AN(stacksize);
@@ -143,6 +145,8 @@ WRK_Thread(struct pool *qp, size_t stacksize, unsigned thread_workspace)
 	AZ(pthread_cond_init(&w->cond, NULL));
 
 	WS_Init(w->aws, "wrk", ws, thread_workspace);
+	VPI_wrk_init(w, vpi, sizeof vpi);
+	AN(w->vpi);
 
 	VSL(SLT_WorkThread, 0, "%p start", w);
 

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -53,6 +53,14 @@ struct vpi_ref {
 	const char	*token;
 };
 
+/* VPI's private part of the worker */
+struct wrk_vpi {
+	unsigned	magic;
+#define WRK_VPI_MAGIC	0xaa3d3df3
+	unsigned	handling;
+};
+
+
 void VPI_count(VRT_CTX, unsigned);
 void VPI_vcl_fini(VRT_CTX);
 

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -58,6 +58,7 @@ struct wrk_vpi {
 	unsigned	magic;
 #define WRK_VPI_MAGIC	0xaa3d3df3
 	unsigned	handling;
+	unsigned	ref;	// index into (struct vpi_ref)[]
 };
 
 

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -46,6 +46,8 @@ void v_noreturn_ VPI_Fail(const char *func, const char *file, int line,
  */
 
 struct vpi_ref {
+	unsigned	magic;
+#define VPI_REF_MAGIC	0xd955f567
 	unsigned	source;
 	unsigned	offset;
 	unsigned	line;

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -279,6 +279,7 @@ struct VSC_main;
 struct vsc_seg;
 struct vsl_log;
 struct vsmw_cluster;
+struct wrk_vpi;
 struct ws;
 
 typedef const struct stream_close *stream_close_t;
@@ -385,7 +386,8 @@ struct vrt_ctx {
 	unsigned			syntax;
 	unsigned			vclver;
 	unsigned			method;
-	unsigned			*handling;
+
+	struct wrk_vpi			*vpi;
 
 	/*
 	 * msg is for error messages and exists only for

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -410,7 +410,7 @@ EmitCoordinates(const struct vcc *tl, struct vsb *vsb)
 				pos++;
 
 		}
-		VSB_printf(vsb, "  [%3u] = { %u, %8tu, %4u, %3u, ",
+		VSB_printf(vsb, "  [%3u] = { VPI_REF_MAGIC, %u, %8tu, %4u, %3u, ",
 		    t->cnt, sp->idx, t->b - sp->b, lin, pos + 1);
 		if (t->tok == CSRC)
 			VSB_cat(vsb, " \"C{\"},\n");

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -451,7 +451,7 @@ EmitInitFini(const struct vcc *tl)
 		if (VSB_len(p->ini))
 			Fc(tl, 0, "\t/* %u */\n%s\n", p->n, VSB_data(p->ini));
 		if (p->ignore_errors == 0) {
-			Fc(tl, 0, "\tif (*ctx->handling == VCL_RET_FAIL)\n");
+			Fc(tl, 0, "\tif (ctx->vpi->handling == VCL_RET_FAIL)\n");
 			Fc(tl, 0, "\t\treturn(1);\n");
 		}
 		Fc(tl, 0, "\tvgc_inistep = %u;\n\n", p->n);
@@ -464,9 +464,9 @@ EmitInitFini(const struct vcc *tl)
 
 	/* Handle failures from vcl_init */
 	Fc(tl, 0, "\n");
-	Fc(tl, 0, "\tif (*ctx->handling != VCL_RET_OK)\n");
+	Fc(tl, 0, "\tif (ctx->vpi->handling != VCL_RET_OK)\n");
 	Fc(tl, 0, "\t\treturn(1);\n");
-	Fc(tl, 0, "\t*ctx->handling = 0;\n");
+	Fc(tl, 0, "\tctx->vpi->handling = 0;\n");
 
 	VTAILQ_FOREACH(sy, &tl->sym_objects, sideways) {
 		Fc(tl, 0, "\tif (!%s) {\n", sy->rname);
@@ -620,7 +620,7 @@ vcc_CompileSource(struct vcc *tl, struct source *sp, const char *jfile)
 	Fh(tl, 0, "/* ---===### VCC generated .h code ###===---*/\n");
 	Fc(tl, 0, "\n/* ---===### VCC generated .c code ###===---*/\n");
 
-	Fc(tl, 0, "\n#define END_ if (*ctx->handling) return\n");
+	Fc(tl, 0, "\n#define END_ if (ctx->vpi->handling) return\n");
 
 	vcc_Parse_Init(tl);
 

--- a/tools/coccinelle/archive/wrk_vpi.cocci
+++ b/tools/coccinelle/archive/wrk_vpi.cocci
@@ -1,0 +1,55 @@
+/*
+ * This patch was used to introduce struct wrk_vpi once
+ *
+ * Retained for reference only
+ */
+using "varnish.iso"
+
+@@
+idexpression struct worker *wrk;
+@@
+
+- wrk->handling
++ wrk->vpi->handling
+
+@@
+idexpression struct vrt_ctx *ctx;
+expression reqbo;
+@@
+
+- ctx->handling = &reqbo->wrk->handling;
++ ctx->vpi = reqbo->wrk->vpi;
+
+@@
+idexpression struct vrt_ctx *ctx;
+expression X;
+@@
+
+- *ctx->handling = X
++ ctx->vpi->handling = X
+
+/*
+ * not using idexpression for ctx behind this point
+ * because I failed to teach coccinelle VRT_CTX
+ * (which is not just an iso, but rather a macro
+ * also used in the argument list
+ */
+@@
+identifier F;
+@@
+
+- F(ctx->handling)
++ F(ctx->vpi)
+
+@@
+identifier F;
+@@
+
+- F(*ctx->handling)
++ F(ctx->vpi->handling)
+
+@@
+@@
+
+- *ctx->handling
++ ctx->vpi->handling

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -38,6 +38,8 @@
 
 #include "cache/cache_varnishd.h"
 #include "cache/cache_filter.h"
+#include "vcc_interface.h"	// struct wrk_vpi
+
 
 #include "vsa.h"
 #include "vtim.h"
@@ -458,7 +460,7 @@ event_load(VRT_CTX, struct vmod_priv *priv)
 	// This should fail
 	AN(VRT_AddFilter(ctx, &xyzzy_vfp_rot13, &xyzzy_vdp_rot13));
 	// Reset the error, we know what we're doing.
-	*ctx->handling = 0;
+	ctx->vpi->handling = 0;
 
 	VRT_RemoveFilter(ctx, &xyzzy_vfp_rot13, &xyzzy_vdp_rot13);
 	AZ(VRT_AddFilter(ctx, &xyzzy_vfp_rot13, &xyzzy_vdp_rot13));

--- a/vmod/vmod_debug_dyn.c
+++ b/vmod/vmod_debug_dyn.c
@@ -120,8 +120,7 @@ xyzzy_dyn__init(VRT_CTX, struct xyzzy_debug_dyn **dynp,
 	AN(vcl_name);
 
 	if (*addr == '\0' || *port == '\0') {
-		AN(ctx->handling);
-		AZ(*ctx->handling);
+		AZ(VRT_handled(ctx));
 		VRT_fail(ctx, "Missing dynamic backend address or port");
 		return;
 	}


### PR DESCRIPTION
As documented in [this comment](https://github.com/varnishcache/varnish-cache/pull/3512#issuecomment-770905412), I was asked to make VCL source line information (as tracked by `VPI_count()`) available in panics. This would actually be very handy for analysis, and if there _was_ a place for the vpi count in `VRT_CTX`, we could make `VCL_Trace` a VCC flag (turning tracing on only if explicitly asked for at compile time), turn `VPI_count()` into a very efficient inline function and spare a lot of function calls while VCL code is executing.

And so I went down a rabbit role:
* Panics use thread local storage as provided by `pthread_setspecific()` to get hold of the panicking thread's context (req, bo etc)
* We want use tls sparsely due to the cost involved
* We cannot just track additional information in `VRT_CTX`, because it is (for very good reasons) `const`.

So I looked at the one case where VCL (actually VGC) modifies the CTX - indirectly, which is `*ctx->handling`. Outside the CLI, it lives in the worker. A simple approach would have been to just add `unsigned vpi_count` to `struct worker` and `unsigned *vpi_count` to `struct vrt_ctx`. But that would have eaten up half the space I just found wasted in adfac94537004b1b273316e911ca61dfa8960fae and also it appeared to me that it might be about time to give VGC it's own writable bit of `VRT_CTX`, to not only accommodate the to-be-moved `vpi_count`, but also to solve the nuisance that evil vmods could fiddle directly with `*ctx->handling` (this was discussed in the course of #3163).

This PR is an *RFC* (really!) to discuss
* if we want to go this route
* and, if yes, how

You will find at least one spot which I am not happy about, and we can discuss implementation questions later. At this point, my question really is the above.