### PR TITLE
circleci: Pass CFLAGS via the environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
         type: string
       arch:
         description: build architecture
-        default: "x86-64"
+        default: amd64
         type: string
       extra_conf:
         description: platform-specific configure arguments
@@ -228,7 +228,7 @@ jobs:
       - run:
           name: Extract and distcheck
           command: |
-            docker create --name workspace -v /workspace << parameters.dist >>:<< parameters.release >>:<< parameters.arch >> /bin/true
+            docker create --arch=<< parameters.arch >> --name workspace -v /workspace << parameters.dist >>:<< parameters.release >> /bin/true
             docker cp /workspace workspace:/
             docker run --volumes-from workspace -w /workspace << parameters.dist >>:<< parameters.release >> sh -c '
             if [ << parameters.dist >> = centos ]; then
@@ -385,7 +385,7 @@ workflows:
           release: bionic
           extra_env: CFLAGS
           export_env: export CFLAGS="-g -O2 -m32"
-          arch: x86
+          arch: i386
       - distcheck:
           name: distcheck_alpine
           dist: alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,10 @@ jobs:
       release:
         description: the release name (stretch|buster|bionic|focal)
         type: string
+      arch:
+        description: build architecture
+        default: "x86-64"
+        type: string
       extra_conf:
         description: platform-specific configure arguments
         default: ""
@@ -224,7 +228,7 @@ jobs:
       - run:
           name: Extract and distcheck
           command: |
-            docker create --name workspace -v /workspace << parameters.dist >>:<< parameters.release >> /bin/true
+            docker create --name workspace -v /workspace << parameters.dist >>:<< parameters.release >>:<< parameters.arch >> /bin/true
             docker cp /workspace workspace:/
             docker run --volumes-from workspace -w /workspace << parameters.dist >>:<< parameters.release >> sh -c '
             if [ << parameters.dist >> = centos ]; then
@@ -379,8 +383,9 @@ workflows:
           name: distcheck_ubuntu_bionic
           dist: ubuntu
           release: bionic
-          extra_env: CC
-          export_env: export CC="gcc -m32"
+          extra_env: CFLAGS
+          export_env: export CFLAGS="-g -O2 -m32"
+          arch: x86
       - distcheck:
           name: distcheck_alpine
           dist: alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,8 +378,8 @@ workflows:
           name: distcheck_ubuntu_bionic
           dist: ubuntu
           release: bionic
-          extra_env: CFLAGS
-          export_env: export CFLAGS="-g -O2 -m32"
+          extra_env: CC
+          export_env: export CC="gcc -m32"
       - distcheck:
           name: distcheck_alpine
           dist: alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,8 +375,8 @@ workflows:
           name: distcheck_ubuntu_bionic
           dist: ubuntu
           release: bionic
-          extra_env: CFLAGS
-          export_env: export CFLAGS="-g -O2 -m32"
+          extra_env: CC
+          export_env: export CC='gcc -m32'
       - distcheck:
           name: distcheck_alpine
           dist: alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,8 +375,8 @@ workflows:
           name: distcheck_ubuntu_bionic
           dist: ubuntu
           release: bionic
-          extra_env: CC
-          export_env: export CC="gcc -m32"
+          extra_env: CFLAGS
+          export_env: export CFLAGS="-g -O2 -m32"
       - distcheck:
           name: distcheck_alpine
           dist: alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,14 @@ jobs:
         description: platform-specific configure arguments
         default: ""
         type: string
+      extra_env:
+        description: platform-specific environment variables names
+        default: ""
+        type: string
+      export_env:
+        description: export platform-specific environment variables
+        default: ""
+        type: string
     docker:
       - image: centos:7
     working_directory: /workspace
@@ -320,8 +328,9 @@ jobs:
                 ./configure \
                 << pipeline.parameters.configure_args >> \
                 << parameters.extra_conf >>
+            << parameters.export_env >>
             sudo -u varnish \
-                --preserve-env=ASAN_OPTIONS,LSAN_OPTIONS,TSAN_OPTIONS,UBSAN_OPTIONS \
+                --preserve-env=ASAN_OPTIONS,LSAN_OPTIONS,TSAN_OPTIONS,UBSAN_OPTIONS,<< parameters.extra_env >> \
                 make distcheck VERBOSE=1 -j 4 -k \
                 DISTCHECK_CONFIGURE_FLAGS="<< pipeline.parameters.configure_args >> \
                 << parameters.extra_conf >>"
