### PR TITLE
Fixed build on macOS 11

### DIFF
--- a/bin/varnishd/http2/cache_http2_panic.c
+++ b/bin/varnishd/http2/cache_http2_panic.c
@@ -29,6 +29,8 @@
  *
  */
 
+#include <inttypes.h>
+
 #include "config.h"
 
 #include "cache/cache_varnishd.h"
@@ -107,13 +109,13 @@ h2_sess_panic(struct vsb *vsb, const struct sess *sp)
 		    r2->h2sess, r2->scheduled, h2_panic_error(r2->error));
 		VSB_printf(vsb, "t_send = %f, t_winupd = %f,\n",
 		    r2->t_send, r2->t_winupd);
-		VSB_printf(vsb, "t_window = %jd, r_window = %jd,\n",
+		VSB_printf(vsb, "t_window = %" PRId64 ", r_window = %" PRId64 ",\n",
 		    r2->t_window, r2->r_window);
 
 		if (!PAN_dump_struct(vsb, r2->rxbuf, H2_RXBUF_MAGIC, "rxbuf")) {
 			VSB_printf(vsb, "stvbuf = %p,\n", r2->rxbuf->stvbuf);
 			VSB_printf(vsb,
-			    "{size, tail, head} = {%u, %ju, %ju},\n",
+			    "{size, tail, head} = {%u, %" PRIu64 ", %" PRIu64 "},\n",
 			    r2->rxbuf->size, r2->rxbuf->tail, r2->rxbuf->head);
 			VSB_indent(vsb, -2);
 			VSB_cat(vsb, "},\n");


### PR DESCRIPTION
`%jd` and `%ju` should be used only for `int64_t` and `uint64_t`. `intmax_t` and `uintmax_t` not always is this type.

The right way is using macros `PRId64` and `PRIu64` which is points to the right format on this system.