### PR TITLE
vre: New VRE_capture() function

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -112,13 +112,6 @@ struct worker_priv;
 
 /*--------------------------------------------------------------------*/
 
-typedef struct {
-	const char		*b;
-	const char		*e;
-} txt;
-
-/*--------------------------------------------------------------------*/
-
 struct lock { void *priv; };	// Opaque
 
 /*--------------------------------------------------------------------
@@ -819,24 +812,6 @@ unsigned RFC2616_Req_Gzip(const struct http *);
 int RFC2616_Do_Cond(const struct req *sp);
 void RFC2616_Weaken_Etag(struct http *hp);
 void RFC2616_Vary_AE(struct http *hp);
-
-#define Tcheck(t) do {						\
-		AN((t).b);					\
-		AN((t).e);					\
-		assert((t).b <= (t).e);				\
-	} while(0)
-
-/*
- * unsigned length of a txt
- */
-
-static inline unsigned
-Tlen(const txt t)
-{
-
-	Tcheck(t);
-	return ((unsigned)(t.e - t.b));
-}
 
 /*
  * We want to cache the most recent timestamp in wrk->lastused to avoid

--- a/include/vas.h
+++ b/include/vas.h
@@ -127,6 +127,8 @@ static inline size_t
 pdiff(const void *b, const void *e)
 {
 
+	AN(b);
+	AN(e);
 	assert(b <= e);
 	return ((size_t)((const char *)e - (const char *)b));
 }

--- a/include/vdef.h
+++ b/include/vdef.h
@@ -184,3 +184,15 @@
 typedef double vtim_mono;
 typedef double vtim_real;
 typedef double vtim_dur;
+
+/**********************************************************************
+ * txt (vas.h needed for the macros)
+ */
+
+typedef struct {
+	const char		*b;
+	const char		*e;
+} txt;
+
+#define Tcheck(t)	do { (void)pdiff((t).b, (t).e); } while (0)
+#define Tlen(t)		(pdiff((t).b, (t).e))

--- a/include/vre.h
+++ b/include/vre.h
@@ -60,6 +60,8 @@ vre_t *VRE_export(const vre_t *, size_t *);
 int VRE_error(struct vsb *, int err);
 int VRE_match(const vre_t *code, const char *subject, size_t length,
     int options, const volatile struct vre_limits *lim);
+int VRE_capture(vre_t *code, const char *subject, size_t length, int options,
+    txt *groups, size_t count, const volatile struct vre_limits *lim);
 int VRE_sub(const vre_t *code, const char *subject, const char *replacement,
     struct vsb *vsb, const volatile struct vre_limits *lim, int all);
 void VRE_free(vre_t **);

--- a/lib/libvarnish/vre.c
+++ b/lib/libvarnish/vre.c
@@ -245,6 +245,29 @@ VRE_match(const vre_t *code, const char *subject, size_t length,
 }
 
 int
+VRE_capture(vre_t *code, const char *subject, size_t length, int options,
+    txt *groups, size_t count, const volatile struct vre_limits *lim)
+{
+	int i;
+
+	CHECK_OBJ_NOTNULL(code, VRE_MAGIC);
+	AN(subject);
+	AZ(options & (~VRE_MASK_MATCH));
+	AN(groups);
+	AN(count);
+
+	if (length == 0)
+		length = PCRE2_ZERO_TERMINATED;
+	vre_limit(code, lim);
+	i = vre_capture(code, subject, length, 0, options,
+	    groups, &count, NULL);
+
+	if (i <= 0)
+		return (i);
+	return (count);
+}
+
+int
 VRE_sub(const vre_t *code, const char *subject, const char *replacement,
     struct vsb *vsb, const volatile struct vre_limits *lim, int all)
 {

--- a/lib/libvarnishapi/generate.py
+++ b/lib/libvarnishapi/generate.py
@@ -192,6 +192,7 @@ fo.write("""
 #include <ctype.h>
 #include <stdio.h>
 
+#include "vdef.h"
 #include "vqueue.h"
 #include "vre.h"
 


### PR DESCRIPTION
It populates an array of txt provided by the caller with the groups that were captured on a successful match, and returns the number of such groups or a VRE error. Because the underlying `vre_capture()` function is covered by `VRE_sub()` we can probably spare ourselves `VRE_capture()` coverage via vmod_debug.

Doing so, this patch series makes `txt` available more widely in the code base.

Alternative to #3655.