### PR TITLE
Refactoring of the acceptor sockopt inheritance

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -87,20 +87,20 @@ static struct tcp_opt {
 	socklen_t	sz;
 	void		*ptr;
 	int		need;
-	int		iponly;
 } tcp_opts[] = {
-#define TCPO(lvl, nam, sz, ip) { lvl, nam, #nam, sizeof(sz), 0, 0, ip},
+#define TCPO(lvl, nam, typ) { lvl, nam, #nam, sizeof(typ), NULL, 0 },
 
-	TCPO(SOL_SOCKET, SO_LINGER, struct linger, 0)
-	TCPO(SOL_SOCKET, SO_KEEPALIVE, int, 0)
-	TCPO(IPPROTO_TCP, TCP_NODELAY, int, 1)
-	TCPO(SOL_SOCKET, SO_SNDTIMEO, struct timeval, 0)
-	TCPO(SOL_SOCKET, SO_RCVTIMEO, struct timeval, 0)
+	TCPO(SOL_SOCKET, SO_LINGER, struct linger)
+	TCPO(SOL_SOCKET, SO_KEEPALIVE, int)
+	TCPO(SOL_SOCKET, SO_SNDTIMEO, struct timeval)
+	TCPO(SOL_SOCKET, SO_RCVTIMEO, struct timeval)
+
+	TCPO(IPPROTO_TCP, TCP_NODELAY, int)
 
 #ifdef HAVE_TCP_KEEP
-	TCPO(IPPROTO_TCP, TCP_KEEPIDLE, int, 1)
-	TCPO(IPPROTO_TCP, TCP_KEEPCNT, int, 1)
-	TCPO(IPPROTO_TCP, TCP_KEEPINTVL, int, 1)
+	TCPO(IPPROTO_TCP, TCP_KEEPIDLE, int)
+	TCPO(IPPROTO_TCP, TCP_KEEPCNT, int)
+	TCPO(IPPROTO_TCP, TCP_KEEPINTVL, int)
 #endif
 
 #undef TCPO
@@ -219,7 +219,7 @@ vca_tcp_opt_test(const int sock, const unsigned uds)
 
 	for (n = 0; n < n_tcp_opts; n++) {
 		to = &tcp_opts[n];
-		if (to->iponly && uds)
+		if (to->level == IPPROTO_TCP && uds)
 			continue;
 		to->need = 1;
 		ptr = calloc(1, to->sz);
@@ -242,7 +242,7 @@ vca_tcp_opt_set(const int sock, const unsigned uds, const int force)
 
 	for (n = 0; n < n_tcp_opts; n++) {
 		to = &tcp_opts[n];
-		if (to->iponly && uds)
+		if (to->level == IPPROTO_TCP && uds)
 			continue;
 		if (to->need || force) {
 			VTCP_Assert(setsockopt(sock,

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -116,11 +116,11 @@ static const int n_sock_opts = sizeof sock_opts / sizeof sock_opts[0];
 
 /*--------------------------------------------------------------------
  * We want to get out of any kind of trouble-hit TCP connections as fast
- * as absolutely possible, so we set them LINGER enabled with zero timeout,
- * so that even if there are outstanding write data on the socket, a close(2)
- * will return immediately.
+ * as absolutely possible, so we set them LINGER disabled, so that even if
+ * there are outstanding write data on the socket, a close(2) will return
+ * immediately.
  */
-static const struct linger linger = {
+static const struct linger disable_so_linger = {
 	.l_onoff	=	0,
 };
 
@@ -129,12 +129,12 @@ static const struct linger linger = {
  * hung up on connections returning from waitinglists
  */
 
-static const unsigned so_keepalive = 1;
+static const unsigned enable_so_keepalive = 1;
 
 /* We disable Nagle's algorithm in favor of low latency setups.
  */
 
-static const unsigned tcp_nodelay = 1;
+static const unsigned enable_tcp_nodelay = 1;
 
 static unsigned		need_test;
 
@@ -195,13 +195,13 @@ vca_sock_opt_init(void)
 		}							\
 	} while (0)
 
-		SET_VAL(SO_LINGER, so, lg, linger);
-		SET_VAL(SO_KEEPALIVE, so, i, so_keepalive);
+		SET_VAL(SO_LINGER, so, lg, disable_so_linger);
+		SET_VAL(SO_KEEPALIVE, so, i, enable_so_keepalive);
 		NEW_VAL(SO_SNDTIMEO, so, tv,
 		    VTIM_timeval(cache_param->idle_send_timeout));
 		NEW_VAL(SO_RCVTIMEO, so, tv,
 		    VTIM_timeval(cache_param->timeout_idle));
-		SET_VAL(TCP_NODELAY, so, i, tcp_nodelay);
+		SET_VAL(TCP_NODELAY, so, i, enable_tcp_nodelay);
 #ifdef HAVE_TCP_KEEP
 		NEW_VAL(TCP_KEEPIDLE, so, i,
 		    (int)cache_param->tcp_keepalive_time);

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -129,6 +129,13 @@ static const struct linger linger = {
  * hung up on connections returning from waitinglists
  */
 
+static const unsigned so_keepalive = 1;
+
+/* We disable Nagle's algorithm in favor of low latency setups.
+ */
+
+static const unsigned tcp_nodelay = 1;
+
 static unsigned		need_test;
 
 /*--------------------------------------------------------------------
@@ -189,13 +196,13 @@ vca_sock_opt_init(void)
 	} while (0)
 
 		SET_VAL(SO_LINGER, so, lg, linger);
-		SET_VAL(SO_KEEPALIVE, so, i, 1);
+		SET_VAL(SO_KEEPALIVE, so, i, so_keepalive);
 		NEW_VAL(SO_SNDTIMEO, so, tv,
 		    VTIM_timeval(cache_param->idle_send_timeout));
 		NEW_VAL(SO_RCVTIMEO, so, tv,
 		    VTIM_timeval(cache_param->timeout_idle));
+		SET_VAL(TCP_NODELAY, so, i, tcp_nodelay);
 #ifdef HAVE_TCP_KEEP
-		SET_VAL(TCP_NODELAY, so, i, 1);
 		NEW_VAL(TCP_KEEPIDLE, so, i,
 		    (int)cache_param->tcp_keepalive_time);
 		NEW_VAL(TCP_KEEPCNT, so, i,

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -233,15 +233,27 @@ vca_sock_opt_test(const struct listen_sock *ls, const struct sess *sp)
 	for (n = 0; n < n_sock_opts; n++) {
 		so = &sock_opts[n];
 		ch = &ls->conn_heritage[n];
-		if (ch->sess_set)
-			continue; /* Already set, no need to retest */
-		if (so->level == IPPROTO_TCP && ls->uds)
+		if (ch->sess_set) {
+			VSL(SLT_Debug, sp->vxid,
+			    "sockopt: Not testing nonhereditary %s for %s=%s",
+			    so->strname, ls->name, ls->endpoint);
 			continue;
+		}
+		if (so->level == IPPROTO_TCP && ls->uds) {
+			VSL(SLT_Debug, sp->vxid,
+			    "sockopt: Not testing incompatible %s for %s=%s",
+			    so->strname, ls->name, ls->endpoint);
+			continue;
+		}
 		memset(&tmp, 0, sizeof tmp);
 		l = so->sz;
 		i = getsockopt(sp->fd, so->level, so->optname, &tmp, &l);
-		if (i == 0 && memcmp(&tmp, so->arg, so->sz))
+		if (i == 0 && memcmp(&tmp, so->arg, so->sz)) {
+			VSL(SLT_Debug, sp->vxid,
+			    "sockopt: Test confirmed %s non heredity for %s=%s",
+			    so->strname, ls->name, ls->endpoint);
 			ch->sess_set = 1;
+		}
 		if (i && errno != ENOPROTOOPT)
 			VTCP_Assert(i);
 	}
@@ -252,21 +264,44 @@ vca_sock_opt_set(const struct listen_sock *ls, const struct sess *sp)
 {
 	struct conn_heritage *ch;
 	struct sock_opt *so;
+	unsigned vxid;
 	int n, sock;
 
 	CHECK_OBJ_NOTNULL(ls, LISTEN_SOCK_MAGIC);
-	CHECK_OBJ_ORNULL(sp, SESS_MAGIC);
-	sock = sp != NULL ? sp->fd : ls->sock;
+
+	if (sp != NULL) {
+		CHECK_OBJ(sp, SESS_MAGIC);
+		sock = sp->fd;
+		vxid = sp->vxid;
+	} else {
+		sock = ls->sock;
+		vxid = 0;
+	}
 
 	for (n = 0; n < n_sock_opts; n++) {
 		so = &sock_opts[n];
 		ch = &ls->conn_heritage[n];
-		if (so->level == IPPROTO_TCP && ls->uds)
+		if (so->level == IPPROTO_TCP && ls->uds) {
+			VSL(SLT_Debug, vxid,
+			    "sockopt: Not setting incompatible %s for %s=%s",
+			    so->strname, ls->name, ls->endpoint);
 			continue;
-		if (sp == NULL && ch->listen_mod == so->mod)
+		}
+		if (sp == NULL && ch->listen_mod == so->mod) {
+			VSL(SLT_Debug, vxid,
+			    "sockopt: Not setting unmodified %s for %s=%s",
+			    so->strname, ls->name, ls->endpoint);
 			continue;
-		if  (sp != NULL && !ch->sess_set)
+		}
+		if  (sp != NULL && !ch->sess_set) {
+			VSL(SLT_Debug, sp->vxid,
+			    "sockopt: %s may be inherited for %s=%s",
+			    so->strname, ls->name, ls->endpoint);
 			continue;
+		}
+		VSL(SLT_Debug, vxid,
+		    "sockopt: Setting %s for %s=%s",
+		    so->strname, ls->name, ls->endpoint);
 		VTCP_Assert(setsockopt(sock,
 		    so->level, so->optname, so->arg, so->sz));
 		if (sp == NULL)

--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -90,11 +90,13 @@ static struct sock_opt {
 	int		level;
 	int		optname;
 	const char	*strname;
-	int		need;
+	unsigned	mod;
 	socklen_t	sz;
 	union sock_arg	arg[1];
 } sock_opts[] = {
-#define SOCK_OPT(lvl, nam, typ) { lvl, nam, #nam, 0, sizeof(typ) },
+	/* Note: Setting the mod counter to something not-zero is needed
+	 * to force the setsockopt() calls on startup */
+#define SOCK_OPT(lvl, nam, typ) { lvl, nam, #nam, 1, sizeof(typ) },
 
 	SOCK_OPT(SOL_SOCKET, SO_LINGER, struct linger)
 	SOCK_OPT(SOL_SOCKET, SO_KEEPALIVE, int)
@@ -113,6 +115,11 @@ static struct sock_opt {
 };
 
 static const int n_sock_opts = sizeof sock_opts / sizeof sock_opts[0];
+
+struct conn_heritage {
+	unsigned	sess_set;
+	unsigned	listen_mod;
+};
 
 /*--------------------------------------------------------------------
  * We want to get out of any kind of trouble-hit TCP connections as fast
@@ -135,8 +142,6 @@ static const unsigned enable_so_keepalive = 1;
  */
 
 static const unsigned enable_tcp_nodelay = 1;
-
-static unsigned		need_test;
 
 /*--------------------------------------------------------------------
  * lacking a better place, we put some generic periodic updates
@@ -188,9 +193,8 @@ vca_sock_opt_init(void)
 			tmp.fld = (val);				\
 			if (memcmp(&so->arg->fld, &(tmp.fld), sz)) {	\
 				memcpy(&so->arg->fld, &(tmp.fld), sz);	\
-				so->need = 1;				\
+				so->mod++;				\
 				chg = 1;				\
-				need_test = 1;				\
 			}						\
 		}							\
 	} while (0)
@@ -217,6 +221,7 @@ vca_sock_opt_init(void)
 static void
 vca_sock_opt_test(const struct listen_sock *ls, const struct sess *sp)
 {
+	struct conn_heritage *ch;
 	struct sock_opt *so;
 	union sock_arg tmp;
 	socklen_t l;
@@ -227,14 +232,16 @@ vca_sock_opt_test(const struct listen_sock *ls, const struct sess *sp)
 
 	for (n = 0; n < n_sock_opts; n++) {
 		so = &sock_opts[n];
+		ch = &ls->conn_heritage[n];
+		if (ch->sess_set)
+			continue; /* Already set, no need to retest */
 		if (so->level == IPPROTO_TCP && ls->uds)
 			continue;
-		so->need = 1;
 		memset(&tmp, 0, sizeof tmp);
 		l = so->sz;
 		i = getsockopt(sp->fd, so->level, so->optname, &tmp, &l);
-		if (i == 0 && !memcmp(&tmp, so->arg, so->sz))
-			so->need = 0;
+		if (i == 0 && memcmp(&tmp, so->arg, so->sz))
+			ch->sess_set = 1;
 		if (i && errno != ENOPROTOOPT)
 			VTCP_Assert(i);
 	}
@@ -243,6 +250,7 @@ vca_sock_opt_test(const struct listen_sock *ls, const struct sess *sp)
 static void
 vca_sock_opt_set(const struct listen_sock *ls, const struct sess *sp)
 {
+	struct conn_heritage *ch;
 	struct sock_opt *so;
 	int n, sock;
 
@@ -252,12 +260,17 @@ vca_sock_opt_set(const struct listen_sock *ls, const struct sess *sp)
 
 	for (n = 0; n < n_sock_opts; n++) {
 		so = &sock_opts[n];
+		ch = &ls->conn_heritage[n];
 		if (so->level == IPPROTO_TCP && ls->uds)
 			continue;
-		if (so->need || sp == NULL) {
-			VTCP_Assert(setsockopt(sock,
-			    so->level, so->optname, so->arg, so->sz));
-		}
+		if (sp == NULL && ch->listen_mod == so->mod)
+			continue;
+		if  (sp != NULL && !ch->sess_set)
+			continue;
+		VTCP_Assert(setsockopt(sock,
+		    so->level, so->optname, so->arg, so->sz));
+		if (sp == NULL)
+			ch->listen_mod = so->mod;
 	}
 }
 
@@ -403,9 +416,9 @@ vca_make_session(struct worker *wrk, void *arg)
 	vca_pace_good();
 	wrk->stats->sess_conn++;
 
-	if (need_test) {
+	if (wa->acceptlsock->test_heritage) {
 		vca_sock_opt_test(wa->acceptlsock, sp);
-		need_test = 0;
+		wa->acceptlsock->test_heritage = 0;
 	}
 	vca_sock_opt_set(wa->acceptlsock, sp);
 
@@ -600,6 +613,17 @@ vca_acct(void *arg)
 					continue;	// VCA_Shutdown
 				assert (ls->sock > 0);
 				vca_sock_opt_set(ls, NULL);
+				/* If one of the options on a socket has
+				 * changed, also force a retest of whether
+				 * the values are inherited to the
+				 * accepted sockets. This should then
+				 * catch any false positives from previous
+				 * tests that could happen if the set
+				 * value of an option happened to just be
+				 * the OS default for that value, and
+				 * wasn't actually inherited from the
+				 * listening socket. */
+				ls->test_heritage = 1;
 			}
 			AZ(pthread_mutex_unlock(&shut_mtx));
 		}
@@ -635,14 +659,17 @@ ccf_start(struct cli *cli, const char * const *av, void *priv)
 			    ls->endpoint, VAS_errtxt(errno));
 			return;
 		}
+		AZ(ls->conn_heritage);
+		ls->conn_heritage = calloc(n_sock_opts,
+		    sizeof *ls->conn_heritage);
+		AN(ls->conn_heritage);
+		ls->test_heritage = 1;
 		vca_sock_opt_set(ls, NULL);
 		if (cache_param->accept_filter && VTCP_filter_http(ls->sock))
 			VSL(SLT_Error, 0,
 			    "Kernel filtering: sock=%d, errno=%d %s",
 			    ls->sock, errno, VAS_errtxt(errno));
 	}
-
-	need_test = 1;
 
 	AZ(pthread_create(&VCA_thread, NULL, vca_acct, NULL));
 }

--- a/bin/varnishd/common/heritage.h
+++ b/bin/varnishd/common/heritage.h
@@ -37,6 +37,7 @@ struct listen_sock;
 struct transport;
 struct VCLS;
 struct uds_perms;
+struct conn_heritage;
 
 struct listen_sock {
 	unsigned			magic;
@@ -50,6 +51,8 @@ struct listen_sock {
 	struct suckaddr			*addr;
 	const struct transport		*transport;
 	const struct uds_perms		*perms;
+	unsigned			test_heritage;
+	struct conn_heritage		*conn_heritage;
 };
 
 VTAILQ_HEAD(listen_sock_head, listen_sock);

--- a/bin/varnishtest/tests/l00000.vtc
+++ b/bin/varnishtest/tests/l00000.vtc
@@ -11,7 +11,7 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g session {
 	expect 0 1000	Begin		sess
 	expect 0 =	SessOpen
-	expect 0 =	Link		"req 1001"
+	expect * =	Link		"req 1001"
 	expect 0 =	SessClose
 	expect 0 =	End
 

--- a/bin/varnishtest/tests/o00001.vtc
+++ b/bin/varnishtest/tests/o00001.vtc
@@ -74,7 +74,7 @@ logexpect l1 -v v1 -g raw {
 	expect * 1016	Proxy		"2 1.2.3.4 2314 5.6.7.8 2828"
 	expect * 1019	Proxy		"2 102:304:506::d0e:f10 2314 8182:8384:8586::8d8e:8f80 2828"
 	expect * 1022	Begin		"^sess 0 PROXY"
-	expect 1 1022	SessClose	"^RX_OVERFLOW"
+	expect * 1022	SessClose	"^RX_OVERFLOW"
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/o00006.vtc
+++ b/bin/varnishtest/tests/o00006.vtc
@@ -12,7 +12,7 @@ varnish v1 -arg "-p pool_sess=0,0,0" -proto "PROXY" -vcl+backend {} -start
 logexpect l1 -v v1 -g raw {
 	expect 0 1000	Begin		"sess 0 PROXY"
 	expect 0 =	SessOpen
-	expect 0 =	Proxy		"2 217.70.181.33 60822 95.142.168.34 443"
+	expect * =	Proxy		"2 217.70.181.33 60822 95.142.168.34 443"
 	expect 0 =	Error		{\Qinsufficient workspace (proto_priv)\E}
 	expect 0 =	SessClose	"RX_JUNK"
 } -start

--- a/bin/varnishtest/tests/r01804.vtc
+++ b/bin/varnishtest/tests/r01804.vtc
@@ -13,7 +13,7 @@ varnish v1 -vcl+backend "" -start
 logexpect l1 -v v1 -g session {
 	expect * 1000	Begin		{^sess .* PROXY$}
 	expect 0 =	SessOpen	{^.* foo .*}
-	expect 0 =	Proxy		{^1 }
+	expect * =	Proxy		{^1 }
 	expect * 1001	Begin		{^req}
 } -start
 
@@ -28,7 +28,7 @@ logexpect l1 -wait
 logexpect l2 -v v1 -g session {
 	expect * 1003	Begin		{^sess .* PROXY$}
 	expect 0 =	SessOpen	{^.* foo .*}
-	expect 0 =	Proxy		{^2 }
+	expect * =	Proxy		{^2 }
 	expect * 1004	Begin		{^req}
 } -start
 

--- a/bin/varnishtest/tests/r02722.vtc
+++ b/bin/varnishtest/tests/r02722.vtc
@@ -1,0 +1,37 @@
+varnishtest "TCP vs UDS sockopt inheritance"
+
+feature cmd {test $(uname) != SunOS}
+
+server s0 {
+        rxreqhdrs
+        non_fatal
+        rxreqbody
+        txresp
+} -dispatch
+
+varnish v1 -arg {-a :0 -a "${tmpdir}/v1.sock"}
+varnish v1 -cliok "param.set debug +flush_head"
+varnish v1 -cliok "param.set timeout_idle 1"
+varnish v1 -vcl+backend { } -start
+
+client c1 {
+        txreq -req POST -hdr "Content-Length: 100"
+        send some
+        rxresp
+        expect resp.status == 503
+}
+
+# This run performs the inheritance test on a TCP connection
+client c1 -run
+
+# This run relies on the inheritance test results
+client c1 -run
+
+varnish v1 -vsl_catchup
+
+# This run checks that TCP results aren't applied to a UDS
+client c1 -connect "${tmpdir}/v1.sock"
+client c1 -run
+
+# And finally this run checks UDS inheritance test results
+client c1 -run

--- a/bin/varnishtest/tests/r02722.vtc
+++ b/bin/varnishtest/tests/r02722.vtc
@@ -9,7 +9,7 @@ server s0 {
         txresp
 } -dispatch
 
-varnish v1 -arg {-a :0 -a "${tmpdir}/v1.sock"}
+varnish v1 -arg {-a TCP=:0 -a "UDS=${tmpdir}/v1.sock"}
 varnish v1 -cliok "param.set debug +flush_head"
 varnish v1 -cliok "param.set timeout_idle 1"
 varnish v1 -vcl+backend { } -start


### PR DESCRIPTION
See individual commits for all the details, and a test case in the last commit that fixes a bug that exists at least on Linux that would result in missing socket options on unix domain sockets under certain circumstances.

Before back-porting this to 6.0, we should probably back-port #3704 first.