### PR TITLE
VRE API revamp

### DIFF
--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -159,7 +159,6 @@ nobase_pkginclude_HEADERS = \
 vcldir=$(datarootdir)/$(PACKAGE)/vcl
 
 varnishd_CFLAGS = \
-	@PCRE_CFLAGS@ \
 	@SAN_CFLAGS@ \
 	-DNOT_IN_A_VMOD \
 	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
@@ -174,7 +173,6 @@ varnishd_LDADD = \
 	$(top_builddir)/lib/libvgz/libvgz.a \
 	@SAN_LDFLAGS@ \
 	@JEMALLOC_LDADD@ \
-	@PCRE_LIBS@ \
 	${DL_LIBS} ${PTHREAD_LIBS} ${NET_LIBS} ${RT_LIBS} ${LIBM}
 
 if WITH_UNWIND

--- a/bin/varnishd/cache/cache_ban.c
+++ b/bin/varnishd/cache/cache_ban.c
@@ -32,7 +32,7 @@
 
 #include "config.h"
 
-#include <pcre.h>
+#include <stdlib.h>
 #include <stdio.h>
 
 #include "cache_varnishd.h"
@@ -495,6 +495,7 @@ ban_evaluate(struct worker *wrk, const uint8_t *bsarg, struct objcore *oc,
 	const char *p;
 	const char *arg1;
 	double darg1, darg2;
+	int rv;
 
 	/*
 	 * for ttl and age, fix the point in time such that banning refers to
@@ -567,15 +568,15 @@ ban_evaluate(struct worker *wrk, const uint8_t *bsarg, struct objcore *oc,
 			}
 			break;
 		case BANS_OPER_MATCH:
-			if (arg1 == NULL ||
-			    pcre_exec(bt.arg2_spec, NULL, arg1, strlen(arg1),
-			    0, 0, NULL, 0) < 0)
+			rv = VRE_match(bt.arg2_spec, arg1, 0, 0, NULL);
+			xxxassert(rv >= -1);
+			if (arg1 == NULL || rv < 0)
 				return (0);
 			break;
 		case BANS_OPER_NMATCH:
-			if (arg1 != NULL &&
-			    pcre_exec(bt.arg2_spec, NULL, arg1, strlen(arg1),
-			    0, 0, NULL, 0) >= 0)
+			rv = VRE_match(bt.arg2_spec, arg1, 0, 0, NULL);
+			xxxassert(rv >= -1);
+			if (arg1 == NULL || rv >= 0)
 				return (0);
 			break;
 		case BANS_OPER_GT:

--- a/bin/varnishd/cache/cache_ban.h
+++ b/bin/varnishd/cache/cache_ban.h
@@ -55,11 +55,6 @@
  *	4 bytes - be32: length
  *	n bytes - content
  *
- * In a perfect world, we should vector through VRE to get to PCRE,
- * but since we rely on PCRE's ability to encode the regexp into a
- * byte string, that would be a little bit artificial, so this is
- * the exception that confirms the rule.
- *
  */
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_ban_build.c
+++ b/bin/varnishd/cache/cache_ban_build.c
@@ -32,7 +32,7 @@
 
 #include "config.h"
 
-#include <pcre.h>
+#include <stdlib.h>
 
 #include "cache_varnishd.h"
 #include "cache_ban.h"
@@ -40,6 +40,7 @@
 #include "vend.h"
 #include "vtim.h"
 #include "vnum.h"
+#include "vre.h"
 
 void BAN_Build_Init(void);
 void BAN_Build_Fini(void);
@@ -187,18 +188,26 @@ ban_parse_http(const struct ban_proto *bp, const char *a1)
 static const char *
 ban_parse_regexp(struct ban_proto *bp, const char *a3)
 {
-	const char *error;
-	int erroroffset, rc;
+	struct vsb vsb[1];
+	char errbuf[VRE_ERROR_LEN];
+	int errorcode, erroroffset;
 	size_t sz;
-	pcre *re;
+	vre_t *re, *rex;
 
-	re = pcre_compile(a3, 0, &error, &erroroffset, NULL);
-	if (re == NULL)
-		return (ban_error(bp, "Regex compile error: %s", error));
-	rc = pcre_fullinfo(re, NULL, PCRE_INFO_SIZE, &sz);
-	AZ(rc);
-	ban_add_lump(bp, re, sz);
-	pcre_free(re);
+	re = VRE_compile(a3, 0, &errorcode, &erroroffset, 0);
+	if (re == NULL) {
+		AN(VSB_init(vsb, errbuf, sizeof errbuf));
+		AZ(VRE_error(vsb, errorcode));
+		AZ(VSB_finish(vsb));
+		VSB_fini(vsb);
+		return (ban_error(bp, "Regex compile error: %s", errbuf));
+	}
+
+	rex = VRE_export(re, &sz);
+	AN(rex);
+	ban_add_lump(bp, rex, sz);
+	VRE_free(&rex);
+	VRE_free(&re);
 	return (0);
 }
 

--- a/bin/varnishd/cache/cache_vrt_re.c
+++ b/bin/varnishd/cache/cache_vrt_re.c
@@ -45,7 +45,8 @@ VPI_re_init(vre_t **rep, const char *re)
 	int error, erroroffset;
 
 	/* This was already check-compiled by the VCL compiler */
-	t = VRE_compile(re, 0, &error, &erroroffset);
+	t = VRE_compile(re, 0, &error, &erroroffset,
+	    cache_param->pcre_jit_compilation);
 	AN(t);
 	*rep = t;
 }

