### PR TITLE
[LTS Backport] Don't recycle a backend when a Connection: close header is present

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -435,6 +435,10 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 
 	VCL_backend_response_method(bo->vcl, wrk, NULL, bo, NULL);
 
+	if (bo->htc != NULL && bo->htc->doclose == SC_NULL &&
+	    http_GetHdrField(bo->beresp, H_Connection, "close", NULL))
+		bo->htc->doclose = SC_RESP_CLOSE;
+
 	if (wrk->handling == VCL_RET_ABANDON || wrk->handling == VCL_RET_FAIL ||
 	    wrk->handling == VCL_RET_ERROR) {
 		if (bo->htc)

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -433,6 +433,10 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 	if (http_IsStatus(bo->beresp, 304) && vbf_304_logic(bo) < 0)
 		return (F_STP_ERROR);
 
+	if (bo->htc->doclose == SC_NULL &&
+	    http_GetHdrField(bo->bereq, H_Connection, "close", NULL))
+		bo->htc->doclose = SC_REQ_CLOSE;
+
 	VCL_backend_response_method(bo->vcl, wrk, NULL, bo, NULL);
 
 	if (bo->htc != NULL && bo->htc->doclose == SC_NULL &&

--- a/bin/varnishtest/tests/b00073.vtc
+++ b/bin/varnishtest/tests/b00073.vtc
@@ -1,0 +1,39 @@
+varnishtest "backend connection close"
+
+server s1 {
+	rxreq
+	expect req.http.beresp-connection ~ close
+	txresp
+	expect_close
+
+	accept
+	rxreq
+	expect req.http.beresp-connection !~ close
+	txresp -hdr "connection: close"
+	expect_close
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pass);
+	}
+	sub vcl_backend_response {
+		# NB: this overrides unconditionally on purpose
+		set beresp.http.connection = bereq.http.beresp-connection;
+	}
+} -start
+
+client c1 {
+	txreq -hdr "beresp-connection: close, x-varnish"
+	rxresp
+	expect resp.status == 200
+
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+server s1 -wait
+
+varnish v1 -expect MAIN.backend_recycle == 0
+varnish v1 -expect VBE.vcl1.s1.conn == 0

--- a/bin/varnishtest/tests/b00073.vtc
+++ b/bin/varnishtest/tests/b00073.vtc
@@ -2,14 +2,30 @@ varnishtest "backend connection close"
 
 server s1 {
 	rxreq
+	expect req.http.connection ~ close
+	expect req.http.beresp-connection !~ close
+	txresp
+	expect_close
+
+	accept
+	rxreq
+	expect req.http.connection !~ close
 	expect req.http.beresp-connection ~ close
 	txresp
 	expect_close
 
 	accept
 	rxreq
+	expect req.http.connection !~ close
 	expect req.http.beresp-connection !~ close
 	txresp -hdr "connection: close"
+	expect_close
+
+	accept
+	rxreq
+	expect req.http.connection ~ close
+	expect req.http.unset-connection == true
+	txresp
 	expect_close
 } -start
 
@@ -17,18 +33,32 @@ varnish v1 -vcl+backend {
 	sub vcl_recv {
 		return (pass);
 	}
+	sub vcl_backend_fetch {
+		set bereq.http.connection = bereq.http.bereq-connection;
+	}
 	sub vcl_backend_response {
+		if (bereq.http.unset-connection) {
+			unset bereq.http.connection;
+		}
 		# NB: this overrides unconditionally on purpose
 		set beresp.http.connection = bereq.http.beresp-connection;
 	}
 } -start
 
 client c1 {
+	txreq -hdr "bereq-connection: close, x-varnish"
+	rxresp
+	expect resp.status == 200
+
 	txreq -hdr "beresp-connection: close, x-varnish"
 	rxresp
 	expect resp.status == 200
 
 	txreq
+	rxresp
+	expect resp.status == 200
+
+	txreq -hdr "bereq-connection: close" -hdr "unset-connection: true"
 	rxresp
 	expect resp.status == 200
 } -run

--- a/doc/sphinx/whats-new/changes-6.0.rst
+++ b/doc/sphinx/whats-new/changes-6.0.rst
@@ -50,6 +50,31 @@ this should make life simpler for everybody we hope.
 
 And it goes without saying that we have fixed a lot of bugs too.
 
+Changes to VCL
+==============
+
+VCL variables
+~~~~~~~~~~~~~
+
+It is now possible to manually set a ``Connection: close`` header in
+``beresp`` to signal that the backend connection shouldn't be recycled.
+This might help dealing with backends that would under certain circumstances
+have trouble managing their end of the connection, for example for certain
+kinds of resources.
+
+Care should be taken to preserve other headers listed in the connection
+header::
+
+    sub vcl_backend_response {
+        if (beresp.backend == faulty_backend) {
+            if (beresp.http.Connection) {
+                set beresp.http.Connection += ", close";
+            } else {
+                set beresp.http.Connection = "close";
+            }
+        }
+    }
+
 
 Under the hood (mostly for developers)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION

Original PRs: https://github.com/varnishcache/varnish-cache/pull/3405 https://github.com/varnishcache/varnish-cache/pull/3423

First discussed: https://github.com/varnishcache/varnish-cache/pull/3400