### PR TITLE
build: Don't warn on system headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,7 +331,7 @@ workflows:
           name: distcheck_alpine
           dist: alpine
           release: "latest"
-          extra_conf: --disable-developer-warnings --disable-dependency-tracking
+          #extra_conf: --without-jemalloc
       - distcheck:
           name: distcheck_archlinux
           dist: archlinux

--- a/wflags.py
+++ b/wflags.py
@@ -61,7 +61,6 @@ DESIRABLE_WFLAGS = [
     "-Wstrict-prototypes",
     "-Wstring-plus-int",
     "-Wswitch",
-    "-Wsystem-headers",
     "-Wunused-parameter",
     "-Wunused-parameters",
     "-Wunused-result",
@@ -69,15 +68,12 @@ DESIRABLE_WFLAGS = [
 ]
 
 UNDESIRABLE_WFLAGS = [
+    "-Wno-system-headers" # Outside of our control
     "-Wno-thread-safety", # Does not understand our mutexs are wrapped
     "-Wno-old-style-definition", # Does not like vgz
     "-Wno-sign-compare", # Fixable
     "-Wno-implicit-fallthrough", # Probably Fixable
-    "-Wno-builtin-requires-header", # Complains about linux::pthread.h
-    "-Wno-incomplete-setjmp-declaration", # Clang complains about glibc::pthread.h
-    "-Wno-redundant-decls", # Complains about centos::stdio.h
     "-Wno-missing-variable-declarations", # Complains about optreset
-    "-Wno-parentheses", # GCC complains about musl::endian.h
     "-Wno-nullability-completeness", # Barfs all over MacOSx
 ]
 


### PR DESCRIPTION
Since we turn warnings into errors, that means failing the build because
something we have no control over in /usr/include does not have a strict
prototype or some other shenanigan.

Just in case it might be added by Wall or Wextra in a future clang or
GCC release, we may disable it explicitly too.

Refs #3565

---

Waiting for cci to see the effect of this change.