### PR TITLE
build: Revisit coverage and sanitizer setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,10 @@ cscope.*out
 /lib/libvarnishapi/vsl_glob_test
 /lib/libvarnishapi/vxp_test
 
+# GCOV droppings
+*.gcda
+*.gcno
+
 # vtc-bisect.sh default vtc
 /bisect.vtc
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,9 @@ install-data-local:
 	$(install_sh) -d -m 0755 $(DESTDIR)$(localstatedir)/varnish
 
 
+distclean-local:
+	find . '(' -name '*.gcda' -o -name '*.gcda' ')' -exec rm '{}' ';'
+
 distcleancheck_listfiles = \
 	find . -type f -exec sh -c 'test -f $(srcdir)/$$1 || echo $$1' \
 		sh '{}' ';'

--- a/bin/varnishadm/Makefile.am
+++ b/bin/varnishadm/Makefile.am
@@ -8,11 +8,9 @@ bin_PROGRAMS = varnishadm
 
 varnishadm_SOURCES = varnishadm.c
 
-varnishadm_CFLAGS = @LIBEDIT_CFLAGS@ \
-	@SAN_CFLAGS@
+varnishadm_CFLAGS = @LIBEDIT_CFLAGS@
 
 varnishadm_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 	$(top_builddir)/lib/libvarnish/libvarnish.la \
-	${PTHREAD_LIBS} ${RT_LIBS} ${NET_LIBS} @LIBEDIT_LIBS@ ${LIBM} \
-	@SAN_LDFLAGS@
+	${PTHREAD_LIBS} ${RT_LIBS} ${NET_LIBS} @LIBEDIT_LIBS@ ${LIBM}

--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -159,7 +159,6 @@ nobase_pkginclude_HEADERS = \
 vcldir=$(datarootdir)/$(PACKAGE)/vcl
 
 varnishd_CFLAGS = \
-	@SAN_CFLAGS@ \
 	-DNOT_IN_A_VMOD \
 	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
 	-DVARNISH_VMOD_DIR='"${vmoddir}"' \
@@ -171,7 +170,6 @@ varnishd_LDADD = \
 	$(top_builddir)/lib/libvcc/libvcc.a \
 	$(top_builddir)/lib/libvarnish/libvarnish.la \
 	$(top_builddir)/lib/libvgz/libvgz.a \
-	@SAN_LDFLAGS@ \
 	@JEMALLOC_LDADD@ \
 	${DL_LIBS} ${PTHREAD_LIBS} ${NET_LIBS} ${RT_LIBS} ${LIBM}
 
@@ -182,31 +180,25 @@ endif
 
 noinst_PROGRAMS = vhp_gen_hufdec
 vhp_gen_hufdec_SOURCES = hpack/vhp_gen_hufdec.c
-vhp_gen_hufdec_CFLAGS = @SAN_CFLAGS@ \
-			-include config.h
-vhp_gen_hufdec_LDADD = \
-	$(top_builddir)/lib/libvarnish/libvarnish.la
+vhp_gen_hufdec_CFLAGS = -include config.h
+vhp_gen_hufdec_LDADD = $(top_builddir)/lib/libvarnish/libvarnish.la
 
 noinst_PROGRAMS += vhp_table_test
 vhp_table_test_SOURCES = hpack/vhp_table.c
-vhp_table_test_CFLAGS = @SAN_CFLAGS@ \
-			-DTABLE_TEST_DRIVER -include config.h
-vhp_table_test_LDADD = \
-	$(top_builddir)/lib/libvarnish/libvarnish.la
+vhp_table_test_CFLAGS = -DTABLE_TEST_DRIVER -include config.h
+vhp_table_test_LDADD = $(top_builddir)/lib/libvarnish/libvarnish.la
 
 noinst_PROGRAMS += vhp_decode_test
 vhp_decode_test_SOURCES = hpack/vhp_decode.c hpack/vhp_table.c
-vhp_decode_test_CFLAGS = @SAN_CFLAGS@ \
-			 -DDECODE_TEST_DRIVER -include config.h
-vhp_decode_test_LDADD = \
-	$(top_builddir)/lib/libvarnish/libvarnish.la
+vhp_decode_test_CFLAGS = -DDECODE_TEST_DRIVER -include config.h
+vhp_decode_test_LDADD = $(top_builddir)/lib/libvarnish/libvarnish.la
 
 noinst_PROGRAMS += esi_parse_fuzzer
 esi_parse_fuzzer_SOURCES = \
 	cache/cache_esi_parse.c \
 	fuzzers/esi_parse_fuzzer.c
 esi_parse_fuzzer_CFLAGS = \
-	@SAN_CFLAGS@ -DNOT_IN_A_VMOD -DTEST_DRIVER -include config.h
+	-DNOT_IN_A_VMOD -DTEST_DRIVER -include config.h
 esi_parse_fuzzer_LDADD = \
 	$(top_builddir)/lib/libvarnish/libvarnish.la \
 	$(top_builddir)/lib/libvgz/libvgz.a

--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -180,17 +180,16 @@ endif
 
 noinst_PROGRAMS = vhp_gen_hufdec
 vhp_gen_hufdec_SOURCES = hpack/vhp_gen_hufdec.c
-vhp_gen_hufdec_CFLAGS = -include config.h
 vhp_gen_hufdec_LDADD = $(top_builddir)/lib/libvarnish/libvarnish.la
 
 noinst_PROGRAMS += vhp_table_test
 vhp_table_test_SOURCES = hpack/vhp_table.c
-vhp_table_test_CFLAGS = -DTABLE_TEST_DRIVER -include config.h
+vhp_table_test_CFLAGS = -DTABLE_TEST_DRIVER
 vhp_table_test_LDADD = $(top_builddir)/lib/libvarnish/libvarnish.la
 
 noinst_PROGRAMS += vhp_decode_test
 vhp_decode_test_SOURCES = hpack/vhp_decode.c hpack/vhp_table.c
-vhp_decode_test_CFLAGS = -DDECODE_TEST_DRIVER -include config.h
+vhp_decode_test_CFLAGS = -DDECODE_TEST_DRIVER
 vhp_decode_test_LDADD = $(top_builddir)/lib/libvarnish/libvarnish.la
 
 noinst_PROGRAMS += esi_parse_fuzzer
