### PR TITLE
HTTP case sensitivity hardening (compliance improvements)

### DIFF
--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -53,7 +53,7 @@ sub vcl_req_host {
 	}
 	if (!req.http.host &&
 	    req.esi_level == 0 &&
-	    req.proto ~ "^(?i)HTTP/1.1") {
+	    req.proto == "HTTP/1.1") {
 		# In HTTP/1.1, Host is required.
 		return (synth(400));
 	}

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -646,6 +646,36 @@ extern const char H__Status[];
 extern const char H__Proto[];
 extern const char H__Reason[];
 
+// rfc7233,l,1207,1208
+#define http_tok_eq(s1, s2)		(!strcasecmp(s1, s2))
+#define http_tok_at(s1, s2, l)		(!strncasecmp(s1, s2, l))
+#define http_ctok_at(s, cs)		(!strncasecmp(s, cs, sizeof(cs) - 1))
+
+// rfc7230,l,1037,1038
+#define http_scheme_at(str, tok)	http_ctok_at(str, #tok "://")
+
+// rfc7230,l,1144,1144
+// rfc7231,l,1156,1158
+#define http_method_eq(str, tok)	(!strcmp(str, #tok))
+
+// rfc7230,l,1222,1222
+// rfc7230,l,2848,2848
+// rfc7231,l,3883,3885
+// rfc7234,l,1339,1340
+// rfc7234,l,1418,1419
+#define http_hdr_eq(s1, s2)		http_tok_eq(s1, s2)
+#define http_hdr_at(s1, s2, l)		http_tok_at(s1, s2, l)
+
+// rfc7230,l,1952,1952
+// rfc7231,l,604,604
+#define http_coding_eq(str, tok)	http_tok_eq(str, #tok)
+
+// rfc7231,l,1864,1864
+#define http_expect_eq(str, tok)	http_tok_eq(str, #tok)
+
+// rfc7233,l,1207,1208
+#define http_range_at(str, tok)		http_ctok_at(str, #tok)
+
 /* cache_main.c */
 #define VXID(u) ((u) & VSL_IDENTMASK)
 uint32_t VXID_Get(const struct worker *, uint32_t marker);

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -862,7 +862,7 @@ ved_deliver(struct req *req, struct boc *boc, int wantbody)
 		return;
 
 	if (http_GetHdr(req->resp, H_Content_Encoding, &p))
-		i = !strcasecmp(p, "gzip");
+		i = http_coding_eq(p, gzip);
 	if (i)
 		i = ObjCheckFlag(req->wrk, req->objcore, OF_GZIPED);
 

--- a/bin/varnishd/cache/cache_range.c
+++ b/bin/varnishd/cache/cache_range.c
@@ -108,7 +108,7 @@ vrg_dorange(struct req *req, const char *r, void **priv)
 	ssize_t low, high, has_low, has_high, t;
 	struct vrg_priv *vrg_priv;
 
-	if (strncasecmp(r, "bytes=", 6))
+	if (!http_range_at(r, bytes=))
 		return ("Not Bytes");
 	r += 6;
 
@@ -214,6 +214,7 @@ vrg_ifrange(struct req *req)
 			return (0);
 		if ((e[0] == 'W' && e[1] == '/'))	// rfc7232,l,547,548
 			return (0);
