### PR TITLE
synth: obj.fetch_{failed,abandoned}

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -337,13 +337,11 @@ struct objcore {
 	float			grace;
 	float			keep;
 
-	uint8_t			flags;
-
+	unsigned		timer_idx;	// XXX 4Gobj limit
+	uint16_t		oa_present;
+	uint16_t		flags;
 	uint8_t			exp_flags;
 
-	uint16_t		oa_present;
-
-	unsigned		timer_idx;	// XXX 4Gobj limit
 	vtim_real		last_lru;
 	VTAILQ_ENTRY(objcore)	hsh_list;
 	VTAILQ_ENTRY(objcore)	lru_list;

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -993,7 +993,7 @@ vbf_stp_fail(struct worker *wrk, struct busyobj *bo)
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
 	assert(oc->boc->state < BOS_FINISHED);
-	HSH_Fail(oc);
+	HSH_Fail(oc, wrk->handling == VCL_RET_ABANDON);
 	if (!(oc->flags & OC_F_BUSY))
 		HSH_Kill(oc);
 	ObjSetState(wrk, oc, BOS_FAILED);

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -735,7 +735,7 @@ HSH_Purge(struct worker *wrk, struct objhead *oh, vtim_real ttl_now,
  */
 
 void
-HSH_Fail(struct objcore *oc)
+HSH_Fail(struct objcore *oc, unsigned abandoned)
 {
 	struct objhead *oh;
 
@@ -752,6 +752,8 @@ HSH_Fail(struct objcore *oc)
 
 	Lck_Lock(&oh->mtx);
 	oc->flags |= OC_F_FAILED;
+	if (abandoned)
+		oc->flags |= OC_F_ABANDONED;
 	Lck_Unlock(&oh->mtx);
 }
 

--- a/bin/varnishd/cache/cache_objhead.h
+++ b/bin/varnishd/cache/cache_objhead.h
@@ -56,7 +56,7 @@ struct objhead {
 #define hoh_head _u.n.u_n_hoh_head
 };
 
-void HSH_Fail(struct objcore *);
+void HSH_Fail(struct objcore *, unsigned);
 void HSH_Kill(struct objcore *);
 void HSH_Insert(struct worker *, const void *hash, struct objcore *,
     struct ban *);

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -502,6 +502,9 @@ cnt_fetch(struct worker *wrk, struct req *req)
 	if (req->objcore->flags & OC_F_FAILED) {
 		req->err_code = 503;
 		req->req_step = R_STP_SYNTH;
+		req->fetch_failed = 1;
+		if (req->objcore->flags & OC_F_ABANDONED)
+			req->fetch_abandoned = 1;
 		(void)HSH_DerefObjCore(wrk, &req->objcore, 1);
 		AZ(req->objcore);
 		return (REQ_FSM_MORE);
@@ -874,6 +877,8 @@ cnt_recv_prep(struct req *req, const char *ci)
 		req->storage = NULL;
 	}
 
+	req->fetch_failed = 0;
+	req->fetch_abandoned = 0;
 	req->is_hit = 0;
 	req->is_hitmiss = 0;
 	req->is_hitpass = 0;

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -497,6 +497,20 @@ VRT_r_obj_can_esi(VRT_CTX)
 
 /*--------------------------------------------------------------------*/
 
+#define OBJ_FETCH_VAR(what)				\
+VCL_BOOL						\
+VRT_r_obj_fetch_ ## what(VRT_CTX)			\
+{							\
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);		\
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);		\
+	return (ctx->req->fetch_ ## what);		\
+}
+
+OBJ_FETCH_VAR(failed)
+OBJ_FETCH_VAR(abandoned)
+
+/*--------------------------------------------------------------------*/
+
 #define REQ_VAR_L(nm, elem, type, extra)				\
 									\
 VCL_VOID								\

--- a/bin/varnishtest/tests/b00038.vtc
+++ b/bin/varnishtest/tests/b00038.vtc
@@ -20,20 +20,30 @@ varnish v1 -arg "-pfirst_byte_timeout=0.1" -vcl+backend {
 	sub vcl_backend_error {
 		return (abandon);
 	}
+	sub vcl_synth {
+		set resp.http.failed = obj.fetch_failed;
+		set resp.http.abandoned = obj.fetch_abandoned;
+	}
 } -start
 
 client c1 {
 	txreq -url /foo
 	rxresp
 	expect resp.status == 503
+	expect resp.http.failed == true
+	expect resp.http.abandoned == true
 
 	txreq -url /bar
 	rxresp
 	expect resp.status == 503
+	expect resp.http.failed == true
+	expect resp.http.abandoned == true
 
 	txreq -url /baz
 	rxresp
 	expect resp.status == 503
+	expect resp.http.failed == true
+	expect resp.http.abandoned == true
 } -run
 
 varnish v1 -expect fetch_failed == 1

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1121,6 +1121,23 @@ obj.can_esi
 	``vcl_deliver {}`` would cause the response body to be ESI
 	processed.
 
+obj.fetch_failed
+
+	Type: BOOL
+
+	Readable from: vcl_synth
+
+	Returns true when vcl_synth was reached because a fetch failed.
+
+obj.fetch_abandoned
+
+	Type: BOOL
+
+	Readable from: vcl_synth
+
+	Returns true when vcl_synth was reached because a fetch was
+	abandoned. This implies that the fetch was also failed.
+
 
 resp
 ~~~~

--- a/include/tbl/oc_flags.h
+++ b/include/tbl/oc_flags.h
@@ -38,6 +38,7 @@ OC_FLAG(ABANDON,	abandon,	(1<<4))
 OC_FLAG(PRIVATE,	private,	(1<<5))
 OC_FLAG(FAILED,		failed,		(1<<6))
 OC_FLAG(DYING,		dying,		(1<<7))
+OC_FLAG(ABANDONED,	abandoned,	(1<<8))
 #undef OC_FLAG
 
 /*lint -restore */

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -41,6 +41,8 @@ REQ_FLAG(is_hitpass,		1, 0, "")
 REQ_FLAG(waitinglist,		0, 0, "")
 REQ_FLAG(want100cont,		0, 0, "")
 REQ_FLAG(late100cont,		0, 0, "")
+REQ_FLAG(fetch_failed,		0, 0, "")
+REQ_FLAG(fetch_abandoned,	0, 0, "")
 #undef REQ_FLAG
 
 /*lint -restore */


### PR DESCRIPTION
This is scratching an old itch, the inability to know in `vcl_synth` whether we come from a failed fetch, and whether that failed fetch was abandoned.