### PR TITLE
vcl: Introduce req.uncacheable

### DIFF
--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -282,6 +282,7 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 	req->t_req = NAN;
 	req->req_body_status = NULL;
 
+	req->uncacheable = 0;
 	req->hash_always_miss = 0;
 	req->hash_ignore_busy = 0;
 	req->hash_ignore_vary = 0;

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -880,6 +880,7 @@ cnt_recv_prep(struct req *req, const char *ci)
 		req->storage = NULL;
 	}
 
+	req->uncacheable = 0;
 	req->is_hit = 0;
 	req->is_hitmiss = 0;
 	req->is_hitpass = 0;
@@ -954,6 +955,9 @@ cnt_recv(struct worker *wrk, struct req *req)
 		req->doclose = SC_RX_BODY;
 		return (REQ_FSM_DONE);
 	}
+
+	if (wrk->handling == VCL_RET_HASH && req->uncacheable)
+		wrk->handling = VCL_RET_PASS;
 
 	recv_handling = wrk->handling;
 

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -790,6 +790,21 @@ VRT_r_req_##field(VRT_CTX)						\
 	VREQW##w(l)
 #include "tbl/req_flags.h"
 
+VCL_VOID
+VRT_l_req_uncacheable(VRT_CTX, VCL_BOOL a)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+
+	if (ctx->req->uncacheable && !a) {
+		VSLb(ctx->vsl, SLT_VCL_Error,
+		    "Ignoring attempt to reset req.uncacheable");
+	} else if (a) {
+		ctx->req->uncacheable = 1;
+	}
+}
+
 /*--------------------------------------------------------------------*/
 
 #define GIP(fld)						\

--- a/bin/varnishtest/tests/c00109.vtc
+++ b/bin/varnishtest/tests/c00109.vtc
@@ -1,0 +1,46 @@
+varnishtest "req.uncacheable"
+
+server s1 {
+	loop 3 {
+		rxreq
+		txresp
+	}
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.http.uncacheable) {
+			set req.uncacheable = true;
+			if (req.http.uncacheable == "restart") {
+				unset req.http.uncacheable;
+				return (restart);
+			}
+		}
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.X-Varnish == 1001
+
+	txreq
+	rxresp
+	expect resp.http.X-Varnish == "1003 1002"
+
+	txreq -hdr "uncacheable: true"
+	rxresp
+	expect resp.http.X-Varnish == 1004
+
+	txreq -hdr "uncacheable: true"
+	rxresp
+	expect resp.http.X-Varnish == 1006
+
+	txreq -hdr "uncacheable: restart"
+	rxresp
+	expect resp.http.X-Varnish == "1009 1002"
+} -run
+
+varnish v1 -expect cache_miss == 1
+varnish v1 -expect cache_hit == 2
+varnish v1 -expect s_pass == 2

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -393,6 +393,27 @@ req.hash_always_miss
 	This is useful to force-update the cache without invalidating
 	existing entries in case the fetch fails.
 
+req.uncacheable
+
+	Type: BOOL
+
+	Readable from: client
+
+	Writable from: client
+
+	Default: ``false``.
+
+	Force a cache pass for this request, even if perfectly
+	good matching objects are in the cache.
+
+	This allows to mark a request as uncacheable in ``vcl_recv``
+	without immediately returning from the subroutine with a
+	``pass`` transition.
+
+	Clearing the variable has no effect and will log the warning
+	"Ignoring attempt to reset req.uncacheable".
+
+
 req.is_hitmiss
 
 	Type: BOOL
@@ -593,9 +614,9 @@ bereq.uncacheable
 	Readable from: backend
 
 
-	Indicates whether this request is uncacheable due to a
-	`pass` in the client side or a hit on an hit-for-pass object.
-
+	Indicates whether this request is uncacheable due to a ``pass``
+	transition or ``req.uncacheable`` being set on the client side
+	or a hit on an hit-for-pass object.
 
 bereq.connect_timeout
 
@@ -1125,8 +1146,8 @@ obj.uncacheable
 
 	Readable from: vcl_deliver
 
-	Whether the object is uncacheable (pass, hit-for-pass or
-	hit-for-miss).
+	Whether the object is uncacheable (pass, ``req.uncacheable``,
+	hit-for-pass or hit-for-miss).
 
 
 obj.storage

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -42,6 +42,7 @@ REQ_FLAG(is_hitpass,		1, 0, "")
 REQ_FLAG(waitinglist,		0, 0, "")
 REQ_FLAG(want100cont,		0, 0, "")
 REQ_FLAG(late100cont,		0, 0, "")
+REQ_FLAG(uncacheable,		1, 0, "")
 #undef REQ_FLAG
 
 /*lint -restore */


### PR DESCRIPTION
The current way to bypass the cache is to either return(pass) in
vcl_recv or to trigger an HfP/HfM on the backend side.

The former forces you to interrupt the request processing, such as
header normalization, or to set a variable/header to remember your
choice so that you can return(pass) once processing is done.

The latter is nicer but has to deal with request coalescing and it
doesn't really make sense to wait that long before making this decision.

The new req.uncacheable mirrors beresp.uncacheable but really just
transforms a return(hash) into a return(pass). This means that it
takes precedence over req.hash_always_miss but also operate slightly
earlier, at the end of vcl_recv rather than at the end of vcl_hash.

Signed-off-by: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>

---

I found this patch from @gquintard in my inbox, this is a followup to #3457  but with a batter name for the flag that matches the `uncacheable` property of `bereq`, `beresp` and `obj`.

I think this patch is in much better shape than #3457 and with the VCL built-in split in mind, I think we should set this flag instead of initiating a pass transition in `vcl_req_method`, `vcl_req_authorization` and `vcl_req_cookie`.

Despite the improvements of the built-in VCL thanks to the split, as it is today a POST request processed by the built-in VCL would break the flow before calling `vcl_req_cookie` and getting a chance for example to normalize and clean up cookies even for uncacheable requests.

Yes, I know, one can actively `call vcl_req_cookie;` but I'm talking about turnkey behavior that would mirror what `vcl_backend_response` does and flow more naturally.