--- a/bin/varnishd/cache/cache_vrt_re.c
+++ b/bin/varnishd/cache/cache_vrt_re.c
@@ -70,7 +70,7 @@ VRT_re_match(VRT_CTX, const char *s, VCL_REGEX re)
 	if (s == NULL)
 		s = "";
 	AN(re);
-	i = VRE_exec(re, s, strlen(s), 0, 0, NULL, 0, &cache_param->vre_limits);
+	i = VRE_match(re, s, 0, 0, &cache_param->vre_limits);
 	if (i >= 0)
 		return (1);
 	if (i < VRE_ERROR_NOMATCH )

--- a/bin/varnishd/cache/cache_vrt_re.c
+++ b/bin/varnishd/cache/cache_vrt_re.c
@@ -42,8 +42,7 @@ void
 VPI_re_init(vre_t **rep, const char *re)
 {
 	vre_t *t;
-	const char *error;
-	int erroroffset;
+	int error, erroroffset;
 
 	/* This was already check-compiled by the VCL compiler */
 	t = VRE_compile(re, 0, &error, &erroroffset);

--- a/bin/varnishtest/tests/u00006.vtc
+++ b/bin/varnishtest/tests/u00006.vtc
@@ -44,7 +44,7 @@ shell -err -expect {-I: "foo" matches zero tags} \
 	"varnishlog -I foo:bar"
 shell -err -expect {-I: "Resp" is ambiguous} \
 	"varnishlog -I Resp:bar"
-shell -err -expect {-I: Regex error at position 4 (missing ))} \
+shell -err -expect {-I: Regex error at position 4 (pcre error 14)} \
 	{varnishlog -I "(foo"}
 shell -err -expect "-t: Invalid argument" \
 	"varnishlog -t -1"

--- a/bin/varnishtest/vtc_haproxy.c
+++ b/bin/varnishtest/vtc_haproxy.c
@@ -323,7 +323,7 @@ cmd_haproxy_cli_expect(CMD_ARGS)
 		vtc_fatal(hc->vl, "CLI regexp error: '%s' (@%d) (%s)",
 		    error, erroroffset, spec);
 
-	i = VRE_exec(vre, hc->rxbuf, strlen(hc->rxbuf), 0, 0, NULL, 0, 0);
+	i = VRE_match(vre, hc->rxbuf, 0, 0, NULL);
 
 	VRE_free(&vre);
 

--- a/bin/varnishtest/vtc_haproxy.c
+++ b/bin/varnishtest/vtc_haproxy.c
@@ -318,7 +318,7 @@ cmd_haproxy_cli_expect(CMD_ARGS)
 
 	haproxy_cli_recv(hc);
 
