### PR TITLE
vut: Write to stdout with a "-w -" option

### DIFF
--- a/bin/varnishlog/varnishlog.c
+++ b/bin/varnishlog/varnishlog.c
@@ -72,9 +72,12 @@ openout(int append)
 {
 
 	AN(LOG.w_arg);
-	if (LOG.A_opt)
-		LOG.fo = fopen(LOG.w_arg, append ? "a" : "w");
-	else
+	if (LOG.A_opt) {
+		if (!strcmp(LOG.w_arg, "-"))
+			LOG.fo = stdout;
+		else
+			LOG.fo = fopen(LOG.w_arg, append ? "a" : "w");
+	} else
 		LOG.fo = VSL_WriteOpen(vut->vsl, LOG.w_arg, append, LOG.u_opt);
 	if (LOG.fo == NULL)
 		VUT_Error(vut, 2, "Cannot open output file (%s)",
@@ -147,6 +150,9 @@ main(int argc, char * const *argv)
 
 	if (vut->D_opt && !LOG.w_arg)
 		VUT_Error(vut, 1, "Missing -w option");
+
+	if (vut->D_opt && !strcmp(LOG.w_arg, "-"))
+		VUT_Error(vut, 1, "Daemon cannot write to stdout");
 
 	/* Setup output */
 	if (LOG.A_opt || !LOG.w_arg) {

--- a/bin/varnishlog/varnishlog_options.h
+++ b/bin/varnishlog/varnishlog_options.h
@@ -32,22 +32,24 @@
 #include "vapi/vapi_options.h"
 #include "vut_options.h"
 
+#define LOG_NOTICE_w " This option has no effect without the -w option."
+
 #define LOG_OPT_a							\
 	VOPT("a", "[-a]", "Append to file",				\
 	    "When writing output to a file with the -w option, append"	\
-	    " to it rather than overwrite it."				\
+	    " to it rather than overwrite it." LOG_NOTICE_w		\
 	)
 
 #define LOG_OPT_A							\
 	VOPT("A", "[-A]", "Text output",				\
 	    "When writing output to a file with the -w option, output"	\
-	    " data in ascii format."					\
+	    " data in ascii format." LOG_NOTICE_w			\
 	)
 
 #define LOG_OPT_u							\
 	VOPT("u", "[-u]", "Unbuffered output",				\
 	    "When writing output to a file with the -w option, output"	\
-	    " data is not buffered."					\
+	    " data is not buffered." LOG_NOTICE_w			\
 	)
 
 #define LOG_OPT_w							\

--- a/bin/varnishlog/varnishlog_options.h
+++ b/bin/varnishlog/varnishlog_options.h
@@ -58,7 +58,9 @@
 	    " reopened allowing the old one to be rotated away. The"	\
 	    " file can then be read by varnishlog and other tools with"	\
 	    " the -r option, unless the -A option was specified. This"	\
-	    " option is required when running in daemon mode."		\
+	    " option is required when running in daemon mode. If the"	\
+	    " filename is -, varnishlog writes to the standard output"	\
+	    " and cannot work as a daemon."				\
 	)
 
 LOG_OPT_a

--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -167,7 +167,10 @@ openout(int append)
 {
 
 	AN(CTX.w_arg);
-	CTX.fo = fopen(CTX.w_arg, append ? "a" : "w");
+	if (!strcmp(CTX.w_arg, "-"))
+		CTX.fo = stdout;
+	else
+		CTX.fo = fopen(CTX.w_arg, append ? "a" : "w");
 	if (CTX.fo == NULL)
 		VUT_Error(vut, 1, "Can't open output file (%s)",
 		    strerror(errno));
@@ -1216,6 +1219,9 @@ main(int argc, char * const *argv)
 
 	if (vut->D_opt && !CTX.w_arg)
 		VUT_Error(vut, 1, "Missing -w option");
+
+	if (vut->D_opt && !strcmp(CTX.w_arg, "-"))
+		VUT_Error(vut, 1, "Daemon cannot write to stdout");
 
 	/* Check for valid grouping mode */
 	assert(vut->g_arg < VSL_g__MAX);

--- a/bin/varnishncsa/varnishncsa_options.h
+++ b/bin/varnishncsa/varnishncsa_options.h
@@ -34,7 +34,8 @@
 #define NCSA_OPT_a							\
 	VOPT("a", "[-a]", "Append to file",				\
 	    "When writing output to a file, append to it rather than"	\
-	    " overwrite it."						\
+	    " overwrite it. This option has no effect without the -w"	\
+	    " option."							\
 	)
 
 #define NCSA_OPT_F							\
@@ -62,7 +63,9 @@
 	    " unless the -a option was specified. If the application"	\
 	    " receives a SIGHUP in daemon mode the file will be"	\
 	    " reopened allowing the old one to be rotated away. This"	\
-	    " option is required when running in daemon mode."		\
+	    " option is required when running in daemon mode. If the"	\
+	    " filename is -, varnishncsa writes to the standard output"	\
+	    " and cannot work as a daemon."				\
 	)
 #define NCSA_OPT_b							\
 	VOPT("b", "[-b]", "Backend mode",				\

--- a/bin/varnishtest/tests/u00003.vtc
+++ b/bin/varnishtest/tests/u00003.vtc
@@ -69,6 +69,8 @@ shell -expect "Copyright (c) 2006 Verdens Gang AS" \
 	"varnishncsa -V"
 shell -err -expect "Missing -w option" \
 	{varnishncsa -D}
+shell -err -expect "Daemon cannot write to stdout" \
+	"varnishlog -D -w -"
 shell -err -expect "Unknown format specifier at: %{foo}A" \
 	{varnishncsa -F "%{foo}A"}
 shell -err -expect "Unknown format specifier at: %A" \

--- a/bin/varnishtest/tests/u00006.vtc
+++ b/bin/varnishtest/tests/u00006.vtc
@@ -9,7 +9,7 @@ varnish v1 -vcl+backend {} -start
 
 # We use this to make sure we know there is a "0 CLI" in the binary log.
 process p1 {
-	exec varnishlog -n ${v1_name} -g raw -u -A
+	exec varnishlog -n ${v1_name} -g raw -u -A -w -
 } -start
 
 shell {

--- a/bin/varnishtest/tests/u00006.vtc
+++ b/bin/varnishtest/tests/u00006.vtc
@@ -26,6 +26,8 @@ shell -err -match "Usage: .*varnishlog <options>" \
 	"varnishlog extra"
 shell -err -expect "Missing -w option" \
 	"varnishlog -D"
+shell -err -expect "Daemon cannot write to stdout" \
+	"varnishlog -D -w -"
 shell -err -expect "Ambiguous grouping type: r" \
 	"varnishlog -g r"
 shell -err -expect "Unknown grouping type: foo" \

--- a/bin/varnishtest/tests/u00019.vtc
+++ b/bin/varnishtest/tests/u00019.vtc
@@ -1,0 +1,18 @@
+varnishtest "varnishlog write vsl to stdout"
+
+feature cmd "command -v gzip"
+feature cmd "command -v zcat"
+
+varnish v1 -vcl {
+	backend be none;
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 503
+} -run
+
+shell {varnishlog -d -w - -n ${v1_name} | gzip >vsl.gz}
+shell {ls -l}
+shell -match "RespStatus +503" {zcat vsl.gz | varnishlog -r -}

--- a/include/vut_options.h
+++ b/include/vut_options.h
@@ -93,7 +93,9 @@
 #define VUT_OPT_r							\
 	VOPT("r:", "[-r <filename>]", "Binary file input",		\
 	    "Read log in binary file format from this file. The file"	\
-	    " can be created with ``varnishlog -w filename``."		\
+	    " can be created with ``varnishlog -w filename``. If the"	\
+	    " filename is -, logs are read from the standard input."	\
+	    " and cannot work as a daemon."				\
 	)
 
 #define VUT_OPT_t							\

--- a/lib/libvarnishapi/vsl.c
+++ b/lib/libvarnishapi/vsl.c
@@ -413,14 +413,17 @@ VSL_WriteOpen(struct VSL_data *vsl, const char *name, int append, int unbuf)
 {
 	const char head[] = VSL_FILE_ID;
 	FILE* f;
-	f = fopen(name, append ? "a" : "w");
+	if (!strcmp(name, "-"))
+		f = stdout;
+	else
+		f = fopen(name, append ? "a" : "w");
 	if (f == NULL) {
 		vsl_diag(vsl, "%s", strerror(errno));
 		return (NULL);
 	}
 	if (unbuf)
 		setbuf(f, NULL);
-	if (0 == ftell(f)) {
+	if (ftell(f) == 0 || f == stdout) {
 		if (fwrite(head, 1, sizeof head, f) != sizeof head) {
 			vsl_diag(vsl, "%s", strerror(errno));
 			(void)fclose(f);

--- a/lib/libvarnishapi/vut.c
+++ b/lib/libvarnishapi/vut.c
@@ -302,6 +302,9 @@ VUT_Setup(struct VUT *vut)
 	    (vut->r_arg == NULL ? 0 : 2) > 2)
 		VUT_Error(vut, 1, "Only one of -n and -r options may be used");
 
+	if (vut->r_arg != NULL && !strcmp(vut->r_arg, "-") && vut->D_opt)
+		VUT_Error(vut, 1, "Daemon cannot read from stdin");
+
 	/* Create and validate the query expression */
 	vut->vslq = VSLQ_New(vut->vsl, NULL,
 	    (enum VSL_grouping_e)vut->g_arg, vut->q_arg);


### PR DESCRIPTION
As suggested in the https://github.com/varnishcache/varnish-cache/issues/3740#issuecomment-975240592 summary, I'm adding "-" meaning `stdout` for the `-w` option for parity with the `-r` option. Because VUTs daemonize closing the standard streams, it is now treated as an error to both daemonize and read or write from `stdin` or `stdout`.

Instead of adding errors as suggested for `-A` without `-w`, it is documented as a no-op in this situation, and the same is done for `-a` and `-u`.