### PR TITLE
vcl: Change the order of sess.* variables

### DIFF
--- a/bin/varnishtest/tests/r03564.vtc
+++ b/bin/varnishtest/tests/r03564.vtc
@@ -1,0 +1,31 @@
+varnishtest "sess.* symbols and vcl syntax"
+
+varnish v1 -vcl {
+	backend be none;
+
+	sub vcl_deliver {
+		set resp.http.sess-xid = sess.xid;
+		set resp.http.sess-timeout-idle = sess.timeout_idle;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.sess-xid == 1000
+	expect resp.http.sess-timeout-idle == 5.000
+} -run
+
+varnish v1 -syntax 4.0 -vcl {
+	backend be none;
+	sub vcl_deliver {
+		set resp.http.sess-timeout-idle = sess.timeout_idle;
+	}
+}
+
+varnish v1 -syntax 4.0 -errvcl "Symbol not found: 'sess.xid'" {
+	backend be none;
+	sub vcl_deliver {
+		set resp.http.sess-xid = sess.xid;
+	}
+}

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1172,14 +1172,6 @@ transactions may take place. It may comprise the traffic over an
 HTTP/1 keep-alive connection, or the multiplexed traffic over an
 HTTP/2 connection.
 
-sess.xid	``VCL >= 4.1``
-
-	Type: STRING
-
-	Readable from: client, backend
-
-	Unique ID of this session.
-
 sess.timeout_idle
 
 	Type: DURATION
@@ -1190,6 +1182,14 @@ sess.timeout_idle
 
 	Idle timeout for this session, defaults to the
 	``timeout_idle`` parameter, see :ref:`varnishd(1)`
+
+sess.xid	``VCL >= 4.1``
+
+	Type: STRING
+
+	Readable from: client, backend
+
+	Unique ID of this session.
 
 storage
 ~~~~~~~


### PR DESCRIPTION
This is just the order of their declaration in the VCL manual.

As a side effect it works around a bug where the sess.xid syntax
requirements would prevent sess.timeout_idle to be used in VCL 4.0,
which is less intrusive than a proper fix.

The bug was fixed in trunk without being noticed in the first place
after many heavy changes to libvcc. For a stable branch this is less
risky than a back-port since there are only two sess.* symbols.

Fixes #3564