### PR TITLE
param: Cleanup of cc_command (and collaterals)

### DIFF
--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -233,6 +233,7 @@ void mgt_vcl_startup(struct cli *, const char *vclsrc, const char *origin,
 int mgt_push_vcls(struct cli *, unsigned *status, char **p);
 const char *mgt_has_vcl(void);
 extern char *mgt_cc_cmd;
+extern char *mgt_cc_cmd_def;
 extern char *mgt_cc_warn;
 extern const char *mgt_vcl_path;
 extern const char *mgt_vmod_path;

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -233,6 +233,7 @@ void mgt_vcl_startup(struct cli *, const char *vclsrc, const char *origin,
 int mgt_push_vcls(struct cli *, unsigned *status, char **p);
 const char *mgt_has_vcl(void);
 extern char *mgt_cc_cmd;
+extern char *mgt_cc_warn;
 extern const char *mgt_vcl_path;
 extern const char *mgt_vmod_path;
 #define MGT_VCC(t, n, cc) extern t mgt_vcc_ ## n;

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -110,6 +110,11 @@ static const char PLATFORM_DEPENDENT_TEXT[] =
 	"NB: This parameter depends on a feature which is not available"
 	" on all platforms.";
 
+static const char BUILD_OPTIONS_TEXT[] =
+	"\n\n"
+	"NB: The actual default value for this parameter depends on the"
+	" Varnish build environment and options.";
+
 /*--------------------------------------------------------------------*/
 
 static struct parspec *
@@ -343,6 +348,8 @@ mcf_param_show(struct cli *cli, const char * const *av, void *priv)
 				mcf_wrap(cli, PROTECTED_TEXT);
 			if (pp->flags & ONLY_ROOT)
 				mcf_wrap(cli, ONLY_ROOT_TEXT);
+			if (pp->flags & BUILD_OPTIONS)
+				mcf_wrap(cli, BUILD_OPTIONS_TEXT);
 			VCLI_Out(cli, "\n\n");
 		}
 	}
@@ -464,6 +471,7 @@ mcf_param_show_json(struct cli *cli, const char * const *av, void *priv)
 		flag_out(WIZARD, wizard);
 		flag_out(PROTECTED, protected);
 		flag_out(ONLY_ROOT, only_root);
+		flag_out(BUILD_OPTIONS, build_options);
 
 #undef flag_out
 
@@ -806,6 +814,9 @@ MCF_DumpRstParam(void)
 		if (pp->flags && pp->flags & PLATFORM_DEPENDENT)
 			printf("\n%s\n\n", PLATFORM_DEPENDENT_TEXT);
 
+		if (pp->flags && pp->flags & BUILD_OPTIONS)
+			printf("\n%s\n\n", BUILD_OPTIONS_TEXT);
+
 		if (pp->units != NULL && *pp->units != '\0')
 			printf("\t* Units: %s\n", pp->units);
 #define MCF_DYN_REASON(lbl, nm)					\
@@ -823,7 +834,7 @@ MCF_DumpRstParam(void)
 		 * XXX: that say if ->min/->max are valid, so we
 		 * XXX: can emit those also in help texts.
 		 */
