### PR TITLE
Improve vcl caching

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -446,7 +446,7 @@ vca_accept_task(struct worker *wrk, void *arg)
 
 	/* Dont hold on to (possibly) discarded VCLs */
 	if (wrk->wpriv->vcl != NULL)
-		VCL_Rel(&wrk->wpriv->vcl);
+		VCL_Rel(&wrk->wpriv->vcl, NULL);
 
 	while (!ps->pool->die) {
 		INIT_OBJ(&wa, WRK_ACCEPT_MAGIC);

--- a/bin/varnishd/cache/cache_busyobj.c
+++ b/bin/varnishd/cache/cache_busyobj.c
@@ -180,7 +180,7 @@ VBO_ReleaseBusyObj(struct worker *wrk, struct busyobj **pbo)
 		    HSH_RUSH_POLICY);
 	}
 
-	VCL_Recache(wrk, &bo->vcl);
+	VCL_Rel(&bo->vcl, wrk);
 
 	memset(&bo->retries, 0,
 	    sizeof *bo - offsetof(struct busyobj, retries));

--- a/bin/varnishd/cache/cache_busyobj.c
+++ b/bin/varnishd/cache/cache_busyobj.c
@@ -139,7 +139,7 @@ VBO_GetBusyObj(const struct worker *wrk, const struct req *req)
 
 	bo->director_req = req->director_hint;
 	bo->vcl = req->vcl;
-	VCL_Ref(bo->vcl);
+	VCL_Ref(bo->vcl, wrk);
 
 	bo->t_first = bo->t_prev = NAN;
 
@@ -180,7 +180,7 @@ VBO_ReleaseBusyObj(struct worker *wrk, struct busyobj **pbo)
 		    HSH_RUSH_POLICY);
 	}
 
-	VCL_Rel(&bo->vcl);
+	VCL_Recache(wrk, &bo->vcl);
 
 	memset(&bo->retries, 0,
 	    sizeof *bo - offsetof(struct busyobj, retries));

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -207,7 +207,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 		AZ(req->wrk);
 	}
 
-	VCL_Recache(wrk, &req->vcl);
+	VCL_Rel(&req->vcl, wrk);
 
 	req->wrk = NULL;
 	THR_SetRequest(preq);

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -180,7 +180,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 		req->vcl = req->top->vcl0;
 	else
 		req->vcl = preq->vcl;
-	VCL_Ref(req->vcl);
+	VCL_Ref(req->vcl, wrk);
 
 	assert(req->req_step == R_STP_TRANSPORT);
 	req->t_req = preq->t_req;
@@ -207,7 +207,7 @@ ved_include(struct req *preq, const char *src, const char *host,
 		AZ(req->wrk);
 	}
 
-	VCL_Rel(&req->vcl);
+	VCL_Recache(wrk, &req->vcl);
 
 	req->wrk = NULL;
 	THR_SetRequest(preq);

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -230,7 +230,7 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 	req->restarts = 0;
 
 	if (req->vcl != NULL)
