### PR TITLE
[ncsa] -j will escape control characters

### DIFF
--- a/bin/varnishtest/tests/u00017.vtc
+++ b/bin/varnishtest/tests/u00017.vtc
@@ -1,0 +1,31 @@
+varnishtest "SLT_Debug can be printed by varnishncsa -j"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import cookie;
+
+	sub vcl_recv {
+		cookie.parse("");
+	}
+} -start
+
+varnish v1 -cliok "param.show vsl_mask +Debug"
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+# Let's fist create a script to reduce in all the variants below.
+
+shell {
+	varnishncsa -d -n ${v1_name} -F '%{VSL:Debug}x' -j | grep "^cookie: nothing to parse\\\\u0000"
+}
+
+shell -err -expect "Tag Debug can contain control characters" {
+	varnishncsa -d -n ${v1_name} -F '%{VSL:Debug}x'
+}

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -57,6 +57,8 @@ Varnish Cache 7.x.x (2021-09-15)
 
 * ACLs default to `pedantic` which is now a per-ACL feature flag.
 
+* `varnishncsa -j` will now accept to print fields with control characters.
+
 ================================
 Varnish Cache 6.6.0 (2021-03-15)
 ================================


### PR DESCRIPTION
open question: does the trailing character count as part of the message, and should it be printed too?