@@ -198,7 +197,7 @@ esi_parse_fuzzer_SOURCES = \
 	cache/cache_esi_parse.c \
 	fuzzers/esi_parse_fuzzer.c
 esi_parse_fuzzer_CFLAGS = \
-	-DNOT_IN_A_VMOD -DTEST_DRIVER -include config.h
+	-DNOT_IN_A_VMOD -DTEST_DRIVER
 esi_parse_fuzzer_LDADD = \
 	$(top_builddir)/lib/libvarnish/libvarnish.la \
 	$(top_builddir)/lib/libvgz/libvgz.a

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -614,7 +614,7 @@ pan_backtrace(struct vsb *vsb)
 
 #else /* WITH_UNWIND */
 
-#if __SANITIZER
+#if ENABLE_SANITIZER
 #  define BACKTRACE_LEVELS	20
 #else
 #  define BACKTRACE_LEVELS	10

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -65,10 +65,6 @@
  *
  */
 
-#ifdef GCOVING
-    int __gcov_flush(void);
-#endif
-
 static struct vsb pan_vsb_storage, *pan_vsb;
 static pthread_mutex_t panicstr_mtx;
 
@@ -812,9 +808,7 @@ pan_ic(const char *func, const char *file, int line, const char *cond,
 	VSB_cat(pan_vsb, "\n");
 	VSB_putc(pan_vsb, '\0');	/* NUL termination */
 
-#ifdef GCOVING
-	__gcov_flush();
-#endif
+	v_gcov_flush();
 	abort();
 }
 

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -514,7 +514,7 @@ void VCL_TaskLeave(VRT_CTX, struct vrt_privs *);
 void VMOD_Init(void);
 void VMOD_Panic(struct vsb *);
 
-#if defined(GCOVING) || defined(__SANITIZER)
+#if defined(ENABLE_COVERAGE) || defined(__SANITIZER)
 #  define DONT_DLCLOSE_VMODS
 #endif
 

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -514,6 +514,10 @@ void VCL_TaskLeave(VRT_CTX, struct vrt_privs *);
 void VMOD_Init(void);
 void VMOD_Panic(struct vsb *);
 
+#if defined(GCOVING) || defined(__SANITIZER)
+#  define DONT_DLCLOSE_VMODS
+#endif
+
 /* cache_wrk.c */
 void WRK_Init(void);
 void WRK_AddStat(const struct worker *);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -514,7 +514,7 @@ void VCL_TaskLeave(VRT_CTX, struct vrt_privs *);
 void VMOD_Init(void);
 void VMOD_Panic(struct vsb *);
 
-#if defined(ENABLE_COVERAGE) || defined(__SANITIZER)
+#if defined(ENABLE_COVERAGE) || defined(ENABLE_SANITIZER)
 #  define DONT_DLCLOSE_VMODS
 #endif
 

--- a/bin/varnishd/fuzzers/esi_parse_fuzzer.c
+++ b/bin/varnishd/fuzzers/esi_parse_fuzzer.c
@@ -30,6 +30,8 @@
  * ESI parser fuzzer.
  */
 
+#include "config.h"
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/bin/varnishd/hpack/vhp_gen_hufdec.c
+++ b/bin/varnishd/hpack/vhp_gen_hufdec.c
@@ -28,6 +28,8 @@
  * SUCH DAMAGE.
  */
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdint.h>

--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -63,10 +63,6 @@ static const struct cli_cmd_desc *cmds[] = {
 #include "tbl/cli_cmds.h"
 };
 
-#ifdef GCOVING
-    int __gcov_flush(void);
-#endif
-
 static const int ncmds = sizeof cmds / sizeof cmds[0];
 
 static int		cli_i = -1, cli_o = -1;
@@ -112,9 +108,7 @@ mcf_panic(struct cli *cli, const char * const *av, void *priv)
 	(void)cli;
 	(void)av;
 	(void)priv;
-#ifdef GCOVING
-	__gcov_flush();
-#endif
+	v_gcov_flush();
 	AZ(strcmp("", "You asked for it"));
 	/* NOTREACHED */
 	abort();

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -688,7 +688,7 @@ MCF_InitParams(struct cli *cli)
 	low = sysconf(_SC_THREAD_STACK_MIN);
 	MCF_ParamConf(MCF_MINIMUM, "thread_pool_stack", "%jdb", (intmax_t)low);
 
-#if defined(__SANITIZER) || __has_feature(address_sanitizer) || defined(GCOVING)
+#if defined(__SANITIZER) || __has_feature(address_sanitizer) || defined(ENABLE_COVERAGE)
 	def = 192 * 1024;
 #endif
 

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -688,7 +688,7 @@ MCF_InitParams(struct cli *cli)
 	low = sysconf(_SC_THREAD_STACK_MIN);
 	MCF_ParamConf(MCF_MINIMUM, "thread_pool_stack", "%jdb", (intmax_t)low);
 
-#if defined(__SANITIZER) || __has_feature(address_sanitizer) || defined(ENABLE_COVERAGE)
+#if defined(ENABLE_SANITIZER) || defined(ENABLE_COVERAGE)
 	def = 192 * 1024;
 #endif
 

--- a/bin/varnishhist/Makefile.am
+++ b/bin/varnishhist/Makefile.am
@@ -12,11 +12,6 @@ varnishhist_SOURCES = \
 	varnishhist_options.h \
 	varnishhist_profiles.h
 
-varnishhist_CFLAGS = \
-	@SAN_CFLAGS@
-
 varnishhist_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
-	-lm \
-	@SAN_LDFLAGS@ \
-	@CURSES_LIBS@ ${RT_LIBS} ${PTHREAD_LIBS}
+	-lm @CURSES_LIBS@ ${RT_LIBS} ${PTHREAD_LIBS}

--- a/bin/varnishlog/Makefile.am
+++ b/bin/varnishlog/Makefile.am
@@ -10,10 +10,6 @@ varnishlog_SOURCES = \
 	varnishlog.c \
 	varnishlog_options.h
 
-varnishlog_CFLAGS = \
-	@SAN_CFLAGS@
-
 varnishlog_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
