### PR TITLE
vcl: Allow header names to be quoted (compliance improvements)

### DIFF
--- a/bin/varnishtest/tests/b00076.vtc
+++ b/bin/varnishtest/tests/b00076.vtc
@@ -1,0 +1,51 @@
+varnishtest "Non-symbolic HTTP headers names"
+
+varnish v1 -errvcl "Invalid character '\\n' in header name" {
+	backend be none;
+	sub vcl_recv {
+		set req.http.{"line
+break"} = "invalid";
+	}
+}
+
+varnish v1 -errvcl "Expected '=' got '.'" {
+	backend be none;
+	sub vcl_recv {
+		set req."http".wrong-quote = "invalid";
+	}
+}
+
+varnish v1 -syntax 4.0 -errvcl "Quoted headers are available for VCL >= 4.1" {
+	backend be none;
+	sub vcl_recv {
+		set req.http."quoted" = "invalid";
+	}
+}
+
+varnish v1 -vcl {
+	import std;
+	backend be none;
+	sub vcl_recv {
+		std.collect(req.http."...");
+		return (synth(200));
+	}
+	sub vcl_synth {
+		set resp.http."123" = "456";
+		set resp.http."456" = resp.http."123";
+		set resp.http.{"!!!"} = "???";
+		set resp.http."""resp.http.foo""" = "bar";
+		set resp.http.bar = resp.http."resp.http.foo".upper();
+		set resp.http."..." = req.http."...";
+	}
+} -start
+
+client c1 {
+	txreq -hdr "...: a" -hdr "...: b"
+	rxresp
+	expect resp.http.123 == 456
+	expect resp.http.456 == 456
+	expect resp.http.!!! == ???
+	expect resp.http.resp.http.foo == bar
+	expect resp.http.bar == BAR
+	expect resp.http.... == "a, b"
+} -run

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -225,11 +225,15 @@ req.http.*
 	The headers of request, things like ``req.http.date``.
 
 	The RFCs allow multiple headers with the same name, and both
-	``set`` and ``unset`` will remove *all* headers with the name given.
+	``set`` and ``unset`` will remove *all* headers with the name
+	given.
 
 	The header name ``*`` is a VCL symbol and as such cannot, for
-	example, start with a numeral. Custom VMODs exist for handling
-	of such header names.
+	example, start with a numeral. To work with valid header that
+	can't be represented as VCL symbols it is possible to quote the
+	name, like ``req.http."grammatically.valid"``. None of the HTTP
+	headers present in IANA registries need to be quoted, so the
+	quoted syntax is discouraged but available for interoperability.
 
 
 req.restarts

--- a/lib/libvcc/vcc_var.c
+++ b/lib/libvcc/vcc_var.c
@@ -36,12 +36,15 @@
 
 #include "vcc_compile.h"
 
+#include "vct.h"
+
 /*--------------------------------------------------------------------*/
 
 void v_matchproto_(sym_wildcard_t)
 vcc_Var_Wildcard(struct vcc *tl, struct symbol *parent, struct symbol *sym)
 {
 	struct vsb *vsb;
+	const char *p;
 
 	assert(parent->type == HEADER);
 
@@ -50,6 +53,16 @@ vcc_Var_Wildcard(struct vcc *tl, struct symbol *parent, struct symbol *sym)
 		    sym->name);
 		tl->err = 1;
 		return;
+	}
+
+	for (p = sym->name; *p != '\0'; p++) {
+		if (!vct_istchar(*p)) {
+			VSB_cat(tl->sb, "Invalid character '");
+			VSB_quote(tl->sb, p, 1, VSB_QUOTE_PLAIN);
+			VSB_cat(tl->sb, "' in header name.\n");
+			tl->err = 1;
+			return;
+		}
 	}
 
 	AN(sym);


### PR DESCRIPTION
Because we funnel HTTP header names through the symbol table they have
to be valid VCL identifiers. It means that we can't support all valid
header names, which are tokens in the HTTP grammar. To finally close this
loophole without the help of a VMOD we allow header names to be quoted:

    req.http.regular-header
    req.http."quoted.header"

However we don't want to allow any component of a symbol to be quoted:

    req."http".we-dont-want-this

So we teach the symbol table that wildcard symbols may be quoted. There
used to be several use cases for wildcards but it is now limited to HTTP
headers.

Refs #3246
Refs #3379