### PR TITLE
build: Use libunwind if available at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -369,17 +369,26 @@ AC_CHECK_FUNCS([setproctitle])
 # if the default libexecinfo on alpine causes issues, you can use libunwind
 AC_ARG_WITH([unwind],
             [AS_HELP_STRING([--with-unwind],
-              [use libunwind to print stacktraces (use libexecinfo otherwise). Recommended on alpine linux. Defaults to no.])])
+              [use libunwind to print stacktraces (use libexecinfo otherwise). Recommended on alpine linux. Defaults to auto.])])
 
-if test "$with_unwind" = yes; then
+if test "$with_unwind" != no; then
     case $target in
     *-*-darwin*)
         # Always present but .pc is not installed
+        have_unwind=yes
         ;;
     *)
-        PKG_CHECK_MODULES([LIBUNWIND], [libunwind])
+        PKG_CHECK_MODULES([LIBUNWIND], [libunwind], [have_unwind=yes],
+                [have_unwind=no])
         ;;
     esac
+fi
+
+if test "$with_unwind" = yes && test "$have_unwind" != yes; then
+        AC_MSG_ERROR([Could not find libunwind])
+fi
+
+if test "$have_unwind" = yes; then
     AC_DEFINE([WITH_UNWIND], [1],
               [Define to 1 to use libunwind instead of libexecinfo])
 else
@@ -388,8 +397,7 @@ else
     ])
 fi
 
-AM_CONDITIONAL([WITH_UNWIND],
-	[test "$with_unwind" = yes])
+AM_CONDITIONAL([WITH_UNWIND], [test "$have_unwind" = yes])
 
 # white lie - we don't actually test it
 AC_MSG_CHECKING([whether daemon() works])


### PR DESCRIPTION
One can still use the --without-unwind configure flag.

Refs #3717