### PR TITLE
Master h2 rxbuf padding

### DIFF
--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -555,6 +555,11 @@ void STV_BanExport(const uint8_t *banlist, unsigned len);
 int STV_NewObject(struct worker *, struct objcore *,
     const struct stevedore *, unsigned len);
 
+struct stv_buffer;
+struct stv_buffer *STV_AllocBuf(struct worker *wrk, const struct stevedore *stv,
+    size_t size);
+void STV_FreeBuf(struct worker *wrk, struct stv_buffer **pstvbuf);
+void *STV_GetBufPtr(struct stv_buffer *stvbuf, size_t *psize);
 
 #if WITH_PERSISTENT_STORAGE
 /* storage_persistent.c */

--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -115,6 +115,16 @@ enum h2_stream_e {
 #define H2_FRAME_FLAGS(l,u,v)   extern const uint8_t H2FF_##u;
 #include "tbl/h2_frames.h"
 
+struct h2_rxbuf {
+	unsigned			magic;
+#define H2_RXBUF_MAGIC			0x73f9fb27
+	unsigned			size;
+	uint64_t			tail;
+	uint64_t			head;
+	struct stv_buffer		*stvbuf;
+	uint8_t				data[];
+};
+
 struct h2_req {
 	unsigned			magic;
 #define H2_REQ_MAGIC			0x03411584
@@ -134,7 +144,7 @@ struct h2_req {
 	/* Where to wake this stream up */
 	struct worker			*wrk;
 
-	ssize_t				reqbody_bytes;
+	struct h2_rxbuf			*rxbuf;
 
 	VTAILQ_ENTRY(h2_req)		tx_list;
 	h2_error			error;
@@ -147,7 +157,6 @@ struct h2_sess {
 #define H2_SESS_MAGIC			0xa16f7e4b
 
 	pthread_t			rxthr;
-	struct h2_req			*mailcall;
 	pthread_cond_t			*cond;
 	pthread_cond_t			winupd_cond[1];
 

--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -237,7 +237,7 @@ void H2_Send(struct worker *, struct h2_req *, h2_frame type, uint8_t flags,
 struct h2_req * h2_new_req(const struct worker *, struct h2_sess *,
     unsigned stream, struct req *);
 int h2_stream_tmo(struct h2_sess *, const struct h2_req *, vtim_real);
-void h2_del_req(struct worker *, const struct h2_req *);
+void h2_del_req(struct worker *, struct h2_req *);
 void h2_kill_req(struct worker *, struct h2_sess *, struct h2_req *, h2_error);
 int h2_rxframe(struct worker *, struct h2_sess *);
 h2_error h2_set_setting(struct h2_sess *, const uint8_t *);

--- a/bin/varnishd/http2/cache_http2_panic.c
+++ b/bin/varnishd/http2/cache_http2_panic.c
@@ -88,6 +88,15 @@ h2_sess_panic(struct vsb *vsb, const struct sess *sp)
 		VSB_printf(vsb, "t_window = %jd, r_window = %jd,\n",
 		    r2->t_window, r2->r_window);
 
+		if (!PAN_dump_struct(vsb, r2->rxbuf, H2_RXBUF_MAGIC, "rxbuf")) {
+			VSB_printf(vsb, "stvbuf = %p,\n", r2->rxbuf->stvbuf);
+			VSB_printf(vsb,
+			    "{size, tail, head} = {%u, %ju, %ju},\n",
+			    r2->rxbuf->size, r2->rxbuf->tail, r2->rxbuf->head);
+			VSB_indent(vsb, -2);
+			VSB_cat(vsb, "},\n");
+		}
+
 		VSB_indent(vsb, -2);
 		VSB_cat(vsb, "},\n");
 	}

--- a/bin/varnishd/http2/cache_http2_panic.c
+++ b/bin/varnishd/http2/cache_http2_panic.c
@@ -45,6 +45,20 @@ h2_panic_error(const struct h2_error_s *e)
 		return (e->name);
 }
 
+static void
+h2_panic_settings(struct vsb *vsb, const struct h2_settings *s)
+{
+	int cont = 0;
+
+#define H2_SETTING(U,l,...)			\
+	if (cont)				\
+		VSB_printf(vsb, ", ");		\
+	cont = 1;				\
+	VSB_printf(vsb, "0x%x", s->l);
+#include "tbl/h2_settings.h"
+#undef H2_SETTING
+}
+
 void
 h2_sess_panic(struct vsb *vsb, const struct sess *sp)
 {
@@ -64,6 +78,12 @@ h2_sess_panic(struct vsb *vsb, const struct sess *sp)
 	    "open_streams = %u, highest_stream = %u,"
 	    " goaway_last_stream = %u,\n",
 	    h2->open_streams, h2->highest_stream, h2->goaway_last_stream);
+	VSB_cat(vsb, "local_settings = {");
+	h2_panic_settings(vsb, &h2->local_settings);
+	VSB_cat(vsb, "},\n");
+	VSB_cat(vsb, "remote_settings = {");
+	h2_panic_settings(vsb, &h2->remote_settings);
+	VSB_cat(vsb, "},\n");
 	VSB_printf(vsb,
 	    "{rxf_len, rxf_type, rxf_flags, rxf_stream} ="
 	    " {%u, %u, 0x%x, %u},\n",

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -763,6 +763,7 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 	char buf[4];
 	uint64_t l, l2, head;
 	const uint8_t *src;
+	unsigned len;
 
 	/* XXX: Shouldn't error handling, setting of r2->error and
 	 * r2->cond signalling be handled more generally at the end of
@@ -790,13 +791,31 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 		return (h2->error ? h2->error : r2->error);
 	}
 
+	/* Check padding if present */
+	src = h2->rxf_data;
+	len = h2->rxf_len;
+	if (h2->rxf_flags & H2FF_DATA_PADDED) {
+		if (*src >= len) {
+			VSLb(h2->vsl, SLT_Debug,
+			    "H2: stream %u: Padding larger than frame length",
+			    h2->rxf_stream);
+			r2->error = H2CE_PROTOCOL_ERROR;
+			if (r2->cond)
+				AZ(pthread_cond_signal(r2->cond));
+			Lck_Unlock(&h2->sess->mtx);
+			return (H2CE_PROTOCOL_ERROR);
+		}
+		len -= 1 + *src;
+		src += 1;
+	}
+
 	/* Check against the Content-Length header if given */
 	if (r2->req->htc->content_length >= 0) {
 		if (r2->rxbuf)
 			l = r2->rxbuf->head;
 		else
 			l = 0;
-		l += h2->rxf_len;
+		l += len;
 		if (l > r2->req->htc->content_length ||
 		    ((h2->rxf_flags & H2FF_DATA_END_STREAM) &&
 		     l != r2->req->htc->content_length)) {
@@ -811,17 +830,8 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 		}
 	}
 
-	/* Handle zero size frame before starting to allocate buffers */
-	if (h2->rxf_len == 0) {
-		if (h2->rxf_flags & H2FF_DATA_END_STREAM)
-			r2->state = H2_S_CLOS_REM;
-		if (r2->cond)
-			AZ(pthread_cond_signal(r2->cond));
-		Lck_Unlock(&h2->sess->mtx);
-		return (0);
-	}
-
-	/* Check and charge connection window */
+	/* Check and charge connection window. The entire frame including
+	 * padding (h2->rxf_len) counts towards the window. */
 	if (h2->rxf_len > h2->req0->r_window) {
 		VSLb(h2->vsl, SLT_Debug,
 		    "H2: stream %u: Exceeded connection receive window",
@@ -843,7 +853,8 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 		Lck_Lock(&h2->sess->mtx);
 	}
 
-	/* Check stream window */
+	/* Check stream window. The entire frame including padding
+	 * (h2->rxf_len) counts towards the window. */
 	if (h2->rxf_len > r2->r_window) {
 		VSLb(h2->vsl, SLT_Debug,
 		    "H2: stream %u: Exceeded stream receive window",
@@ -855,6 +866,41 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 		return (H2SE_FLOW_CONTROL_ERROR);
 	}
 
+	/* Handle zero size frame before starting to allocate buffers */
+	if (len == 0) {
+		r2->r_window -= h2->rxf_len;
+
+		/* Handle the specific corner case where the entire window
+		 * has been exhausted using nothing but padding
+		 * bytes. Since no bytes have been buffered, no bytes
+		 * would be consumed by the request thread and no stream
+		 * window updates sent. Unpaint ourselves from this corner
+		 * by sending a stream window update here. */
+		CHECK_OBJ_ORNULL(r2->rxbuf, H2_RXBUF_MAGIC);
+		if (r2->r_window == 0 &&
+		    (r2->rxbuf == NULL || r2->rxbuf->tail == r2->rxbuf->head)) {
+			if (r2->rxbuf)
+				l = r2->rxbuf->size;
+			else
+				l = h2->local_settings.initial_window_size;
+			r2->r_window += l;
+			Lck_Unlock(&h2->sess->mtx);
+			vbe32enc(buf, l);
+			H2_Send_Get(wrk, h2, h2->req0);
+			H2_Send_Frame(wrk, h2, H2_F_WINDOW_UPDATE, 0, 4,
+			    r2->stream, buf);
+			H2_Send_Rel(h2, h2->req0);
+			Lck_Lock(&h2->sess->mtx);
+		}
+
+		if (h2->rxf_flags & H2FF_DATA_END_STREAM)
+			r2->state = H2_S_CLOS_REM;
+		if (r2->cond)
+			AZ(pthread_cond_signal(r2->cond));
+		Lck_Unlock(&h2->sess->mtx);
+		return (0);
+	}
+
 	/* Make the buffer on demand */
 	if (r2->rxbuf == NULL) {
 		unsigned bufsize;
@@ -864,15 +910,20 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 
 		Lck_Unlock(&h2->sess->mtx);
 
-		bufsize = r2->r_window;
-		/* This is the first data frame, so r_window will be the
-		 * initial window size. */
+		bufsize = h2->local_settings.initial_window_size;
+		if (bufsize < r2->r_window) {
+			/* This will not happen because we do not have any
+			 * mechanism to change the initial window size on
+			 * a running session. But if we gain that ability,
+			 * this future proofs it. */
+			bufsize = r2->r_window;
+		}
 		assert(bufsize > 0);
 		if ((h2->rxf_flags & H2FF_DATA_END_STREAM) &&
-		    bufsize > h2->rxf_len)
+		    bufsize > len)
 			/* Cap the buffer size when we know this is the
 			 * single data frame. */
-			bufsize = h2->rxf_len;
+			bufsize = len;
 		stvbuf = STV_AllocBuf(wrk, stv_transient,
 		    bufsize + sizeof *rxbuf);
 		if (stvbuf == NULL) {
@@ -905,13 +956,11 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 	l = r2->rxbuf->head - r2->rxbuf->tail;
 	assert(l <= r2->rxbuf->size);
 	l = r2->rxbuf->size - l;
-	assert(h2->rxf_len <= l); /* Stream window handling ensures
-				   * this */
+	assert(len <= l); /* Stream window handling ensures this */
 
 	Lck_Unlock(&h2->sess->mtx);
 
-	src = h2->rxf_data;
-	l = h2->rxf_len;
+	l = len;
 	head = r2->rxbuf->head;
 	do {
 		l2 = l;
@@ -925,9 +974,14 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 	} while (l > 0);
 
 	Lck_Lock(&h2->sess->mtx);
-	/* Charge stream window */
+
+	/* Charge stream window. The entire frame including padding
+	 * (h2->rxf_len) counts towards the window. The used padding
+	 * bytes will be included in the next connection window update
+	 * sent when the buffer bytes are consumed because that is
+	 * calculated against the available buffer space. */
 	r2->r_window -= h2->rxf_len;
-	r2->rxbuf->head += h2->rxf_len;
+	r2->rxbuf->head += len;
 	assert(r2->rxbuf->tail <= r2->rxbuf->head);
 	if (h2->rxf_flags & H2FF_DATA_END_STREAM)
 		r2->state = H2_S_CLOS_REM;

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -168,7 +168,7 @@ h2_new_req(const struct worker *wrk, struct h2_sess *h2,
 }
 
 void
-h2_del_req(struct worker *wrk, const struct h2_req *r2)
+h2_del_req(struct worker *wrk, struct h2_req *r2)
 {
 	struct h2_sess *h2;
 	struct sess *sp;

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -924,7 +924,8 @@ h2_rx_data(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 			/* Cap the buffer size when we know this is the
 			 * single data frame. */
 			bufsize = len;
-		stvbuf = STV_AllocBuf(wrk, stv_transient,
+		CHECK_OBJ_NOTNULL(stv_h2_rxbuf, STEVEDORE_MAGIC);
+		stvbuf = STV_AllocBuf(wrk, stv_h2_rxbuf,
 		    bufsize + sizeof *rxbuf);
 		if (stvbuf == NULL) {
 			VSLb(h2->vsl, SLT_Debug,

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -360,10 +360,14 @@ h2_new_session(struct worker *wrk, void *arg)
 	AZ(h2->htc->priv);
 	h2->htc->priv = h2;
 
+	AZ(wrk->vsl);
+	wrk->vsl = h2->vsl;
+
 	if (req->err_code == H2_OU_MARKER && !h2_ou_session(wrk, h2, req)) {
 		assert(h2->refcnt == 1);
 		h2_del_req(wrk, h2->req0);
 		h2_del_sess(wrk, h2, SC_RX_JUNK);
+		wrk->vsl = NULL;
 		return;
 	}
 	assert(HTC_S_COMPLETE == H2_prism_complete(h2->htc));
@@ -434,6 +438,7 @@ h2_new_session(struct worker *wrk, void *arg)
 	assert(h2->refcnt == 1);
 	h2_del_req(wrk, h2->req0);
 	h2_del_sess(wrk, h2, h2->error->reason);
+	wrk->vsl = NULL;
 }
 
 struct transport H2_transport = {

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -218,6 +218,7 @@ char **MGT_NamedArg(const char *, const char **, const char *);
 
 
 /* stevedore_mgt.c */
+extern const char *mgt_stv_h2_rxbuf;
 void STV_Config(const char *spec);
 void STV_Config_Transient(void);
 

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -78,6 +78,7 @@ tweak_t tweak_timeout;
 tweak_t tweak_uint;
 tweak_t tweak_vsl_buffer;
 tweak_t tweak_vsl_reclen;
+tweak_t tweak_h2_rxbuf_storage;
 
 extern struct parspec mgt_parspec[]; /* mgt_param_tbl.c */
 extern struct parspec VSL_parspec[]; /* mgt_param_vsl.c */

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -42,6 +42,7 @@
 #include "mgt/mgt.h"
 
 #include "mgt/mgt_param.h"
+#include "storage/storage.h"
 #include "vav.h"
 #include "vnum.h"
 
@@ -487,4 +488,44 @@ tweak_thread_pool_max(struct vsb *vsb, const struct parspec *par,
 	MCF_ParamConf(MCF_MAXIMUM, "thread_pool_min",
 	    "%u", mgt_param.wthread_max);
 	return (0);
+}
+
+/*--------------------------------------------------------------------
+ * Tweak 'h2_rxbuf_storage'
+ *
+ */
+
+int v_matchproto_(tweak_t)
+tweak_h2_rxbuf_storage(struct vsb *vsb, const struct parspec *par,
+    const char *arg)
+{
+	struct stevedore *stv;
+
+	/* XXX: If we want to remove the MUST_RESTART flag from the
+	 * h2_rxbuf_storage parameter, we could have a mechanism here
+	 * that when the child is running calls out through CLI to change
+	 * the stevedore being used. */
+
+	if (arg == NULL || arg == JSON_FMT)
+		return (tweak_string(vsb, par, arg));
+
+	if (!strcmp(arg, "Transient")) {
+		/* Always allow setting to the special name
+		 * "Transient". There will always be a stevedore with this
+		 * name, but it may not have been configured at the time
+		 * this is called. */
+	} else {
+		/* Only allow setting the value to a known configured
+		 * stevedore */
+		STV_Foreach(stv) {
+			CHECK_OBJ_NOTNULL(stv, STEVEDORE_MAGIC);
+			if (!strcmp(stv->ident, arg))
+				break;
+		}
+		if (stv == NULL) {
+			VSB_printf(vsb, "unknown storage backend '%s'", arg);
+			return (-1);
+		}
+	}
+	return (tweak_string(vsb, par, arg));
 }

--- a/bin/varnishd/storage/mgt_stevedore.c
+++ b/bin/varnishd/storage/mgt_stevedore.c
@@ -54,6 +54,8 @@ static VTAILQ_HEAD(, stevedore) stevedores =
 
 struct stevedore *stv_transient;
 
+const char *mgt_stv_h2_rxbuf;
+
 /*--------------------------------------------------------------------*/
 
 int
@@ -247,7 +249,6 @@ STV_Config(const char *spec)
 void
 STV_Config_Transient(void)
 {
-
 	ASSERT_MGT();
 
 	VCLS_AddFunc(mgt_cls, MCF_AUTH, cli_stv);

--- a/bin/varnishd/storage/stevedore.c
+++ b/bin/varnishd/storage/stevedore.c
@@ -43,6 +43,9 @@
 #include "storage/storage.h"
 #include "vrt_obj.h"
 
+extern const char *mgt_stv_h2_rxbuf;
+struct stevedore *stv_h2_rxbuf = NULL;
+
 static pthread_mutex_t stv_mtx;
 
 /*--------------------------------------------------------------------
@@ -172,13 +175,23 @@ STV_open(void)
 
 	ASSERT_CLI();
 	AZ(pthread_mutex_init(&stv_mtx, NULL));
+
+	/* This string was prepared for us before the fork, and should
+	 * point to a configured stevedore. */
+	AN(mgt_stv_h2_rxbuf);
+
+	stv_h2_rxbuf = NULL;
 	STV_Foreach(stv) {
+		CHECK_OBJ_NOTNULL(stv, STEVEDORE_MAGIC);
 		bprintf(buf, "storage.%s", stv->ident);
 		stv->vclname = strdup(buf);
 		AN(stv->vclname);
 		if (stv->open != NULL)
 			stv->open(stv);
+		if (!strcmp(stv->ident, mgt_stv_h2_rxbuf))
+			stv_h2_rxbuf = stv;
 	}
+	AN(stv_h2_rxbuf);
 }
 
 void

--- a/bin/varnishd/storage/storage.h
+++ b/bin/varnishd/storage/storage.h
@@ -75,6 +75,10 @@ typedef void storage_banexport_f(const struct stevedore *, const uint8_t *bans,
     unsigned len);
 typedef void storage_panic_f(struct vsb *vsb, const struct objcore *oc);
 
+typedef void *storage_allocbuf_f(struct worker *, const struct stevedore *,
+    size_t size, uintptr_t *ppriv);
+typedef void storage_freebuf_f(struct worker *, const struct stevedore *,
+    uintptr_t priv);
 
 typedef struct object *sml_getobj_f(struct worker *, struct objcore *);
 typedef struct storage *sml_alloc_f(const struct stevedore *, size_t size);
@@ -104,6 +108,8 @@ struct stevedore {
 	storage_baninfo_f	*baninfo;
 	storage_banexport_f	*banexport;
 	storage_panic_f		*panic;
+	storage_allocbuf_f	*allocbuf;
+	storage_freebuf_f	*freebuf;
 
 	/* Only if SML is used */
 	sml_alloc_f		*sml_alloc;

--- a/bin/varnishd/storage/storage.h
+++ b/bin/varnishd/storage/storage.h
@@ -134,6 +134,7 @@ struct stevedore {
 };
 
 extern struct stevedore *stv_transient;
+extern struct stevedore *stv_h2_rxbuf;
 
 /*--------------------------------------------------------------------*/
 

--- a/bin/varnishd/storage/storage_file.c
+++ b/bin/varnishd/storage/storage_file.c
@@ -501,6 +501,8 @@ const struct stevedore smf_stevedore = {
 	.allocobj	=	SML_allocobj,
 	.panic		=	SML_panic,
 	.methods	=	&SML_methods,
+	.allocbuf	=	SML_AllocBuf,
+	.freebuf	=	SML_FreeBuf,
 };
 
 #ifdef INCLUDE_TEST_DRIVER

--- a/bin/varnishd/storage/storage_malloc.c
+++ b/bin/varnishd/storage/storage_malloc.c
@@ -232,4 +232,6 @@ const struct stevedore sma_stevedore = {
 	.methods	=	&SML_methods,
 	.var_free_space =	sma_free_space,
 	.var_used_space =	sma_used_space,
+	.allocbuf	=	SML_AllocBuf,
+	.freebuf	=	SML_FreeBuf,
 };

--- a/bin/varnishd/storage/storage_simple.h
+++ b/bin/varnishd/storage/storage_simple.h
@@ -68,6 +68,9 @@ extern const struct obj_methods SML_methods;
 
 struct object *SML_MkObject(const struct stevedore *, struct objcore *,
     void *ptr);
+void *SML_AllocBuf(struct worker *, const struct stevedore *, size_t,
+    uintptr_t *);
+void SML_FreeBuf(struct worker *, const struct stevedore *, uintptr_t);
 
 storage_allocobj_f SML_allocobj;
 storage_panic_f SML_panic;

--- a/bin/varnishtest/tests/f00007.vtc
+++ b/bin/varnishtest/tests/f00007.vtc
@@ -62,6 +62,7 @@ client c3 {
 	stream 1 {
 		txreq -req POST -url /3 -hdr "content-length" "1" -nostrend
 		txdata -data "A" -nostrend
+		delay 0.5
 		txdata -data "GET /FAIL HTTP/1.1\r\n\r\n"
 		rxrst
 		expect rst.err == PROTOCOL_ERROR

--- a/bin/varnishtest/tests/r02679.vtc
+++ b/bin/varnishtest/tests/r02679.vtc
@@ -22,7 +22,6 @@ client c1 {
 	stream 1 {
 		txreq -req POST -hdr "content-length" "31469" -nostrend
 		txdata -datalen 1550 -nostrend
-		rxwinup
 		txdata -datalen 16000 -nostrend
 		txdata -datalen 13919
 		rxresp

--- a/bin/varnishtest/tests/t02014.vtc
+++ b/bin/varnishtest/tests/t02014.vtc
@@ -2,13 +2,25 @@ varnishtest "Exercise h/2 sender flow control code"
 
 barrier b1 sock 3 -cyclic
 
-server s1 -repeat 2 {
+server s1 {
+	rxreq
+	txresp -bodylen 66300
+} -start
+
+server s2 {
+	non_fatal
 	rxreq
 	txresp -bodylen 66300
 } -start
 
 varnish v1 -vcl+backend {
 	import vtc;
+
+	sub vcl_backend_fetch {
+		if (bereq.method == "POST") {
+			set bereq.backend = s2;
+		}
+	}
 
 	sub vcl_deliver {
 		vtc.barrier_sync("${b1_sock}");
@@ -47,7 +59,7 @@ client c1 {
 	stream 0 -wait
 } -run
 
-client c1 {
+client c2 {
 	stream 0 {
 		barrier b1 sync
 	} -start
@@ -63,7 +75,7 @@ client c1 {
 	stream 0 -wait
 } -run
 
-client c1 {
+client c3 {
 	stream 0 {
 		barrier b1 sync
 		barrier b1 sync
@@ -79,7 +91,6 @@ client c1 {
 	stream 1 {
 		txreq -req "POST" -nostrend
 		txdata -data "ok"
-		rxwinup
 		txdata -data "fail"
 		rxrst
 		expect rst.err == STREAM_CLOSED

--- a/bin/varnishtest/tests/t02017.vtc
+++ b/bin/varnishtest/tests/t02017.vtc
@@ -1,0 +1,46 @@
+varnishtest "H/2 stream data head of line blocking"
+
+barrier b1 cond 2
+barrier b2 cond 2
+barrier b3 cond 2
+barrier b4 cond 2
+
+server s1 {
+	rxreq
+	barrier b4 sync
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.url == "/2") {
+			return (synth(700));
+		}
+	}
+} -start
+
+varnish v1 -cliok "param.set feature +http2"
+
+client c1 {
+	stream 1 {
+		txreq -req GET -url /1 -hdr "content-length" "1" -nostrend
+		barrier b1 sync
+		barrier b2 sync
+		txdata -data 1
+#		rxwinup
+		barrier b3 sync
+		rxresp
+		expect resp.status == 200
+	} -start
+	stream 3 {
+		barrier b1 sync
+		txreq -req GET -url /2 -hdr "content-length" "1" -nostrend
+		barrier b2 sync
+		barrier b3 sync
+		txdata -data 2
+#		rxwinup
+		rxresp
+		expect resp.status == 700
+		barrier b4 sync
+	} -start
+} -run

--- a/bin/varnishtest/tests/t02018.vtc
+++ b/bin/varnishtest/tests/t02018.vtc
@@ -1,0 +1,36 @@
+varnishtest "H/2 stream multiple buffer exhaustion"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+} -start
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.reset h2_initial_window_size"
+varnish v1 -cliok "param.reset h2_rx_window_low_water"
+
+client c1 {
+	stream 1 {
+		txreq -req GET -url /1 -hdr "content-length" "131072" -nostrend
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384
+		rxresp
+		expect resp.status == 200
+	} -start
+} -run

--- a/bin/varnishtest/tests/t02019.vtc
+++ b/bin/varnishtest/tests/t02019.vtc
@@ -1,0 +1,43 @@
+varnishtest "H/2 stream early buffer exhaustion"
+
+barrier b1 sock 2
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import vtc;
+	sub vcl_recv {
+		vtc.barrier_sync("${b1_sock}");
+		vtc.sleep(0.1s);
+	}
+} -start
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.reset h2_initial_window_size"
+varnish v1 -cliok "param.reset h2_rx_window_low_water"
+
+client c1 {
+	stream 1 {
+		txreq -req POST -url /1 -hdr "content-length" "131072" -nostrend
+		txdata -datalen 16384 -nostrend
+		txdata -datalen 16384 -nostrend
+		txdata -datalen 16384 -nostrend
+		txdata -datalen 16383 -nostrend
+		barrier b1 sync
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 16384 -nostrend
+		rxwinup
+		txdata -datalen 1
+		rxresp
+		expect resp.status == 200
+	} -run
+} -run

--- a/bin/varnishtest/tests/t02020.vtc
+++ b/bin/varnishtest/tests/t02020.vtc
@@ -1,0 +1,66 @@
+varnishtest "H/2 received data frames with padding"
+
+barrier b1 sock 2
+
+server s1 {
+	rxreq
+	expect req.url == /1
+	expect req.body == abcde
+	txresp
+	rxreq
+	txresp
+	rxreq
+	txresp
+	expect req.body == a
+} -start
+
+varnish v1 -vcl+backend {
+	import vtc;
+	sub vcl_recv {
+		if (req.url == "/3") {
+			vtc.barrier_sync("${b1_sock}");
+		}
+	}
+} -start
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.reset h2_initial_window_size"
+varnish v1 -cliok "param.reset h2_rx_window_low_water"
+varnish v1 -cliok "param.set debug +syncvsl"
+
+client c1 {
+	stream 1 {
+		txreq -req POST -url /1 -hdr "content-length" "5" -nostrend
+		txdata -data abcde -padlen 1
+		rxresp
+		expect resp.status == 200
+	} -run
+
+	stream 3 {
+		txreq -req POST -url /3 -hdr "content-length" "131072" -nostrend
+		txdata -datalen 16300 -padlen 83 -nostrend
+		txdata -datalen 16300 -padlen 83 -nostrend
+		txdata -datalen 16300 -padlen 83 -nostrend
+		txdata -datalen 16300 -padlen 82 -nostrend
+		barrier b1 sync
+		rxwinup
+		txdata -datalen 16300 -padlen 83 -nostrend
+		rxwinup
+		txdata -datalen 16300 -padlen 83 -nostrend
+		rxwinup
+		txdata -datalen 16300 -padlen 83 -nostrend
+		rxwinup
+		txdata -datalen 16300 -padlen 83 -nostrend
+		rxwinup
+		txdata -datalen 672
+		rxresp
+		expect resp.status == 200
+	} -run
+
+	stream 5 {
+		txreq -req POST -url /5 -nostrend
+		txdata -data a -padlen 255
+		rxresp
+		expect resp.status == 200
+	} -run
+} -run

--- a/bin/varnishtest/tests/t02021.vtc
+++ b/bin/varnishtest/tests/t02021.vtc
@@ -1,0 +1,36 @@
+varnishtest "H/2 data frame padding exhaust window"
+
+server s1 {
+	rxreq
+	expect req.body == abcde
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+} -start
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.reset h2_initial_window_size"
+varnish v1 -cliok "param.reset h2_rx_window_low_water"
+
+client c1 {
+	stream 1 {
+		txreq -req POST -url /1 -hdr "content-length" "5" -nostrend
+
+		# Fill 65535 bytes of stream window using padding only
+		# Note that each frame consumes 256 bytes of window (padlen + 1)
+
+		loop 255 {
+			txdata -padlen 255 -nostrend
+		}
+		txdata -padlen 254 -nostrend
+
+		# Here the window have been exhausted, so we should receive
+		# a window update
+		rxwinup
+
+		txdata -data abcde
+		rxresp
+		expect resp.status == 200
+	} -run
+} -run

--- a/bin/varnishtest/tests/t02022.vtc
+++ b/bin/varnishtest/tests/t02022.vtc
@@ -1,0 +1,86 @@
+varnishtest "Test non-transient rxbuf stevedore with LRU nuking"
+
+barrier b1 sock 2 -cyclic
+
+server s1 {
+	rxreq
+	txresp -body asdf
+	rxreq
+	txresp -bodylen 1048000
+	rxreq
+	txresp -body ASDF
+} -start
+
+varnish v1 -arg "-srxbuf=malloc,1m -smain=malloc,1m" -vcl+backend {
+	import vtc;
+	sub vcl_recv {
+		if (req.url == "/1") {
+			vtc.barrier_sync("${b1_sock}");
+		}
+	}
+	sub vcl_backend_response {
+		if (bereq.url == "/2") {
+			set beresp.storage = storage.rxbuf;
+		} else {
+			set beresp.storage = storage.main;
+		}
+	}
+}
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.reset h2_initial_window_size"
+varnish v1 -cliok "param.reset h2_rx_window_low_water"
+varnish v1 -cliok "param.set h2_rxbuf_storage rxbuf"
+varnish v1 -cliok "param.set debug +syncvsl"
+
+varnish v1 -start
+
+client c1 {
+	stream 1 {
+		txreq -req POST -url /1 -hdr "content-length" "2048" -nostrend
+		txdata -datalen 2048
+		rxresp
+		expect resp.status == 200
+	} -start
+} -start
+
+varnish v1 -expect SMA.rxbuf.g_bytes >= 2048
+varnish v1 -expect SMA.Transient.g_bytes == 0
+varnish v1 -expect MAIN.n_lru_nuked == 0
+
+barrier b1 sync
+client c1 -wait
+
+varnish v1 -expect SMA.rxbuf.g_bytes == 0
+varnish v1 -expect SMA.Transient.g_bytes == 0
+varnish v1 -expect MAIN.n_lru_nuked == 0
+
+client c2 {
+	txreq -url /2
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 1048000
+} -run
+
+varnish v1 -expect SMA.rxbuf.g_bytes >= 1048000
+varnish v1 -expect MAIN.n_lru_nuked == 0
+
+client c3 {
+	stream 1 {
+		txreq -req POST -url /1 -hdr "content-length" "2048" -nostrend
+		txdata -datalen 2048
+		rxresp
+		expect resp.status == 200
+	} -start
+} -start
+
+varnish v1 -expect SMA.rxbuf.g_bytes >= 2048
+varnish v1 -expect SMA.rxbuf.g_bytes < 3000
+varnish v1 -expect SMA.Transient.g_bytes == 0
+varnish v1 -expect MAIN.n_lru_nuked == 1
+
+barrier b1 sync
+client c3 -wait
+
+varnish v1 -expect SMA.rxbuf.g_bytes == 0
+varnish v1 -expect SMA.Transient.g_bytes == 0

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -1633,8 +1633,8 @@ cmd_tx11obj(CMD_ARGS)
 			exclusive_stream_dependency(s);
 	}
 	if (pad) {
-		if (strlen(pad) >= 128)
-			vtc_fatal(vl, "Padding is limited to 128 bytes");
+		if (strlen(pad) > 255)
+			vtc_fatal(vl, "Padding is limited to 255 bytes");
 		f.flags |= PADDED;
 		assert(f.size + strlen(pad) < BUF_SIZE);
 		memmove(buf + 1, buf, f.size);
@@ -1726,8 +1726,8 @@ cmd_txdata(CMD_ARGS)
 
 	if (pad) {
 		f.flags |= PADDED;
-		if (strlen(pad) >= 128)
-			vtc_fatal(vl, "Padding is limited to 128 bytes");
+		if (strlen(pad) > 255)
+			vtc_fatal(vl, "Padding is limited to 255 bytes");
 		data = malloc( 1 + strlen(body) + strlen(pad));
 		AN(data);
 		*((uint8_t *)data) = strlen(pad);

--- a/bin/varnishtest/vtc_http2.c
+++ b/bin/varnishtest/vtc_http2.c
@@ -2302,9 +2302,11 @@ cmd_rxmsg(CMD_ARGS)
 	else
 		ONLY_H2_CLIENT(s->hp, av);
 
-	f = rxstuff(s);
-	if (!f)
-		return;
+	do {
+		f = rxstuff(s);
+		if (!f)
+			return;
+	} while (f->type == TYPE_WINDOW_UPDATE);
 
 	rcv++;
 	CHKFRAME(f->type, TYPE_HEADERS, rcv, *av);

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1657,10 +1657,28 @@ PARAM_PCRE2(
 	" messages."
 )
 
+/*--------------------------------------------------------------------
+ * Custom parameters with separate tweak function
+ */
+
+#  define PARAM_CUSTOM(nm, pv, def, ...) \
+	PARAM(, , nm, tweak_ ## nm, pv, NULL, NULL, def, NULL, __VA_ARGS__)
+
+PARAM_CUSTOM(
+	/* name */	h2_rxbuf_storage,
+	/* priv */	&mgt_stv_h2_rxbuf,
+	/* def */	"Transient",
+	/* descr */
+	"The name of the storage backend that HTTP/2 receive buffers"
+	" should be allocated from.",
+	/* flags */	MUST_RESTART
+)
+
 #  undef PARAM_ALL
 #  undef PARAM_PCRE2
 #  undef PARAM_STRING
 #  undef PARAM_VCC
+#  undef PARAM_CUSTOM
 #endif /* defined(PARAM_ALL) */
 
 #undef PARAM_MEMPOOL

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1195,15 +1195,19 @@ PARAM_SIMPLE(
 	"at the same time for a single HTTP2 connection."
 )
 
+/* We have a strict min at the protocol default here. This is because we
+ * don't have the 'use settings only after peer ack' in place yet. If the
+ * value is lower than the protocol default, the very first stream could
+ * get a flow control error. */
 PARAM_SIMPLE(
 	/* name */	h2_initial_window_size,
 	/* type */	bytes_u,
-	/* min */	"0",
+	/* min */	"65535b",
 	/* max */	"2147483647b",
 	/* def */	"65535b",
 	/* units */	"bytes",
 	/* descr */
-	"HTTP2 initial flow control window size."
+	"HTTP2 initial flow control window size.",
 )
 
 PARAM_SIMPLE(


### PR DESCRIPTION
This PR solves two H/2 related bugs:

* Adds a buffer for incoming data frames between the session handling thread and the individual H/2 stream threads. This avoids having the session handling thread block while waiting for a stream thread to come around and request the incoming data, which would block most progress on the H/2 session.
* Implements handling of padding bytes in incoming data frames. Previously we would ingore their presence and treat all the bytes as data bytes.

The patch set also improves on panic output for H/2.