-		if (pp->flags & ~(NOT_IMPLEMENTED|PLATFORM_DEPENDENT)) {
+		if (pp->flags & ~DOCS_FLAGS) {
 			printf("\t* Flags: ");
 			q = "";
 

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -765,6 +765,9 @@ MCF_InitParams(struct cli *cli)
 		mcf_wash_param(cli, pp, MCF_DEFAULT, "default", vsb);
 	}
 	VSB_destroy(&vsb);
+
+	AN(mgt_cc_cmd);
+	REPLACE(mgt_cc_cmd_def, mgt_cc_cmd);
 }
 
 /*--------------------------------------------------------------------*/

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -57,6 +57,9 @@ struct parspec {
 #define ONLY_ROOT		(1<<7)
 #define NOT_IMPLEMENTED		(1<<8)
 #define PLATFORM_DEPENDENT	(1<<9)
+#define BUILD_OPTIONS		(1<<10)
+
+#define DOCS_FLAGS	(NOT_IMPLEMENTED|PLATFORM_DEPENDENT|BUILD_OPTIONS)
 
 	const char	*dyn_min_reason;
 	const char	*dyn_max_reason;

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -63,6 +63,7 @@ struct vcc_priv {
 };
 
 char *mgt_cc_cmd;
+char *mgt_cc_warn;
 const char *mgt_vcl_path;
 const char *mgt_vmod_path;
 #define MGT_VCC(t, n, cc) t mgt_vcc_ ## n;
@@ -149,6 +150,9 @@ run_cc(void *priv)
 				break;
 			case 'o':
 				VSB_cat(sb, VGC_LIB);
+				break;
+			case 'w':
+				VSB_cat(sb, mgt_cc_warn);
 				break;
 			case '%':
 				VSB_putc(sb, '%');

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -63,6 +63,7 @@ struct vcc_priv {
 };
 
 char *mgt_cc_cmd;
+char *mgt_cc_cmd_def;
 char *mgt_cc_warn;
 const char *mgt_vcl_path;
 const char *mgt_vmod_path;
@@ -153,6 +154,9 @@ run_cc(void *priv)
 				break;
 			case 'w':
 				VSB_cat(sb, mgt_cc_warn);
+				break;
+			case 'd':
+				VSB_cat(sb, mgt_cc_cmd_def);
 				break;
 			case '%':
 				VSB_putc(sb, '%');

--- a/bin/varnishtest/tests/c00109.vtc
+++ b/bin/varnishtest/tests/c00109.vtc
@@ -1,0 +1,9 @@
+varnishtest "cc_command and cc_warnings"
+
+varnish v1 -cliok {param.set debug +vcl_keep}
+varnish v1 -cliok {param.set cc_command "! printf '%w' >world"}
+varnish v1 -cliok {param.set cc_warnings hello}
+
+varnish v1 -errvcl "VCL compilation failed" "backend be none;"
+
+shell -expect hello "cat v1/vcl_*/world"

--- a/bin/varnishtest/tests/c00109.vtc
+++ b/bin/varnishtest/tests/c00109.vtc
@@ -1,9 +1,11 @@
 varnishtest "cc_command and cc_warnings"
 
 varnish v1 -cliok {param.set debug +vcl_keep}
-varnish v1 -cliok {param.set cc_command "! printf '%w' >world"}
 varnish v1 -cliok {param.set cc_warnings hello}
+varnish v1 -cliok {param.set cc_command << EOF
+! printf 'd="%%s" w="%%s"' '%d' '%w' >world
+EOF}
 
 varnish v1 -errvcl "VCL compilation failed" "backend be none;"
 
-shell -expect hello "cat v1/vcl_*/world"
+shell -match {d=".+" w="hello"} "cat v1/vcl_*/world"

--- a/bin/varnishtest/tests/c00109.vtc
+++ b/bin/varnishtest/tests/c00109.vtc
@@ -3,9 +3,9 @@ varnishtest "cc_command and cc_warnings"
 varnish v1 -cliok {param.set debug +vcl_keep}
 varnish v1 -cliok {param.set cc_warnings hello}
 varnish v1 -cliok {param.set cc_command << EOF
-! printf 'd="%%s" w="%%s"' '%d' '%w' >world
+! printf 'd="%%s" D="%%s" w="%%s"' '%d' '%D' '%w' >world
 EOF}
 
 varnish v1 -errvcl "VCL compilation failed" "backend be none;"
 
-shell -match {d=".+" w="hello"} "cat v1/vcl_*/world"
+shell -match {d=".+" D=".+hello.+" w="hello"} "cat v1/vcl_*/world"

--- a/bin/varnishtest/tests/c00109.vtc
+++ b/bin/varnishtest/tests/c00109.vtc
@@ -3,9 +3,11 @@ varnishtest "cc_command and cc_warnings"
 varnish v1 -cliok {param.set debug +vcl_keep}
 varnish v1 -cliok {param.set cc_warnings hello}
 varnish v1 -cliok {param.set cc_command << EOF
-! printf 'd="%%s" D="%%s" w="%%s"' '%d' '%D' '%w' >world
+! printf 'd="%%s" D="%%s" w="%%s" n="%%s"' '%d' '%D' '%w' '%n' >world
 EOF}
 
 varnish v1 -errvcl "VCL compilation failed" "backend be none;"
 
-shell -match {d=".+" D=".+hello.+" w="hello"} "cat v1/vcl_*/world"
+shell -match {d=".+" D=".+hello.+" w="hello" n="${v1_name}"} {
+	exec cat v1/vcl_*/world
+}

--- a/configure.ac
+++ b/configure.ac
@@ -654,9 +654,11 @@ gl_LD_VERSION_SCRIPT
 # idiocy where write is marked as warn_unused_result, causing build
 # failures.
 
+WFLAGS=
+
 AX_CHECK_COMPILE_FLAG([-Wall],
      [CFLAGS="${CFLAGS} -Wall"
-      OCFLAGS="${OCFLAGS} -Wall"])
+      WFLAGS="${WFLAGS} -Wall"])
 
 if test "$SUNCC" = "yes" ; then
     SUNCC_CFLAGS=" \
@@ -665,27 +667,27 @@ if test "$SUNCC" = "yes" ; then
 	"
     AX_CHECK_COMPILE_FLAG([${SUNCC_CFLAGS}],
 	[CFLAGS="${CFLAGS} ${SUNCC_CFLAGS}"
-	 OCFLAGS="${OCFLAGS} ${SUNCC_CFLAGS}"])
+	 WFLAGS="${WFLAGS} ${SUNCC_CFLAGS}"])
 else
     AX_CHECK_COMPILE_FLAG([-Werror],
 	[CFLAGS="${CFLAGS} -Werror"
-	 OCFLAGS="${OCFLAGS} -Werror"])
+	 WFLAGS="${WFLAGS} -Werror"])
 fi
 
 case $target in
     *-*-darwin*)
 	AX_CHECK_COMPILE_FLAG([-Wno-expansion-to-defined],
 	[CFLAGS="${CFLAGS} -Wno-expansion-to-defined"
-	 OCFLAGS="${OCFLAGS} -Wno-expansion-to-defined"])
+	 WFLAGS="${WFLAGS} -Wno-expansion-to-defined"])
 	;;
 esac
 
 AX_CHECK_COMPILE_FLAG([-Werror=unused-result],
     [CFLAGS="${CFLAGS} -Wno-error=unused-result"
-     OCFLAGS="${OCFLAGS} -Wno-error=unused-result"],
+     WFLAGS="${WFLAGS} -Wno-error=unused-result"],
     [AX_CHECK_COMPILE_FLAG([-Wunused-result],
      [CFLAGS="${CFLAGS} -Wno-unused-result"
-      OCFLAGS="${OCFLAGS} -Wno-unused-result"])])
+      WFLAGS="${WFLAGS} -Wno-unused-result"])])
 
 # This corresponds to FreeBSD's WARNS level 6
 DEVELOPER_CFLAGS=`$PYTHON $srcdir/wflags.py`
