### PR TITLE
[LTS Backport] properly maintain the obans list when pruning the ban list tail

### DIFF
--- a/bin/varnishtest/tests/r03006.vtc
+++ b/bin/varnishtest/tests/r03006.vtc
@@ -1,0 +1,54 @@
+varnishtest "test ban lurker destination being completed by dup ban"
+
+server s1 -repeat 4 -keepalive {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {} -start
+
+varnish v1 -cliok "param.set ban_lurker_age 99"
+
+# this ban becomes the pruned tail
+varnish v1 -cliok "ban obj.http.t == 1"
+client c1 {
+	txreq -url /1
+	rxresp
+} -run
+
+# this ban becomes the new tail
+varnish v1 -cliok "ban obj.http.t == 2"
+client c1 {
+	txreq -url /2
+	rxresp
+} -run
+
+# req ban to define where the tail goes (at t == 2)
+varnish v1 -cliok "ban req.http.barrier == here"
+client c1 {
+	txreq -url /3
+	rxresp
+} -run
+
+# dup ban to trigger #3006
+varnish v1 -cliok "ban obj.http.t == 2"
+client c1 {
+	txreq -url /4
+	rxresp
+} -run
+
+varnish v1 -cliok "ban.list"
+
+varnish v1 -cliok "param.set ban_lurker_age 0.1"
+
+varnish v1 -cliok "ban.list"
+
+delay 2
+
+varnish v1 -expect bans == 3
+varnish v1 -expect bans_completed == 2
+
+varnish v1 -cliok "ban.list"
+
+varnish v1 -expect bans == 3
+varnish v1 -expect bans_completed == 2


### PR DESCRIPTION
Original body below:

background: When the ban lurker has finished working the bottom of the
ban list, conceptually we mark all bans it has evaluated as completed
and then remove the tail of the ban list which has no references any
more.

Yet, for efficiency, we first remove the tail and then mark only those
bans completed, which we did not remove. Doing so depends on knowing
where in the (obans) list of bans to be completed is the new tail of
the bans list after pruning.

5dd54f8390739c62c201e62c36eb515b1e03c2ee was intended to solve this,
but the fix was incomplete (and also unnecessarily complicated): For
example when a duplicate ban was issued, ban_lurker_test_ban() could
remove a ban from the obans list which later happens to become the new
ban tail.

We now - hopefully - solve the problem for real by properly cleaning
the obans list when we prune the ban list.

Fixes #3006
Fixes #2779
Fixes #2556 for real (5dd54f8390739c62c201e62c36eb515b1e03c2ee was
incomplete)

 Conflicts:
	bin/varnishd/cache/cache_ban_lurker.c