-	@SAN_LDFLAGS@ \
 	${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}

--- a/bin/varnishncsa/Makefile.am
+++ b/bin/varnishncsa/Makefile.am
@@ -12,10 +12,6 @@ varnishncsa_SOURCES = \
 	b64.h \
 	b64.c
 
-varnishncsa_CFLAGS = \
-	@SAN_CFLAGS@
-
 varnishncsa_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
-	@SAN_LDFLAGS@ \
 	${RT_LIBS} ${LIBM}

--- a/bin/varnishstat/Makefile.am
+++ b/bin/varnishstat/Makefile.am
@@ -28,14 +28,9 @@ varnishstat_curses_help.c: varnishstat_help_gen
 	$(AM_V_GEN) ./varnishstat_help_gen >$@_
 	@mv $@_ $@
 
-varnishstat_CFLAGS = \
-	@SAN_CFLAGS@
-
 varnishstat_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
-	@SAN_LDFLAGS@ \
 	@CURSES_LIBS@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}
 
 varnishstat_help_gen_LDADD = \
-	$(top_builddir)/lib/libvarnish/libvarnish.la \
-	@SAN_LDFLAGS@
+	$(top_builddir)/lib/libvarnish/libvarnish.la

--- a/bin/varnishtest/Makefile.am
+++ b/bin/varnishtest/Makefile.am
@@ -55,11 +55,9 @@ varnishtest_LDADD = \
 		$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 		$(top_builddir)/lib/libvarnish/libvarnish.la \
 		$(top_builddir)/lib/libvgz/libvgz.a \
-		@SAN_LDFLAGS@ \
 		${PTHREAD_LIBS} ${NET_LIBS} ${LIBM}
 
 varnishtest_CFLAGS = \
-		@SAN_CFLAGS@ \
 		-DVTEST_WITH_VTC_LOGEXPECT \
 		-DVTEST_WITH_VTC_VARNISH \
 		-DTOP_BUILDDIR='"${top_builddir}"'

--- a/bin/varnishtest/tests/v00004.vtc
+++ b/bin/varnishtest/tests/v00004.vtc
@@ -2,9 +2,7 @@ varnishtest "test if our default paramers make sense ..."
 
 feature 64bit
 feature !sanitizer
-
-# Skip this test in GCOV mode, 68xx bytes extra per level makes it fail
-feature cmd {test -z "$GCOVPROG"}
+feature !coverage
 
 # ... for our definition of a standard use case:
 # - 2019 header madness

--- a/bin/varnishtest/vtc_misc.c
+++ b/bin/varnishtest/vtc_misc.c
@@ -438,6 +438,8 @@ addr_no_randomize_works(void)
  *        recognized as a macro.
  * persistent_storage
  *        Varnish was built with the deprecated persistent storage.
+ * coverage
+ *        Varnish was built with code coverage enabled.
  * sanitizer
  *        Varnish was built with a sanitizer.
  *
@@ -448,6 +450,12 @@ addr_no_randomize_works(void)
  * misspelled macro to fail silently. You should only need it if you must
  * run a test with strings of the form "${...}".
  */
+
+#if ENABLE_COVERAGE
+static const unsigned coverage = 1;
+#else
+static const unsigned coverage = 0;
+#endif
 
 #if WITH_PERSISTENT_STORAGE
 static const unsigned with_persistent_storage = 1;
@@ -513,6 +521,7 @@ cmd_feature(CMD_ARGS)
 		FEATURE("user_vcache", getpwnam("vcache") != NULL);
 		FEATURE("group_varnish", getgrnam("varnish") != NULL);
 		FEATURE("persistent_storage", with_persistent_storage);
+		FEATURE("coverage", coverage);
 		FEATURE("sanitizer", sanitizer);
 		FEATURE("SO_RCVTIMEO_WORKS", so_rcvtimeo_works);
 

--- a/bin/varnishtest/vtc_misc.c
+++ b/bin/varnishtest/vtc_misc.c
@@ -440,6 +440,14 @@ addr_no_randomize_works(void)
  *        Varnish was built with the deprecated persistent storage.
  * coverage
  *        Varnish was built with code coverage enabled.
+ * asan
+ *        Varnish was built with the address sanitizer.
+ * msan
+ *        Varnish was built with the memory sanitizer.
+ * tsan
+ *        Varnish was built with the thread sanitizer.
+ * ubsan
+ *        Varnish was built with the undefined behavior sanitizer.
  * sanitizer
  *        Varnish was built with a sanitizer.
  *
@@ -455,6 +463,30 @@ addr_no_randomize_works(void)
 static const unsigned coverage = 1;
 #else
 static const unsigned coverage = 0;
+#endif
+
+#if ENABLE_ASAN
+static const unsigned asan = 1;
+#else
+static const unsigned asan = 0;
+#endif
+
+#if ENABLE_MSAN
+static const unsigned msan = 1;
+#else
+static const unsigned msan = 0;
+#endif
+
+#if ENABLE_TSAN
+static const unsigned tsan = 1;
+#else
+static const unsigned tsan = 0;
+#endif
+
+#if ENABLE_UBSAN
+static const unsigned ubsan = 1;
+#else
+static const unsigned ubsan = 0;
 #endif
 
 #if ENABLE_SANITIZER
@@ -522,6 +554,10 @@ cmd_feature(CMD_ARGS)
 		FEATURE("group_varnish", getgrnam("varnish") != NULL);
 		FEATURE("persistent_storage", with_persistent_storage);
 		FEATURE("coverage", coverage);
+		FEATURE("asan", asan);
+		FEATURE("msan", msan);
+		FEATURE("tsan", tsan);
+		FEATURE("ubsan", ubsan);
 		FEATURE("sanitizer", sanitizer);
 		FEATURE("SO_RCVTIMEO_WORKS", so_rcvtimeo_works);
 

--- a/bin/varnishtest/vtc_misc.c
+++ b/bin/varnishtest/vtc_misc.c
@@ -457,16 +457,16 @@ static const unsigned coverage = 1;
 static const unsigned coverage = 0;
 #endif
 