@@ -721,7 +723,7 @@ if test "x$SUNCC" != "xyes" && test "x$enable_developer_warnings" != "xno"; then
 		[])
 
 	CFLAGS="${CFLAGS} ${DEVELOPER_CFLAGS}"
-	OCFLAGS="${OCFLAGS} ${DEVELOPER_CFLAGS}"
+	WFLAGS="${WFLAGS} ${DEVELOPER_CFLAGS}"
 fi
 
 # gcc on solaris needs -fstack-protector when calling gcc in linker
@@ -804,22 +806,24 @@ else
 	*-*-solaris*)
 		case $PTHREAD_CC in
 		*gcc*)
-			VCC_CC="$PTHREAD_CC $OCFLAGS $PTHREAD_CFLAGS -fpic -shared -o %o %s"
+			VCC_CC="$PTHREAD_CC $OCFLAGS $WFLAGS $PTHREAD_CFLAGS -fpic -shared -o %o %s"
 			break
 			;;
 		*cc)
-			VCC_CC="$PTHREAD_CC $OCFLAGS -errwarn=%all,no%E_STATEMENT_NOT_REACHED $PTHREAD_CFLAGS -Kpic -G -o %o %s"
+			VCC_CC="$PTHREAD_CC $OCFLAGS $WFLAGS -errwarn=%all,no%E_STATEMENT_NOT_REACHED $PTHREAD_CFLAGS -Kpic -G -o %o %s"
 			;;
 		esac
 		;;
 	*-*-darwin*)
