### PR TITLE
vdef: implement vmin[_t], vmax[_t] and vlimit[_t] 

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -633,8 +633,7 @@ vbp_set_defaults(struct vbp_target *vt, const struct vrt_backend_probe *vp)
 	if (vt->initial == ~0U)
 		vt->initial = vt->threshold - 1;
 
-	if (vt->initial > vt->threshold)
-		vt->initial = vt->threshold;
+	vt->initial = vmin(vt->initial, vt->threshold);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -663,8 +663,7 @@ ved_gzgz_bytes(struct vdp_ctx *vdx, enum vdp_action act, void **priv,
 		/* The main body of the object */
 		dl = foo->last / 8 - foo->ll;
 		if (dl > 0) {
-			if (dl > len)
-				dl = len;
+			dl = vmin(dl, len);
 			if (ved_bytes(foo->ecx, act, pp, dl))
 				return (-1);
 			foo->ll += dl;
@@ -686,8 +685,7 @@ ved_gzgz_bytes(struct vdp_ctx *vdx, enum vdp_action act, void **priv,
 		/* Last block */
 		dl = foo->stop / 8 - foo->ll;
 		if (dl > 0) {
-			if (dl > len)
-				dl = len;
+			dl = vmin(dl, len);
 			if (ved_bytes(foo->ecx, act, pp, dl))
 				return (-1);
 			foo->ll += dl;

--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -271,7 +271,6 @@ static enum vfp_status v_matchproto_(vfp_pull_f)
 vfp_esi_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p, ssize_t *lp)
 {
 	enum vfp_status vp;
-	ssize_t d;
 	struct vef_priv *vef;
 
 	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
@@ -280,9 +279,7 @@ vfp_esi_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p, ssize_t *lp)
 	AN(p);
 	AN(lp);
 	if (DO_DEBUG(DBG_ESI_CHOP)) {
-		d = (VRND_RandomTestable() & 3) + 1;
-		if (d < *lp)
-			*lp = d;
+		*lp = vmin(*lp, (VRND_RandomTestable() & 3) + 1);
 	}
 	vp = VFP_Suck(vc, p, lp);
 	if (vp != VFP_ERROR && *lp > 0)

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -110,8 +110,7 @@ vbf_allocobj(struct busyobj *bo, unsigned l)
 	 * on Transient storage.
 	 */
 
-	if (oc->ttl > cache_param->shortlived)
-		oc->ttl = cache_param->shortlived;
+	oc->ttl = vmin_t(float, oc->ttl, cache_param->shortlived);
 	oc->grace = 0.0;
 	oc->keep = 0.0;
 	return (STV_NewObject(bo->wrk, oc, stv_transient, l));
@@ -762,8 +761,7 @@ vbf_objiterator(void *priv, unsigned flush, const void *ptr, ssize_t len)
 		l = len;
 		if (VFP_GetStorage(bo->vfc, &l, &pd) != VFP_OK)
 			return (1);
-		if (len < l)
-			l = len;
+		l = vmin(l, len);
 		memcpy(pd, ps, l);
 		VFP_Extend(bo->vfc, l, l == len ? VFP_END : VFP_OK);
 		ps += l;
@@ -966,8 +964,7 @@ vbf_stp_error(struct worker *wrk, struct busyobj *bo)
 		l = ll;
 		if (VFP_GetStorage(bo->vfc, &l, &ptr) != VFP_OK)
 			break;
-		if (l > ll)
-			l = ll;
+		l = vmin(l, ll);
 		memcpy(ptr, VSB_data(synth_body) + o, l);
 		VFP_Extend(bo->vfc, l, l == ll ? VFP_END : VFP_OK);
 		ll -= l;

--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -319,9 +319,7 @@ child_sigmagic(size_t altstksz)
 	memset(&sa, 0, sizeof sa);
 
 #ifdef HAVE_SIGALTSTACK
-	size_t sz = SIGSTKSZ + 4096;
-	if (sz < altstksz)
-		sz = altstksz;
+	size_t sz = vmax_t(size_t, SIGSTKSZ + 4096, altstksz);
 	altstack.ss_sp = mmap(NULL, sz,  PROT_READ | PROT_WRITE,
 			      MAP_PRIVATE | MAP_ANONYMOUS,
 			      -1, 0);

--- a/bin/varnishd/cache/cache_range.c
+++ b/bin/varnishd/cache/cache_range.c
@@ -85,9 +85,7 @@ vrg_range_bytes(struct vdp_ctx *vdx, enum vdp_action act, void **priv,
 			p += l;
 			len -= l;
 		}
-		l = vrg_priv->range_high - vrg_priv->range_off;
-		if (l > len)
-			l = len;
+		l = vmin(vrg_priv->range_high - vrg_priv->range_off, len);
 		vrg_priv->range_off += len;
 		if (vrg_priv->range_off >= vrg_priv->range_high)
 			act = VDP_END;

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -100,8 +100,7 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 		req->want100cont = 0;
 		(void)req->transport->minimal_response(req, 100);
 	}
-	if (yet < 0)
-		yet = 0;
+	yet = vmax_t(ssize_t, yet, 0);
 	do {
 		AZ(vfc->failed);
 		if (maxsize >= 0 && req_bodybytes > maxsize) {

--- a/bin/varnishd/cache/cache_shmlog.c
+++ b/bin/varnishd/cache/cache_shmlog.c
@@ -80,9 +80,7 @@ strands_cat(char *buf, unsigned bufl, const struct strands *s)
 	for (i = 0; i < s->n && bufl > 0; i++) {
 		if (s->p[i] == NULL || *s->p[i] == '\0')
 			continue;
-		ll = strlen(s->p[i]);
-		if (ll > bufl)
-			ll = bufl;
+		ll = vmin_t(unsigned, strlen(s->p[i]), bufl);
 		memcpy(buf, s->p[i], ll);
 		l += ll;
 		buf += ll;
@@ -271,9 +269,8 @@ VSLv(enum VSL_tag_e tag, uint32_t vxid, const char *fmt, va_list ap)
 	if (strchr(fmt, '%') == NULL) {
 		vslr(tag, vxid, fmt, strlen(fmt) + 1);
 	} else {
-		n = vsnprintf(buf, mlen, fmt, ap);
-		if (n > mlen - 1)
-			n = mlen - 1;
+		/* XXX: should probably check return value of vsnprintf */
+		n = vmin_t(unsigned, vsnprintf(buf, mlen, fmt, ap), mlen - 1);
 		buf[n++] = '\0'; /* NUL-terminated */
 		vslr(tag, vxid, buf, n);
 	}
@@ -381,9 +378,7 @@ VSLbs(struct vsl_log *vsl, enum VSL_tag_e tag, const struct strands *s)
 	mlen = cache_param->vsl_reclen;
 
 	/* including NUL */
-	l = strands_len(s) + 1;
-	if (l > mlen)
-		l = mlen;
+	l = vmin(strands_len(s) + 1, mlen);
 
 	assert(vsl->wlp < vsl->wle);
 
@@ -508,8 +503,7 @@ VSLb_bin(struct vsl_log *vsl, enum VSL_tag_e tag, ssize_t len, const void *ptr)
 	mlen = cache_param->vsl_reclen;
 
 	/* Truncate */
-	if (len > mlen)
-		len = mlen;
+	len = vmin_t(ssize_t, len, mlen);
 
 	assert(vsl->wlp < vsl->wle);
 

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -1011,8 +1011,7 @@ VRT_l_sess_##x(VRT_CTX, VCL_DURATION d)		\
 {							\
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);		\
 	CHECK_OBJ_NOTNULL(ctx->sp, SESS_MAGIC);		\
-	if (d < 0.0)					\
-		d = 0.0;				\
+	d = vmax(d, 0.0);				\
 	setter;						\
 	ctx->sp->x = d;					\
 }							\

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -682,8 +682,9 @@ pool_herder(void *priv)
 				VSC_C_main->threads_destroyed++;
 				Lck_Unlock(&pool_mtx);
 				delay = cache_param->wthread_destroy_delay;
-			} else if (delay < cache_param->wthread_destroy_delay)
-				delay = cache_param->wthread_destroy_delay;
+			} else
+				delay = vmax(delay, 
+				    cache_param->wthread_destroy_delay);
 		}
 
 		if (pp->die) {

--- a/bin/varnishd/cache/cache_ws_emu.c
+++ b/bin/varnishd/cache/cache_ws_emu.c
@@ -540,9 +540,7 @@ WS_Dump(const struct ws *ws, char where, size_t off, void *buf, size_t len)
 				break;
 			if (wa->ptr == NULL)
 				break;
-			l = wa->len;
-			if (l > len)
-				l = len;
+			l = vmin_t(size_t, wa->len, len);
 			memcpy(b, wa->ptr, l);
 			b += l;
 			len -= l;

--- a/bin/varnishd/hpack/vhp_decode.c
+++ b/bin/varnishd/hpack/vhp_decode.c
@@ -270,9 +270,7 @@ vhd_lookup(struct vhd_ctx *ctx, unsigned first)
 
 	assert(lu->l <= l);
 	p += l - lu->l;
-	l = lu->l;
-	if (l > ctx->out_e - ctx->out)
-		l = ctx->out_e - ctx->out;
+	l = vmin_t(size_t, lu->l, ctx->out_e - ctx->out);
 	memcpy(ctx->out, p, l);
 	ctx->out += l;
 	lu->l -= l;

--- a/bin/varnishd/hpack/vhp_gen_hufdec.c
+++ b/bin/varnishd/hpack/vhp_gen_hufdec.c
@@ -236,8 +236,7 @@ main(int argc, const char **argv)
 	for (u = 0; u < HUF_LEN; u++) {
 		if (maxlen < huf[u].blen)
 			maxlen = huf[u].blen;
-		if (minlen > huf[u].blen)
-			minlen = huf[u].blen;
+		minlen = vmin(minlen, huf[u].blen);
 	}
 
 	top = tbl_new(8);

--- a/bin/varnishd/hpack/vhp_gen_hufdec.c
+++ b/bin/varnishd/hpack/vhp_gen_hufdec.c
@@ -234,8 +234,7 @@ main(int argc, const char **argv)
 	(void)argv;
 
 	for (u = 0; u < HUF_LEN; u++) {
-		if (maxlen < huf[u].blen)
-			maxlen = huf[u].blen;
+		maxlen = vmax(maxlen, huf[u].blen);
 		minlen = vmin(minlen, huf[u].blen);
 	}
 

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -65,8 +65,7 @@ v1f_read(const struct vfp_ctx *vc, struct http_conn *htc, void *d, ssize_t len)
 	if (htc->pipeline_b) {
 		l = htc->pipeline_e - htc->pipeline_b;
 		assert(l > 0);
-		if (l > len)
-			l = len;
+		l = vmin(l, len);
 		memcpy(p, htc->pipeline_b, l);
 		p += l;
 		len -= l;
@@ -210,8 +209,7 @@ v1f_pull_straight(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 
 	if (vfe->priv2 == 0) // XXX: Optimize Content-Len: 0 out earlier
 		return (VFP_END);
-	if (vfe->priv2 < l)
-		l = vfe->priv2;
+	l = vmin(l, vfe->priv2);
 	lr = v1f_read(vc, htc, p, l);
 	if (lr <= 0)
 		return (VFP_Error(vc, "straight insufficient bytes"));

--- a/bin/varnishd/mgt/mgt_acceptor.c
+++ b/bin/varnishd/mgt/mgt_acceptor.c
@@ -130,8 +130,7 @@ MAC_reopen_sockets(void)
 		VJ_master(JAIL_MASTER_LOW);
 		if (err == 0)
 			continue;
-		if (err > fail)
-			fail = err;
+		fail = vmax(fail, err);
 		MGT_Complain(C_ERR,
 		    "Could not reopen listen socket %s: %s",
 		    ls->endpoint, VAS_errtxt(err));

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -204,8 +204,7 @@ MCH_TrackHighFd(int fd)
 	 * in the master process.
 	 */
 	assert(fd > 0);
-	if (fd > mgt_max_fd)
-		mgt_max_fd = fd;
+	mgt_max_fd = vmax(mgt_max_fd, fd);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -574,8 +574,7 @@ MCF_AddParams(struct parspec *ps)
 			exit(4);
 		}
 		mcf_addpar(pp);
-		if ((int)strlen(pp->name) + 1 > margin2)
-			margin2 = (int)strlen(pp->name) + 1;
+		margin2 = vmax_t(int, margin2, strlen(pp->name) + 1);
 	}
 }
 

--- a/bin/varnishd/storage/stevedore_utils.c
+++ b/bin/varnishd/storage/stevedore_utils.c
@@ -157,8 +157,7 @@ STV_FileSize(int fd, const char *size, unsigned *granularity, const char *ctx)
 
 	AZ(VFIL_fsinfo(fd, &bs, &fssize, NULL));
 	/* Increase granularity if it is lower than the filesystem block size */
-	if (*granularity < bs)
-		*granularity = bs;
+	*granularity = vmax(*granularity, bs);
 
 	if ((size == NULL || *size == '\0') && st.st_size != 0) {
 		/*

--- a/bin/varnishhist/varnishhist.c
+++ b/bin/varnishhist/varnishhist.c
@@ -174,8 +174,7 @@ update(void)
 		assert(l < n);
 		bm[l] += bucket_miss[k];
 		bh[l] += bucket_hit[k];
-		if (bm[l] + bh[l] > max)
-			max = bm[l] + bh[l];
+		max = vmax(max, bm[l] + bh[l]);
 	}
 
 	/* scale,time */
@@ -210,7 +209,6 @@ update(void)
 inline static void
 upd_vsl_ts(const char *p)
 {
-	double t;
 
 	if (timebend == 0)
 		return;
@@ -220,10 +218,7 @@ upd_vsl_ts(const char *p)
 	if (p == NULL)
 		return;
 
-	t = strtod(p + 1, NULL);
-
-	if (t > vsl_ts)
-		vsl_ts = t;
+	vsl_ts = vmax(vsl_ts, strtod(p + 1, NULL));
 }
 
 static int v_matchproto_ (VSLQ_dispatch_f)
@@ -432,9 +427,7 @@ do_curses(void *arg)
 			ms_delay = 1000U << (ch - '0');
 			break;
 		case '+':
-			ms_delay /= 2;
-			if (ms_delay < 1)
-				ms_delay = 1;
+			ms_delay = vmax(ms_delay >> 1, 1);
 			break;
 		case '-':
 			ms_delay *= 2;

--- a/bin/varnishhist/varnishhist.c
+++ b/bin/varnishhist/varnishhist.c
@@ -300,12 +300,9 @@ accumulate(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 			continue;
 
 		/* select bucket */
-		i = lround(HIST_RES * log(value) / log_ten);
-		if (i < hist_low * HIST_RES)
-			i = hist_low * HIST_RES;
-		if (i >= hist_high * HIST_RES)
-			i = hist_high * HIST_RES - 1;
-		i -= hist_low * HIST_RES;
+		i = vlimit_t(int, lround(HIST_RES * log(value) / log_ten),
+		    hist_low * HIST_RES, hist_high * HIST_RES - 1) -
+			hist_low * HIST_RES;
 		assert(i >= 0);
 		assert((unsigned)i < hist_buckets);
 

--- a/bin/varnishstat/varnishstat_curses.c
+++ b/bin/varnishstat/varnishstat_curses.c
@@ -177,8 +177,7 @@ update_position(void)
 			current = 0;
 		if (current > n_ptarray - 1)
 			current = n_ptarray - 1;
-		if (current < page_start)
-			page_start = current;
+		page_start = vmin(page_start, current);
 		if (current > page_start + (l_points - 1))
 			page_start = current - (l_points - 1);
 		if (page_start < 0)

--- a/bin/varnishstat/varnishstat_curses.c
+++ b/bin/varnishstat/varnishstat_curses.c
@@ -173,17 +173,11 @@ update_position(void)
 		current = 0;
 		page_start = 0;
 	} else {
-		if (current < 0)
-			current = 0;
-		if (current > n_ptarray - 1)
-			current = n_ptarray - 1;
+		current = vlimit(current, 0, n_ptarray - 1);
 		page_start = vmin(page_start, current);
 		if (current > page_start + (l_points - 1))
 			page_start = current - (l_points - 1);
-		if (page_start < 0)
-			page_start = 0;
-		if (page_start > n_ptarray - 1)
-			page_start = n_ptarray - 1;
+		page_start = vlimit(page_start, 0, n_ptarray - 1);
 	}
 
 	if (current != old_current || page_start != old_page_start)
@@ -1071,12 +1065,7 @@ handle_help_keypress(enum kb_e kb)
 		WRONG("unhandled key binding");
 	}
 
-	if (help_line > bindings_help_len - l_points)
-		help_line = bindings_help_len - l_points;
-
-	if (help_line < 0)
-		help_line = 0;
-
+	help_line = vlimit(help_line, 0, bindings_help_len - l_points);
 	redraw = (help_line != hl);
 }
 

