### PR TITLE
Bring back VRE_exec()

### DIFF
--- a/include/vre.h
+++ b/include/vre.h
@@ -60,8 +60,12 @@ vre_t *VRE_export(const vre_t *, size_t *);
 int VRE_error(struct vsb *, int err);
 int VRE_match(const vre_t *code, const char *subject, size_t length,
     int options, const volatile struct vre_limits *lim);
+int VRE_exec(const vre_t *code, const char *subject, size_t length,
+    int startoffset, int options, int *ovector, int ovecsize,
+    const volatile struct vre_limits *lim);
 int VRE_sub(const vre_t *code, const char *subject, const char *replacement,
     struct vsb *vsb, const volatile struct vre_limits *lim, int all);
+
 void VRE_free(vre_t **);
 void VRE_quote(struct vsb *, const char *);
 


### PR DESCRIPTION
We bring back `VRE_exec()` for VMODs which require back references.

This comes after some discussion with @Dridi who argues that vmods could call into pcre2 directly using `VRE_Unpack()` as part of the API (renamed `static pcre2_code *vre_unpack(const vre_t *code)`).
While I agree that `VRE_Unpack()` should indeed exist, I also think that adding back `VRE_exec()` is still justified: Having it
* reduces the amount of required changes in vmods,
* reduces code duplication and
* avoids vmods accidentally linking to pcre2, which avoids potential conflicts from potentially compiling and executing pcre2 with different versions of the library

Also I would hope that we will be able to taylor pcre2-VRE to Varnish better (e.g. by avoiding the remaining mallocs) and this alone could justify wrapping all relevant pcre2 use cases in VRE.

ping @slimhazard 