+		/* XXX: should we also have http_etag_cmp() ? */
 		return (strcmp(p, e) == 0);		// rfc7232,l,548,548
 	}
 

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -93,7 +93,7 @@ cnt_transport(struct worker *wrk, struct req *req)
 	AN(req->req_body_status);
 
 	if (http_GetHdr(req->http, H_Expect, &p)) {
-		if (strcasecmp(p, "100-continue")) {
+		if (!http_expect_eq(p, 100-continue)) {
 			req->doclose = SC_RX_JUNK;
 			(void)req->transport->minimal_response(req, 417);
 			wrk->stats->client_req_417++;
@@ -421,7 +421,7 @@ cnt_transmit(struct worker *wrk, struct req *req)
 	clval = http_GetContentLength(req->resp);
 	/* RFC 7230, 3.3.3 */
 	status = http_GetStatus(req->resp);
-	head = !strcmp(req->http0->hd[HTTP_HDR_METHOD].b, "HEAD");
+	head = http_method_eq(req->http0->hd[HTTP_HDR_METHOD].b, HEAD);
 
 	if (boc != NULL)
 		req->resp_len = clval;

--- a/bin/varnishd/cache/cache_rfc2616.c
+++ b/bin/varnishd/cache/cache_rfc2616.c
@@ -265,6 +265,7 @@ rfc2616_strong_compare(const char *p, const char *e)
 	if ((p[0] == 'W' && p[1] == '/') ||
 	    (e[0] == 'W' && e[1] == '/'))
 		return (0);
+	/* XXX: should we also have http_etag_cmp() ? */
 	return (strcmp(p, e) == 0);
 }
 
@@ -276,6 +277,7 @@ rfc2616_weak_compare(const char *p, const char *e)
 		p += 2;
 	if (e[0] == 'W' && e[1] == '/')
 		e += 2;
+	/* XXX: should we also have http_etag_cmp() ? */
 	return (strcmp(p, e) == 0);
 }
 

--- a/bin/varnishd/cache/cache_vary.c
+++ b/bin/varnishd/cache/cache_vary.c
@@ -200,7 +200,7 @@ vry_cmp(const uint8_t *v1, const uint8_t *v2)
 		/* Different header */
 		retval = 1;
 	} else if (cache_param->http_gzip_support &&
-	    !strcasecmp(H_Accept_Encoding, (const char*) v1 + 2)) {
+	    http_hdr_eq(H_Accept_Encoding, (const char*) v1 + 2)) {
 		/*
 		 * If we do gzip processing, we do not vary on Accept-Encoding,
 		 * because we want everybody to get the gzip'ed object, and

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -240,7 +240,7 @@ V1F_FetchRespHdr(struct busyobj *bo)
 	 * Figure out how the fetch is supposed to happen, before the
 	 * headers are adultered by VCL
 	 */
-	if (!strcasecmp(http_GetMethod(bo->bereq), "head")) {
+	if (http_method_eq(http_GetMethod(bo->bereq), HEAD)) {
 		/*
 		 * A HEAD request can never have a body in the reply,
 		 * no matter what the headers might say.

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -1201,7 +1201,7 @@ cmd_http_txreq(CMD_ARGS)
 		} else if (!strcmp(*av, "-method") ||
 		    !strcmp(*av, "-req")) {
 			req = av[1];
-			hp->head_method = !strcasecmp(av[1], "HEAD") ;
+			hp->head_method = !strcmp(av[1], "HEAD") ;
 			av++;
 		} else if (!hp->sfd && !strcmp(*av, "-up")) {
 			up = av[1];
@@ -1216,7 +1216,7 @@ cmd_http_txreq(CMD_ARGS)
 				"Upgrade: h2c%s"
 				"HTTP2-Settings: %s%s", nl, nl, up, nl);
 
-	nohost = strcasecmp(proto, "HTTP/1.1") != 0;
+	nohost = strcmp(proto, "HTTP/1.1") != 0;
 	av = http_tx_parse_args(av, vl, hp, NULL, nohost);
 	if (*av != NULL)
 		vtc_fatal(hp->vl, "Unknown http txreq spec: %s\n", *av);


### PR DESCRIPTION
This change is in two parts: string comparison macros for the cache process and a general sweep through the code base for other places dealing with HTTP syntax.

The macros are meant to convey and abstract the comparison of components of the HTTP grammar. They are also used as anchors to reference what the RFCs have to say about case sensitivity for comparisons. In other words, avoiding the direct use of `strcmp()`-type functions.

This should hopefully signal that we aren't merely comparing strings, but specific kinds of strings, and prevent regressions in that area.

Some parts I left alone on purpose, sometimes adding XXX comments for reviewers are h2 and VTIM. I wanted to see how this first batch would be received and didn't want to limit myself to a mere sweep through the code like I did for example in varnishtest (where for example that level of detail didn't seem critical enough).

As usual see individual commits.

Refs #3246