### PR TITLE
vav: Tighten arguments parsing

### DIFF
--- a/lib/libvarnish/vav.c
+++ b/lib/libvarnish/vav.c
@@ -102,7 +102,8 @@ vav_backslash_txt(const char *s, const char *e, char *res)
 		}
 		break;
 	case 'x':
-		if (l >= 4 && sscanf(s + 1, "x%02x", &u) == 1) {
+		if (l >= 4 && isxdigit(s[2]) && isxdigit(s[3]) &&
+		    sscanf(s + 1, "x%02x", &u) == 1) {
 			AZ(u & ~0xff);
 			c = u;	/*lint !e734 loss of precision */
 			r = 4;
@@ -355,6 +356,7 @@ static const struct test_case *tests[] = {
 	TEST_FAIL(0    , "\\", invalid_backslash),
 	TEST_FAIL(0    , "\\x", invalid_backslash),
 	TEST_FAIL(0    , "\\x2", invalid_backslash),
+	TEST_FAIL(0    , "\\x2O", invalid_backslash),
 	TEST_PASS(0    , "\\x20", " "),
 	TEST_FAIL(0    , "\"foo", missing_quote),
 	NULL


### PR DESCRIPTION
Commas unlike spaces are hard separators, so a trailing comma leads to a
last empty parameter.

A comma may appear after an argument's "trailing" spaces and should not
result in an additional parameter. In <foo  , bar> we should expect two
fields, not three.

Comments are only treated as such at arguments boundaries: <foo #bar>
parses one field <foo> and <foo#bar> parses one field <foo#bar>, taking
the shell word splitting as the model, cementing what was the existing
VAV behavior in the first place.

Unlike the shell, we don't expect quotes to start in the middle of a
token so <foo"bar> is invalid unless escaping was disabled.

Fields that are quoted need a separator: <"foo""bar"> is therefore
invalid unless escaping was disabled.