### PR TITLE
[LTS Backport] Shard fixes

### DIFF
--- a/bin/varnishtest/tests/d06001.vtc
+++ b/bin/varnishtest/tests/d06001.vtc
@@ -1,0 +1,30 @@
+varnishtest "Empty shard reconfig"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import directors;
+
+	sub vcl_init {
+		new shard1 = directors.shard();
+		new shard2 = directors.shard();
+
+		shard1.reconfigure();
+
+		shard2.add_backend(s1);
+		shard2.reconfigure();
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = shard2.backend();
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run

--- a/lib/libvmod_directors/shard_cfg.c
+++ b/lib/libvmod_directors/shard_cfg.c
@@ -290,7 +290,7 @@ shardcfg_hashcircle(struct sharddir *shardd)
 		}
 		/* not used in current interface */
 		shardd->backend[h].canon_point =
-		    shardd->hashcircle[i].point;
+		    shardd->hashcircle[i - j].point;
 	}
 	assert (i == n_points);
 	qsort( (void *) shardd->hashcircle, n_points,


### PR DESCRIPTION
Technically not a backport, these are fixes specific to shard and 6.0.

`canon_point` - This was dropped in master before a big change which added weights. In trying to keep 6.0 stable, we left this in and had to approximate what this value is based on the new algorithm. Previously we used the last point (which sometimes doesn't exist), but upon closer inspection, we should be using the first point.

`shard.reconfigure()` - There is a bug where if you `reconfigure()` and empty shard, future calls of `reconfigure()` will fail. This does not exist anymore in master since `reconfigure()` was made optional and the shared state has been removed. The root of the problem is that we do not cleanup our state when we see there are no backends. I also moved the lock up to cover more operations safely.