### PR TITLE
vcc: Give the REGEX treatment to ACL expressions

### DIFF
--- a/bin/varnishtest/tests/v00021.vtc
+++ b/bin/varnishtest/tests/v00021.vtc
@@ -151,6 +151,15 @@ varnish v1 -errvcl {Symbols named 'vcl_*' are reserved.} {
 	}
 }
 
+# 3628
+varnish v1 -vcl {
+	backend be none;
+	acl foo { }
+	sub vcl_recv {
+		if (client.ip ~ foo || server.ip ~ foo) { }
+	}
+}
+
 varnish v1 -errvcl {Expression has type BOOL, expected ACL} {
 	sub vcl_recv {
 		if (client.ip ~ true) { }


### PR DESCRIPTION
It seems that the common point between both is that we technically start
a brand new expression (expr0) in the RHS of an ongoing expression
instead of using an RHS-specialized function (like expr4 or expr_add).

In practice, we do recursively start a brand new expression, so we need
the subsequent conversion work performed by expr0. Except that expr0
starts with a boolean OR parsing which we don't want here.

Instead of adding another special case to expr0, we can instead split
the conversion work to its own function and parse the RHS of a REGEX or
an ACL match expression as expr4+expr_convert.

Fixes #3628