### PR TITLE
Clear the status and response on a retry

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -331,6 +331,8 @@ vbf_stp_retry(struct worker *wrk, struct busyobj *bo)
 	bo->do_esi = 0;
 	bo->do_stream = 1;
 	bo->was_304 = 0;
+	bo->err_code = 0;
+	bo->err_reason = NULL;
 
 	// XXX: BereqEnd + BereqAcct ?
 	VSL_ChgId(bo->vsl, "bereq", "retry", VXID_Get(wrk, VSL_BACKENDMARKER));

--- a/bin/varnishtest/tests/r03525.vtc
+++ b/bin/varnishtest/tests/r03525.vtc
@@ -1,0 +1,24 @@
+varnishtest "Clear beresp status and reason on a retry"
+
+server s1 {
+	rxreq
+	txresp -status 500 -reason "my reason"
+} -start
+
+varnish v1 -arg "-p first_byte_timeout=0.2" -vcl+backend {
+	sub vcl_backend_response {
+		return (error(beresp.status, beresp.reason));
+	}
+	sub vcl_backend_error {
+		if (bereq.retries == 0) {
+			return (retry);
+		}
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+	expect resp.reason == "Backend fetch failed"
+} -run


### PR DESCRIPTION
The bo fields err_code and err_reason need to be reset on a retry otherwise the values are kept.

Fixes #3525