### PR TITLE
vrg: Consistency check of backend responses (compliance improvements)

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -607,6 +607,7 @@ int http_GetHdrField(const struct http *hp, hdr_t,
 double http_GetHdrQ(const struct http *hp, hdr_t, const char *field);
 ssize_t http_GetContentLength(const struct http *hp);
 ssize_t http_GetContentRange(const struct http *hp, ssize_t *lo, ssize_t *hi);
+const char * http_GetRange(const struct http *hp, ssize_t *lo, ssize_t *hi);
 uint16_t http_GetStatus(const struct http *hp);
 int http_IsStatus(const struct http *hp, int);
 void http_SetStatus(struct http *to, uint16_t status, const char *reason);

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -606,6 +606,7 @@ int http_GetHdrField(const struct http *hp, hdr_t,
     const char *field, const char **ptr);
 double http_GetHdrQ(const struct http *hp, hdr_t, const char *field);
 ssize_t http_GetContentLength(const struct http *hp);
+ssize_t http_GetContentRange(const struct http *hp, ssize_t *lo, ssize_t *hi);
 uint16_t http_GetStatus(const struct http *hp);
 int http_IsStatus(const struct http *hp, int);
 void http_SetStatus(struct http *to, uint16_t status, const char *reason);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -492,6 +492,11 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 	    http_GetHdrField(bo->beresp, H_Connection, "close", NULL))
 		bo->htc->doclose = SC_RESP_CLOSE;
 
