### PR TITLE
param: Infrastructure for deprecated aliases

### DIFF
--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -101,10 +101,12 @@ static const char ONLY_ROOT_TEXT[] =
 	"NB: This parameter only works if varnishd is run as root.";
 
 static const char NOT_IMPLEMENTED_TEXT[] =
-	"This parameter depends on a feature which is not available"
+	"\n\n"
+	"NB: This parameter depends on a feature which is not available"
 	" on this platform.";
 
 static const char PLATFORM_DEPENDENT_TEXT[] =
+	"\n\n"
 	"NB: This parameter depends on a feature which is not available"
 	" on all platforms.";
 

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -778,6 +778,8 @@ MCF_DumpRstParam(void)
 	    "output from varnishd -x parameter\n\n");
 	VTAILQ_FOREACH(pl, &phead, list) {
 		pp = pl->spec;
+		if (!strcmp("deprecated_dummy", pp->name))
+		    continue;
 		printf(".. _ref_param_%s:\n\n", pp->name);
 		printf("%s\n", pp->name);
 		for (z = 0; z < strlen(pp->name); z++)

--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -262,6 +262,10 @@ mcf_param_show(struct cli *cli, const char * const *av, void *priv)
 		pp = pl->spec;
 		if (lfmt && strcmp(pp->name, av[2]) && strcmp("-l", av[2]))
 			continue;
+		if (pp->func == tweak_alias && !lfmt)
+			continue;
+		if (pp->func == tweak_alias && strcmp(pp->name, av[2]))
+			continue;
 		n++;
 
 		VSB_clear(vsb);
@@ -382,6 +386,10 @@ mcf_param_show_json(struct cli *cli, const char * const *av, void *priv)
 	VTAILQ_FOREACH(pl, &phead, list) {
 		pp = pl->spec;
 		if (show != NULL && strcmp(pp->name, show) != 0)
+			continue;
+		if (pp->func == tweak_alias && show == NULL)
+			continue;
+		if (pp->func == tweak_alias && strcmp(pp->name, show))
 			continue;
 		n++;
 
@@ -621,6 +629,13 @@ mcf_wash_param(struct cli *cli, struct parspec *pp, enum mcf_which_e which,
 		WRONG("bad 'which'");
 	}
 	AN(val);
+
+	if (pp->func == tweak_alias) {
+		assert(which == MCF_DEFAULT);
+		pp->priv = mcf_findpar(pp->def);
+		pp->def = NULL;
+		return;
+	}
 
 	VSB_clear(vsb);
 	VSB_printf(vsb, "FAILED to set %s for param %s: %s\n",

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -66,6 +66,7 @@ struct parspec {
 	char		*dyn_def;
 };
 
+tweak_t tweak_alias;
 tweak_t tweak_boolean;
 tweak_t tweak_bytes;
 tweak_t tweak_bytes_u;

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -492,7 +492,6 @@ tweak_thread_pool_max(struct vsb *vsb, const struct parspec *par,
 
 /*--------------------------------------------------------------------
  * Tweak storage
- *
  */
 
 int v_matchproto_(tweak_t)

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -527,3 +527,15 @@ tweak_storage(struct vsb *vsb, const struct parspec *par, const char *arg)
 	}
 	return (tweak_string(vsb, par, arg));
 }
+
+/*--------------------------------------------------------------------
+ * Tweak alias
+ */
+
+int v_matchproto_(tweak_t)
+tweak_alias(struct vsb *vsb, const struct parspec *par, const char *arg)
+{
+
+	par = TRUST_ME(par->priv);
+	return (par->func(vsb, par, arg));
+}

--- a/bin/varnishtest/tests/b00078.vtc
+++ b/bin/varnishtest/tests/b00078.vtc
@@ -1,0 +1,23 @@
+varnishtest "deprecated parameters"
+
+varnish v1 -cliok "param.set debug +syncvsl"
+
+shell -expect "+syncvsl" {
+	varnishadm -n ${v1_name} "param.show deprecated_dummy"
+}
+
+shell -expect "+syncvsl" {
+	varnishadm -n ${v1_name} "param.show -j deprecated_dummy"
+}
+
+shell -err {
+	varnishadm -n ${v1_name} "param.show" | grep deprecated_dummy
+}
+
+shell -err {
+	varnishadm -n ${v1_name} "param.show -l" | grep deprecated_dummy
+}
+
+shell -err {
+	varnishadm -n ${v1_name} "param.show -j" | grep deprecated_dummy
+}

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1641,6 +1641,21 @@ PARAM_PCRE2(
 	" messages."
 )
 
+/*--------------------------------------------------------------------
+ * Parameter deprecated aliases
+ *
+ * When a parameter is renamed, but the a deprecated alias is kept for
+ * compatibility, its documentation is minimal: only a description in
+ * manual pages, a description and current value in the CLI.
+ */
+
+#define PARAM_ALIAS(al, nm) \
+	PARAM(, , al, tweak_alias, NULL, NULL, NULL, #nm, NULL, \
+	    "Deprecated alias for the " #nm " parameter.")
+
+/* PARAM_ALIAS(old, new) */
+
+#  undef PARAM_ALIAS
 #  undef PARAM_ALL
 #  undef PARAM_PCRE2
 #  undef PARAM_STRING

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -37,8 +37,8 @@
 /*lint -save -e525 -e539 -e835 */
 
 /*--------------------------------------------------------------------
- *  * Simple parameters
- *   */
+ * Simple parameters
+ */
 
 #define PARAM_SIMPLE(nm, typ, ...) \
 	PARAM(typ, nm, nm, tweak_##typ, &mgt_param.nm, __VA_ARGS__)
@@ -1167,7 +1167,8 @@ PARAM_SIMPLE(
 /* We have a strict min at the protocol default here. This is because we
  * don't have the 'use settings only after peer ack' in place yet. If the
  * value is lower than the protocol default, the very first stream could
- * get a flow control error. */
+ * get a flow control error.
+ */
 PARAM_SIMPLE(
 	/* name */	h2_initial_window_size,
 	/* type */	bytes_u,

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1647,13 +1647,15 @@ PARAM_PCRE2(
  * When a parameter is renamed, but the a deprecated alias is kept for
  * compatibility, its documentation is minimal: only a description in
  * manual pages, a description and current value in the CLI.
+ *
+ * The deprecated_dummy alias is here for test coverage.
  */
 
 #define PARAM_ALIAS(al, nm) \
 	PARAM(, , al, tweak_alias, NULL, NULL, NULL, #nm, NULL, \
 	    "Deprecated alias for the " #nm " parameter.")
 
-/* PARAM_ALIAS(old, new) */
+PARAM_ALIAS(deprecated_dummy, debug)
 
 #  undef PARAM_ALIAS
 #  undef PARAM_ALL


### PR DESCRIPTION
With this change, we can formalize the renaming of a parameter while
maintaining the old name temporarily for compatibility.

A deprecated alias can be set with either `param.set` or the `-p` option,
but won't be listed by:

- `param.show [-j]`
- `param.show [-j] changed`
- `param.show -l`

Only an explicit `param.show` for the name of the alias will provide a
minimal documentation with a deprecation notice and the current value.
In the manual, there is only a deprecation notice. The rationale is
that administration tools shouldn't pick them up when enumerating the
parameters.

Since we currently don't have deprecated parameters, this can only be
tested manually, for example:

    PARAM_ALIAS(vcl_dir, vcl_path)

To ensure that we don't break this, we could consider having a perpetual
deprecated parameter.