### PR TITLE
Use "perfect hash" to find headers to be filtered out.

### DIFF
--- a/bin/varnishtest/tests/c00016.vtc
+++ b/bin/varnishtest/tests/c00016.vtc
@@ -1,10 +1,15 @@
-varnishtest "Test Connection header handling"
+varnishtest "Test header filtering Table/Connection header"
 
 server s1 {
 	rxreq
 	expect req.url == "/foo"
 	expect req.http.Foo == "bar"
 	expect req.http.FromVCL == "123"
+	expect req.http.Proxy-Authenticate == "<undef>"
+	expect req.http.pROXY-aUTHENTICATE == "<undef>"
+	expect req.http.Proxy-Authenticat == "3"
+	expect req.http.Proxy-Authenticatd == "4"
+	expect req.http.Proxy-Authenticatef == "5"
 	txresp -hdr "Bar: foo" -body "foobar"
 
 	rxreq
@@ -23,7 +28,13 @@ varnish v1 -vcl+backend {
 } -start
 
 client c1 {
-	txreq -url "/foo" -hdr "Foo: bar"
+	txreq -url "/foo" -hdr "Foo: bar" \
+		-hdr "Proxy-Authenticate: 1" \
+		-hdr "pROXY-aUTHENTICATE: 2" \
+		-hdr "Proxy-Authenticat: 3" \
+		-hdr "Proxy-Authenticatd: 4" \
+		-hdr "Proxy-Authenticatef: 5"
+
 	rxresp
 	expect resp.http.Bar == "foo"
 

--- a/include/tbl/http_headers.h
+++ b/include/tbl/http_headers.h
@@ -36,6 +36,9 @@
  *
  * see [RFC2616 13.5.1 End-to-end and Hop-by-hop Headers]
  *
+ * When fields with non-zero flags are added, the "perfect hash" at the
+ * top of cache_http.c will need to be reworked.  See the comments there
+ * for instructions.
  */
 
 /*lint -save -e525 -e539 */


### PR DESCRIPTION
The actual agorithm was found with `gperf` but its output is
not directly usable and include/tbl/http_headers.h change so
infrequently that this step is not automated.  (Asserts protect
against overlooking this step if new headers are added to
the table.)