### PR TITLE
thaw pile: Polish testcase

### DIFF
--- a/bin/varnishtest/tests/d00029.vtc
+++ b/bin/varnishtest/tests/d00029.vtc
@@ -1,16 +1,16 @@
 varnishtest "shard director LAZY - d18.vtc"
 
-server s1 -repeat 3 {
+server s1 -repeat 2 {
 	rxreq
 	txresp -body "ech3Ooj"
 } -start
 
-server s2 -repeat 3 {
+server s2 -repeat 2 {
 	rxreq
 	txresp -body "ieQu2qua"
 } -start
 
-server s3 -repeat 3 {
+server s3 -repeat 2 {
 	rxreq
 	txresp -body "xiuFi3Pe"
 } -start


### PR DESCRIPTION
we only use one passed and one piped requests, so our servers should
only ever see two requests.

Motivated by a failure on fedora armv7hl, which I do not understand:

```**   c1    === txreq -url /1 -hdr "pipe: true"
**** c1    txreq|GET /1 HTTP/1.1\r
**** c1    txreq|pipe: true\r
**** c1    txreq|Host: 127.0.0.1\r
**** c1    txreq|\r
**   c1    === rxresp
**** dT    3.832
**** c1    rxhdrlen = 0
---- c1    HTTP header is incomplete
**** dT    3.833```