-		VCC_CC="exec cc $OCFLAGS -dynamiclib -Wl,-undefined,dynamic_lookup -o %o %s"
+		VCC_CC="exec cc $OCFLAGS $WFLAGS -dynamiclib -Wl,-undefined,dynamic_lookup -o %o %s"
 		;;
 	*)
-		VCC_CC="exec $PTHREAD_CC $OCFLAGS $PTHREAD_CFLAGS $SAN_CFLAGS -fpic -shared -Wl,-x -o %o %s"
+		VCC_CC="exec $PTHREAD_CC $OCFLAGS $WFLAGS $PTHREAD_CFLAGS $SAN_CFLAGS -fpic -shared -Wl,-x -o %o %s"
 		;;
 	esac
 fi
+
+OCFLAGS="$OCFLAGS $WFLAGS"
 
 AC_DEFINE_UNQUOTED([VCC_CC],"$VCC_CC",[C compiler command line for VCL code])
 

--- a/configure.ac
+++ b/configure.ac
@@ -810,7 +810,7 @@ else
 			break
 			;;
 		*cc)
-			VCC_CC="$PTHREAD_CC $OCFLAGS %w -errwarn=%all,no%E_STATEMENT_NOT_REACHED $PTHREAD_CFLAGS -Kpic -G -o %o %s"
+			VCC_CC="$PTHREAD_CC $OCFLAGS %w -errwarn=%%all,no%%E_STATEMENT_NOT_REACHED $PTHREAD_CFLAGS -Kpic -G -o %o %s"
 			;;
 		esac
 		;;

--- a/configure.ac
+++ b/configure.ac
@@ -806,26 +806,33 @@ else
 	*-*-solaris*)
 		case $PTHREAD_CC in
 		*gcc*)
-			VCC_CC="$PTHREAD_CC $OCFLAGS $WFLAGS $PTHREAD_CFLAGS -fpic -shared -o %o %s"
+			VCC_CC="$PTHREAD_CC $OCFLAGS %w $PTHREAD_CFLAGS -fpic -shared -o %o %s"
 			break
 			;;
 		*cc)
-			VCC_CC="$PTHREAD_CC $OCFLAGS $WFLAGS -errwarn=%all,no%E_STATEMENT_NOT_REACHED $PTHREAD_CFLAGS -Kpic -G -o %o %s"
+			VCC_CC="$PTHREAD_CC $OCFLAGS %w -errwarn=%all,no%E_STATEMENT_NOT_REACHED $PTHREAD_CFLAGS -Kpic -G -o %o %s"
 			;;
 		esac
 		;;
 	*-*-darwin*)
-		VCC_CC="exec cc $OCFLAGS $WFLAGS -dynamiclib -Wl,-undefined,dynamic_lookup -o %o %s"
+		VCC_CC="exec cc $OCFLAGS %w -dynamiclib -Wl,-undefined,dynamic_lookup -o %o %s"
 		;;
 	*)
