### PR TITLE
[vnum] more lenient test

### DIFF
--- a/include/vnum.h
+++ b/include/vnum.h
@@ -31,6 +31,7 @@
  */
 
 /* from libvarnish/vnum.c */
+#define VNUM_EPSILON (1e-9d)
 double VNUM(const char *p);
 vtim_dur VNUM_duration_unit(vtim_dur r, const char *b, const char *e);
 vtim_dur VNUM_duration(const char *p);

--- a/lib/libvarnish/vnum.c
+++ b/lib/libvarnish/vnum.c
@@ -693,9 +693,10 @@ main(int argc, char *argv[])
 		++ec;
 	}
 	d1 = VNUM_duration(" 365.24219d ");
-	if (d1 != 31556908.8) {
+	d2 = 31556908.8;
+	if (fabs(d1 - d2) > VNUM_EPSILON) {
 		printf("%s: VNUM_Duration() wrong, %.3f delta = %e\n",
-		    *argv, d1, d1 - 31556908.8);
+		    *argv, d1, d1 - d2);
 		++ec;
 	}
 	/* TODO: test invalid strings */


### PR DESCRIPTION
fixes #3697

@Dridi, I know we discussed `VTIM_EPSILON` but `VNUM_EPSILON` kept things in vnum land, and we use it to test `VNUM_duration`, so it made sense?