### PR TITLE
Fix callling a dynamic sub for object methods

### DIFF
--- a/bin/varnishtest/tests/m00053.vtc
+++ b/bin/varnishtest/tests/m00053.vtc
@@ -192,3 +192,46 @@ logexpect l3 -wait
 client c4 -wait
 client c5 -wait
 client c6 -wait
+
+varnish v1 -vcl {
+	import debug;
+	backend b None;
+
+	sub foo {
+		set resp.http.Foo = "Called";
+	}
+
+	sub vcl_init {
+		new c = debug.caller(foo);
+	}
+
+	sub vcl_recv {
+		return (synth(200));
+	}
+
+	sub vcl_synth {
+		if (req.url == "/call") {
+			call c.xsub();
+		} else {
+			c.call();
+		}
+		return (deliver);
+	}
+}
+
+client c1 {
+	txreq -url "/call"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Foo == "Called"
+} -start
+
+client c2 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.http.Foo == "Called"
+} -start
+
+client c1 -wait
+client c2 -wait

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -50,8 +50,8 @@ vcc_act_call(struct vcc *tl, struct token *t, struct symbol *sym)
 	(void)t;
 	ExpectErr(tl, ID);
 	t0 = tl->t;
-	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_NONE, SYMTAB_NOERR, XREF_REF);
-
+	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_NONE, SYMTAB_PARTIAL_NOERR,
+	    XREF_REF);
 	if (sym == NULL)
 		sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_SUB, SYMTAB_CREATE,
 		    XREF_REF);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -387,6 +387,7 @@ extern const struct symmode SYMTAB_NOERR[1];
 extern const struct symmode SYMTAB_CREATE[1];
 extern const struct symmode SYMTAB_EXISTING[1];
 extern const struct symmode SYMTAB_PARTIAL[1];
+extern const struct symmode SYMTAB_PARTIAL_NOERR[1];
 
 struct symbol *VCC_SymbolGet(struct vcc *, vcc_ns_t, vcc_kind_t,
     const struct symmode *, const struct symxref *);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -382,7 +382,11 @@ extern const struct symxref XREF_NONE[1];
 extern const struct symxref XREF_DEF[1];
 extern const struct symxref XREF_REF[1];
 
-struct symmode { const char *name; };
+struct symmode {
+	const char	*name;
+	unsigned	noerr;
+	unsigned	partial;
+};
 extern const struct symmode SYMTAB_NOERR[1];
 extern const struct symmode SYMTAB_CREATE[1];
 extern const struct symmode SYMTAB_EXISTING[1];

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -254,6 +254,7 @@ const struct symmode SYMTAB_NOERR[1] = {{"sym_noerror"}};
 const struct symmode SYMTAB_CREATE[1] = {{"sym_create"}};
 const struct symmode SYMTAB_EXISTING[1] = {{"Symbol not found"}};
 const struct symmode SYMTAB_PARTIAL[1] = {{"Symbol not found"}};
+const struct symmode SYMTAB_PARTIAL_NOERR[1] = {{"Symbol not found"}};
 
 struct symbol *
 VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
@@ -301,13 +302,13 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 	}
 	if (sym != NULL && sym->kind == SYM_VMOD && e == SYMTAB_PARTIAL)
 		e = SYMTAB_EXISTING;
