### PR TITLE
HTTP1: Read data on backend connection reset

### DIFF
--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -210,7 +210,7 @@ sub vcl_backend_response {
 }
 
 sub vcl_builtin_backend_response {
-	if (beresp.send_failed || beresp.fetch_failed) {
+	if (bereq.send_failed || beresp.fetch_failed) {
 		set beresp.uncacheable = true;
 	}
 	if (bereq.uncacheable) {

--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -210,6 +210,9 @@ sub vcl_backend_response {
 }
 
 sub vcl_builtin_backend_response {
+	if (beresp.send_failed || beresp.fetch_failed) {
+		set beresp.uncacheable = true;
+	}
 	if (bereq.uncacheable) {
 		return (deliver);
 	}

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -313,19 +313,13 @@ vbe_dir_gethdrs(VRT_CTX, VCL_BACKEND d)
 		}
 
 		/*
-		 * If the backend closed the connection, but it sent
-		 * response with a status, use that as a response
+		 * Try to read a response too if we failed to send
+		 * the full request to the backend, as it might have
+		 * replied and closed the connection
 		 */
-		if (bo->beresp && bo->beresp->status)
-		{
-			AZ(bo->bereq_body);
-			AN(bo->htc->priv);
-			return (0);
-		}
-
-		if (bo->htc->doclose == SC_NULL) {
+		if (bo->htc->doclose == SC_NULL || bo->send_failed) {
 			assert(PFD_State(pfd) == PFD_STATE_USED);
-			if (i == 0)
+			if (i == 0 || bo->send_failed)
 				i = V1F_FetchRespHdr(bo);
 			if (i == 0) {
 				AN(bo->htc->priv);

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -321,6 +321,7 @@ vbe_dir_gethdrs(VRT_CTX, VCL_BACKEND d)
 				return (0);
 			}
 		}
+
 		/*
 		 * Try to read a response if we failed to send the full request to
 		 * the backend, as it might have replied before closing the connection

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -312,6 +312,17 @@ vbe_dir_gethdrs(VRT_CTX, VCL_BACKEND d)
 			}
 		}
 
+		/*
+		 * If the backend closed the connection, but it sent
+		 * response with a status, use that as a response
+		 */
+		if (bo->beresp && bo->beresp->status)
+		{
+			AZ(bo->bereq_body);
+			AN(bo->htc->priv);
+			return (0);
+		}
+
 		if (bo->htc->doclose == SC_NULL) {
 			assert(PFD_State(pfd) == PFD_STATE_USED);
 			if (i == 0)

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -331,6 +331,8 @@ vbf_stp_retry(struct worker *wrk, struct busyobj *bo)
 	bo->do_esi = 0;
 	bo->do_stream = 1;
 	bo->was_304 = 0;
+	bo->fetch_failed = 0;
+	bo->send_failed = 0;
 	bo->err_code = 0;
 	bo->err_reason = NULL;
 

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -139,20 +139,16 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 		*ctr_bodybytes += bytes - hdrbytes;
 	}
 
+	bo->send_failed = sc != SC_NULL;
 	if (sc == SC_NULL && i < 0)
 		sc = SC_TX_ERROR;
 
-	if (sc == SC_NULL) {
-		bo->send_failed = 0;
-	} else {
+	if (sc != SC_NULL) {
+		VSLb(bo->vsl, SLT_FetchError, "backend write error: %d (%s)",
+		    errno, VAS_errtxt(errno));
 		VSLb_ts_busyobj(bo, "Bereq", W_TIM_real(wrk));
 		htc->doclose = sc;
-		bo->send_failed = 1;
-
-		VSLb(bo->vsl, SLT_FetchError, "backend write error: %d (%s)",
-			 errno, VAS_errtxt(errno));
 		return (-1);
-
 	}
 	VSLb_ts_busyobj(bo, "Bereq", W_TIM_real(wrk));
 	return (0);

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -149,8 +149,8 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 		 * If the backend closed the connection, it might have sent some
 		 * headers explaining the situation
 		 */
-		if ((errno == ECONNRESET || errno == ENOTCONN || errno == EPIPE)
-			&& !V1F_FetchRespHdr(bo) && bo->beresp && bo->beresp->status) {
+		if (VTCP_Check(-1) && !V1F_FetchRespHdr(bo) &&
+			bo->beresp && bo->beresp->status) {
 			VSLb(bo->vsl, SLT_FetchError,
 				 "backend write error: %d (%s) but status received: %d",
 				 errno, VAS_errtxt(errno), bo->beresp->status);

--- a/bin/varnishtest/tests/b00078.vtc
+++ b/bin/varnishtest/tests/b00078.vtc
@@ -1,0 +1,25 @@
+varnishtest 3686
+
+barrier b1 cond 2
+
+server s1 {
+        rxreqhdrs
+        txresp -status 400 -body "Invalid request"
+} -start
+
+varnish v1 -vcl+backend { } -start
+
+client c1 {
+        txreq -method POST -hdr "Transfer-Encoding: chunked"
+        chunkedlen 100
+        barrier b1 sync
+        chunkedlen 100
+        chunkedlen 0
+        rxresp
+        expect resp.status == 400
+        expect resp.body == "Invalid request"
+} -start
+
+server s1 -wait
+barrier b1 sync
+client c1 -wait

--- a/bin/varnishtest/tests/b00078.vtc
+++ b/bin/varnishtest/tests/b00078.vtc
@@ -24,6 +24,12 @@ varnish v1 -vcl+backend {
 
 } -start
 
+logexpect l1 -v v1 -q "vxid == 1002" {
+    expect * 1002 Begin
+	expect * 1002 BackendClose {^\d+ s1 close}
+	fail clear
+} -start
+
 client c1 {
         txreq -method POST -hdr "Transfer-Encoding: chunked"
         chunkedlen 100
@@ -41,3 +47,4 @@ client c1 {
 server s1 -wait
 barrier b1 sync
 client c1 -wait
+logexpect l1 -wait

--- a/bin/varnishtest/tests/b00078.vtc
+++ b/bin/varnishtest/tests/b00078.vtc
@@ -12,13 +12,13 @@ varnish v1 -vcl+backend {
 
 	sub vcl_backend_response {
         set beresp.http.br_uncacheable = beresp.uncacheable;
-        set beresp.http.br_send_failed = beresp.send_failed;
+        set beresp.http.br_send_failed = bereq.send_failed;
         set beresp.http.br_fetch_failed = beresp.fetch_failed;
 	}
 
 	sub vcl_backend_error {
         set beresp.http.be_uncacheable = true;
-        set beresp.http.be_send_failed = beresp.send_failed;
+        set beresp.http.be_send_failed = bereq.send_failed;
         set beresp.http.be_fetch_failed = beresp.fetch_failed;
 	}
 

--- a/bin/varnishtest/tests/b00079.vtc
+++ b/bin/varnishtest/tests/b00079.vtc
@@ -23,6 +23,12 @@ varnish v1 -vcl+backend {
 
 } -start
 
+logexpect l1 -v v1 -q "vxid == 1002" {
+    expect * 1002 Begin
+	expect * 1002 BackendClose {^\d+ s1 close}
+	fail clear
+} -start
+
 client c1 {
         txreq -method POST -hdr "Transfer-Encoding: chunked"
         chunkedlen 100
@@ -39,4 +45,5 @@ client c1 {
 server s1 -wait
 barrier b1 sync
 client c1 -wait
+logexpect l1 -wait
 

--- a/bin/varnishtest/tests/b00079.vtc
+++ b/bin/varnishtest/tests/b00079.vtc
@@ -1,10 +1,9 @@
-varnishtest "3686: Server disconnects after reading the headers but sends a response first"
+varnishtest "3686: Server disconnects after reading the headers without sending a response"
 
 barrier b1 cond 2
 
 server s1 {
         rxreqhdrs
-        txresp -status 400 -body "Invalid request"
 } -start
 
 varnish v1 -vcl+backend {
@@ -28,16 +27,16 @@ client c1 {
         txreq -method POST -hdr "Transfer-Encoding: chunked"
         chunkedlen 100
         barrier b1 sync
-        chunkedlen 100
         chunkedlen 0
         rxresp
-        expect resp.status == 400
-        expect resp.body == "Invalid request"
-        expect resp.http.br_uncacheable == true
-        expect resp.http.br_send_failed == true
-        expect resp.http.br_fetch_failed == false
+        expect resp.status == 503
+        expect resp.reason == "Backend fetch failed"
+        expect resp.http.be_uncacheable == true
+        expect resp.http.be_send_failed == true
+        expect resp.http.be_fetch_failed == true
 } -start
 
 server s1 -wait
 barrier b1 sync
 client c1 -wait
+

--- a/bin/varnishtest/tests/b00079.vtc
+++ b/bin/varnishtest/tests/b00079.vtc
@@ -11,13 +11,13 @@ varnish v1 -vcl+backend {
 
 	sub vcl_backend_response {
         set beresp.http.br_uncacheable = beresp.uncacheable;
-        set beresp.http.br_send_failed = beresp.send_failed;
+        set beresp.http.br_send_failed = bereq.send_failed;
         set beresp.http.br_fetch_failed = beresp.fetch_failed;
 	}
 
 	sub vcl_backend_error {
         set beresp.http.be_uncacheable = true;
-        set beresp.http.be_send_failed = beresp.send_failed;
+        set beresp.http.be_send_failed = bereq.send_failed;
         set beresp.http.be_fetch_failed = beresp.fetch_failed;
 	}
 

--- a/bin/varnishtest/tests/b00080.vtc
+++ b/bin/varnishtest/tests/b00080.vtc
@@ -23,6 +23,12 @@ varnish v1 -vcl+backend {
 
 } -start
 
+logexpect l1 -v v1 -q "vxid == 1002" {
+    expect * 1002 Begin
+	expect * 1002 BackendClose {^\d+ s1 close}
+	fail clear
+} -start
+
 client c1 {
         txreq
         rxresp
@@ -35,4 +41,5 @@ client c1 {
 
 server s1 -wait
 client c1 -wait
+logexpect l1 -wait
 

--- a/bin/varnishtest/tests/b00080.vtc
+++ b/bin/varnishtest/tests/b00080.vtc
@@ -11,13 +11,13 @@ varnish v1 -vcl+backend {
 
 	sub vcl_backend_response {
         set beresp.http.br_uncacheable = beresp.uncacheable;
-        set beresp.http.br_send_failed = beresp.send_failed;
+        set beresp.http.br_send_failed = bereq.send_failed;
         set beresp.http.br_fetch_failed = beresp.fetch_failed;
 	}
 
 	sub vcl_backend_error {
         set beresp.http.be_uncacheable = true;
-        set beresp.http.be_send_failed = beresp.send_failed;
+        set beresp.http.be_send_failed = bereq.send_failed;
         set beresp.http.be_fetch_failed = beresp.fetch_failed;
 	}
 

--- a/bin/varnishtest/tests/b00080.vtc
+++ b/bin/varnishtest/tests/b00080.vtc
@@ -1,10 +1,9 @@
-varnishtest "3686: Server disconnects after reading the headers but sends a response first"
+varnishtest "3686: Server reads the whole request and disconnects without answer"
 
 barrier b1 cond 2
 
 server s1 {
-        rxreqhdrs
-        txresp -status 400 -body "Invalid request"
+        rxreq
 } -start
 
 varnish v1 -vcl+backend {
@@ -25,19 +24,15 @@ varnish v1 -vcl+backend {
 } -start
 
 client c1 {
-        txreq -method POST -hdr "Transfer-Encoding: chunked"
-        chunkedlen 100
-        barrier b1 sync
-        chunkedlen 100
-        chunkedlen 0
+        txreq
         rxresp
-        expect resp.status == 400
-        expect resp.body == "Invalid request"
-        expect resp.http.br_uncacheable == true
-        expect resp.http.br_send_failed == true
-        expect resp.http.br_fetch_failed == false
+        expect resp.status == 503
+        expect resp.reason == "Backend fetch failed"
+        expect resp.http.be_uncacheable == true
+        expect resp.http.be_send_failed == false
+        expect resp.http.be_fetch_failed == true
 } -start
 
 server s1 -wait
-barrier b1 sync
 client c1 -wait
+

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1025,6 +1025,29 @@ beresp.filters
 	After beresp.filters is set, using any of the beforementioned
 	``beresp.do_*`` switches is a VCL error.
 
+
+beresp.send_failed
+
+	Type: BOOL
+
+	Readable from: vcl_backend_response, vcl_backend_error
+
+
+	When ``true`` this indicates that we failed to send
+    the full request to the backend. The backend might
+    have still replied with a full response.
+
+beresp.fetch_failed
+
+	Type: BOOL
+
+	Readable from: vcl_backend_response, vcl_backend_error
+
+
+	When ``true`` this indicates that we failed to read
+    a full response from the backend
+
+
 obj
 ~~~
 

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -671,6 +671,16 @@ bereq.is_hitpass
 
 	If this backend request was caused by a hitpass.
 
+bereq.send_failed
+
+	Type: BOOL
+
+	Readable from: vcl_backend_response, vcl_backend_error
+
+	When ``true`` this indicates that we failed to send
+	the full request to the backend. The backend might
+	have still replied with a valid response.
+
 beresp
 ~~~~~~
 
@@ -1025,18 +1035,6 @@ beresp.filters
 	After beresp.filters is set, using any of the beforementioned
 	``beresp.do_*`` switches is a VCL error.
 
-
-beresp.send_failed
-
-	Type: BOOL
-
-	Readable from: vcl_backend_response, vcl_backend_error
-
-
-	When ``true`` this indicates that we failed to send
-    the full request to the backend. The backend might
-    have still replied with a full response.
-
 beresp.fetch_failed
 
 	Type: BOOL
@@ -1045,7 +1043,7 @@ beresp.fetch_failed
 
 
 	When ``true`` this indicates that we failed to read
-    a full response from the backend
+	a full response from the backend
 
 
 obj

--- a/include/tbl/bo_flags.h
+++ b/include/tbl/bo_flags.h
@@ -44,7 +44,7 @@ BO_FLAG(was_304,	0, 1, 0, 0, "")
 BO_FLAG(is_bgfetch,	1, 0, 0, 0, "")
 BO_FLAG(is_hitmiss,	1, 0, 0, 0, "")
 BO_FLAG(is_hitpass,	1, 0, 0, 0, "")
-BO_FLAG(send_failed,	0, 1, 0, 0, "")
+BO_FLAG(send_failed,	1, 0, 0, 0, "")
 BO_FLAG(fetch_failed,	0, 1, 0, 0, "")
 #undef BO_FLAG
 

--- a/include/tbl/bo_flags.h
+++ b/include/tbl/bo_flags.h
@@ -44,6 +44,8 @@ BO_FLAG(was_304,	0, 1, 0, 0, "")
 BO_FLAG(is_bgfetch,	1, 0, 0, 0, "")
 BO_FLAG(is_hitmiss,	1, 0, 0, 0, "")
 BO_FLAG(is_hitpass,	1, 0, 0, 0, "")
+BO_FLAG(send_failed,	0, 1, 0, 0, "")
+BO_FLAG(fetch_failed,	0, 1, 0, 0, "")
 #undef BO_FLAG
 
 /*lint -restore */


### PR DESCRIPTION
If the backend closes a connection, try to read any available data to see if there is information about it.
This is to deal with common behaviour on some web servers that close the connection as soon as they find an issue with it, for example a large content length.

References https://github.com/varnishcache/varnish-cache/issues/2332

The PR is missing tests (I need to learn how they work and how to recreate this setup within the tests) but I wanted to open it in order to receive feedback as soon as possible as this is my first contribution to the project.

An example with a server that returns `400 Bad Request` based on Content-Length and closes the connection to interrupt the upload:

Before:

```
*              << BeReq    >>   3         
-            3 Begin          b bereq 2 pass
-            3 VCL_use        b boot
-            3 Timestamp      b Start: 1630953265.053809 0.000000 0.000000
-            3 BereqMethod    b POST
-            3 BereqURL       b /v0/datasources?name=stock_prices_1M&mode=append
-            3 BereqProtocol  b HTTP/1.1
-            3 BereqHeader    b Host: localhost:6081
-            3 BereqHeader    b User-Agent: curl/7.78.0
-            3 BereqHeader    b Accept: */*
-            3 BereqHeader    b Authorization: Bearer p.eyJ1IjogImRlMzExNzI4LWY3M2ItNGRmOS05ZWFlLTA2Yzc0Y2VkZGFlNCIsICJpZCI6ICIzYTFiYTQzMC0zYzNlLTRlN2QtYjcyZS0wOTljMjE1NmNlYTQifQ.1kpgmxugmlRk6WYRB38Z6bQskT9d9qnwpEb0BAz01gM
-            3 BereqHeader    b Content-Length: 84248385
-            3 BereqHeader    b Content-Type: application/x-www-form-urlencoded
-            3 BereqHeader    b X-Forwarded-For: 127.0.0.1
-            3 BereqHeader    b X-Varnish: 3
-            3 VCL_call       b BACKEND_FETCH
-            3 VCL_return     b fetch
-            3 Timestamp      b Fetch: 1630953265.053821 0.000012 0.000012
-            3 Timestamp      b Connected: 1630953265.053908 0.000098 0.000086
-            3 BackendOpen    b 26 server1 127.0.0.1 8001 127.0.0.1 56358 connect
-            3 FetchError     b req.body read error: 104 (Connection reset by peer)
-            3 FetchError     b backend write error: 104 (Connection reset by peer)
-            3 Timestamp      b Bereq: 1630953265.056756 0.002947 0.002848
-            3 BackendClose   b 26 server1 close
-            3 Timestamp      b Beresp: 1630953265.056763 0.002954 0.000006
-            3 Timestamp      b Error: 1630953265.056764 0.002954 0.000000
-            3 BerespProtocol b HTTP/1.1
-            3 BerespStatus   b 503
-            3 BerespReason   b Backend fetch failed
-            3 BerespHeader   b Date: Mon, 06 Sep 2021 18:34:25 GMT
-            3 BerespHeader   b Server: Varnish
-            3 VCL_call       b BACKEND_ERROR
-            3 BerespHeader   b Content-Type: text/html; charset=utf-8
-            3 BerespHeader   b Retry-After: 5
-            3 VCL_return     b deliver
-            3 Storage        b malloc Transient
-            3 Length         b 278
-            3 BereqAcct      b 435 2652075 2652510 0 0 0
-            3 End            b 

*              << Request  >>   2         
-            2 Begin          c req 1 rxreq
-            2 Timestamp      c Start: 1630953265.053717 0.000000 0.000000
-            2 Timestamp      c Req: 1630953265.053717 0.000000 0.000000
-            2 VCL_use        c boot
-            2 ReqUnset       c Expect: 100-continue
-            2 ReqStart       c 127.0.0.1 56556 a0
-            2 ReqMethod      c POST
-            2 ReqURL         c /v0/datasources?name=stock_prices_1M&mode=append
-            2 ReqProtocol    c HTTP/1.1
-            2 ReqHeader      c Host: localhost:6081
-            2 ReqHeader      c User-Agent: curl/7.78.0
-            2 ReqHeader      c Accept: */*
-            2 ReqHeader      c Authorization: Bearer p.eyJ1IjogImRlMzExNzI4LWY3M2ItNGRmOS05ZWFlLTA2Yzc0Y2VkZGFlNCIsICJpZCI6ICIzYTFiYTQzMC0zYzNlLTRlN2QtYjcyZS0wOTljMjE1NmNlYTQifQ.1kpgmxugmlRk6WYRB38Z6bQskT9d9qnwpEb0BAz01gM
-            2 ReqHeader      c Content-Length: 84248385
-            2 ReqHeader      c Content-Type: application/x-www-form-urlencoded
-            2 ReqHeader      c X-Forwarded-For: 127.0.0.1
-            2 VCL_call       c RECV
-            2 VCL_return     c pass
-            2 RespProtocol   c HTTP/1.1
-            2 RespStatus     c 100
-            2 RespReason     c Continue
-            2 VCL_call       c HASH
-            2 VCL_return     c lookup
-            2 VCL_call       c PASS
-            2 VCL_return     c fetch
-            2 Link           c bereq 3 pass
-            2 Storage        c malloc Transient
-            2 Timestamp      c ReqBody: 1630953265.056595 0.002877 0.002877
-            2 Timestamp      c Fetch: 1630953265.056799 0.003082 0.000204
-            2 RespProtocol   c HTTP/1.1
-            2 RespStatus     c 503
-            2 RespReason     c Backend fetch failed
-            2 RespHeader     c Date: Mon, 06 Sep 2021 18:34:25 GMT
-            2 RespHeader     c Server: Varnish
-            2 RespHeader     c Content-Type: text/html; charset=utf-8
-            2 RespHeader     c Retry-After: 5
-            2 RespHeader     c X-Varnish: 2
-            2 RespHeader     c Age: 0
-            2 RespHeader     c Via: 1.1 varnish (Varnish/6.6)
-            2 VCL_call       c DELIVER
-            2 RespUnset      c Via: 1.1 varnish (Varnish/6.6)
-            2 RespUnset      c X-Varnish: 2
-            2 RespUnset      c Age: 0
-            2 VCL_return     c deliver
-            2 Timestamp      c Process: 1630953265.056806 0.003089 0.000007
-            2 Filters        c 
-            2 RespHeader     c Content-Length: 278
-            2 RespHeader     c Connection: close
-            2 Timestamp      c Resp: 1630953265.056848 0.003131 0.000041
-            2 ReqAcct        c 415 4390912 4391327 212 278 490
-            2 End            c 

*              << Session  >>   1         
-            1 Begin          c sess 0 HTTP/1
-            1 SessOpen       c 127.0.0.1 56556 a0 127.0.0.1 6081 1630953265.053680 24
-            1 Link           c req 2 rxreq
-            1 SessClose      c RX_BODY 0.003
-            1 End            c 

```


After:

```
*              << BeReq    >>   3         
-            3 Begin          b bereq 2 pass
-            3 VCL_use        b boot
-            3 Timestamp      b Start: 1630953155.802987 0.000000 0.000000
-            3 BereqMethod    b POST
-            3 BereqURL       b /v0/datasources?name=stock_prices_1M&mode=append
-            3 BereqProtocol  b HTTP/1.1
-            3 BereqHeader    b Host: localhost:6081
-            3 BereqHeader    b User-Agent: curl/7.78.0
-            3 BereqHeader    b Accept: */*
-            3 BereqHeader    b Authorization: Bearer p.eyJ1IjogImRlMzExNzI4LWY3M2ItNGRmOS05ZWFlLTA2Yzc0Y2VkZGFlNCIsICJpZCI6ICIzYTFiYTQzMC0zYzNlLTRlN2QtYjcyZS0wOTljMjE1NmNlYTQifQ.1kpgmxugmlRk6WYRB38Z6bQskT9d9qnwpEb0BAz01gM
-            3 BereqHeader    b Content-Length: 84248385
-            3 BereqHeader    b Content-Type: application/x-www-form-urlencoded
-            3 BereqHeader    b X-Forwarded-For: 127.0.0.1
-            3 BereqHeader    b X-Varnish: 3
-            3 VCL_call       b BACKEND_FETCH
-            3 VCL_return     b fetch
-            3 Timestamp      b Fetch: 1630953155.803004 0.000017 0.000017
-            3 Timestamp      b Connected: 1630953155.803081 0.000093 0.000076
-            3 BackendOpen    b 26 server1 127.0.0.1 8001 127.0.0.1 56304 connect
-            3 FetchError     b req.body read error: 104 (Connection reset by peer)
-            3 Timestamp      b Bereq: 1630953155.805908 0.002920 0.002826
-            3 FetchError     b backend write error: 104 (Connection reset by peer) but status received: 400
-            3 Timestamp      b Beresp: 1630953155.805916 0.002928 0.000008
-            3 BerespProtocol b HTTP/1.1
-            3 BerespStatus   b 400
-            3 BerespReason   b Bad Request
-            3 BerespHeader   b Date: Mon, 06 Sep 2021 18:32:35 GMT
-            3 VCL_call       b BACKEND_RESPONSE
-            3 TTL            b VCL 60 0 0 1630953156 uncacheable
-            3 TTL            b VCL 60 60 0 1630953156 uncacheable
-            3 VCL_return     b deliver
-            3 Timestamp      b Process: 1630953155.805925 0.002938 0.000009
-            3 Filters        b 
-            3 Storage        b malloc Transient
-            3 Fetch_Body     b 4 eof stream
-            3 BackendClose   b 26 server1 close
-            3 Timestamp      b BerespBody: 1630953155.805949 0.002961 0.000023
-            3 Length         b 0
-            3 BereqAcct      b 435 2652075 2652510 28 0 28
-            3 End            b 

*              << Request  >>   2         
-            2 Begin          c req 1 rxreq
-            2 Timestamp      c Start: 1630953155.802913 0.000000 0.000000
-            2 Timestamp      c Req: 1630953155.802913 0.000000 0.000000
-            2 VCL_use        c boot
-            2 ReqUnset       c Expect: 100-continue
-            2 ReqStart       c 127.0.0.1 56554 a0
-            2 ReqMethod      c POST
-            2 ReqURL         c /v0/datasources?name=stock_prices_1M&mode=append
-            2 ReqProtocol    c HTTP/1.1
-            2 ReqHeader      c Host: localhost:6081
-            2 ReqHeader      c User-Agent: curl/7.78.0
-            2 ReqHeader      c Accept: */*
-            2 ReqHeader      c Authorization: Bearer p.eyJ1IjogImRlMzExNzI4LWY3M2ItNGRmOS05ZWFlLTA2Yzc0Y2VkZGFlNCIsICJpZCI6ICIzYTFiYTQzMC0zYzNlLTRlN2QtYjcyZS0wOTljMjE1NmNlYTQifQ.1kpgmxugmlRk6WYRB38Z6bQskT9d9qnwpEb0BAz01gM
-            2 ReqHeader      c Content-Length: 84248385
-            2 ReqHeader      c Content-Type: application/x-www-form-urlencoded
-            2 ReqHeader      c X-Forwarded-For: 127.0.0.1
-            2 VCL_call       c RECV
-            2 VCL_return     c pass
-            2 RespProtocol   c HTTP/1.1
-            2 RespStatus     c 100
-            2 RespReason     c Continue
-            2 VCL_call       c HASH
-            2 VCL_return     c lookup
-            2 VCL_call       c PASS
-            2 VCL_return     c fetch
-            2 Link           c bereq 3 pass
-            2 Storage        c malloc Transient
-            2 Timestamp      c ReqBody: 1630953155.805755 0.002841 0.002841
-            2 Timestamp      c Fetch: 1630953155.805938 0.003024 0.000182
-            2 RespProtocol   c HTTP/1.1
-            2 RespStatus     c 400
-            2 RespReason     c Bad Request
-            2 RespHeader     c Date: Mon, 06 Sep 2021 18:32:35 GMT
-            2 RespHeader     c X-Varnish: 2
-            2 RespHeader     c Age: 0
-            2 RespHeader     c Via: 1.1 varnish (Varnish/6.6)
-            2 VCL_call       c DELIVER
-            2 RespUnset      c Via: 1.1 varnish (Varnish/6.6)
-            2 RespUnset      c X-Varnish: 2
-            2 RespUnset      c Age: 0
-            2 VCL_return     c deliver
-            2 Timestamp      c Process: 1630953155.805943 0.003029 0.000005
-            2 Filters        c 
-            2 RespHeader     c Connection: close
-            2 RespHeader     c Transfer-Encoding: chunked
-            2 Timestamp      c Resp: 1630953155.805983 0.003070 0.000040
-            2 ReqAcct        c 415 4193191 4193606 137 0 137
-            2 End            c 

*              << Session  >>   1         
-            1 Begin          c sess 0 HTTP/1
-            1 SessOpen       c 127.0.0.1 56554 a0 127.0.0.1 6081 1630953155.802880 22
-            1 Link           c req 2 rxreq
-            1 SessClose      c RX_BODY 0.003
-            1 End            c 
```