-		VCC_CC="exec $PTHREAD_CC $OCFLAGS $WFLAGS $PTHREAD_CFLAGS $SAN_CFLAGS -fpic -shared -Wl,-x -o %o %s"
+		VCC_CC="exec $PTHREAD_CC $OCFLAGS %w $PTHREAD_CFLAGS $SAN_CFLAGS -fpic -shared -Wl,-x -o %o %s"
 		;;
 	esac
+fi
+
+if test "$ac_cv_env_VCC_WARN_set" = set; then
+	VCC_WARN=$ac_cv_env_VCC_WARN_value
+else
+	VCC_WARN=$WFLAGS
 fi
 
 OCFLAGS="$OCFLAGS $WFLAGS"
 
 AC_DEFINE_UNQUOTED([VCC_CC],"$VCC_CC",[C compiler command line for VCL code])
+AC_DEFINE_UNQUOTED([VCC_WARN],"$VCC_WARN",[C compiler warnings for VCL code])
 
 # Stupid automake needs this
 VTC_TESTS="$(cd $srcdir/bin/varnishtest && echo tests/*.vtc)"

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1533,7 +1533,20 @@ PARAM_STRING(
 	"Command used for compiling the C source code to a "
 	"dlopen(3) loadable object.  Any occurrence of %s in "
 	"the string will be replaced with the source file name, "
-	"and %o will be replaced with the output file name.",
+	"%o will be replaced with the output file name, and %w "
+	"will be replaced by the cc_warnings parameter.",
+	/* flags */	MUST_RELOAD
+)
+
+PARAM_STRING(
+	/* name */	cc_warnings,
+	/* tweak */	tweak_string,
+	/* priv */	&mgt_cc_warn,
+	/* def */	VCC_WARN,
+	/* descr */
+	"Warnings used when compiling the C source code with "
+	"the cc_command parameter. By default, VCL is compiled "
+	"with the same set of warnings as Varnish itself.",
 	/* flags */	MUST_RELOAD
 )
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1535,7 +1535,10 @@ PARAM_STRING(
 	"the string will be replaced with the source file name, "
 	"%o will be replaced with the output file name, and %w "
 	"will be replaced by the cc_warnings parameter.",
-	/* flags */	MUST_RELOAD
+	/* flags */	MUST_RELOAD | BUILD_OPTIONS,
+	/* dyn_min_reason */	NULL,
+	/* dyn_max_reason */	NULL,
+	/* dyn_def_reason */	"exec $CC $CFLAGS %w -shared -o %o %s"
 )
 
 PARAM_STRING(
@@ -1547,7 +1550,10 @@ PARAM_STRING(
 	"Warnings used when compiling the C source code with "
 	"the cc_command parameter. By default, VCL is compiled "
 	"with the same set of warnings as Varnish itself.",
-	/* flags */	MUST_RELOAD
+	/* flags */	MUST_RELOAD | BUILD_OPTIONS,
+	/* dyn_min_reason */	NULL,
+	/* dyn_max_reason */	NULL,
+	/* dyn_def_reason */	"-Wall -Werror"
 )
 
 PARAM_STRING(
@@ -1573,7 +1579,11 @@ PARAM_STRING(
 	"VCL files in both the system configuration and shared "
 	"data directories to allow packages to drop their VCL "
 	"files in a standard location where relative includes "
-	"would work."
+	"would work.",
+	/* flags */	BUILD_OPTIONS,
+	/* dyn_min_reason */	NULL,
+	/* dyn_max_reason */	NULL,
+	/* dyn_def_reason */	"${sysconfdir}/varnish:${datadir}/varnish/vcl"
 )
 
 PARAM_STRING(
@@ -1583,7 +1593,11 @@ PARAM_STRING(
 	/* def */	VARNISH_VMOD_DIR,
 	/* descr */
 	"Directory (or colon separated list of directories) "
-	"where VMODs are to be found."
+	"where VMODs are to be found.",
+	/* flags */	BUILD_OPTIONS,
+	/* dyn_min_reason */	NULL,
+	/* dyn_max_reason */	NULL,
+	/* dyn_def_reason */	"${libdir}/varnish/vmods"
 )
 
 /*--------------------------------------------------------------------

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1538,6 +1538,7 @@ PARAM_STRING(
 	"- %w: the cc_warnings parameter\n"
 	"- %d: the raw default cc_command\n"
 	"- %D: the expanded default cc_command\n"
+	"- %n: the working directory (-n option)\n"
 	"- %%: a percent sign\n"
 	"\n"
 	"Unknown percent expansion sequences are ignored, and to "

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1530,12 +1530,22 @@ PARAM_STRING(
 	/* priv */	&mgt_cc_cmd,
 	/* def */	VCC_CC,
 	/* descr */
-	"Command used for compiling the C source code to a "
-	"dlopen(3) loadable object.  Any occurrence of %s in "
-	"the string will be replaced with the source file name, "
-	"%o will be replaced with the output file name, and %w "
-	"will be replaced by the cc_warnings parameter. The %d "
-	"sequence expands to the default value for cc_command.",
+	"The command used for compiling the C source code to a "
+	"dlopen(3) loadable object. The following expansions can "
+	"be used:\n\n"
+	"- %s: the source file name\n"
+	"- %o: the output file name\n"
+	"- %w: the cc_warnings parameter\n"
+	"- %d: the raw default cc_command\n"
+	"- %D: the expanded default cc_command\n"
+	"- %%: a percent sign\n"
+	"\n"
+	"Unknown percent expansion sequences are ignored, and to "
+	"avoid future incompatibilities percent characters should "
+	"be escaped with a double percent sequence.\n\n"
+	"The %d and %D expansions allow passing the parameter's "
+	"default value to a wrapper script to perform additional "
+	"processing.",
 	/* flags */	MUST_RELOAD | BUILD_OPTIONS,
 	/* dyn_min_reason */	NULL,
 	/* dyn_max_reason */	NULL,

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1534,7 +1534,8 @@ PARAM_STRING(
 	"dlopen(3) loadable object.  Any occurrence of %s in "
 	"the string will be replaced with the source file name, "
 	"%o will be replaced with the output file name, and %w "
-	"will be replaced by the cc_warnings parameter.",
+	"will be replaced by the cc_warnings parameter. The %d "
+	"sequence expands to the default value for cc_command.",
 	/* flags */	MUST_RELOAD | BUILD_OPTIONS,
 	/* dyn_min_reason */	NULL,
 	/* dyn_max_reason */	NULL,


### PR DESCRIPTION
See the current trunk docs for `cc_command`:

https://varnish-cache.org/docs/trunk/reference/varnishd.html#cc-command

Currently it says:

> Default: exec clang -g -O2 -Wall -Werror -Wno-error=unused-result -fstack-protector-strong -Werror -Wall -Wcast-align -Wcast-qual -Wchar-subscripts -Wempty-body -Wextra -Wformat -Wformat-y2k -Wformat -Wformat-zero-length -Wmissing-field-initializers -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wpointer-sign -Wreturn-type -Wshadow -Wstrict-aliasing -Wstrict-prototypes -Wstring-plus-int -Wswitch -Wunused-parameter -Wunused-result -Wwrite-strings -Wno-old-style-definition -Wno-sign-compare -Wno-implicit-fallthrough -Wno-missing-variable-declarations -Wno-nullability-completeness -fstack-protector -Wno-missing-field-initializers -pthread -fpic -shared -Wl,-x -o %o %s

On the environment building the online docs, `param.show cc_command` would report the same default value.

After merging this pull request it would say, in the docs:

> Default: exec c99 -lpthread -shared -fPIC -o %o %s

The default value reported by `param.show cc_command` for the environment building the online docs would become:

> Default: exec clang -g -O2 -pthread -fpic -shared -Wl,-x -o %o %s

The collaterals are `vcl_path` and `vmod_path`, see individual commits for more details.

I would like to target 7.0 with this change.