### PR TITLE
Add a NULL VCL_STRANDS

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -56,6 +56,10 @@
 
 const void * const vrt_magic_string_end = &vrt_magic_string_end;
 const void * const vrt_magic_string_unset = &vrt_magic_string_unset;
+const struct strands *vrt_null_strands = &(struct strands){
+	.n = 0,
+	.p = (const char *[1]){NULL}
+};
 
 /*--------------------------------------------------------------------*/
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -238,6 +238,11 @@ struct strands {
 	const char	**p;
 };
 
+/*
+ * A VCL_STRANDS return value must never be NULL. Use this instead
+ */
+extern const struct strands *vrt_null_strands;
+
 /***********************************************************************
  * VCL_BLOB:
  *


### PR DESCRIPTION
... and document it

The size of 1 for the `p` array would not be required, it is a safety measure only.
Should we have this or rather set `.p = NULL`?