+#if ENABLE_SANITIZER
+static const unsigned sanitizer = 1;
+#else
+static const unsigned sanitizer = 0;
+#endif
+
 #if WITH_PERSISTENT_STORAGE
 static const unsigned with_persistent_storage = 1;
 #else
 static const unsigned with_persistent_storage = 0;
-#endif
-
-#if __SANITIZER
-static const unsigned sanitizer = 1;
-#else
-static const unsigned sanitizer = 0;
 #endif
 
 #ifdef SO_RCVTIMEO_WORKS

--- a/bin/varnishtop/Makefile.am
+++ b/bin/varnishtop/Makefile.am
@@ -11,11 +11,6 @@ varnishtop_SOURCES = \
 	varnishtop.c \
 	varnishtop_options.h
 
-
-varnishtop_CFLAGS = \
-	@SAN_CFLAGS@
-
 varnishtop_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
-	@SAN_LDFLAGS@ \
 	@CURSES_LIBS@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}

--- a/configure.ac
+++ b/configure.ac
@@ -780,7 +780,7 @@ AC_ARG_ENABLE(debugging-symbols,
 	    [enable_debugging_symbols=no])
 
 if test "$enable_coverage" != no; then
-	AC_DEFINE([GCOVING], [1], [Define to 1 if code coverage is enabled.])
+	AC_DEFINE([ENABLE_COVERAGE], [1], [Define to 1 if code coverage is enabled.])
 	save_CFLAGS=$CFLAGS
 	CFLAGS=
 	AX_CHECK_COMPILE_FLAG([--coverage],

--- a/configure.ac
+++ b/configure.ac
@@ -273,17 +273,29 @@ CFLAGS="${save_CFLAGS}"
 AC_ARG_ENABLE(ubsan,
 	AS_HELP_STRING([--enable-ubsan],
 		[enable undefined behavior sanitizer (default is NO)]),
-	[UBSAN_FLAGS=-fsanitize=undefined])
+	[
+		AC_DEFINE([ENABLE_UBSAN], [1],
+			[Define to 1 if UBSAN is enabled.])
+		UBSAN_FLAGS=-fsanitize=undefined
+	])
 
 AC_ARG_ENABLE(tsan,
 	AS_HELP_STRING([--enable-tsan],
 		[enable thread sanitizer (default is NO)]),
-	[TSAN_FLAGS=-fsanitize=thread])
+	[
+		AC_DEFINE([ENABLE_TSAN], [1],
+			[Define to 1 if TSAN is enabled.])
+		TSAN_FLAGS=-fsanitize=thread
+	])
 
 AC_ARG_ENABLE(asan,
 	AS_HELP_STRING([--enable-asan],
 		[enable address sanitizer (default is NO)]),
-	[ASAN_FLAGS=-fsanitize=address])
+	[
+		AC_DEFINE([ENABLE_ASAN], [1],
+			[Define to 1 if ASAN sanitizer is enabled.])
+		ASAN_FLAGS=-fsanitize=address
+	])
 
 if test -n "$ASAN_FLAGS"; then
 	AX_CHECK_COMPILE_FLAG(
@@ -294,7 +306,11 @@ fi
 AC_ARG_ENABLE(msan,
 	AS_HELP_STRING([--enable-msan],
 		[enable memory sanitizer (default is NO)]),
-	[MSAN_FLAGS=-fsanitize=memory])
+	[
+		AC_DEFINE([ENABLE_MSAN], [1],
+			[Define to 1 if MSAN is enabled.])
+		MSAN_FLAGS=-fsanitize=memory
+	])
 
 if test "x$UBSAN_FLAGS$TSAN_FLAGS$ASAN_FLAGS$MSAN_FLAGS" != "x"; then
 	AC_DEFINE([ENABLE_SANITIZER], [1],

--- a/configure.ac
+++ b/configure.ac
@@ -765,12 +765,38 @@ case $CFLAGS in
     ;;
 esac
 
+# --enable-coverage
+AC_ARG_ENABLE(coverage,
+	AS_HELP_STRING([--enable-coverage],
+		[enable coverage (implies debugging symbols, default is NO)]),
+	    [],
+	    [enable_coverage=no])
+
 # --enable-debugging-symbols
 AC_ARG_ENABLE(debugging-symbols,
 	AS_HELP_STRING([--enable-debugging-symbols],
 		[enable debugging symbols (default is NO)]),
 	    [],
 	    [enable_debugging_symbols=no])
+
+if test "$enable_coverage" != no; then
+	AC_DEFINE([GCOVING], [1], [Define to 1 if code coverage is enabled.])
+	save_CFLAGS=$CFLAGS
+	CFLAGS=
+	AX_CHECK_COMPILE_FLAG([--coverage],
+		[COV_FLAGS=--coverage],
+		[AX_CHECK_COMPILE_FLAG([-fprofile-arcs -ftest-coverage],
+			[COV_FLAGS="-fprofile-arcs -ftest-coverage"])])
+	AX_CHECK_COMPILE_FLAG([-fprofile-abs-path],
+		[COV_FLAGS="$COV_FLAGS -fprofile-abs-path"])
+	AX_CHECK_COMPILE_FLAG([-fPIC], [COV_FLAGS="$COV_FLAGS -fPIC"])
+	CFLAGS=$COV_FLAGS
+	AC_CHECK_FUNCS([__gcov_flush])
+	AC_CHECK_FUNCS([__gcov_dump])
+	AC_CHECK_FUNCS([__llvm_gcov_flush])
+	CFLAGS="$save_CFLAGS $COV_FLAGS"
+	enable_debugging_symbols=yes
+fi
 
 if test "$enable_debugging_symbols" != no; then
 	if test "x$SUNCC" = "xyes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -297,7 +297,8 @@ AC_ARG_ENABLE(msan,
 	[MSAN_FLAGS=-fsanitize=memory])
 
 if test "x$UBSAN_FLAGS$TSAN_FLAGS$ASAN_FLAGS$MSAN_FLAGS" != "x"; then