-		VCL_Recache(wrk, &req->vcl);
+		VCL_Rel(&req->vcl, wrk);
 
 	/* Charge and log byte counters */
 	if (req->vsl->wid) {

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -1097,9 +1097,7 @@ CNT_Embark(struct worker *wrk, struct req *req)
 	req->vfc->wrk = req->wrk = wrk;
 	wrk->vsl = req->vsl;
 	if (req->req_step == R_STP_TRANSPORT && req->vcl == NULL) {
-		VCL_Refresh(&wrk->wpriv->vcl);
-		req->vcl = wrk->wpriv->vcl;
-		wrk->wpriv->vcl = NULL;
+		VCL_Refresh(&req->vcl, wrk);
 		VSLb(req->vsl, SLT_VCL_use, "%s", VCL_Name(req->vcl));
 	}
 

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -1157,7 +1157,7 @@ CNT_Request(struct req *req)
 		if (IS_TOPREQ(req)) {
 			VCL_TaskLeave(ctx, req->top->privs);
 			if (req->top->vcl0 != NULL)
-				VCL_Recache(wrk, &req->top->vcl0);
+				VCL_Rel(&req->top->vcl0, wrk);
 		}
 		VCL_TaskLeave(ctx, req->privs);
 		AN(req->vsl->wid);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -480,7 +480,7 @@ void VCL_VRT_Init(void);
 /* cache_vrt_vcl.c */
 const char *VCL_Return_Name(unsigned);
 const char *VCL_Method_Name(unsigned);
-void VCL_Refresh(struct vcl **);
+void VCL_Refresh(struct vcl **, const struct worker *);
 void VCL_Ref(struct vcl *, const struct worker *);
 void VCL_Rel(struct vcl **, const struct worker *);
 VCL_BACKEND VCL_DefaultDirector(const struct vcl *);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -482,7 +482,7 @@ const char *VCL_Return_Name(unsigned);
 const char *VCL_Method_Name(unsigned);
 void VCL_Refresh(struct vcl **);
 void VCL_Recache(const struct worker *, struct vcl **);
-void VCL_Ref(struct vcl *);
+void VCL_Ref(struct vcl *, const struct worker *);
 void VCL_Rel(struct vcl **);
 VCL_BACKEND VCL_DefaultDirector(const struct vcl *);
 const struct vrt_backend_probe *VCL_DefaultProbe(const struct vcl *);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -481,9 +481,8 @@ void VCL_VRT_Init(void);
 const char *VCL_Return_Name(unsigned);
 const char *VCL_Method_Name(unsigned);
 void VCL_Refresh(struct vcl **);
-void VCL_Recache(const struct worker *, struct vcl **);
 void VCL_Ref(struct vcl *, const struct worker *);
-void VCL_Rel(struct vcl **);
+void VCL_Rel(struct vcl **, const struct worker *);
 VCL_BACKEND VCL_DefaultDirector(const struct vcl *);
 const struct vrt_backend_probe *VCL_DefaultProbe(const struct vcl *);
 

--- a/bin/varnishd/cache/cache_vrt_vcl.c
+++ b/bin/varnishd/cache/cache_vrt_vcl.c
@@ -78,16 +78,22 @@ VCL_Method_Name(unsigned m)
 /*--------------------------------------------------------------------*/
 
 void
-VCL_Refresh(struct vcl **vcc)
+VCL_Refresh(struct vcl **vclp, const struct worker *wrk)
 {
+	AN(vclp);
+	AZ(*vclp);
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 
 	while (vcl_active == NULL)
 		(void)usleep(100000);
 
-	if (*vcc == vcl_active)
+	*vclp = wrk->wpriv->vcl;
+	wrk->wpriv->vcl = NULL;
+
+	if (*vclp == vcl_active)
 		return;
 
-	VCL_Update(vcc, NULL);
+	VCL_Update(vclp, NULL);
 }
 
 static inline int

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -156,7 +156,7 @@ WRK_Thread(struct pool *qp, size_t stacksize, unsigned thread_workspace)
 
 	VSL(SLT_WorkThread, 0, "%p end", w);
 	if (w->wpriv->vcl != NULL)
-		VCL_Rel(&w->wpriv->vcl);
+		VCL_Rel(&w->wpriv->vcl, NULL);
 	AZ(pthread_cond_destroy(&w->cond));
 	HSH_Cleanup(w);
 	Pool_Sumstat(w);
@@ -469,7 +469,7 @@ Pool_Work_Thread(struct pool *pp, struct worker *wrk)
 					// assert this because pthread condvars
 					// are not airtight.
 					if (wrk->wpriv->vcl)
-						VCL_Rel(&wrk->wpriv->vcl);
+						VCL_Rel(&wrk->wpriv->vcl, NULL);
 					now = VTIM_real();
 				}
 			} while (tp == NULL);
@@ -484,7 +484,7 @@ Pool_Work_Thread(struct pool *pp, struct worker *wrk)
 			assert(wrk->pool == pp);
 			tp->func(wrk, tp->priv);
 			if (DO_DEBUG(DBG_VCLREL) && wrk->wpriv->vcl != NULL)
-				VCL_Rel(&wrk->wpriv->vcl);
+				VCL_Rel(&wrk->wpriv->vcl, NULL);
 			tpx = *wrk->task;
 			tp = &tpx;
 		} while (tp->func != NULL);

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -348,7 +348,7 @@ h2_new_session(struct worker *wrk, void *arg)
 	CHECK_OBJ_NOTNULL(sp, SESS_MAGIC);
 
 	if (wrk->wpriv->vcl)
-		VCL_Rel(&wrk->wpriv->vcl);
+		VCL_Rel(&wrk->wpriv->vcl, NULL);
 
 	assert(req->transport == &H2_transport);
 


### PR DESCRIPTION
#3245 continued, which, for some reasons, I cannot reopen any more

@bsdphk I agree with your analysis that proper VCL caching with labels is non trivial, yet this PR merely makes an opportunistic attempt to improve it.

Nevertheless, this PR proposes other improvements which are mostly relevant for the non-label case (which is still the most common one, at least in my world):

* The first commit enables vcl reference caching also for backend requests and ESI subrequests
* The third commit collapses `VCL_Recache()` into `VCL_Rel()`, cutting the number `vcl_mtx' operations in half for the former `VCL_Recache()` case

As always, I will accept your veto (if it is one), but in this case I would like to make sure that we do not throw away what I think is sensible optimization potential.