### PR TITLE
std.ip: Always provide some form of fallback (6.0)

### DIFF
--- a/lib/libvmod_std/vmod_std_conversions.c
+++ b/lib/libvmod_std/vmod_std_conversions.c
@@ -90,7 +90,7 @@ vmod_ip(VRT_CTX, VCL_STRING s, VCL_IP d, VCL_BOOL n, VCL_STRING default_port)
 	p = WS_Alloc(ctx->ws, vsa_suckaddr_len);
 	if (p == NULL) {
 		VRT_fail(ctx, "std.ip: insufficient workspace");
-		return (NULL);
+		return (d);
 	}
 
 	if (s != NULL)


### PR DESCRIPTION
Otherwise valid code can panic on workspace exhaustion:

    std.ip(req.http.X-Real-IP, std.ip(req.http.X-Client-IP, client.ip))

If the nested std.ip() call runs out of workspace, it will return a null
ip instead of the fallback, and the outer std.ip() call will panic upon
checking the suckaddr sanity.

Refs #3746