### PR TITLE
req: New hash_ignore_vary flag

### DIFF
--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -435,6 +435,7 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp)
 				continue;
 
 			if (oc->boc && oc->boc->vary != NULL &&
+			    !req->hash_ignore_vary &&
 			    !VRY_Match(req, oc->boc->vary)) {
 				wrk->strangelove++;
 				continue;
@@ -453,7 +454,7 @@ HSH_Lookup(struct req *req, struct objcore **ocp, struct objcore **bocp)
 			continue;
 		}
 
-		if (ObjHasAttr(wrk, oc, OA_VARY)) {
+		if (!req->hash_ignore_vary && ObjHasAttr(wrk, oc, OA_VARY)) {
 			vary = ObjGetAttr(wrk, oc, OA_VARY, NULL);
 			AN(vary);
 			if (!VRY_Match(req, vary)) {

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -253,6 +253,7 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 
 	req->hash_always_miss = 0;
 	req->hash_ignore_busy = 0;
+	req->hash_ignore_vary = 0;
 	req->esi_level = 0;
 	req->is_hit = 0;
 	req->req_step = R_STP_TRANSPORT;

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -873,6 +873,7 @@ cnt_recv_prep(struct req *req, const char *ci)
 		req->disable_esi = 0;
 		req->hash_always_miss = 0;
 		req->hash_ignore_busy = 0;
+		req->hash_ignore_vary = 0;
 		req->client_identity = NULL;
 		req->storage = NULL;
 	}

--- a/bin/varnishtest/tests/c00107.vtc
+++ b/bin/varnishtest/tests/c00107.vtc
@@ -1,0 +1,42 @@
+varnishtest req.hash_ignore_vary
+
+server s1 {
+	rxreq
+	expect req.http.cookie ~ ab=a
+	txresp -hdr "vary: cookie" -body a
+
+	rxreq
+	expect req.http.cookie ~ ab=b
+	txresp -hdr "vary: cookie" -body b
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		set req.hash_ignore_vary = req.http.user-agent ~ "bot";
+	}
+
+	sub vcl_req_cookie {
+		return;
+	}
+} -start
+
+client ca {
+	txreq -hdr "cookie: ab=a"
+	rxresp
+	expect resp.body == a
+} -run
+
+client cb {
+	txreq -hdr "cookie: ab=b"
+	rxresp
+	expect resp.body == b
+} -run
+
+client cbot {
+	txreq -hdr "user-agent: googlebot"
+	rxresp
+	expect resp.body == b
+} -run
+
+client ca -run
+client cb -run

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -352,6 +352,27 @@ req.hash_ignore_busy
 	up content sideways from each other to avoid deadlocks.
 
 
+req.hash_ignore_vary
+
+	Type: BOOL
+
+	Readable from: client
+
+	Writable from: client
+
+	Default: ``false``.
+
+	Ignore objects vary headers during cache lookup.
+
+	This returns the very first match regardless of the object
+	compatibility with the client request. This is useful when
+	variants are irrelevant to certain clients, and differences
+	in the way the resouce is presented don't change how the
+	client will interpret it.
+
+	Use with caution.
+
+
 req.hash_always_miss
 
 	Type: BOOL

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -34,6 +34,7 @@
 /* lower, vcl_r, vcl_w, doc */
 REQ_FLAG(disable_esi,		0, 0, "")
 REQ_FLAG(hash_ignore_busy,	1, 1, "")
+REQ_FLAG(hash_ignore_vary,	1, 1, "")
 REQ_FLAG(hash_always_miss,	1, 1, "")
 REQ_FLAG(is_hit,		0, 0, "")
 REQ_FLAG(is_hitmiss,		1, 0, "")


### PR DESCRIPTION
It works like the hash_ignore_busy flag: it is disabled by default
and survives a restart, but as the name implies will skip vary checks
for object candidates.