### PR TITLE
Use correct list var name in mgt_vcl_discard_depcheck

### DIFF
--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -754,7 +754,7 @@ mgt_vcl_discard_depcheck(struct cli *cli)
 	struct vclprog *vp;
 	struct vcldep *vd;
 
-	VTAILQ_FOREACH(vp, &discardhead, list) {
+	VTAILQ_FOREACH(vp, &discardhead, discard_list) {
 		VTAILQ_FOREACH(vd, &vp->dto, lto)
 			if (!vd->from->discard) {
 				mgt_vcl_discard_depfail(cli, vp);

--- a/bin/varnishtest/tests/r03734.vtc
+++ b/bin/varnishtest/tests/r03734.vtc
@@ -1,0 +1,44 @@
+varnishtest "Issue 3734 - Discard dependency check and labels"
+
+varnish v1 -vcl {
+	backend default none;
+
+	sub vcl_recv {
+		return (synth(200, "vcl1"));
+	}
+} -start
+
+varnish v1 -vcl {
+	backend default none;
+
+	sub vcl_recv {
+		return (synth(200, "vcl2"));
+	}
+}
+
+varnish v1 -cliok { vcl.label lbl_vcl2 vcl2 }
+
+varnish v1 -vcl {
+	backend default none;
+
+	sub vcl_recv {
+		if (req.url == "/label") {
+			return (vcl(lbl_vcl2));
+		}
+		return (synth(200, "vcl3"));
+	}
+}
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.reason == vcl3
+
+	txreq -url /label
+	rxresp
+	expect resp.status == 200
+	expect resp.reason == vcl2
+} -run
+
+varnish v1 -cliok { vcl.discard vcl1 }


### PR DESCRIPTION
Using the wrong list variable would cause the dependency check to consider
VCLs that were not attempted discarded.

Fixes: #3734