### PR TITLE
Compile VCL 4.0  from 4.1

### DIFF
--- a/bin/varnishtest/tests/r03368.vtc
+++ b/bin/varnishtest/tests/r03368.vtc
@@ -1,0 +1,27 @@
+varnishtest "include vcl 4.0 from vcl 4.1"
+
+shell {
+	cat >foo.vcl <<-EOF
+	vcl 4.0;
+
+	import std;
+
+	sub esi_status {
+		# this symbol is 4.0 only
+		std.log("ESI:" + req.esi);
+	}
+	EOF
+}
+
+varnish v1 -syntax 4.1 -errvcl {Variable is read only.} {
+	backend be none;
+
+	include "${tmpdir}/foo.vcl";
+
+	# should be in 4.1 syntax
+	sub vcl_recv {
+		call esi_status;
+		# this symbol is read only since 4.1
+		set req.proto = "HTTP/0.9";
+	}
+}

--- a/bin/varnishtest/tests/v00021.vtc
+++ b/bin/varnishtest/tests/v00021.vtc
@@ -168,6 +168,15 @@ varnish v1 -syntax 4.1 -errvcl {(Only available when VCL syntax <= 4.0)} {
 		set req.esi = false;
 	}
 }
+
+varnish v1 -syntax 4.1 -vcl {
+	backend be none;
+	vcl 4.0; # drop effective version for legacy symbol
+	sub vcl_recv {
+		set req.esi = false;
+	}
+}
+
 varnish v1 -syntax 4.0 -errvcl {(Only available when 4.1 <= VCL syntax)} {
 	sub vcl_deliver {
 		set resp.do_esi = false;

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -76,6 +76,10 @@ tokens = {
     "CSRC":     None,
     "CBLOB":    None,
 
+    # These are intrinsic tokens
+    "INC_PUSH": None,
+    "INC_POP":  None,
+
     # End of token list
     "EOI":      None,
 }

--- a/lib/libvcc/vcc_acl.c
+++ b/lib/libvcc/vcc_acl.c
@@ -457,7 +457,7 @@ vcc_acl_entry(struct vcc *tl)
  */
 
 static void
-vcc_acl_emit_tokens(const struct vcc *tl, const struct acl_e *ae)
+vcc_acl_emit_tokens(struct vcc *tl, const struct acl_e *ae)
 {
 	struct token *t;
 	const char *sep = "";
@@ -490,7 +490,7 @@ vcc_acl_emit_tokens(const struct vcc *tl, const struct acl_e *ae)
  */
 
 static unsigned
-vcc_acl_emit_tables(const struct vcc *tl, unsigned n, const char *name)
+vcc_acl_emit_tables(struct vcc *tl, unsigned n, const char *name)
 {
 	struct acl_e *ae;
 	unsigned rv = sizeof(ae->data) + 3;

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -416,7 +416,7 @@ vcc_ParseHostDef(struct vcc *tl, const struct token *t_be, const char *vgcname)
 			vcc_NextToken(tl);
 			SkipToken(tl, ';');
 		} else if (vcc_IdIs(t_field, "path")) {
-			if (tl->syntax < VCL_41) {
+			if (tl->esyntax < VCL_41) {
 				VSB_cat(tl->sb,
 				    "Unix socket backends only supported"
 				    " in VCL4.1 and higher.\n");

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -822,6 +822,7 @@ VCC_New(void)
 
 	ALLOC_OBJ(tl, VCC_MAGIC);
 	AN(tl);
+	VTAILQ_INIT(&tl->vcl_syntax);
 	VTAILQ_INIT(&tl->inifin);
 	VTAILQ_INIT(&tl->tokens);
 	VTAILQ_INIT(&tl->sources);

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -385,7 +385,7 @@ EmitCoordinates(const struct vcc *tl, struct vsb *vsb)
 	sp = 0;
 	p = NULL;
 	VTAILQ_FOREACH(t, &tl->tokens, list) {
-		if (t->cnt == 0)
+		if (t->b == NULL || t->cnt == 0)
 			continue;
 		assert(t->src != NULL);
 		if (t->src != sp) {

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -244,6 +244,7 @@ struct vcc {
 	unsigned		magic;
 #define VCC_MAGIC		0x24ad719d
 	int			syntax;
+	int			esyntax;	/* effective syntax */
 
 	char			*builtin_vcl;
 	struct vfil_path	*vcl_path;

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -240,9 +240,19 @@ struct inifin {
 
 VTAILQ_HEAD(inifinhead, inifin);
 
+struct syntax {
+#define SYNTAX_MAGIC		0x42397890
+	const struct source	*src;
+	int			version;
+	VTAILQ_ENTRY(syntax)	list;
+};
+
+VTAILQ_HEAD(syntaxhead, syntax);
+
 struct vcc {
 	unsigned		magic;
 #define VCC_MAGIC		0x24ad719d
+	struct syntaxhead	vcl_syntax;
 	int			syntax;
 	int			esyntax;	/* effective syntax */
 
@@ -373,6 +383,8 @@ struct source * vcc_new_source(const char *src, const char *kind,
     const char *name);
 struct source *vcc_file_source(struct vcc *tl, const char *fn);
 void vcc_lex_source(struct vcc *tl, struct source *sp, int eoi);
+void vcc_IncludePush(struct vcc *, struct token *);
+void vcc_IncludePop(struct vcc *, struct token *);
 
 /* vcc_storage.c */
 void vcc_stevedore(struct vcc *vcc, const char *stv_name);
@@ -416,13 +428,14 @@ void vcc_Warn(struct vcc *);
 
 void vcc__Expect(struct vcc *tl, unsigned tok, unsigned line);
 int vcc_IdIs(const struct token *t, const char *p);
-void vcc_PrintTokens(const struct vcc *tl, const struct token *tb,
+void vcc_PrintTokens(struct vcc *tl, const struct token *tb,
     const struct token *te);
 void vcc_ExpectVid(struct vcc *tl, const char *what);
 void vcc_Lexer(struct vcc *tl, struct source *sp);
 void vcc_NextToken(struct vcc *tl);
-struct token * vcc_PeekToken(const struct vcc *tl);
-struct token * vcc_PeekTokenFrom(const struct vcc *tl, const struct token *t);
+struct token * vcc_NextTokenFrom(struct vcc *tl, const struct token *t);
+struct token * vcc_PeekToken(struct vcc *tl);
+struct token * vcc_PeekTokenFrom(struct vcc *tl, const struct token *t);
 void vcc__ErrInternal(struct vcc *tl, const char *func,
     unsigned line);
 

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -336,6 +336,14 @@ vcc_ParseVcl(struct vcc *tl)
 		vcc_ErrWhere2(tl, tok0, tl->t);
 		ERRCHK(tl);
 	}
+	if (syntax < tl->syntax && (syntax / 10) != (tl->syntax / 10)) {
+		VSB_printf(tl->sb,
+		    "VCL version %.1f cannot be included from %.1f.\n",
+		    .1 * syntax, .1 * tl->syntax);
+		vcc_ErrWhere2(tl, tok0, tl->t);
+		ERRCHK(tl);
+	}
+	tl->esyntax = syntax;
 }
 
 /*--------------------------------------------------------------------
@@ -385,6 +393,7 @@ vcc_Parse(struct vcc *tl)
 	vcc_ParseVcl(tl);
 	ERRCHK(tl);
 	AN(tl->syntax);
+	assert(tl->esyntax == tl->syntax);
 	while (tl->t->tok != EOI) {
 		ERRCHK(tl);
 		switch (tl->t->tok) {

--- a/lib/libvcc/vcc_source.c
+++ b/lib/libvcc/vcc_source.c
@@ -257,3 +257,37 @@ vcc_lex_source(struct vcc *tl, struct source *src_sp, int eoi)
 			return;
 	}
 }
+
+/*--------------------------------------------------------------------*/
+
+void
+vcc_IncludePush(struct vcc *tl, struct token *t)
+{
+	struct syntax *s;
+
+	CHECK_OBJ_NOTNULL(tl, VCC_MAGIC);
+	AN(t);
+	assert(t->tok == INC_PUSH);
+
+	s = calloc(1, sizeof *s);
+	AN(s);
+	s->version = tl->esyntax;
+	s->src = t->src;
+	VTAILQ_INSERT_TAIL(&tl->vcl_syntax, s, list);
+}
+
+void
+vcc_IncludePop(struct vcc *tl, struct token *t)
+{
+	struct syntax *s;
+
+	CHECK_OBJ_NOTNULL(tl, VCC_MAGIC);
+	AN(t);
+	assert(t->tok == INC_POP);
+
+	s = VTAILQ_LAST(&tl->vcl_syntax, syntaxhead);
+	AN(s);
+	tl->esyntax = s->version;
+	VTAILQ_REMOVE(&tl->vcl_syntax, s, list);
+	free(s);
+}

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -289,7 +289,7 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 	tn = tl->t;
 	while (1) {
 		st = vcc_symtab_str(st, tn->b, tn->e);
-		sym2 = vcc_sym_in_tab(tl, st, kind, tl->syntax, tl->syntax);
+		sym2 = vcc_sym_in_tab(tl, st, kind, tl->esyntax, tl->syntax);
 		if (sym2 != NULL) {
 			sym = sym2;
 			st2 = st;
@@ -316,7 +316,7 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 	AN(st);
 	AN(tn);
 	if (sym == NULL && e == SYMTAB_CREATE)
-		sym = vcc_new_symbol(tl, st, kind, tl->syntax, tl->syntax);
+		sym = vcc_new_symbol(tl, st, kind, tl->esyntax, tl->syntax);
 	tl->t = vcc_NextTokenFrom(tl, tn);
 	if (tl->err)
 		return (NULL);

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -185,6 +185,7 @@ vcc_new_symbol(struct vcc *tl, struct symtab *st,
 {
 	struct symbol *sym;
 
+	assert(vlo <= vhi);
 	sym = TlAlloc(tl, sizeof *sym);
 	INIT_OBJ(sym, SYMBOL_MAGIC);
 	AN(sym);
@@ -205,6 +206,7 @@ vcc_sym_in_tab(struct vcc *tl, struct symtab *st,
 	const struct symtab *pst;
 	struct symbol *sym, *psym;
 
+	assert(vlo <= vhi);
 	VTAILQ_FOREACH(sym, &st->symbols, list) {
 		if (sym->lorev > vhi || sym->hirev < vlo)
 			continue;

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -295,10 +295,10 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 			st2 = st;
 			tn2 = tn;
 		}
-		tn1 = vcc_PeekTokenFrom(tl, tn);
+		tn1 = vcc_NextTokenFrom(tl, tn);
 		if (tn1 == NULL || tn1->tok != '.')
 			break;
-		tn1 = vcc_PeekTokenFrom(tl, tn1);
+		tn1 = vcc_NextTokenFrom(tl, tn1);
 		if (tn1 == NULL || tn1->tok != ID)
 			break;
 		tn = tn1;
@@ -317,7 +317,7 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 	AN(tn);
 	if (sym == NULL && e == SYMTAB_CREATE)
 		sym = vcc_new_symbol(tl, st, kind, tl->syntax, tl->syntax);
-	tl->t = vcc_PeekTokenFrom(tl, tn);
+	tl->t = vcc_NextTokenFrom(tl, tn);
 	if (tl->err)
 		return (NULL);
 	if (sym == NULL) {

--- a/lib/libvcc/vcc_token.c
+++ b/lib/libvcc/vcc_token.c
@@ -263,30 +263,67 @@ vcc_ErrWhere(struct vcc *tl, const struct token *t)
 
 /*--------------------------------------------------------------------*/
 
-struct token *
-vcc_PeekTokenFrom(const struct vcc *tl, const struct token *t)
+static struct token *
+vcc_next_token_from(struct vcc *tl, const struct token *t, unsigned peek)
 {
 	struct token *t2;
 
 	CHECK_OBJ_NOTNULL(tl, VCC_MAGIC);
 	AN(t);
 	assert(t->tok != EOI);
+
 	t2 = VTAILQ_NEXT(t, list);
 	AN(t2);
 
-	while (t2->b == NULL) {
+	/* ignore intrinsic tokens */
+	while (peek && t2->b == NULL) {
 		t2 = VTAILQ_NEXT(t2, list);
 		AN(t2);
 	}
+
+	/* process intrinsic tokens */
+	while (!peek && t2->b == NULL) {
+		switch (t2->tok) {
+		case INC_PUSH:
+			vcc_IncludePush(tl, t2);
+			break;
+		case INC_POP:
+			vcc_IncludePop(tl, t2);
+			break;
+		default:
+			WRONG("invalid intrinsic token");
+		}
+		t2 = VTAILQ_NEXT(t2, list);
+		AN(t2);
+	}
+
 	return (t2);
 }
 
 struct token *
-vcc_PeekToken(const struct vcc *tl)
+vcc_PeekTokenFrom(struct vcc *tl, const struct token *t)
 {
 
 	CHECK_OBJ_NOTNULL(tl, VCC_MAGIC);
-	return (vcc_PeekTokenFrom(tl, tl->t));
+	AN(t);
+	return (vcc_next_token_from(tl, t, 1));
+}
+
+struct token *
+vcc_PeekToken(struct vcc *tl)
+{
+
+	CHECK_OBJ_NOTNULL(tl, VCC_MAGIC);
+	return (vcc_next_token_from(tl, tl->t, 1));
+}
+
+struct token *
+vcc_NextTokenFrom(struct vcc *tl, const struct token *t)
+{
+
+	CHECK_OBJ_NOTNULL(tl, VCC_MAGIC);
+	AN(t);
+	return (vcc_next_token_from(tl, t, 0));
 }
 
 void
@@ -294,7 +331,7 @@ vcc_NextToken(struct vcc *tl)
 {
 
 	CHECK_OBJ_NOTNULL(tl, VCC_MAGIC);
-	tl->t = vcc_PeekTokenFrom(tl, tl->t);
+	tl->t = vcc_next_token_from(tl, tl->t, 0);
 }
 
 void
@@ -331,8 +368,7 @@ vcc_IdIs(const struct token *t, const char *p)
  */
 
 void
-vcc_PrintTokens(const struct vcc *tl,
-    const struct token *tb, const struct token *te)
+vcc_PrintTokens(struct vcc *tl, const struct token *tb, const struct token *te)
 {
 
 	CHECK_OBJ_NOTNULL(tl, VCC_MAGIC);

--- a/lib/libvcc/vcc_token.c
+++ b/lib/libvcc/vcc_token.c
@@ -273,6 +273,11 @@ vcc_PeekTokenFrom(const struct vcc *tl, const struct token *t)
 	assert(t->tok != EOI);
 	t2 = VTAILQ_NEXT(t, list);
 	AN(t2);
+
+	while (t2->b == NULL) {
+		t2 = VTAILQ_NEXT(t2, list);
+		AN(t2);
+	}
 	return (t2);
 }
 
@@ -402,7 +407,7 @@ vcc_addtoken(struct vcc *tl, unsigned tok,
 	struct token *t;
 
 	t = TlAlloc(tl, sizeof *t);
-	assert(t != NULL);
+	AN(t);
 	t->tok = tok;
 	t->b = b;
 	t->e = e;
@@ -520,6 +525,9 @@ vcc_Lexer(struct vcc *tl, struct source *sp)
 	unsigned u;
 	struct vsb *vsb;
 	char namebuf[40];
+
+	if (sp->parent != NULL)
+		vcc_addtoken(tl, INC_PUSH, sp, NULL, NULL);
 
 	for (p = sp->b; p < sp->e; ) {
 
@@ -670,5 +678,8 @@ vcc_Lexer(struct vcc *tl, struct source *sp)
 		vcc_ErrWhere(tl, tl->t);
 		return;
 	}
+
+	if (sp->parent != NULL)
+		vcc_addtoken(tl, INC_POP, sp, NULL, NULL);
 	vcc_addtoken(tl, EOI, sp, sp->e, sp->e);
 }


### PR DESCRIPTION
Despite the apparent compatibility in terms of versions between 4.0 and 4.1, we can have 4.0 syntax in a 4.1 VCL: this is essentially what the built-in VCL does by having a 4.0 version but being appended even to 4.1 code. However, this breaks down once the 4.0 code uses symbols that were removed from VCL 4.1 like `req.esi`.

It can be problematic with includes, as one may need to maintain two almost identical reusable VCL files when there's only a tiny difference.

It's in essence the problem described in #3368 and even though we decided that it would be simpler to make this an explicit syntax I found after addressing https://github.com/varnishcache/varnish-cache/pull/3613#issuecomment-845958677 that I had almost all I needed to make this possible.

I took the work I had started in February, rebuilt it on top of #3613 and solved the conflicts that had cropped up, and that resulted in the last 5 commits of this pull request. The rest comes from #3613 itself. The implementation makes the push/pop operations implicit.

I purposefully left one check out because of time constraints: checking that at the end of the parsing there is nothing left on the stack. See individual commits for more information.

Fixes #3368