### PR TITLE
Release of 6.0.8 (LTS release)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_PREREQ(2.59)
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
-Copyright (c) 2006-2020 Varnish Software])
+Copyright (c) 2006-2021 Varnish Software])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [6.0.7], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [6.0.8], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -27,7 +27,7 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
-Varnish Cache 6.0.8 (YYYY-MM-DD)
+Varnish Cache 6.0.8 (2021-05-26)
 ================================
 
 * Fix an issue where a backend fetch can stall after a client has

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -37,7 +37,7 @@ Longer listings like example command output and VCL look like this::
     $ /opt/varnish/sbin/varnishd -V
     varnishd (varnish-trunk revision 199de9b)
     Copyright (c) 2006 Verdens Gang AS
-    Copyright (c) 2006-2020 Varnish Software AS
+    Copyright (c) 2006-2021 Varnish Software AS
 
 
 .. For maintainers:

--- a/lib/libvarnish/version.c
+++ b/lib/libvarnish/version.c
@@ -44,5 +44,5 @@ VCS_Message(const char *progname)
 {
 	fprintf(stderr, "%s (%s)\n", progname, VCS_version);
 	fprintf(stderr, "Copyright (c) 2006 Verdens Gang AS\n");
-	fprintf(stderr, "Copyright (c) 2006-2020 Varnish Software AS\n");
+	fprintf(stderr, "Copyright (c) 2006-2021 Varnish Software AS\n");
 }


### PR DESCRIPTION
This is the commit which marks the next 6.0 LTS release. Any comments about the release can be added here.

The date in this PR is set to 2021-05-26, but it can be adjusted if necessary.