### PR TITLE
Increase vsl_buffer and workspaces

### DIFF
--- a/bin/varnishtest/tests/r01038.vtc
+++ b/bin/varnishtest/tests/r01038.vtc
@@ -45,7 +45,7 @@ server s1 {
 	txresp -body "foo8"
 } -start
 
-varnish v1 -arg "-p workspace_backend=10k" -vcl+backend {
+varnish v1 -arg "-p workspace_backend=10k -p vsl_buffer=4k" -vcl+backend {
 	sub vcl_backend_response {
 		if (bereq.url == "/") {
 			set beresp.do_esi = true;

--- a/bin/varnishtest/tests/r01120.vtc
+++ b/bin/varnishtest/tests/r01120.vtc
@@ -7,7 +7,7 @@ server s1 {
 	txresp -hdr "Vary: Foo" -body "yyyyy"
 } -start
 
-varnish v1 \
+varnish v1 -arg "-p vsl_buffer=4k" \
 	-cliok "param.set workspace_client 10k" \
 	-cliok "param.set workspace_backend 200k" \
 	-vcl+backend {

--- a/bin/varnishtest/tests/r02219.vtc
+++ b/bin/varnishtest/tests/r02219.vtc
@@ -9,7 +9,10 @@ server s1 {
 	txresp
 } -start
 
-varnish v1 -arg "-p workspace_client=9k" -proto PROXY -vcl+backend {
+varnish v1 -arg "-p workspace_client=9k" \
+	   -arg "-p vsl_buffer=4k" \
+	   -proto PROXY \
+	   -vcl+backend {
 	import std;
 	import vtc;
 	sub vcl_recv {

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1022,7 +1022,7 @@ PARAM_SIMPLE(
 	/* type */	vsl_buffer,
 	/* min */	"267",
 	/* max */	NULL,
-	/* def */	"4k",
+	/* def */	"16k",
 	/* units */	"bytes",
 	/* descr */
 	"Bytes of (req-/backend-)workspace dedicated to buffering VSL "
@@ -1082,7 +1082,7 @@ PARAM_SIMPLE(
 	/* type */	bytes_u,
 	/* min */	"1k",
 	/* max */	NULL,
-	/* def */	"64k",
+	/* def */	"96k",
 	/* units */	"bytes",
 	/* descr */
 	"Bytes of HTTP protocol workspace for backend HTTP req/resp.  If "
@@ -1095,7 +1095,7 @@ PARAM_SIMPLE(
 	/* type */	bytes_u,
 	/* min */	"9k",
 	/* max */	NULL,
-	/* def */	"64k",
+	/* def */	"96k",
 	/* units */	"bytes",
 	/* descr */
 	"Bytes of HTTP protocol workspace for clients HTTP req/resp.  Use a "


### PR DESCRIPTION
On many busy production systems, the VSL buffer for transactions often
fills up, triggering a flush to the VSM. If such a transaction takes a
long time, it can happen that the flushed data is overwritten before
the whole transaction completes. The result is that these transactions
are missed by varnishncsa and other tools. Increasing the vsl_buffer
does the trick, at some cost in workspace usage.

The cost implies that one should increase the workspaces, too. Since
the old defaults of 64k each are too low for many common use cases
today, it is natural to increse everything in one patch.