### PR TITLE
Increase default stack space

### DIFF
--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -646,9 +646,9 @@ MCF_InitParams(struct cli *cli)
 	MCF_ParamConf(MCF_MINIMUM, "thread_pool_stack", "%jdb", (intmax_t)low);
 
 #if defined(__SANITIZER) || __has_feature(address_sanitizer)
-	def = 92 * 1024;
+	def = 128 * 1024;
 #else
-	def = 48 * 1024;
+	def = 64 * 1024;
 #endif
 	if (def < low)
 		def = low;

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -27,6 +27,14 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
+Varnish Cache 6.0.9 (unreleased)
+================================
+
+* Increase the default stack size to 64k. (3617_)
+
+.. _3617: https://github.com/varnishcache/varnish-cache/pull/3617
+
+================================
 Varnish Cache 6.0.8 (2021-07-13)
 ================================
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1329,7 +1329,7 @@ PARAM(
 	/* typ */	bytes,
 	/* min */	"2k",
 	/* max */	NULL,
-	/* default */	"48k",
+	/* default */	"64k",
 	/* units */	"bytes",
 	/* flags */	EXPERIMENTAL,
 	/* s-text */


### PR DESCRIPTION
Note: This is a PR into 6.0, our LTS branch.

A default stack space of 48k will cause a stack overflow in _some_ of the test cases (VMOD `blob`, specifically) on _some_ Linux distributions. The increase to 64k seems to be enough to solve this.