--- a/bin/varnishstat/varnishstat_curses.c
+++ b/bin/varnishstat/varnishstat_curses.c
@@ -362,8 +362,7 @@ make_windows(void)
 		l_points += l_info;
 		l_info = 0;
 	}
-	if (l_points < LINES_POINTS_MIN)
-		l_points = LINES_POINTS_MIN;
+	l_points = vmax(l_points, LINES_POINTS_MIN);
 
 	y = 0;
 	y_status = y;

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -1426,9 +1426,7 @@ cmd_http_chunkedlen(CMD_ARGS)
 
 		VSB_printf(hp->vsb, "%x%s", len, nl);
 		for (u = 0; u < len; u += v) {
-			v = len - u;
-			if (v > sizeof buf)
-				v = sizeof buf;
+			v = vmin_t(unsigned, len - u, sizeof buf);
 			VSB_bcat(hp->vsb, buf, v);
 		}
 		VSB_printf(hp->vsb, "%s", nl);

--- a/bin/varnishtop/varnishtop.c
+++ b/bin/varnishtop/varnishtop.c
@@ -222,9 +222,7 @@ update(unsigned p)
 		tp2 = VRBT_NEXT(t_order, &h_order, tp);
 
 		if (++l < LINES) {
-			len = tp->clen;
-			if (len > COLS - 20)
-				len = COLS - 20;
+			len = vmin(tp->clen, COLS - 20);
 			AC(mvprintw(l, 0, "%9.2f %-*.*s %*.*s\n",
 				tp->count, maxfieldlen, maxfieldlen,
 				VSL_tags[tp->tag],

--- a/include/vdef.h
+++ b/include/vdef.h
@@ -165,6 +165,55 @@ int __llvm_gcov_flush(void);
 #define RUP2(x, y)  (((x)+((y)-1))&(~((uintptr_t)(y)-1UL))) /* PWR2(y) true */
 
 /**********************************************************************
+ * Find the minimum or maximum values.
+ * Only evaluate the expression once and perform type checking.
+ */
+
+/* ref: https://stackoverflow.com/a/17624752 */
+
+#define VINDIRECT(a, b, c)	a ## b ## c
+#define VCOMBINE(a, b, c)	VINDIRECT(a, b, c)
+
+#if defined(__COUNTER__)
+#	define VUNIQ_NAME(base)	VCOMBINE(base, __LINE__, __COUNTER__)
+#else
+#	define VUNIQ_NAME(base)	VCOMBINE(base, __LINE__, 0)
+#endif
+
+/* ref: https://gcc.gnu.org/onlinedocs/gcc/Typeof.html */
+
+#define _vmin(a, b, _va, _vb)						\
+({									\
+	typeof (a) _va = (a);						\
+	typeof (b) _vb = (b);						\
+	(void)(&_va == &_vb);						\
+	_va < _vb ? _va : _vb;						\
+})
+
+#define _vmax(a, b, _va, _vb)						\
+({									\
+	typeof (a) _va = (a);						\
+	typeof (b) _vb = (b);						\
+	(void)(&_va == &_vb);						\
+	_va > _vb ? _va : _vb;						\
+})
+
+#define vmin(a, b)		_vmin((a), (b), VUNIQ_NAME(_vmina),	\
+    VUNIQ_NAME(_vminb))
+#define vmax(a, b)		_vmax((a), (b), VUNIQ_NAME(_vmaxa),	\
+    VUNIQ_NAME(_vmaxb))
+
+#define vmin_t(type, a, b)	vmin((type)(a), (type)(b))
+#define vmax_t(type, a, b)	vmax((type)(a), (type)(b))
+
+/**********************************************************************
+ * Clamp the value between two limits.
+ */
+
+#define vlimit(a, l, u)		vmax((l), vmin((a), (u)))
+#define vlimit_t(type, a, l, u)	vmax_t(type, (l), vmin_t(type, (a), (u)))
+
+/**********************************************************************
  * FlexeLint and compiler shutuppery
  */
 

--- a/lib/libvarnish/vre.c
+++ b/lib/libvarnish/vre.c
@@ -218,9 +218,7 @@ vre_capture(const vre_t *code, const char *subject, size_t length,
 		AN(count);
 		AN(*count);
 		ovector = pcre2_get_ovector_pointer(data);
-		nov = pcre2_get_ovector_count(data);
-		if (nov > *count)
-			nov = *count;
+		nov = vmin_t(size_t, pcre2_get_ovector_count(data), *count);
 		for (g = 0; g < nov; g++) {
 			b = ovector[2 * g];
 			e = ovector[2 * g + 1];

--- a/lib/libvarnish/vsb.c
+++ b/lib/libvarnish/vsb.c
@@ -383,9 +383,7 @@ VSB_vprintf(struct vsb *s, const char *fmt, va_list ap)
 	 * vsnprintf() returns the amount that would have been copied,
 	 * given sufficient space, so don't over-increment s_len.
 	 */
-	if (VSB_FREESPACE(s) < len)
-		len = VSB_FREESPACE(s);
-	s->s_len += len;
+	s->s_len += vmin_t(ssize_t, len, VSB_FREESPACE(s));
 	if (!VSB_HASROOM(s) && !VSB_CANEXTEND(s))
 		s->s_error = ENOMEM;
 

--- a/lib/libvarnish/vte.c
+++ b/lib/libvarnish/vte.c
@@ -97,11 +97,7 @@ VCLI_VTE(struct cli *cli, struct vsb **src, int width)
 		return;
 	AN(n_col);
 
-	nsp = (width - (w_ln)) / n_col;
-	if (nsp > 3)
-		nsp = 3;
-	else if (nsp < 1)
-		nsp = 1;
+	nsp = vlimit((width - (w_ln)) / n_col, 1, 3);
 
 	cc = 0;
 	wc = 0;

--- a/lib/libvarnish/vte.c
+++ b/lib/libvarnish/vte.c
@@ -82,12 +82,10 @@ VCLI_VTE(struct cli *cli, struct vsb **src, int width)
 			wc = 0;
 		}
 		if (*p == '\n') {
-			if (cc > n_col)
-				n_col = cc;
+			n_col = vmax(n_col, cc);
+			w_ln = vmax(w_ln, wl);
 			cc = 0;
 			wc = 0;
-			if (wl > w_ln)
-				w_ln = wl;
 			wl = 0;
 		} else {
 			wc++;

--- a/lib/libvarnishapi/vsl_dispatch.c
+++ b/lib/libvarnishapi/vsl_dispatch.c
@@ -933,8 +933,7 @@ vslq_ratelimit(struct VSLQ *vslq)
 	now = VTIM_mono();
 	delta = now - vslq->last_use;
 	vslq->credits += (delta / vslq->vsl->R_opt_p) * vslq->vsl->R_opt_l;
-	if (vslq->credits > vslq->vsl->R_opt_l)
-		vslq->credits = vslq->vsl->R_opt_l;
+	vslq->credits = vmin_t(double, vslq->credits, vslq->vsl->R_opt_l);
 	vslq->last_use = now;
 
 	if (vslq->credits < 1.0)

--- a/lib/libvcc/vcc_acl.c
+++ b/lib/libvcc/vcc_acl.c
@@ -105,9 +105,7 @@ vcl_acl_cmp(const struct acl_e *ae1, const struct acl_e *ae2)
 
 	p1 = ae1->data;
 	p2 = ae2->data;
-	m = ae1->mask;
-	if (ae2->mask < m)
-		m = ae2->mask;
+	m = vmin(ae1->mask, ae2->mask);
 	for (; m >= 8; m -= 8) {
 		CMP(*p1, *p2);
 		p1++;

--- a/vmod/vmod_directors_shard_cfg.c
+++ b/vmod/vmod_directors_shard_cfg.c
@@ -282,10 +282,7 @@ shardcfg_hashcircle(struct sharddir *shardd)
 	rmax = (UINT32_MAX - 1) / shardd->n_backend;
 	for (b = backends; b < backends + shardd->n_backend; b++) {
 		CHECK_OBJ_NOTNULL(b->backend, DIRECTOR_MAGIC);
-		r = b->replicas;
-		if (r > rmax)
-			r = rmax;
-		n_points += r;
+		n_points += vmin(b->replicas, rmax);
 	}
 
 	assert(n_points < UINT32_MAX);
@@ -301,9 +298,7 @@ shardcfg_hashcircle(struct sharddir *shardd)
 		AN(ident);
 		assert(ident[0] != '\0');
 
-		r = b->replicas;
-		if (r > rmax)
-			r = rmax;
+		r = vmin(b->replicas, rmax);
 
 		for (j = 0; j < r; j++) {
 			assert(snprintf(s, len, "%d", j) < len);
@@ -488,8 +483,7 @@ shardcfg_backend_del(struct backend_reconfig *re,
 		re->shardd->n_backend--;
 		if (i < re->shardd->n_backend + re->hole_n) {
 			(re->hole_n)++;
-			if (i < re->hole_i)
-				re->hole_i = i;
+			re->hole_i = vmin(re->hole_i, i);
 		}
 	}
 }

--- a/vmod/vmod_directors_shard_cfg.c
+++ b/vmod/vmod_directors_shard_cfg.c
@@ -411,8 +411,7 @@ shardcfg_backend_expand(const struct backend_reconfig *re)
 
 	CHECK_OBJ_NOTNULL(re->shardd, SHARDDIR_MAGIC);
 
-	if (min < 16)
-		min = 16;
+	min = vmax_t(unsigned, min, 16);
 
 	if (re->shardd->l_backend < min)
 		re->shardd->l_backend = min;

--- a/vmod/vmod_std.c
+++ b/vmod/vmod_std.c
@@ -242,8 +242,7 @@ VCL_BOOL v_matchproto_(td_std_cache_req_body)
 vmod_cache_req_body(VRT_CTX, VCL_BYTES size)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	if (size < 0)
-		size = 0;
+	size = vmax_t(VCL_BYTES, size, 0);
 	if (VRT_CacheReqBody(ctx, (size_t)size) < 0)
 		return (0);
 	return (1);


### PR DESCRIPTION
This should make the code easier to read and stop us from being inconsistent.

Signed-off-by: Asad Sajjad Ahmed <asadsa@varnish-software.com>