### PR TITLE
[LTS Backport] resp.reason and vcl_synth can race with obj.* pointers

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -76,6 +76,14 @@ VRT_synth(VRT_CTX, VCL_INT code, VCL_STRING reason)
 		return;
 	}
 
+	if (reason && !WS_Inside(ctx->ws, reason, NULL)) {
+		reason = WS_Copy(ctx->ws, reason, -1);
+		if (!reason) {
+			VRT_fail(ctx, "Workspace overflow");
+			return;
+		}
+	}
+
 	if (ctx->req == NULL) {
 		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
 		ctx->bo->err_code = (uint16_t)code;

--- a/bin/varnishtest/tests/r03546.vtc
+++ b/bin/varnishtest/tests/r03546.vtc
@@ -1,0 +1,21 @@
+varnishtest "Synth resp.reason race"
+
+varnish v1 -vcl {
+	backend default none;
+
+	sub vcl_backend_error {
+		set beresp.status = 500;
+		set beresp.reason = "VCL";
+	}
+
+	sub vcl_deliver {
+		return (synth(resp.status, resp.reason));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 500
+	expect resp.reason == "VCL"
+} -run


### PR DESCRIPTION
We can incorrectly reference resp.reason from other sources when
jumping into vcl_synth. This also covers passing in a reason in
vcl_backend_error.


Original PR: https://github.com/varnishcache/varnish-cache/pull/3546