+	if (VRG_CheckBo(bo) < 0) {
+		VDI_Finish(bo);
+		return (F_STP_ERROR);
+	}
+
 	if (wrk->handling == VCL_RET_ABANDON || wrk->handling == VCL_RET_FAIL ||
 	    wrk->handling == VCL_RET_ERROR) {
 		/* do not count deliberately ending the backend connection as

--- a/bin/varnishd/cache/cache_range.c
+++ b/bin/varnishd/cache/cache_range.c
@@ -117,7 +117,7 @@ vrg_dorange(struct req *req, void **priv)
 	assert(high >= -1);
 
 	if (low < 0) {
-		if (req->resp_len < 0)
+		if (req->resp_len < 0 || high < 0)
 			return (NULL);		// Allow 200 response
 		assert(high > 0);
 		low = req->resp_len - high;
@@ -228,7 +228,6 @@ vrg_range_init(struct vdp_ctx *vdc, void **priv, struct objcore *oc)
 	(void)oc;
 	req = vdc->req;
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-	assert(http_GetHdr(req->http, H_Range, NULL));
 	if (!vrg_ifrange(req))		// rfc7233,l,455,456
 		return (1);
 	err = vrg_dorange(req, priv);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -396,6 +396,9 @@ void Pool_PurgeStat(unsigned nobj);
 int Pool_Task_Any(struct pool_task *task, enum task_prio prio);
 void pan_pool(struct vsb *);
 
+/* cache_range.c */
+int VRG_CheckBo(struct busyobj *);
+
 /* cache_req.c */
 struct req *Req_New(const struct worker *, struct sess *);
 void Req_Release(struct req *);

--- a/bin/varnishtest/tests/c00034.vtc
+++ b/bin/varnishtest/tests/c00034.vtc
@@ -274,3 +274,23 @@ client c8 {
 	rxresp
 	expect resp.status == 503
 } -run
+
+# range filter without a range header
+
+server s1 {
+	rxreq
+	txresp -bodylen 256
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_deliver {
+		set resp.filters = "range";
+	}
+}
+
+client c1 {
+	txreq -url /5
+	rxresp
+	expect resp.status == 200
+	expect resp.bodylen == 256
+} -run

--- a/bin/varnishtest/tests/c00034.vtc
+++ b/bin/varnishtest/tests/c00034.vtc
@@ -16,7 +16,7 @@ varnish v1 -cliok "param.set http_range_support off"
 client c1 {
 	txreq -hdr "Range: bytes=0-9"
 	rxresp
-	expect resp.accept-ranges == "resp.accept-ranges"
+	expect resp.http.accept-ranges == <undef>
 	expect resp.status == 200
 	expect resp.bodylen == 100
 } -run
@@ -27,7 +27,7 @@ varnish v1 -vsl_catchup
 
 varnish v1 -cliok "param.set http_range_support on"
 
-client c1 {
+client c2 {
 	# Invalid range requests
 
 	txreq -hdr "Range: bytes =0-9"
@@ -78,7 +78,7 @@ varnish v1 -expect s_resp_bodybytes == 100
 
 varnish v1 -vsl_catchup
 
-client c1 {
+client c3 {
 	# Valid range requests
 
 	txreq -hdr "Range: bytes=0-49"
@@ -132,33 +132,21 @@ varnish v1 -vsl_catchup
 # Test Range streaming with streaming objects with C-L
 
 server s1 {
-	rxreq
-	txresp -nolen -hdr "Content-Length: 100"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	delay 2
-	send "0123456789"
-
-	rxreq
-	txresp -nolen -hdr "Content-Length: 100"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	send "0123456789"
-	delay 2
-	send "0123456789"
+	loop 2 {
+		rxreq
+		txresp -nolen -hdr "Content-Length: 100"
+		send "0123456789"
+		send "0123456789"
+		send "0123456789"
+		send "0123456789"
+		send "0123456789"
+		send "0123456789"
+		send "0123456789"
+		send "0123456789"
+		send "0123456789"
+		delay 2
+		send "0123456789"
+	}
 } -start
 
 varnish v1 -vcl+backend {
@@ -169,27 +157,31 @@ varnish v1 -vcl+backend {
 	}
 }
 
-client c1 {
+client c4 {
 	# Open ended range to force C-L usage
 	txreq -url /1 \
 		-hdr "Range: bytes=20-" \
 		-hdr "Connection: close"
-	rxresphdrs
+	rxresp
 	expect resp.status == 206
 	expect resp.http.Content-Range == "bytes 20-99/100"
-	recv 80
+	expect resp.http.Content-Length == 80
+	expect resp.bodylen == 80
 	expect_close
 } -run
 
 varnish v1 -vsl_catchup
 
-client c1 {
+client c5 {
 	# Closed C-L because we cannot use C-L
 	txreq -url /2 \
 		-hdr "Range: bytes=2-5" \
 		-hdr "Accept-encoding: gzip"
 	rxresp
 	expect resp.status == 200
+	expect resp.http.Content-Range == <undef>
+	expect resp.http.Content-Length == <undef>
+	expect resp.http.Content-Encoding == gzip
 	gunzip
 	expect resp.bodylen == 100
 } -run
@@ -204,7 +196,7 @@ server s1 {
 varnish v1 -cliok "param.set feature +http2"
 varnish v1 -vcl+backend ""
 
-client c2 {
+client c6 {
 	stream 1 {
 		txreq -url /3 -hdr "range" "bytes=0-1"
 		rxresp
@@ -232,13 +224,13 @@ varnish v1 -vcl+backend {
 	}
 }
 
-client c1 {
+client c7 {
 	txreq
 	rxresp
 	expect resp.http.foobar == ""
-	expect resp.http.accept-ranges == resp.http.accept-ranges
+	expect resp.http.accept-ranges == <undef>
 	txreq
 	rxresp
-	expect resp.http.foobar == "foobar"
+	expect resp.http.foobar == foobar
 	expect resp.http.accept-ranges == foobar
 } -run

--- a/bin/varnishtest/tests/c00034.vtc
+++ b/bin/varnishtest/tests/c00034.vtc
@@ -190,6 +190,7 @@ client c5 {
 
 server s1 {
 	rxreq
+	expect req.url == "/3"
 	txresp -hdr "Content-length: 3" -body "BLA"
 } -start
 
@@ -233,4 +234,43 @@ client c7 {
 	rxresp
 	expect resp.http.foobar == foobar
 	expect resp.http.accept-ranges == foobar
+} -run
+
+server s1 {
+	rxreq
+	expect req.http.range == "bytes=10-19"
+	txresp -status 206 -hdr "content-range: bytes 0-49/100" -bodylen 40
+
+	rxreq
+	expect req.http.range == "bytes=10-19"
+	txresp -status 206 -hdr "content-range: bytes 10-19/100" -bodylen 40
+
+	rxreq
+	expect req.url == "/4"
+	expect req.http.range == <undef>
+	txresp -hdr "content-range: bytes 0-49/100" -bodylen 40
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.http.return == "pass") {
+			return (pass);
+		}
+	}
+}
+
+client c8 {
+	# range vs content-range vs content-length
+
+	txreq -hdr "range: bytes=10-19" -hdr "return: pass"
+	rxresp
+	expect resp.status == 503
+
+	txreq -hdr "range: bytes=10-19" -hdr "return: pass"
+	rxresp
+	expect resp.status == 503
+
+	txreq -url /4
+	rxresp
+	expect resp.status == 503
 } -run

--- a/bin/varnishtest/tests/r00466.vtc
+++ b/bin/varnishtest/tests/r00466.vtc
@@ -36,10 +36,14 @@ client c1 {
 	expect resp.status == 206
 	expect resp.http.Content-Length == 2
 	expect resp.http.X-Varnish == "1001"
+} -run
 
+varnish v1 -cliok "param.set http_range_support off"
+
+client c2 {
 	# NB: Deliberately bogus Range header
 	txreq -url "/bar" -hdr "Range: 200-300"
 	rxresp
 	expect resp.status == 206
-	expect resp.http.X-Varnish == "1003"
+	expect resp.http.X-Varnish == "1004"
 } -run

--- a/bin/varnishtest/tests/r02530.vtc
+++ b/bin/varnishtest/tests/r02530.vtc
@@ -30,6 +30,8 @@ server s1 {
 	sendhex 1f8b
 } -start
 
+varnish v1 -cliok "param.set http_range_support off"
+
 varnish v1 -vcl+backend {
 	sub vcl_recv {
 		if (req.url == "/pass") {

--- a/include/vnum.h
+++ b/include/vnum.h
@@ -37,6 +37,8 @@ vtim_dur VNUM_duration(const char *p);
 int64_t VNUM_bytes_unit(double r, const char *b, const char *e, uintmax_t rel,
     const char **errtxt);
 const char *VNUM_2bytes(const char *p, uintmax_t *r, uintmax_t rel);
+ssize_t VNUM_uint(const char *b, const char *e, const char **p);
+ssize_t VNUM_hex(const char *b, const char *e, const char **p);
 
 int64_t SF_Parse_Integer(const char **ipp, const char **errtxt);
 double SF_Parse_Decimal(const char **ipp, int strict, const char **errtxt);

--- a/lib/libvarnish/Makefile.am
+++ b/lib/libvarnish/Makefile.am
@@ -44,7 +44,7 @@ libvarnish_la_SOURCES = \
 	vtim.c \
 	vus.c
 
-libvarnish_la_LIBADD = @PCRE2_LIBS@
+libvarnish_la_LIBADD = @PCRE2_LIBS@ $(LIBM)
 
 TESTS = vav_test vbh_test vct_test vjsn_test vnum_c_test vsb_test
 
@@ -64,7 +64,7 @@ vct_test_LDADD = $(AM_LDFLAGS) libvarnish.la
 
 vnum_c_test_SOURCES = vnum.c
 vnum_c_test_CFLAGS = $(AM_CFLAGS) -DNUM_C_TEST
-vnum_c_test_LDADD = $(AM_LDFLAGS) libvarnish.la ${LIBM}
+vnum_c_test_LDADD = $(AM_LDFLAGS) libvarnish.la
 
 vjsn_test_SOURCES = vjsn.c
 vjsn_test_CFLAGS = $(AM_CFLAGS) -DVJSN_TEST

--- a/lib/libvarnish/vav.c
+++ b/lib/libvarnish/vav.c
@@ -43,6 +43,7 @@
 #include "config.h"
 
 #include <ctype.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -51,13 +52,14 @@
 
 #include "vas.h"
 #include "vav.h"
+#include "vnum.h"
 
 static int
 vav_backslash_txt(const char *s, const char *e, char *res)
 {
-	int r, l;
+	int r, l, i;
+	const char *p;
 	char c;
-	unsigned u;
 
 	AN(s);
 	if (e == NULL)
@@ -102,10 +104,10 @@ vav_backslash_txt(const char *s, const char *e, char *res)
 		}
 		break;
 	case 'x':
-		if (l >= 4 && isxdigit(s[2]) && isxdigit(s[3]) &&
-		    sscanf(s + 1, "x%02x", &u) == 1) {
-			AZ(u & ~0xff);
-			c = u;	/*lint !e734 loss of precision */
+		if (l >= 4 && (i = VNUM_hex(s + 2, s + 4, &p)) >= 0 &&
+		    p == s + 4) {
+			AZ(i & ~0xff);
+			c = i;	/*lint !e734 loss of precision */
 			r = 4;
 		}
 		break;

--- a/lib/libvarnish/vnum.c
+++ b/lib/libvarnish/vnum.c
@@ -33,6 +33,9 @@
 
 #include "config.h"
 
+#include <sys/types.h>
+
+#include <limits.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -351,6 +354,66 @@ VNUM_2bytes(const char *p, uintmax_t *r, uintmax_t rel)
 		return (errtxt);
 	*r = (uintmax_t)round(fval);
 	return (NULL);
+}
+
+/**********************************************************************/
+
+static const uint8_t hex_table[] = {
+	0,   1,   2,   3,   4,   5,   6,   7,   8,   9,
+	127, 127, 127, 127, 127, 127, 127, 10,  11,  12,
+	13,  14,  15,  127, 127, 127, 127, 127, 127, 127,
+	127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+	127, 127, 127, 127, 127, 127, 127, 127, 127, 10,
+	11,  12,  13,  14,  15
+};
+
+static ssize_t
+vnum_uint(const char *b, const char *e, const char **p, unsigned base)
+{
+	ssize_t u;
+	unsigned n;
+
+	AN(b);
+	AN(p);
+	if (e == NULL)
+		e = strchr(b, '\0');
+
+	u = 0;
+	if (!vct_ishex(*b) || hex_table[*b - '0'] >= base) {
+		*p = b;
+		return (-1);
+	}
+
+	for (; b < e && vct_ishex(*b) && hex_table[*b - '0'] < base; b++) {
+		if (u > (SSIZE_MAX / base)) {
+			u = -2;
+			break;
+		}
+		u *= base;
+		n = hex_table[*b - '0'];
+		if (u > (SSIZE_MAX - n)) {
+			u = -2;
+			break;
+		}
+		u += n;
+	}
+
+	*p = b;
+	return (u);
+}
+
+ssize_t
+VNUM_uint(const char *b, const char *e, const char **p)
+{
+
+	return (vnum_uint(b, e, p, 10));
+}
+
+ssize_t
+VNUM_hex(const char *b, const char *e, const char **p)
+{
+
+	return (vnum_uint(b, e, p, 16));
 }
 
 #ifdef NUM_C_TEST


### PR DESCRIPTION
That is, only when `http_range_support` is on, which is the default.

Refs #3246

---

The test coverage is by no means comprehensive, and only the last commit changes behavior.