@@ -365,7 +374,8 @@ workflows:
           name: distcheck_ubuntu_bionic
           dist: ubuntu
           release: bionic
-          extra_conf: CFLAGS=-g\ -O2\ -m32
+          extra_env: CFLAGS
+          export_env: export CFLAGS="-g -O2 -m32"
       - distcheck:
           name: distcheck_alpine
           dist: alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,9 +228,9 @@ jobs:
       - run:
           name: Extract and distcheck
           command: |
-            docker create --arch=<< parameters.arch >> --name workspace -v /workspace << parameters.dist >>:<< parameters.release >> /bin/true
-            docker cp --arch=<< parameters.arch >> /workspace workspace:/
-            docker run --arch=<< parameters.arch >> --volumes-from workspace -w /workspace << parameters.dist >>:<< parameters.release >> sh -c '
+            docker create --platform linux/<< parameters.arch >> --name workspace -v /workspace << parameters.dist >>:<< parameters.release >> /bin/true
+            docker cp --platform linux/<< parameters.arch >> /workspace workspace:/
+            docker run --platform linux/<< parameters.arch >> --volumes-from workspace -w /workspace << parameters.dist >>:<< parameters.release >> sh -c '
             if [ << parameters.dist >> = centos ]; then
                 if [ << parameters.release >> = 8 ]; then
                     dnf install -y "dnf-command(config-manager)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,11 +324,12 @@ jobs:
 
             sudo -u varnish \
                 autoreconf -i -v
+            << parameters.export_env >>
             sudo -u varnish \
+                --preserve-env=<< parameters.extra_env >> \
                 ./configure \
                 << pipeline.parameters.configure_args >> \
                 << parameters.extra_conf >>
-            << parameters.export_env >>
             sudo -u varnish \
                 --preserve-env=ASAN_OPTIONS,LSAN_OPTIONS,TSAN_OPTIONS,UBSAN_OPTIONS,<< parameters.extra_env >> \
                 make distcheck VERBOSE=1 -j 4 -k \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,7 @@ jobs:
                     build-essential \
                     ca-certificates \
                     cpio \
+                    gcc-multilib \
                     git \
                     graphviz \
                     libedit-dev \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,10 @@ jobs:
                 --preserve-env=<< parameters.extra_env >> \
                 ./configure \
                 << pipeline.parameters.configure_args >> \
-                << parameters.extra_conf >>
+                << parameters.extra_conf >> || {
+                    cat config.log
+                    exit 1
+            }
             sudo -u varnish \
                 --preserve-env=ASAN_OPTIONS,LSAN_OPTIONS,TSAN_OPTIONS,UBSAN_OPTIONS,<< parameters.extra_env >> \
                 make distcheck VERBOSE=1 -j 4 -k \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ workflows:
           dist: ubuntu
           release: bionic
           extra_env: CC
-          export_env: export CC='gcc -m32'
+          export_env: export CC="gcc -m32"
       - distcheck:
           name: distcheck_alpine
           dist: alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
           name: Extract and distcheck
           command: |
             docker create --platform linux/<< parameters.arch >> --name workspace -v /workspace << parameters.dist >>:<< parameters.release >> /bin/true
-            docker cp --platform linux/<< parameters.arch >> /workspace workspace:/
+            docker cp /workspace workspace:/
             docker run --platform linux/<< parameters.arch >> --volumes-from workspace -w /workspace << parameters.dist >>:<< parameters.release >> sh -c '
             if [ << parameters.dist >> = centos ]; then
                 if [ << parameters.release >> = 8 ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,8 +229,8 @@ jobs:
           name: Extract and distcheck
           command: |
             docker create --arch=<< parameters.arch >> --name workspace -v /workspace << parameters.dist >>:<< parameters.release >> /bin/true
-            docker cp /workspace workspace:/
-            docker run --volumes-from workspace -w /workspace << parameters.dist >>:<< parameters.release >> sh -c '
+            docker cp --arch=<< parameters.arch >> /workspace workspace:/
+            docker run --arch=<< parameters.arch >> --volumes-from workspace -w /workspace << parameters.dist >>:<< parameters.release >> sh -c '
             if [ << parameters.dist >> = centos ]; then
                 if [ << parameters.release >> = 8 ]; then
                     dnf install -y "dnf-command(config-manager)"


### PR DESCRIPTION
It doesn't look like a workflow job can declaratively add environment
variables, so instead we can have a double indirection.