### PR TITLE
[build] add a shebang to tests

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -167,7 +167,7 @@ _vrt.c: Makefile.am vdef.h vrt.h
 	cat $(srcdir)/vdef.h $(srcdir)/vrt.h > $@
 
 vrt_test: _vrt.c
-	echo "exec ${CC} -c -o _vrt_test _vrt.c" > $@
+	echo -e "#!/bin/sh\nexec ${CC} -c -o _vrt_test _vrt.c" > $@
 	chmod +x $@
 
 test: ${TESTS}

--- a/lib/libvarnishapi/Makefile.am
+++ b/lib/libvarnishapi/Makefile.am
@@ -96,7 +96,8 @@ vsl_glob_test_LDADD = libvarnishapi.la @SAN_LDFLAGS@
 TESTS += vsl_glob_test_coverage
 
 vsl_glob_test_coverage:
-	echo './vsl_glob_test 1 2 3 2> /dev/null || true' > ${builddir}/_
+	echo '#!/bin/sh' > ${builddir}/_
+	echo './vsl_glob_test 1 2 3 2> /dev/null || true' >> ${builddir}/_
 	echo './vsl_glob_test "Req*" > /dev/null' >> ${builddir}/_
 	mv ${builddir}/_ ${builddir}/vsl_glob_test_coverage
 	chmod +x ${builddir}/vsl_glob_test_coverage


### PR DESCRIPTION
on alpine/ppc64le, shell tests will fail without shebang (they'll throw an `applet not found` message)