### PR TITLE
[LTS Backport] Backend cooling fix

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -405,7 +405,6 @@ vbe_destroy(const struct director *d)
 {
 	struct backend *be;
 
-	ASSERT_CLI();
 	CAST_OBJ_NOTNULL(be, d->priv, BACKEND_MAGIC);
 
 	if (be->probe != NULL)
@@ -537,8 +536,8 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 	if (retval == 0)
 		return (d);
 
-	VRT_delete_backend(ctx, &d);
-	AZ(d);
+	/* Undo the above */
+	d->destroy(d);
 	return (NULL);
 }
 

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -565,9 +565,9 @@ VRT_delete_backend(VRT_CTX, struct director **dp)
 	Lck_Lock(&be->mtx);
 	be->director->admin_health = VDI_AH_DELETED;
 	be->director->health_changed = VTIM_real();
-	be->cooled = VTIM_real() + 60.;
 	Lck_Unlock(&be->mtx);
 	Lck_Lock(&backends_mtx);
+	be->cooled = VTIM_real() + 60.;
 	VTAILQ_REMOVE(&backends, be, list);
 	VTAILQ_INSERT_TAIL(&cool_backends, be, list);
 	Lck_Unlock(&backends_mtx);

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -566,6 +566,7 @@ VRT_delete_backend(VRT_CTX, struct director **dp)
 	be->director->health_changed = VTIM_real();
 	Lck_Unlock(&be->mtx);
 	Lck_Lock(&backends_mtx);
+	AZ(be->cooled);
 	be->cooled = VTIM_real() + 60.;
 	VTAILQ_REMOVE(&backends, be, list);
 	VTAILQ_INSERT_TAIL(&cool_backends, be, list);

--- a/bin/varnishd/cache/cache_vcl_vrt.c
+++ b/bin/varnishd/cache/cache_vcl_vrt.c
@@ -142,6 +142,7 @@ VCL_AddDirector(struct vcl *vcl, struct director *d, const char *vcl_name)
 	AZ(errno=pthread_rwlock_rdlock(&vcl->temp_rwl));
 	if (vcl->temp == VCL_TEMP_COOLING) {
 		AZ(errno=pthread_rwlock_unlock(&vcl->temp_rwl));
+		REPLACE(d->display_name, NULL);
 		return (1);
 	}
 


### PR DESCRIPTION
This backport does a few things.
1. makes sure we cooling under the correct lock
2. Properly destroys dynamic backends on failures
3. Add an assert that VRT_delete_backend is only called once