### PR TITLE
Add .reset_stickiness() to fallback director

### DIFF
--- a/bin/varnishtest/tests/d00042.vtc
+++ b/bin/varnishtest/tests/d00042.vtc
@@ -1,0 +1,64 @@
+varnishtest "Sticky fallback director, resetting stickiness"
+
+server s1 {
+	rxreq
+	expect req.url == "/baz"
+	txresp
+} -start
+
+server s2 {
+	rxreq
+	expect req.url == "/bar"
+	txresp
+} -start
+
+server s3 {
+	rxreq
+	expect req.url == "/foo"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import directors;
+
+	sub vcl_init {
+		new vd = directors.fallback(sticky = true);
+		vd.add_backend(s1);
+		vd.add_backend(s2);
+		vd.add_backend(s3);
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = vd.backend();
+		return(pass);
+	}
+
+	sub vcl_deliver {
+		vd.reset_stickiness();
+	}
+} -start
+
+varnish v1 -cliok "backend.set_health s1 sick"
+varnish v1 -cliok "backend.set_health s2 sick"
+
+client c1 {
+	txreq -url /foo
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cliok "backend.set_health s2 healthy"
+
+client c1 {
+	txreq -url /bar
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cliok "backend.set_health s1 healthy"
+
+client c1 {
+	txreq -url /baz
+	rxresp
+	expect resp.status == 200
+} -run

--- a/vmod/vmod_directors.vcc
+++ b/vmod/vmod_directors.vcc
@@ -137,6 +137,15 @@ Example::
 
 	vdir.remove_backend(backend1);
 
+$Method VOID .reset_stickiness()
+
+Reset director's internal stickiness cursor in order to start using
+any available higher-priority backend.
+
+Example::
+
+  vdir.reset_stickiness();
+
 $Method BACKEND .backend()
 
 Pick a backend from the director.

--- a/vmod/vmod_directors_fall_back.c
+++ b/vmod/vmod_directors_fall_back.c
@@ -239,6 +239,16 @@ vmod_fallback_remove_backend(VRT_CTX,
 	vdir_remove_backend(ctx, fb->vd, be, &fb->cur);
 }
 
+VCL_VOID v_matchproto_()
+vmod_fallback_reset_stickiness(VRT_CTX, struct vmod_directors_fallback *fb)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(fb, VMOD_DIRECTORS_FALLBACK_MAGIC);
+	vdir_wrlock(fb->vd);
+	fb->cur = 0;
+	vdir_unlock(fb->vd);
+}
+
 VCL_BACKEND v_matchproto_()
 vmod_fallback_backend(VRT_CTX,
     struct vmod_directors_fallback *fb)


### PR DESCRIPTION
This trivial PR adds `.reset_stickiness()` method to fallback directors. It simply allows reseting director's internal stickiness cursor from VCL in order to start using any available higher-priority backend.

Motivation for this PR is a scenario where multiple sticky fallback directors are being used and ability to reset stickiness only in a specific fallback director is needed. Reloading VCL would be a no-go because that would reset stickiness for all fallback directors; even all backends in all directors are healthy again, extra control is needed to guarantee stickiness is reset in a granular a controlled way. Similarly, using `varnishadm backend.set_health` on backends handled by the fallback director to be reseted would also be a no-go because backends could be shared among multiple directors.

I hope you find it useful! :)