-	AC_DEFINE([__SANITIZER], [1], [Define to 1 if any sanitizer is enabled.])
+	AC_DEFINE([ENABLE_SANITIZER], [1],
+		[Define to 1 if any sanitizer is enabled.])
 	SAN_FLAGS="$ASAN_FLAGS $UBSAN_FLAGS $TSAN_FLAGS $MSAN_FLAGS"
 	SAN_CFLAGS="$SAN_FLAGS -fPIC -fPIE -fno-omit-frame-pointer"
 	SAN_LDFLAGS=

--- a/configure.ac
+++ b/configure.ac
@@ -767,12 +767,18 @@ esac
 
 # --enable-debugging-symbols
 AC_ARG_ENABLE(debugging-symbols,
-	AS_HELP_STRING([--enable-debugging-symbols],[enable debugging symbols (default is NO)]),
+	AS_HELP_STRING([--enable-debugging-symbols],
+		[enable debugging symbols (default is NO)]),
+	    [],
+	    [enable_debugging_symbols=no])
+
+if test "$enable_debugging_symbols" != no; then
 	if test "x$SUNCC" = "xyes" ; then
 		CFLAGS="${CFLAGS} -O0 -g"
 	else
 		CFLAGS="${CFLAGS} -O0 -g -fno-inline"
-	fi)
+	fi
+fi
 
 AC_SUBST(AM_LT_LDFLAGS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -270,9 +270,6 @@ if test "$ac_cv_have_viz" = no; then
 fi
 CFLAGS="${save_CFLAGS}"
 
-SAN_CFLAGS=
-SAN_LDFLAGS=
-
 AC_ARG_ENABLE(ubsan,
 	AS_HELP_STRING([--enable-ubsan],
 		[enable undefined behavior sanitizer (default is NO)]),
@@ -299,13 +296,18 @@ AC_ARG_ENABLE(msan,
 		[enable memory sanitizer (default is NO)]),
 	[MSAN_FLAGS=-fsanitize=memory])
 
+SAN_CFLAGS=
+SAN_LDFLAGS=
+
 if test "x$UBSAN_FLAGS$TSAN_FLAGS$ASAN_FLAGS$MSAN_FLAGS" != "x"; then
-	SAN_CFLAGS="-D__SANITIZER=1 ${UBSAN_FLAGS} ${TSAN_FLAGS} ${ASAN_FLAGS} ${MSAN_FLAGS} -fPIC -fPIE -fno-omit-frame-pointer"
-	SAN_LDFLAGS="${UBSAN_FLAGS} ${TSAN_FLAGS} ${ASAN_FLAGS} ${MSAN_FLAGS}"
-	save_CFLAGS="${CFLAGS}"
+	AC_DEFINE([__SANITIZER], [1], [Define to 1 if any sanitizer is enabled.])
+	SAN_FLAGS="$ASAN_FLAGS $UBSAN_FLAGS $TSAN_FLAGS $MSAN_FLAGS"
+	SAN_CFLAGS="$SAN_FLAGS -fPIC -fPIE -fno-omit-frame-pointer"
+	SAN_LDFLAGS=$SAN_FLAGS
+	save_CFLAGS=$CFLAGS
 	CFLAGS="${CFLAGS} -Werror=unused-command-line-argument"
-	AX_CHECK_LINK_FLAG([-pie], [SAN_LDFLAGS="${SAN_LDFLAGS} -pie"])
-	CFLAGS="${save_CFLAGS}"
+	AX_CHECK_LINK_FLAG([-pie], [SAN_LDFLAGS="$SAN_LDFLAGS -pie"])
+	CFLAGS=$save_CFLAGS
 	case $CC in
 	gcc*)
 		SAN_CFLAGS="${SAN_CFLAGS} -fuse-ld=gold"

--- a/configure.ac
+++ b/configure.ac
@@ -272,31 +272,32 @@ CFLAGS="${save_CFLAGS}"
 
 SAN_CFLAGS=
 SAN_LDFLAGS=
-UBSAN_CFLAGS=
-UBSAN_LDFLAGS=
+
 AC_ARG_ENABLE(ubsan,
-	AS_HELP_STRING([--enable-ubsan],[enable undefined behavior sanitizer (default is NO)]),
-	UBSAN_FLAGS="-fsanitize=undefined")
+	AS_HELP_STRING([--enable-ubsan],
+		[enable undefined behavior sanitizer (default is NO)]),
+	[UBSAN_FLAGS=-fsanitize=undefined])
 
-TSAN_CFLAGS=
-TSAN_LDFLAGS=
 AC_ARG_ENABLE(tsan,
-	AS_HELP_STRING([--enable-tsan],[enable thread sanitizer (default is NO)]),
-	TSAN_FLAGS="-fsanitize=thread")
+	AS_HELP_STRING([--enable-tsan],
+		[enable thread sanitizer (default is NO)]),
+	[TSAN_FLAGS=-fsanitize=thread])
 
-ASAN_CFLAGS=
-ASAN_LDFLAGS=
 AC_ARG_ENABLE(asan,
-	AS_HELP_STRING([--enable-asan],[enable address sanitizer (default is NO)]),
-	ASAN_FLAGS="-fsanitize=address"
-	AX_CHECK_COMPILE_FLAG([-fsanitize=address -fsanitize-address-use-after-scope],
-			      [ASAN_FLAGS="${ASAN_FLAGS} -fsanitize-address-use-after-scope"]))
+	AS_HELP_STRING([--enable-asan],
+		[enable address sanitizer (default is NO)]),
+	[ASAN_FLAGS=-fsanitize=address])
 
-MSAN_CFLAGS=
-MSAN_LDFLAGS=
+if test -n "$ASAN_FLAGS"; then
+	AX_CHECK_COMPILE_FLAG(
+		[$ASAN_FLAGS -fsanitize-address-use-after-scope],
+		[ASAN_FLAGS="$ASAN_FLAGS -fsanitize-address-use-after-scope"])
+fi
+
 AC_ARG_ENABLE(msan,
-	AS_HELP_STRING([--enable-msan],[enable memory sanitizer (default is NO)]),
-	MSAN_FLAGS="-fsanitize=memory")
+	AS_HELP_STRING([--enable-msan],
+		[enable memory sanitizer (default is NO)]),
+	[MSAN_FLAGS=-fsanitize=memory])
 
 if test "x$UBSAN_FLAGS$TSAN_FLAGS$ASAN_FLAGS$MSAN_FLAGS" != "x"; then
 	SAN_CFLAGS="-D__SANITIZER=1 ${UBSAN_FLAGS} ${TSAN_FLAGS} ${ASAN_FLAGS} ${MSAN_FLAGS} -fPIC -fPIE -fno-omit-frame-pointer"

