### PR TITLE
Add std.strftime()

### DIFF
--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -346,6 +346,7 @@ child_main(int sigmagic, size_t altstksz)
 #if defined(__FreeBSD__) && __FreeBSD_version >= 1000000
 	malloc_message = child_malloc_fail;
 #endif
+	tzset();
 
 	cache_param = heritage.param;
 

--- a/bin/varnishtest/tests/m00020.vtc
+++ b/bin/varnishtest/tests/m00020.vtc
@@ -1,16 +1,28 @@
-varnishtest "Test std.time"
+varnishtest "Test std.time() and std.strftime()"
 
 server s1 {
 	rxreq
 	txresp
 } -start
 
+setenv TZ MET
+
 varnish v1 -vcl+backend {
 	import std;
+	import vtc;
 
 	sub vcl_deliver {
 		set resp.http.x-date = std.time(
 		    regsub(req.http.x-date, "z", " "), now);
+		if (req.http.over) {
+			vtc.workspace_alloc(client, -1);
+		}
+		set resp.http.met = std.strftime(
+		    std.time(req.http.x-date, now),
+		    "%Y%m%dT%H%M%SZ", local);
+		set resp.http.utc = std.strftime(
+		    std.time(req.http.x-date, now),
+		    "%Y%m%dT%H%M%SZ", utc);
 		if (std.time(req.http.x-date, now) < now - 1y) {
 			set resp.http.x-past = 1;
 		}
@@ -40,6 +52,8 @@ client c1 {
 	expect resp.status == 200
 	expect resp.http.x-past == 1
 	expect resp.http.x-date == "Mon, 20 Dec 2010 00:00:00 GMT"
+	expect resp.http.met == "20101220T010000Z"
+	expect resp.http.utc == "20101220T000000Z"
 
 	# invalid date
 	txreq -hdr "X-Date: Monday, 20-Dec-30 00:00:00 GMT" \
@@ -63,12 +77,16 @@ client c1 {
 	expect resp.status == 200
 	expect resp.http.x-future == 1
 	expect resp.http.x-date == "Fri, 20 Dec 2030 00:00:00 GMT"
+	expect resp.http.met == "20301220T010000Z"
+	expect resp.http.utc == "20301220T000000Z"
 
 	txreq -hdr "X-Date: Mon Dec 20 00:00:00 2010"
 	rxresp
 	expect resp.status == 200
 	expect resp.http.x-past == 1
 	expect resp.http.x-date == "Mon, 20 Dec 2010 00:00:00 GMT"
+	expect resp.http.met == "20101220T010000Z"
+	expect resp.http.utc == "20101220T000000Z"
 
 	txreq -hdr "X-Date: 2030-12-20T00:00:00"
 	rxresp
@@ -76,11 +94,13 @@ client c1 {
 	expect resp.http.x-future == 1
 	expect resp.http.x-date == "Fri, 20 Dec 2030 00:00:00 GMT"
 
-	txreq -hdr "X-Date: 1292803200.00"
+	txreq -hdr "X-Date: 1055455200.00"
 	rxresp
 	expect resp.status == 200
 	expect resp.http.x-past == 1
-	expect resp.http.x-date == "Mon, 20 Dec 2010 00:00:00 GMT"
+	expect resp.http.x-date == "Thu, 12 Jun 2003 22:00:00 GMT"
+	expect resp.http.met == "20030613T000000Z"
+	expect resp.http.utc == "20030612T220000Z"
 
 	txreq -hdr "X-Date: 1923955200"
 	rxresp
@@ -88,6 +108,13 @@ client c1 {
 	expect resp.http.x-future == 1
 	expect resp.http.x-date == "Fri, 20 Dec 2030 00:00:00 GMT"
 
+	# overflow
+	txreq -hdr "X-Date: 1923955200" -hdr "Over: 1"
+	rxresp
+	expect resp.status == 500
+} -run
+
+client c1 {
 	delay .2
 
 	# Coverage tests of vtim.c

--- a/vmod/vmod_std.vcc
+++ b/vmod/vmod_std.vcc
@@ -431,6 +431,23 @@ Examples::
 		...
 	}
 
+$Function STRING strftime(TIME time, STRING format, ENUM {utc, local} tz=utc)
+
+Format the *time* argument with the *format* argument using
+`strftime(3)` and return the result.
+
+The *tz* argument allows to select the timezone basis as either UTC or
+the local timezone as set by the TZ environment variable varnishd is
+runnig with.
+
+The empty string is returned if formatting fails, but may also be
+returned as a valid result.
+
+Example::
+
+	set req.http.iso = std.strftime(now, "%Y%m%dT%H%M%SZ");
+	# e.g. 20210521T175241Z
+
 LOGGING functions
 =================
 
@@ -715,3 +732,4 @@ SEE ALSO
 * :ref:`varnishd(1)`
 * :ref:`vsl(7)`
 * `fnmatch(3)`
+* `strftime(3)`

--- a/vmod/vmod_std_conversions.c
+++ b/vmod/vmod_std_conversions.c
@@ -316,6 +316,39 @@ vmod_time(VRT_CTX, struct VARGS(time)* a)
 	return (0);
 }
 
+VCL_STRING v_matchproto_(td_std_strftime)
+vmod_strftime(VRT_CTX, VCL_TIME t, VCL_STRING fmt,
+    VCL_ENUM tz)
+{
+	struct tm tm;
+	time_t tt;
+	size_t r;
+	unsigned spc;
+	char *s;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+
+	tt = (time_t)(intmax_t)t;
+	if (tz == VENUM(utc)) {
+		if (gmtime_r(&tt, &tm) == NULL)
+			return ("");
+	} else {
+		if (localtime_r(&tt, &tm) == NULL)
+			return ("");
+	}
+
+	spc = WS_ReserveAll(ctx->ws);
+	s = WS_Reservation(ctx->ws);
+	r = strftime(s, spc, fmt, &tm);
+	if (r == 0) {
+		WS_Release(ctx->ws, 0);
+		return ("");
+	}
+	r++;
+	WS_Release(ctx->ws, r);
+	return (s);
+}
+
 /* These functions are deprecated as of 2019-03-15 release */
 
 VCL_INT v_matchproto_(td_std_real2integer)


### PR DESCRIPTION
add a vmod function for `strftime()` formatting with an additional argument to select gmtime or localtime.

As `localtime_r()` requires `tzset()`, that is added to `child_main()` rather than the vmod initialization to avoid possible duplication for other vmods possibly using `localtime_r()`.

Test coverage is integrated with the existing m20.vtc. One of the test dates is changed to fall into the european daylight savings time to expose the two hour time difference between UTC and MET.