### PR TITLE
resp.reason and vcl_synth can race with obj.* pointers

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -85,6 +85,14 @@ VRT_synth(VRT_CTX, VCL_INT code, VCL_STRING reason)
 		return;
 	}
 
+	if (reason && !WS_Inside(ctx->ws, reason, NULL)) {
+		reason = WS_Copy(ctx->ws, reason, -1);
+		if (!reason) {
+			VRT_fail(ctx, "Workspace overflow");
+			return;
+		}
+	}
+
 	if (ctx->req == NULL) {
 		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
 		ctx->bo->err_code = (uint16_t)code;

--- a/bin/varnishtest/tests/r03546.vtc
+++ b/bin/varnishtest/tests/r03546.vtc
@@ -1,0 +1,21 @@
+varnishtest "Synth resp.reason race"
+
+varnish v1 -vcl {
+	backend default none;
+
+	sub vcl_backend_error {
+		set beresp.status = 500;
+		set beresp.reason = "VCL";
+	}
+
+	sub vcl_deliver {
+		return (synth(resp.status, resp.reason));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 500
+	expect resp.reason == "VCL"
+} -run


### PR DESCRIPTION
When an `obj.*` field is passed into the `resp.reason` in a `return(synth())` expression, under certain conditions the `oc` can be dereferenced early and lead to a use after free in `vcl_synth`. The fix is to do a workspace copy if the value is not local when entering a synthetic response. This will also cover `vcl_backend_error`.