-	if (sym != NULL && e == SYMTAB_PARTIAL) {
+	if (sym != NULL && (e == SYMTAB_PARTIAL || e == SYMTAB_PARTIAL_NOERR)) {
 		st = st2;
 		tn = tn2;
 	} else if (st != st2) {
 		sym = NULL;
 	}
-	if (sym == NULL && e == SYMTAB_NOERR)
+	if (sym == NULL && (e == SYMTAB_NOERR || e == SYMTAB_PARTIAL_NOERR))
 		return (sym);
 	AN(st);
 	AN(tn);

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -250,11 +250,26 @@ vcc_sym_in_tab(struct vcc *tl, struct symtab *st,
 const struct symxref XREF_NONE[1] = {{"xref_none"}};
 const struct symxref XREF_DEF[1] = {{"xref_def"}};
 const struct symxref XREF_REF[1] = {{"xref_ref"}};
-const struct symmode SYMTAB_NOERR[1] = {{"sym_noerror"}};
-const struct symmode SYMTAB_CREATE[1] = {{"sym_create"}};
-const struct symmode SYMTAB_EXISTING[1] = {{"Symbol not found"}};
-const struct symmode SYMTAB_PARTIAL[1] = {{"Symbol not found"}};
-const struct symmode SYMTAB_PARTIAL_NOERR[1] = {{"Symbol not found"}};
+
+const struct symmode SYMTAB_NOERR[1] = {{
+		.name = "sym_noerror",
+		.noerr = 1
+	}};
+const struct symmode SYMTAB_CREATE[1] = {{
+		.name = "sym_create"
+	}};
+const struct symmode SYMTAB_EXISTING[1] = {{
+		.name = "Symbol not found"
+	}};
+const struct symmode SYMTAB_PARTIAL[1] = {{
+		.name = "Symbol not found",
+		.partial = 1
+	}};
+const struct symmode SYMTAB_PARTIAL_NOERR[1] = {{
+		.name = "Symbol not found",
+		.partial = 1,
+		.noerr = 1
+	}};
 
 struct symbol *
 VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
@@ -300,15 +315,15 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 			break;
 		tn = tn1;
 	}
-	if (sym != NULL && sym->kind == SYM_VMOD && e == SYMTAB_PARTIAL)
+	if (sym != NULL && sym->kind == SYM_VMOD && e->partial)
 		e = SYMTAB_EXISTING;
-	if (sym != NULL && (e == SYMTAB_PARTIAL || e == SYMTAB_PARTIAL_NOERR)) {
+	if (sym != NULL && e->partial) {
 		st = st2;
 		tn = tn2;
 	} else if (st != st2) {
 		sym = NULL;
 	}
-	if (sym == NULL && (e == SYMTAB_NOERR || e == SYMTAB_PARTIAL_NOERR))
+	if (sym == NULL && e->noerr)
 		return (sym);
 	AN(st);
 	AN(tn);

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1331,3 +1331,62 @@ xyzzy_total_recall(VRT_CTX)
 
 	return (wrong);
 }
+
+/*---------------------------------------------------------------------*/
+
+struct VPFX(debug_caller) {
+       unsigned        magic;
+#define DEBUG_CALLER_MAGIC 0xb47f3449
+       VCL_SUB         sub;
+};
+
+VCL_VOID v_matchproto_(td_xyzzy_debug_caller__init)
+xyzzy_caller__init(VRT_CTX, struct VPFX(debug_caller) **callerp,
+    const char *name, VCL_SUB sub)
+{
+	struct VPFX(debug_caller) *caller;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(callerp);
+	AZ(*callerp);
+	AN(name);
+	AN(sub);
+
+	ALLOC_OBJ(caller, DEBUG_CALLER_MAGIC);
+	AN(caller);
+	*callerp = caller;
+	caller->sub = sub;
+}
+
+VCL_VOID v_matchproto_(td_xyzzy_debug_caller__fini)
+xyzzy_caller__fini(struct VPFX(debug_caller) **callerp)
+{
+	struct VPFX(debug_caller) *caller;
+
+	if (callerp == NULL || *callerp == NULL)
+		return;
+	CHECK_OBJ(*callerp, DEBUG_CALLER_MAGIC);
+	caller = *callerp;
+	*callerp = NULL;
+	FREE_OBJ(caller);
+}
+
+VCL_VOID v_matchproto_(td_xyzzy_debug_caller_call)
+xyzzy_caller_call(VRT_CTX, struct VPFX(debug_caller) *caller)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(caller, DEBUG_CALLER_MAGIC);
+	AN(caller->sub);
+
+	VRT_call(ctx, caller->sub);
+}
+
+VCL_SUB v_matchproto_(td_xyzzy_debug_caller_sub)
+xyzzy_caller_xsub(VRT_CTX, struct VPFX(debug_caller) *caller)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(caller, DEBUG_CALLER_MAGIC);
+	AN(caller->sub);
+
+	return (caller->sub);
+}

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -340,3 +340,9 @@ To test *WRONG* behavior
 $Function SUB total_recall()
 
 To test *WRONG* behavior
+
+$Object caller(SUB)
+
+$Method VOID .call()
+
+$Method SUB .xsub()


### PR DESCRIPTION
7ec28f1ae91bd39e6e89beb7dffd4248c5054414 did not work with object methods because we need a partial symbol table lookup to identify them, otherwise the symbol kind we find is just SUB for the method's return value.

Fixes #3521
