### PR TITLE
cli: param.show -u shows the actual user input

### DIFF
--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -522,7 +522,7 @@ MCF_ParamProtect(struct cli *cli, const char *args)
 void
 MCF_ParamSet(struct cli *cli, const char *param, const char *val)
 {
-	const struct parspec *pp;
+	struct parspec *pp;
 
 	pp = mcf_findpar(param);
 	if (pp == NULL) {
@@ -547,6 +547,9 @@ MCF_ParamSet(struct cli *cli, const char *param, const char *val)
 		val = pp->def;
 	if (pp->func(cli->sb, pp, val))
 		VCLI_SetResult(cli, CLIS_PARAM);
+
+	if (cli->result == CLIS_OK)
+		REPLACE(pp->val, val);
 
 	if (cli->result == CLIS_OK && heritage.param != NULL)
 		*heritage.param = mgt_param;

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -64,6 +64,7 @@ struct parspec {
 	char		*dyn_min;
 	char		*dyn_max;
 	char		*dyn_def;
+	char		*val;
 };
 
 tweak_t tweak_alias;

--- a/bin/varnishtest/tests/b00042.vtc
+++ b/bin/varnishtest/tests/b00042.vtc
@@ -42,3 +42,11 @@ varnish v1 -clierr "106" "param.show -j -l"
 varnish v1 -clierr "106" "param.show -j fofofofo"
 varnish v1 -clierr "105" "param.show debug debug"
 varnish v1 -clierr "105" "param.show -j debug debug"
+
+varnish v1 -cliok "param.set workspace_client 131072"
+varnish v1 -cliexpect {Value is: 128k}   "param.show -u workspace_client"
+varnish v1 -cliexpect {Input is: 131072} "param.show -u workspace_client"
+
+varnish v1 -cliok "param.set workspace_client 128k"
+varnish v1 -cliexpect {"value": 131072,} "param.show -j -u workspace_client"
+varnish v1 -cliexpect {"input": "128k",} "param.show -j -u workspace_client"

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -180,7 +180,7 @@ CLI_CMD(PARAM_RESET,
 
 CLI_CMD(PARAM_SHOW,
 	"param.show",
-	"param.show [-l|-j] [<param>|changed]",
+	"param.show [-l|-j] [-u] [<param>|changed]",
 	"Show parameters and their values.",
 
 	"  The long form with ``-l`` shows additional information, including"
@@ -189,8 +189,10 @@ CLI_CMD(PARAM_SHOW,
 	" the information for the long form is included; only one of ``-l`` or"
 	" ``-j`` is permitted. If a parameter is specified with ``<param>``,"
 	" show only that parameter. If ``changed`` is specified, show only"
-	" those parameters whose values differ from their defaults.",
-	0, 2
+	" those parameters whose values differ from their defaults. The"
+	" parameter value may be adjusted depending on its type, and ``-u``"
+	" shows the actual user input.",
+	0, 3
 )
 
 CLI_CMD(PARAM_SET,


### PR DESCRIPTION
It can be challenging to have a consistency check of certain parameters
because of the way they are displayed. For example bytes parameters are
pretty-printed when possible in plain text, and plainly-printed in JSON
mode.

The new -u option for param.show adds an \<Input is: XXX> line in plain
text and an \<"input": "XXX"> field in JSON mode where XXX is the exact
user input for the current value of the parameter. Consistency checks
can use the user input to verify expectations and update parameters
accordingly, without changing the usual param.show output.