--- a/configure.ac
+++ b/configure.ac
@@ -296,26 +296,23 @@ AC_ARG_ENABLE(msan,
 		[enable memory sanitizer (default is NO)]),
 	[MSAN_FLAGS=-fsanitize=memory])
 
-SAN_CFLAGS=
-SAN_LDFLAGS=
-
 if test "x$UBSAN_FLAGS$TSAN_FLAGS$ASAN_FLAGS$MSAN_FLAGS" != "x"; then
 	AC_DEFINE([__SANITIZER], [1], [Define to 1 if any sanitizer is enabled.])
 	SAN_FLAGS="$ASAN_FLAGS $UBSAN_FLAGS $TSAN_FLAGS $MSAN_FLAGS"
 	SAN_CFLAGS="$SAN_FLAGS -fPIC -fPIE -fno-omit-frame-pointer"
-	SAN_LDFLAGS=$SAN_FLAGS
+	SAN_LDFLAGS=
 	save_CFLAGS=$CFLAGS
 	CFLAGS="${CFLAGS} -Werror=unused-command-line-argument"
-	AX_CHECK_LINK_FLAG([-pie], [SAN_LDFLAGS="$SAN_LDFLAGS -pie"])
+	AX_CHECK_LINK_FLAG([-pie], [SAN_LDFLAGS=-pie])
 	CFLAGS=$save_CFLAGS
 	case $CC in
 	gcc*)
-		SAN_CFLAGS="${SAN_CFLAGS} -fuse-ld=gold"
+		SAN_CFLAGS="$SAN_CFLAGS -fuse-ld=gold"
 		;;
 	esac
+	CFLAGS="$CFLAGS $SAN_CFLAGS"
+	LDFLAGS="$LDFLAGS $SAN_LDFLAGS"
 fi
-AC_SUBST(SAN_CFLAGS)
-AC_SUBST(SAN_LDFLAGS)
 
 # Use jemalloc on Linux
 JEMALLOC_LDADD=

--- a/include/vdef.h
+++ b/include/vdef.h
@@ -112,6 +112,19 @@
 #  define v_dont_optimize
 #endif
 
