### PR TITLE
VCL_REGEX: Support concatenation of constant strings

### DIFF
--- a/bin/varnishtest/tests/b00028.vtc
+++ b/bin/varnishtest/tests/b00028.vtc
@@ -8,7 +8,7 @@ server s1 {
 varnish v1 -vcl+backend {
 
 	sub vcl_backend_response {
-		if (beresp.http.foo ~ "bar") {
+		if (beresp.http.foo ~ "b" + "ar") {
 			set beresp.http.foo1 = "1";
 		} else {
 			set beresp.status = 999;

--- a/bin/varnishtest/tests/c00103.vtc
+++ b/bin/varnishtest/tests/c00103.vtc
@@ -8,7 +8,8 @@ varnish v1 -vcl {
 		# on purpose to ensure we don't treat REGEX expressions
 		# differently.
 		if (req.url ~ (debug.just_return_regex(
-		    debug.just_return_regex("hello")))) {
+		    debug.just_return_regex("he" +
+		      "l" + "lo")))) {
 			return (synth(200));
 		}
 		return (synth(500));

--- a/bin/varnishtest/tests/v00016.vtc
+++ b/bin/varnishtest/tests/v00016.vtc
@@ -80,6 +80,27 @@ varnish v1 -errvcl {Regexp compilation error:} {
 	}
 }
 
+varnish v1 -errvcl {Regexp compilation error:} {
+	backend b none;
+	sub vcl_recv {
+		if (req.url ~ "[" + "a") {}
+	}
+}
+
+varnish v1 -errvcl {Expected CSTR got 'req'} {
+	backend b none;
+	sub vcl_recv {
+		if (req.url ~ "a" + req.http.foo) {}
+	}
+}
+
+varnish v1 -errvcl {Expected ')' got '-'} {
+	backend b none;
+	sub vcl_recv {
+		if (req.url ~ "a" - "b") {}
+	}
+}
+
 varnish v1 -errvcl {Expression has type directors.shard, expected ACL} {
 	import directors;
 	backend b none;


### PR DESCRIPTION
For the `REGEX` type, we now peek ahead after the first CSTR token if a `+` operator follows and, if yes, create the pattern as a concatenation.

Fixes #3726