### PR TITLE
Don't change the C-L if we detect a failed stream

### DIFF
--- a/bin/varnishtest/tests/r03560.vtc
+++ b/bin/varnishtest/tests/r03560.vtc
@@ -1,0 +1,29 @@
+varnishtest "A backend connection error gets returned as a valid short response"
+
+barrier b1 sock 2
+
+server s1 {
+	rxreq
+	txresp -nolen -hdr "Content-Length: 10"
+	barrier b1 sync
+	send "12345"
+	# Early connection close error
+} -start
+
+varnish v1 -vcl+backend {
+	import vtc;
+
+	sub vcl_deliver {
+		# Make sure we are streaming and give the backend time to error out
+		vtc.barrier_sync("${b1_sock}");
+		vtc.sleep(1s);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresphdrs
+	expect resp.http.Content-Length == "10"
+	recv 5
+	expect_close
+} -run


### PR DESCRIPTION
Previously we would read the response Content-Length from a failed oc, which would make the error response valid. Now, if this is detected, we don't touch the Content-Length.

The root of the problem is that we race with a `boc` and end up with a failed `objcore`, all before transmitting anything. I guess we should be careful, anytime we check for a `boc` and don't get one, we should then check if the resulting `oc` is valid. Most of the time this is harmless. In this case, we are changing the `Content-Length` to zero and returning a completely valid response.

Fixes https://github.com/varnishcache/varnish-cache/issues/3560