### PR TITLE
When streaming, send headers if no body data available yet

### DIFF
--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -280,6 +280,8 @@ sml_iterator(struct worker *wrk, struct objcore *oc,
 	l = 0;
 
 	u = 0;
+	if (boc->len_so_far == 0)
+		func(priv, OBJ_ITER_FLUSH, NULL, 0);
 	while (1) {
 		ol = len;
 		nl = ObjWaitExtend(wrk, oc, ol);


### PR DESCRIPTION
This is a TTFB optimization: I noticed that, when streaming, we would only sometimes send headers while waiting for more body data from the backend, depending on the amount of body data read ahead when reading the backend headers.

The `flush_head` debug bit would avoid the delay, but it leads to an extra flush in all cases, even when we could send some body data down the line with the headers.

This trivial patch peeks into the busy object to determine if the first `ObjWaitExtend()` is likely to block and, if so, issues a flush, which will cause the headers to be sent in addition to any initial data VDPs might have to send.