### PR TITLE
Offer a configure --with-unwind switch (6.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export PATH="/usr/local/opt/sphinx-doc/bin:$PATH"
     elif [[ -n "$SAN_FLAGS" ]]; then
-      export CONFIGURE_ARGS="--enable-developer-warnings --enable-debugging-symbols --disable-stack-protector --with-persistent-storage ${SAN_FLAGS}"
+      export CONFIGURE_ARGS="--enable-developer-warnings --enable-debugging-symbols --disable-stack-protector --with-persistent-storage --with-unwind ${SAN_FLAGS}"
       export ASAN_OPTIONS=abort_on_error=1,detect_odr_violation=1,detect_leaks=1,detect_stack_use_after_return=1,detect_invalid_pointer_pairs=1,handle_segv=0,handle_sigbus=0,use_sigaltstack=0,disable_coredump=0
       export LSAN_OPTIONS=abort_on_error=1,use_sigaltstack=0,suppressions=$(pwd)/tools/lsan.suppr
       export TSAN_OPTIONS=abort_on_error=1,halt_on_error=1,use_sigaltstack=0,suppressions=$(pwd)/tools/tsan.suppr

--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -173,6 +173,11 @@ varnishd_LDADD = \
 	@PCRE_LIBS@ \
 	${DL_LIBS} ${PTHREAD_LIBS} ${NET_LIBS} ${RT_LIBS} ${LIBM}
 
+if WITH_UNWIND
+varnishd_CFLAGS += -DUNW_LOCAL_ONLY
+varnishd_LDADD += ${LIBUNWIND_LIBS}
+endif
+
 noinst_PROGRAMS = vhp_gen_hufdec
 vhp_gen_hufdec_SOURCES = hpack/vhp_gen_hufdec.c
 vhp_gen_hufdec_CFLAGS = @SAN_CFLAGS@ \

--- a/configure.ac
+++ b/configure.ac
@@ -336,9 +336,25 @@ esac
 AC_SUBST(JEMALLOC_LDADD)
 
 AC_CHECK_FUNCS([setproctitle])
-AC_SEARCH_LIBS(backtrace, [execinfo], [], [
-   AC_MSG_ERROR([Could not find backtrace() support])
-])
+
+# if the default libexecinfo on alpine causes issues, you can use libunwind
+AC_ARG_WITH([unwind],
+            [AS_HELP_STRING([--with-unwind],
+              [use libunwind to print stacktraces (use libexecinfo otherwise). Recommended on alpine linux. Defaults to no.])])
+
+if test "$with_unwind" = yes; then
+    PKG_CHECK_MODULES([LIBUNWIND], [libunwind])
+    AC_DEFINE([WITH_UNWIND], [1],
+              [Define to 1 to use libunwind instead of libexecinfo])
+else
+    AC_SEARCH_LIBS(backtrace, [execinfo], [], [
+        AC_MSG_ERROR([Could not find backtrace() support])
+    ])
+fi
+
+AM_CONDITIONAL([WITH_UNWIND],
+	[test "$with_unwind" = yes])
+
 # white lie - we don't actually test it
 AC_MSG_CHECKING([whether daemon() works])
 case $target in


### PR DESCRIPTION
```
Conflicts:
	.travis.yml
	bin/varnishd/cache/cache_panic.c
```
---

Test cases m35 to m38 are currently failing on my machine, two of the failures seem to be caused by a segmentation fault in `funlockfile()`. As *usual* (emphasis on usual) libunwind made this much easier to figure out than the libexecinfo back-trace, so I'm submitting a back-port of @gquintard's patch.