### PR TITLE
[6.0] vcc: Insert the built-in source last

### DIFF
--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -504,7 +504,7 @@ static void
 vcc_resolve_includes(struct vcc *tl)
 {
 	struct token *t, *t1, *t2;
-	struct source *sp;
+	struct source *sp, *builtin_sp;
 	struct vsb *vsb;
 	const char *p;
 
@@ -559,7 +559,9 @@ vcc_resolve_includes(struct vcc *tl)
 			vcc_ErrWhere(tl, t1);
 			return;
 		}
-		VTAILQ_INSERT_TAIL(&tl->sources, sp, list);
+		builtin_sp = VTAILQ_LAST(&tl->sources, sourcehead);
+		AN(builtin_sp);
+		VTAILQ_INSERT_BEFORE(builtin_sp, sp, list);
 		sp->idx = tl->nsources++;
 		tl->t = t2;
 		vcc_Lexer(tl, sp);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -208,6 +208,7 @@ struct inifin {
 };
 
 VTAILQ_HEAD(inifinhead, inifin);
+VTAILQ_HEAD(sourcehead, source);
 
 struct vcc {
 	unsigned		magic;
@@ -228,7 +229,7 @@ struct vcc {
 
 	/* Instance section */
 	struct tokenhead	tokens;
-	VTAILQ_HEAD(, source)	sources;
+	struct sourcehead	sources;
 	unsigned		nsources;
 	struct source		*src;
 	struct token		*t;


### PR DESCRIPTION
In the output of vcl.show -v, it means that the least useful file (in the
sense that it is common to every single vcl.load) is now printed last.

This change originates from a larger and more intrusive refactoring.

It also helps get rid of spurious Wstring-contatenation warnings from
clang 12 in the test suite, instead of disabling it altogether.

Refs c8174af68956206115972e72e75ceddbd758116e