+#ifdef HAVE___GCOV_FLUSH
+#  define v_gcov_flush() __gcov_flush()
+int __gcov_flush(void);
+#elif defined HAVE___GCOV_DUMP
+#  define v_gcov_flush() __gcov_dump()
+void __gcov_dump(void);
+#elif defined HAVE___LLVM_GCOV_FLUSH
+#  define v_gcov_flush() __llvm_gcov_flush()
+int __llvm_gcov_flush(void);
+#else
+#  define v_gcov_flush() do { } while (0)
+#endif
+
 /*********************************************************************
  * Fundamental numerical limits
   * These limits track RFC8941

--- a/lib/libvarnish/Makefile.am
+++ b/lib/libvarnish/Makefile.am
@@ -5,8 +5,8 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/include \
 	@PCRE2_CFLAGS@
 
-AM_CFLAGS   = $(AM_LT_CFLAGS)  @SAN_CFLAGS@
-AM_LDFLAGS  = $(AM_LT_LDFLAGS) @SAN_LDFLAGS@
+AM_CFLAGS   = $(AM_LT_CFLAGS)
+AM_LDFLAGS  = $(AM_LT_LDFLAGS)
 
 noinst_LTLIBRARIES = libvarnish.la
 

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -626,7 +626,7 @@ VTCP_Check(ssize_t a)
 	if (errno == EINVAL)
 		return (1);
 #endif
-#if (defined(__SANITIZER) || __has_feature(address_sanitizer))
+#if defined(ENABLE_SANITIZER)
 	if (errno == EINTR)
 		return (1);
 #endif

--- a/lib/libvarnishapi/Makefile.am
+++ b/lib/libvarnishapi/Makefile.am
@@ -35,12 +35,11 @@ libvarnishapi_la_SOURCES += daemon.c
 endif
 
 libvarnishapi_la_CFLAGS = \
-	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
-	@SAN_CFLAGS@
+	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"'
 
 libvarnishapi_la_LIBADD = \
 	$(top_builddir)/lib/libvarnish/libvarnish.la \
-	@SAN_LDFLAGS@ ${NET_LIBS} ${RT_LIBS} ${LIBM}
+	${NET_LIBS} ${RT_LIBS} ${LIBM}
 
 if HAVE_LD_VERSION_SCRIPT
 libvarnishapi_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libvarnishapi.map
@@ -79,17 +78,15 @@ vxp_test_SOURCES = \
 	vxp_test.c
 vxp_test_CFLAGS = \
 	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
-	-DVXP_DEBUG \
-	${SAN_CFLAGS}
+	-DVXP_DEBUG
 vxp_test_LDADD = \
 	$(top_builddir)/lib/libvarnish/libvarnish.la \
-	${RT_LIBS} ${LIBM} ${PTHREAD_LIBS} ${SAN_LDFLAGS}
+	${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}
 
 noinst_PROGRAMS += vsl_glob_test
 
 vsl_glob_test_SOURCES = vsl_glob_test.c
-vsl_glob_test_CFLAGS = @SAN_CFLAGS@
-vsl_glob_test_LDADD = libvarnishapi.la @SAN_LDFLAGS@
+vsl_glob_test_LDADD = libvarnishapi.la
 
 dist_noinst_SCRIPTS = vsl_glob_test_coverage.sh vxp_test_coverage.sh
 

--- a/lib/libvcc/Makefile.am
+++ b/lib/libvcc/Makefile.am
@@ -8,9 +8,6 @@ AM_CPPFLAGS = \
 
 noinst_LIBRARIES = libvcc.a
 
-libvcc_a_CFLAGS = \
-	@SAN_CFLAGS@
-
 libvcc_a_SOURCES = \
 	vcc_compile.h \
 	vcc_namespace.h \

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -56,8 +56,7 @@ vmod_LTLIBRARIES += libvmod_XXX.la
 libvmod_XXX_la_SOURCES = \\
 \tSRC
 
-libvmod_XXX_la_CFLAGS = \\
-\t@SAN_CFLAGS@
+libvmod_XXX_la_CFLAGS =
 
 vmodtoolargs_XXX ?= --strict --boilerplate -o PFX
 vmod_XXX_symbols_regex ?= Vmod_XXX_Data
@@ -65,8 +64,7 @@ vmod_XXX_symbols_regex ?= Vmod_XXX_Data
 libvmod_XXX_la_LDFLAGS = \\
 \t-export-symbols-regex $(vmod_XXX_symbols_regex) \\
 \t$(AM_LDFLAGS) \\
-\t$(VMOD_LDFLAGS) \\
-\t@SAN_LDFLAGS@
+\t$(VMOD_LDFLAGS)
 
 nodist_libvmod_XXX_la_SOURCES = PFX.c PFX.h
 

--- a/lib/libvgz/Makefile.am
+++ b/lib/libvgz/Makefile.am
@@ -5,7 +5,7 @@ AM_LDFLAGS  = $(AM_LT_LDFLAGS)
 noinst_LIBRARIES = libvgz.a
 
 libvgz_a_CFLAGS = -D_LARGEFILE64_SOURCE=1 -DZLIB_CONST \
-	$(libvgz_extra_cflags) @SAN_CFLAGS@
+	$(libvgz_extra_cflags)
 
 libvgz_a_SOURCES = \
 	adler32.c \

--- a/tools/vtest.sh
+++ b/tools/vtest.sh
@@ -129,7 +129,7 @@ autogen () (
 	set -e
 	cd "${SRCDIR}"
 	nice make distclean > /dev/null 2>&1 || true
-	nice sh "${SRCDIR}"/autogen.des
+	nice sh "${SRCDIR}"/autogen.des $AUTOGEN_FLAGS
 )
 
 makedistcheck () (
@@ -207,7 +207,7 @@ if $enable_gcov ; then
 	#export CC=gcc6
 	#export CC=clang80
 	export GCOVPROG='llvm-cov gcov'
-	export CFLAGS="-fprofile-arcs -ftest-coverage -fstack-protector -DDONT_DLCLOSE_VMODS -DGCOVING"
+	export AUTOGEN_FLAGS='--enable-coverage --enable-stack-protector'
 	export MAKEFLAGS=-j1
 fi
 

--- a/vmod/automake_boilerplate_blob.am
+++ b/vmod/automake_boilerplate_blob.am
@@ -12,8 +12,7 @@ libvmod_blob_la_SOURCES = \
 	vmod_blob_tbl_encodings.h \
 	vmod_blob_url.c
 
-libvmod_blob_la_CFLAGS = \
-	@SAN_CFLAGS@
+libvmod_blob_la_CFLAGS =
 
 vmodtoolargs_blob ?= --strict --boilerplate -o vcc_blob_if
 vmod_blob_symbols_regex ?= Vmod_blob_Data
@@ -21,8 +20,7 @@ vmod_blob_symbols_regex ?= Vmod_blob_Data
 libvmod_blob_la_LDFLAGS = \
 	-export-symbols-regex $(vmod_blob_symbols_regex) \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS) \
-	@SAN_LDFLAGS@
+	$(VMOD_LDFLAGS)
 
 nodist_libvmod_blob_la_SOURCES = vcc_blob_if.c vcc_blob_if.h
 

--- a/vmod/automake_boilerplate_cookie.am
+++ b/vmod/automake_boilerplate_cookie.am
@@ -5,8 +5,7 @@ vmod_LTLIBRARIES += libvmod_cookie.la
 libvmod_cookie_la_SOURCES = \
 	vmod_cookie.c
 
-libvmod_cookie_la_CFLAGS = \
-	@SAN_CFLAGS@
+libvmod_cookie_la_CFLAGS =
 
 vmodtoolargs_cookie ?= --strict --boilerplate -o vcc_cookie_if
 vmod_cookie_symbols_regex ?= Vmod_cookie_Data
@@ -14,8 +13,7 @@ vmod_cookie_symbols_regex ?= Vmod_cookie_Data
 libvmod_cookie_la_LDFLAGS = \
 	-export-symbols-regex $(vmod_cookie_symbols_regex) \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS) \
-	@SAN_LDFLAGS@
+	$(VMOD_LDFLAGS)
 
 nodist_libvmod_cookie_la_SOURCES = vcc_cookie_if.c vcc_cookie_if.h
 

--- a/vmod/automake_boilerplate_debug.am
+++ b/vmod/automake_boilerplate_debug.am
@@ -8,8 +8,7 @@ libvmod_debug_la_SOURCES = \
 	vmod_debug_dyn.c \
 	vmod_debug_obj.c
 
-libvmod_debug_la_CFLAGS = \
-	@SAN_CFLAGS@
+libvmod_debug_la_CFLAGS =
 
 vmodtoolargs_debug ?= --strict --boilerplate -o vcc_debug_if
 vmod_debug_symbols_regex ?= Vmod_debug_Data
@@ -17,8 +16,7 @@ vmod_debug_symbols_regex ?= Vmod_debug_Data
 libvmod_debug_la_LDFLAGS = \
 	-export-symbols-regex $(vmod_debug_symbols_regex) \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS) \
-	@SAN_LDFLAGS@
+	$(VMOD_LDFLAGS)
 
 nodist_libvmod_debug_la_SOURCES = vcc_debug_if.c vcc_debug_if.h
 

--- a/vmod/automake_boilerplate_directors.am
+++ b/vmod/automake_boilerplate_directors.am
@@ -15,8 +15,7 @@ libvmod_directors_la_SOURCES = \
 	vmod_directors_shard_dir.c \
 	vmod_directors_shard_dir.h
 
-libvmod_directors_la_CFLAGS = \
-	@SAN_CFLAGS@
+libvmod_directors_la_CFLAGS =
 
 vmodtoolargs_directors ?= --strict --boilerplate -o vcc_directors_if
 vmod_directors_symbols_regex ?= Vmod_directors_Data
@@ -24,8 +23,7 @@ vmod_directors_symbols_regex ?= Vmod_directors_Data
 libvmod_directors_la_LDFLAGS = \
 	-export-symbols-regex $(vmod_directors_symbols_regex) \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS) \
-	@SAN_LDFLAGS@
+	$(VMOD_LDFLAGS)
 
 nodist_libvmod_directors_la_SOURCES = vcc_directors_if.c vcc_directors_if.h
 

--- a/vmod/automake_boilerplate_proxy.am
+++ b/vmod/automake_boilerplate_proxy.am
@@ -5,8 +5,7 @@ vmod_LTLIBRARIES += libvmod_proxy.la
 libvmod_proxy_la_SOURCES = \
 	vmod_proxy.c
 
-libvmod_proxy_la_CFLAGS = \
-	@SAN_CFLAGS@
+libvmod_proxy_la_CFLAGS =
 
 vmodtoolargs_proxy ?= --strict --boilerplate -o vcc_proxy_if
 vmod_proxy_symbols_regex ?= Vmod_proxy_Data
@@ -14,8 +13,7 @@ vmod_proxy_symbols_regex ?= Vmod_proxy_Data
 libvmod_proxy_la_LDFLAGS = \
 	-export-symbols-regex $(vmod_proxy_symbols_regex) \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS) \
-	@SAN_LDFLAGS@
+	$(VMOD_LDFLAGS)
 
 nodist_libvmod_proxy_la_SOURCES = vcc_proxy_if.c vcc_proxy_if.h
 

--- a/vmod/automake_boilerplate_purge.am
+++ b/vmod/automake_boilerplate_purge.am
@@ -5,8 +5,7 @@ vmod_LTLIBRARIES += libvmod_purge.la
 libvmod_purge_la_SOURCES = \
 	vmod_purge.c
 
-libvmod_purge_la_CFLAGS = \
-	@SAN_CFLAGS@
+libvmod_purge_la_CFLAGS =
 
 vmodtoolargs_purge ?= --strict --boilerplate -o vcc_purge_if
 vmod_purge_symbols_regex ?= Vmod_purge_Data
@@ -14,8 +13,7 @@ vmod_purge_symbols_regex ?= Vmod_purge_Data
 libvmod_purge_la_LDFLAGS = \
 	-export-symbols-regex $(vmod_purge_symbols_regex) \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS) \
-	@SAN_LDFLAGS@
+	$(VMOD_LDFLAGS)
 
 nodist_libvmod_purge_la_SOURCES = vcc_purge_if.c vcc_purge_if.h
 

--- a/vmod/automake_boilerplate_std.am
+++ b/vmod/automake_boilerplate_std.am
@@ -8,8 +8,7 @@ libvmod_std_la_SOURCES = \
 	vmod_std_fileread.c \
 	vmod_std_querysort.c
 
-libvmod_std_la_CFLAGS = \
-	@SAN_CFLAGS@
+libvmod_std_la_CFLAGS =
 
 vmodtoolargs_std ?= --strict --boilerplate -o vcc_std_if
 vmod_std_symbols_regex ?= Vmod_std_Data
@@ -17,8 +16,7 @@ vmod_std_symbols_regex ?= Vmod_std_Data
 libvmod_std_la_LDFLAGS = \
 	-export-symbols-regex $(vmod_std_symbols_regex) \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS) \
-	@SAN_LDFLAGS@
+	$(VMOD_LDFLAGS)
 
 nodist_libvmod_std_la_SOURCES = vcc_std_if.c vcc_std_if.h
 

--- a/vmod/automake_boilerplate_unix.am
+++ b/vmod/automake_boilerplate_unix.am
@@ -6,8 +6,7 @@ libvmod_unix_la_SOURCES = \
 	vmod_unix.c \
 	vmod_unix_cred_compat.h
 
-libvmod_unix_la_CFLAGS = \
-	@SAN_CFLAGS@
+libvmod_unix_la_CFLAGS =
 
 vmodtoolargs_unix ?= --strict --boilerplate -o vcc_unix_if
 vmod_unix_symbols_regex ?= Vmod_unix_Data
@@ -15,8 +14,7 @@ vmod_unix_symbols_regex ?= Vmod_unix_Data
 libvmod_unix_la_LDFLAGS = \
 	-export-symbols-regex $(vmod_unix_symbols_regex) \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS) \
-	@SAN_LDFLAGS@
+	$(VMOD_LDFLAGS)
 
 nodist_libvmod_unix_la_SOURCES = vcc_unix_if.c vcc_unix_if.h
 

--- a/vmod/automake_boilerplate_vtc.am
+++ b/vmod/automake_boilerplate_vtc.am
@@ -5,8 +5,7 @@ vmod_LTLIBRARIES += libvmod_vtc.la
 libvmod_vtc_la_SOURCES = \
 	vmod_vtc.c
 
-libvmod_vtc_la_CFLAGS = \
-	@SAN_CFLAGS@
+libvmod_vtc_la_CFLAGS =
 
 vmodtoolargs_vtc ?= --strict --boilerplate -o vcc_vtc_if
 vmod_vtc_symbols_regex ?= Vmod_vtc_Data
@@ -14,8 +13,7 @@ vmod_vtc_symbols_regex ?= Vmod_vtc_Data
 libvmod_vtc_la_LDFLAGS = \
 	-export-symbols-regex $(vmod_vtc_symbols_regex) \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS) \
-	@SAN_LDFLAGS@
+	$(VMOD_LDFLAGS)
 
 nodist_libvmod_vtc_la_SOURCES = vcc_vtc_if.c vcc_vtc_if.h
 


### PR DESCRIPTION
Summary:

- new `--enable-coverage` configure flag
- `GCOVING` becomes `ENABLE_COVERAGE`
- `__SANITIZER` becomes `ENABLE_SANITIZER`
- new individual `ENABLE_*SAN` macros
- `DONT_DLCLOSE_VMODS` is now inferred
- new `coverage` and `*san` feature checks in `varnishtest`

As usual see individual commits for the details.

I'm not pushing directly despite an approval of the plan because vtest client running GCOV will need a restart  and I only tested this on my development environment.