-	vre = VRE_compile(spec, 0, &error, &erroroffset);
+	vre = VRE_compile(spec, 0, &error, &erroroffset, 1);
 	if (vre == NULL) {
 		AN(VSB_init(vsb, errbuf, sizeof errbuf));
 		AZ(VRE_error(vsb, error));

--- a/bin/varnishtest/vtc_logexp.c
+++ b/bin/varnishtest/vtc_logexp.c
@@ -650,7 +650,7 @@ cmd_logexp_common(struct logexp *le, struct vtclog *vl,
 	}
 	vre = NULL;
 	if (av[4]) {
-		vre = VRE_compile(av[4], 0, &err, &pos);
+		vre = VRE_compile(av[4], 0, &err, &pos, 1);
 		if (vre == NULL) {
 			AN(VSB_init(vsb, errbuf, sizeof errbuf));
 			AZ(VRE_error(vsb, err));

--- a/bin/varnishtest/vtc_logexp.c
+++ b/bin/varnishtest/vtc_logexp.c
@@ -394,8 +394,7 @@ logexp_match(const struct logexp *le, struct logexp_test *test,
 	if (test->vre &&
 	    test->tag >= 0 &&
 	    test->tag == tag &&
-	    VRE_ERROR_NOMATCH == VRE_exec(test->vre, data,
-		len, 0, 0, NULL, 0, NULL))
+	    VRE_ERROR_NOMATCH == VRE_match(test->vre, data, len, 0, NULL))
 		ok = 0;
 
 	alt = (test->skip_max == LE_ALT);

--- a/bin/varnishtest/vtc_misc.c
+++ b/bin/varnishtest/vtc_misc.c
@@ -155,7 +155,7 @@ cmd_shell_engine(struct vtclog *vl, int ok, const char *cmd,
 	vsb = VSB_new_auto();
 	AN(vsb);
 	if (re != NULL) {
-		vre = VRE_compile(re, 0, &err, &erroff);
+		vre = VRE_compile(re, 0, &err, &erroff, 1);
 		if (vre == NULL) {
 			AN(VSB_init(re_vsb, errbuf, sizeof errbuf));
 			AZ(VRE_error(re_vsb, err));

--- a/bin/varnishtest/vtc_misc.c
+++ b/bin/varnishtest/vtc_misc.c
@@ -193,10 +193,8 @@ cmd_shell_engine(struct vtclog *vl, int ok, const char *cmd,
 		else
 			vtc_log(vl, 4, "shell_expect found");
 	} else if (vre != NULL) {
-		if (VRE_exec(vre, VSB_data(vsb), VSB_len(vsb), 0, 0,
-		    NULL, 0, NULL) < 1)
-			vtc_fatal(vl,
-			    "shell_match failed: (\"%s\")", re);
+		if (VRE_match(vre, VSB_data(vsb), VSB_len(vsb), 0, NULL) < 1)
+			vtc_fatal(vl, "shell_match failed: (\"%s\")", re);
 		else
 			vtc_log(vl, 4, "shell_match succeeded");
 		VRE_free(&vre);

--- a/bin/varnishtest/vtc_misc.c
+++ b/bin/varnishtest/vtc_misc.c
@@ -143,23 +143,28 @@ static void
 cmd_shell_engine(struct vtclog *vl, int ok, const char *cmd,
     const char *expect, const char *re)
 {
-	struct vsb *vsb;
+	struct vsb *vsb, re_vsb[1];
 	FILE *fp;
 	vre_t *vre = NULL;
-	const char *errptr;
 	int r, c;
-	int err;
+	int err, erroff;
+	char errbuf[VRE_ERROR_LEN];
 
 	AN(vl);
 	AN(cmd);
 	vsb = VSB_new_auto();
 	AN(vsb);
 	if (re != NULL) {
-		vre = VRE_compile(re, 0, &errptr, &err);
-		if (vre == NULL)
+		vre = VRE_compile(re, 0, &err, &erroff);
+		if (vre == NULL) {
+			AN(VSB_init(re_vsb, errbuf, sizeof errbuf));
+			AZ(VRE_error(re_vsb, err));
+			AZ(VSB_finish(re_vsb));
+			VSB_fini(re_vsb);
 			vtc_fatal(vl,
 			    "shell_match invalid regexp (\"%s\" at %d)",
-			    errptr, err);
+			    errbuf, erroff);
+		}
 	}
 	VSB_printf(vsb, "exec 2>&1 ; %s", cmd);
 	AZ(VSB_finish(vsb));

--- a/bin/varnishtest/vtc_subr.c
+++ b/bin/varnishtest/vtc_subr.c
@@ -103,7 +103,7 @@ vtc_expect(struct vtclog *vl,
 		if (vre == NULL)
 			vtc_fatal(vl, "REGEXP error: %s (@%d) (%s)",
 			    error, erroroffset, rhs);
-		i = VRE_exec(vre, lhs, strlen(lhs), 0, 0, NULL, 0, 0);
+		i = VRE_match(vre, lhs, 0, 0, NULL);
 		retval = (i >= 0 && *cmp == '~') || (i < 0 && *cmp == '!');
 		VRE_free(&vre);
 	} else if (!strcmp(cmp, "==")) {

--- a/bin/varnishtest/vtc_subr.c
+++ b/bin/varnishtest/vtc_subr.c
@@ -100,7 +100,7 @@ vtc_expect(struct vtclog *vl,
 		rhs = "<undef>";
 
 	if (!strcmp(cmp, "~") || !strcmp(cmp, "!~")) {
-		vre = VRE_compile(rhs, 0, &error, &erroroffset);
+		vre = VRE_compile(rhs, 0, &error, &erroroffset, 1);
 		if (vre == NULL) {
 			AN(VSB_init(vsb, errbuf, sizeof errbuf));
 			AZ(VRE_error(vsb, error));

--- a/bin/varnishtest/vtc_syslog.c
+++ b/bin/varnishtest/vtc_syslog.c
@@ -411,7 +411,7 @@ cmd_syslog_expect(CMD_ARGS)
 		vtc_fatal(s->vl, "REGEXP error: '%s' (@%d) (%s)",
 		    error, erroroffset, spec);
 
-	i = VRE_exec(vre, s->rxbuf, strlen(s->rxbuf), 0, 0, NULL, 0, 0);
+	i = VRE_match(vre, s->rxbuf, 0, 0, NULL);
 
 	VRE_free(&vre);
 

--- a/bin/varnishtest/vtc_syslog.c
+++ b/bin/varnishtest/vtc_syslog.c
@@ -406,7 +406,7 @@ cmd_syslog_expect(CMD_ARGS)
 
 	assert(!strcmp(cmp, "~") || !strcmp(cmp, "!~"));
 
-	vre = VRE_compile(spec, 0, &error, &erroroffset);
+	vre = VRE_compile(spec, 0, &error, &erroroffset, 1);
 	if (vre == NULL) {
 		AN(VSB_init(vsb, errbuf, sizeof errbuf));
 		AZ(VRE_error(vsb, error));

--- a/bin/varnishtest/vtc_syslog.c
+++ b/bin/varnishtest/vtc_syslog.c
@@ -388,10 +388,10 @@ static void v_matchproto_(cmd_f)
 cmd_syslog_expect(CMD_ARGS)
 {
 	struct syslog_srv *s;
+	struct vsb vsb[1];
 	vre_t *vre;
-	const char *error;
-	int erroroffset, i, ret;
-	char *cmp, *spec;
+	int error, erroroffset, i, ret;
+	char *cmp, *spec, errbuf[VRE_ERROR_LEN];
 
 	(void)vl;
 	CAST_OBJ_NOTNULL(s, priv, SYSLOG_SRV_MAGIC);
@@ -407,9 +407,14 @@ cmd_syslog_expect(CMD_ARGS)
 	assert(!strcmp(cmp, "~") || !strcmp(cmp, "!~"));
 
 	vre = VRE_compile(spec, 0, &error, &erroroffset);
-	if (!vre)
+	if (vre == NULL) {
+		AN(VSB_init(vsb, errbuf, sizeof errbuf));
+		AZ(VRE_error(vsb, error));
+		AZ(VSB_finish(vsb));
+		VSB_fini(vsb);
 		vtc_fatal(s->vl, "REGEXP error: '%s' (@%d) (%s)",
-		    error, erroroffset, spec);
+		    errbuf, erroroffset, spec);
+	}
 
 	i = VRE_match(vre, s->rxbuf, 0, 0, NULL);
 

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -746,7 +746,7 @@ varnish_cli(struct varnish *v, const char *cli, unsigned exp, const char *re)
 
 	VARNISH_LAUNCH(v);
 	if (re != NULL) {
-		vre = VRE_compile(re, 0, &err, &erroff);
+		vre = VRE_compile(re, 0, &err, &erroff, 1);
 		if (vre == NULL) {
 			AN(VSB_init(vsb, errbuf, sizeof errbuf));
 			AZ(VRE_error(vsb, err));

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -755,7 +755,7 @@ varnish_cli(struct varnish *v, const char *cli, unsigned exp, const char *re)
 	if (exp != 0 && exp != (unsigned)u)
 		vtc_fatal(v->vl, "FAIL CLI response %u expected %u", u, exp);
 	if (vre != NULL) {
-		err = VRE_exec(vre, resp, strlen(resp), 0, 0, NULL, 0, NULL);
+		err = VRE_match(vre, resp, 0, 0, NULL);
 		if (err < 1)
 			vtc_fatal(v->vl, "Expect failed (%d)", err);
 		VRE_free(&vre);

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -707,6 +707,17 @@ PARAM_SIMPLE(
 )
 
 PARAM_SIMPLE(
+	/* name */	pcre_jit_compilation,
+	/* type */	boolean,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* def */	"on",
+	/* units */	"bool",
+	/* descr */
+	"Use the pcre JIT compiler if available."
+)
+
+PARAM_SIMPLE(
 	/* name */	ping_interval,
 	/* type */	uint,
 	/* min */	"0",

--- a/include/vre.h
+++ b/include/vre.h
@@ -57,6 +57,7 @@ extern const unsigned VRE_has_jit;
 extern const unsigned VRE_CASELESS;
 
 vre_t *VRE_compile(const char *, unsigned, int *, int *, unsigned);
+vre_t *VRE_export(const vre_t *, size_t *);
 int VRE_error(struct vsb *, int err);
 int VRE_match(const vre_t *code, const char *subject, size_t length,
     int options, const volatile struct vre_limits *lim);

--- a/include/vre.h
+++ b/include/vre.h
@@ -56,7 +56,7 @@ typedef struct vre vre_t;
 extern const unsigned VRE_has_jit;
 extern const unsigned VRE_CASELESS;
 
-vre_t *VRE_compile(const char *, unsigned, int *, int *);
+vre_t *VRE_compile(const char *, unsigned, int *, int *, unsigned);
 int VRE_error(struct vsb *, int err);
 int VRE_match(const vre_t *code, const char *subject, size_t length,
     int options, const volatile struct vre_limits *lim);

--- a/include/vre.h
+++ b/include/vre.h
@@ -37,6 +37,8 @@
 #ifndef VRE_H_INCLUDED
 #define VRE_H_INCLUDED
 
+#define VRE_ERROR_LEN	128
+
 struct vre;
 struct vsb;
 
@@ -54,7 +56,8 @@ typedef struct vre vre_t;
 extern const unsigned VRE_has_jit;
 extern const unsigned VRE_CASELESS;
 
-vre_t *VRE_compile(const char *, unsigned, const char **, int *);
+vre_t *VRE_compile(const char *, unsigned, int *, int *);
+int VRE_error(struct vsb *, int err);
 int VRE_match(const vre_t *code, const char *subject, size_t length,
     int options, const volatile struct vre_limits *lim);
 int VRE_sub(const vre_t *code, const char *subject, const char *replacement,

--- a/include/vre.h
+++ b/include/vre.h
@@ -53,12 +53,10 @@ typedef struct vre vre_t;
 /* And those to PCRE options */
 extern const unsigned VRE_has_jit;
 extern const unsigned VRE_CASELESS;
-extern const unsigned VRE_NOTEMPTY;
 
 vre_t *VRE_compile(const char *, unsigned, const char **, int *);
-int VRE_exec(const vre_t *code, const char *subject, int length,
-    int startoffset, int options, int *ovector, int ovecsize,
-    const volatile struct vre_limits *lim);
+int VRE_match(const vre_t *code, const char *subject, size_t length,
+    int options, const volatile struct vre_limits *lim);
 int VRE_sub(const vre_t *code, const char *subject, const char *replacement,
     struct vsb *vsb, const volatile struct vre_limits *lim, int all);
 void VRE_free(vre_t **);

--- a/include/vre.h
+++ b/include/vre.h
@@ -59,6 +59,8 @@ vre_t *VRE_compile(const char *, unsigned, const char **, int *);
 int VRE_exec(const vre_t *code, const char *subject, int length,
     int startoffset, int options, int *ovector, int ovecsize,
     const volatile struct vre_limits *lim);
+int VRE_sub(const vre_t *code, const char *subject, const char *replacement,
+    struct vsb *vsb, const volatile struct vre_limits *lim, int all);
 void VRE_free(vre_t **);
 void VRE_quote(struct vsb *, const char *);
 

--- a/lib/libvarnish/vre.c
+++ b/lib/libvarnish/vre.c
@@ -81,7 +81,7 @@ const unsigned VRE_CASELESS = PCRE_CASELESS;
 
 vre_t *
 VRE_compile(const char *pattern, unsigned options,
-    int *errptr, int *erroffset)
+    int *errptr, int *erroffset, unsigned jit)
 {
 	const char *errstr = NULL;
 	vre_t *v;
@@ -106,7 +106,11 @@ VRE_compile(const char *pattern, unsigned options,
 		VRE_free(&v);
 		return (NULL);
 	}
-	v->re_extra = pcre_study(v->re, VRE_STUDY_JIT_COMPILE, &errstr);
+
+	errstr = NULL;
+	if (jit)
+		v->re_extra = pcre_study(v->re, VRE_STUDY_JIT_COMPILE, &errstr);
+
 	if (errstr != NULL) {
 		*errptr = PCRE_ERROR_INTERNAL;
 		VRE_free(&v);

--- a/lib/libvarnishapi/vsl.c
+++ b/lib/libvarnishapi/vsl.c
@@ -173,7 +173,7 @@ vsl_match_IX(struct VSL_data *vsl, const vslf_list *list,
 		CHECK_OBJ_NOTNULL(vslf, VSLF_MAGIC);
 		if (vslf->tags != NULL && !vbit_test(vslf->tags, tag))
 			continue;
-		if (VRE_exec(vslf->vre, cdata, len, 0, 0, NULL, 0, NULL) >= 0)
+		if (VRE_match(vslf->vre, cdata, len, 0, NULL) >= 0)
 			return (1);
 	}
 	return (0);

--- a/lib/libvarnishapi/vsl_arg.c
+++ b/lib/libvarnishapi/vsl_arg.c
@@ -283,7 +283,7 @@ vsl_IX_arg(struct VSL_data *vsl, int opt, const char *arg)
 		b = e + 1;
 	}
 
-	vre = VRE_compile(b, vsl->C_opt ? VRE_CASELESS : 0, &err, &off);
+	vre = VRE_compile(b, vsl->C_opt ? VRE_CASELESS : 0, &err, &off, 1);
 	if (vre == NULL) {
 		if (tags)
 			vbit_destroy(tags);

--- a/lib/libvarnishapi/vsl_query.c
+++ b/lib/libvarnishapi/vsl_query.c
@@ -264,13 +264,13 @@ vslq_test_rec(const struct vex *vex, const struct VSLC_ptr *rec)
 		return (0);
 	case '~':		/* ~ */
 		assert(rhs->type == VEX_REGEX && rhs->val_regex != NULL);
-		i = VRE_exec(rhs->val_regex, b, e - b, 0, 0, NULL, 0, NULL);
+		i = VRE_match(rhs->val_regex, b, e - b, 0, NULL);
 		if (i != VRE_ERROR_NOMATCH)
 			return (1);
 		return (0);
 	case T_NOMATCH:		/* !~ */
 		assert(rhs->type == VEX_REGEX && rhs->val_regex != NULL);
-		i = VRE_exec(rhs->val_regex, b, e - b, 0, 0, NULL, 0, NULL);
+		i = VRE_match(rhs->val_regex, b, e - b, 0, NULL);
 		if (i == VRE_ERROR_NOMATCH)
 			return (1);
 		return (0);

--- a/lib/libvarnishapi/vxp_parse.c
+++ b/lib/libvarnishapi/vxp_parse.c
@@ -278,7 +278,7 @@ vxp_expr_regex(struct vxp *vxp, struct vex_rhs **prhs)
 	(*prhs)->type = VEX_REGEX;
 	(*prhs)->val_string = strdup(vxp->t->dec);
 	(*prhs)->val_regex = VRE_compile(vxp->t->dec, vxp->vre_options,
-	    &err, &erroff);
+	    &err, &erroff, 1);
 	if ((*prhs)->val_regex == NULL) {
 		VSB_cat(vxp->sb, "Regular expression error: ");
 		AZ(VRE_error(vxp->sb, err));

--- a/lib/libvarnishapi/vxp_parse.c
+++ b/lib/libvarnishapi/vxp_parse.c
@@ -260,8 +260,7 @@ vxp_expr_str(struct vxp *vxp, struct vex_rhs **prhs)
 static void
 vxp_expr_regex(struct vxp *vxp, struct vex_rhs **prhs)
 {
-	const char *errptr;
-	int erroff;
+	int err, erroff;
 
 	/* XXX: Caseless option */
 
@@ -279,10 +278,11 @@ vxp_expr_regex(struct vxp *vxp, struct vex_rhs **prhs)
 	(*prhs)->type = VEX_REGEX;
 	(*prhs)->val_string = strdup(vxp->t->dec);
 	(*prhs)->val_regex = VRE_compile(vxp->t->dec, vxp->vre_options,
-	    &errptr, &erroff);
+	    &err, &erroff);
 	if ((*prhs)->val_regex == NULL) {
-		AN(errptr);
-		VSB_printf(vxp->sb, "Regular expression error: %s ", errptr);
+		VSB_cat(vxp->sb, "Regular expression error: ");
+		AZ(VRE_error(vxp->sb, err));
+		VSB_putc(vxp->sb, ' ');
 		vxp_ErrWhere(vxp, vxp->t, erroff);
 		return;
 	}

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -53,16 +53,16 @@ vcc_regexp(struct vcc *tl, struct vsb *vgc_name)
 {
 	char buf[BUFSIZ];
 	vre_t *t;
-	const char *error;
-	int erroroffset;
+	int error, erroroffset;
 	struct inifin *ifp;
 
 	assert(tl->t->tok == CSTR);
 
 	t = VRE_compile(tl->t->dec, 0, &error, &erroroffset);
 	if (t == NULL) {
-		VSB_printf(tl->sb,
-		    "Regexp compilation error:\n\n%s\n\n", error);
+		VSB_cat(tl->sb, "Regexp compilation error:\n\n");
+		AZ(VRE_error(tl->sb, error));
+		VSB_cat(tl->sb, "\n\n");
 		vcc_ErrWhere(tl, tl->t);
 		return;
 	}

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -58,7 +58,7 @@ vcc_regexp(struct vcc *tl, struct vsb *vgc_name)
 
 	assert(tl->t->tok == CSTR);
 
-	t = VRE_compile(tl->t->dec, 0, &error, &erroroffset);
+	t = VRE_compile(tl->t->dec, 0, &error, &erroroffset, 0);
 	if (t == NULL) {
 		VSB_cat(tl->sb, "Regexp compilation error:\n\n");
 		AZ(VRE_error(tl->sb, error));


### PR DESCRIPTION
See https://github.com/varnishcache/varnish-cache/pull/3616#issuecomment-864041455.

This revision of the VRE API allows the VRE facade to be the only place in the code where we actually touch pcre and offers a better abstraction for our usage. VMODs interested in more pcre features can as usual use it directly.

We can then perform the pcre2 migration (#3559) in a single `vre.c` file.