### PR TITLE
vcc: New SYM_ALIAS kind for deprecated symbols

### DIFF
--- a/bin/varnishtest/tests/r01332.vtc
+++ b/bin/varnishtest/tests/r01332.vtc
@@ -15,6 +15,7 @@ varnish v1 -vcl+backend {
 	sub vcl_deliver {
 		objx.enum(martin);
 		set resp.http.foo = objx.foo("");
+		set resp.http.bar = objx.bar("");
 	}
 } -start
 
@@ -23,4 +24,5 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 	expect resp.http.foo == "BOO"
+	expect resp.http.bar == "BOO"
 } -run

--- a/include/tbl/symbol_kind.h
+++ b/include/tbl/symbol_kind.h
@@ -33,6 +33,7 @@
 
 VCC_KIND(NONE,		none)
 VCC_KIND(RESERVED,	reserved)
+VCC_KIND(ALIAS,		alias)
 VCC_KIND(ACL,		acl)
 VCC_KIND(ACTION,	action)
 VCC_KIND(BACKEND,	backend)

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -384,6 +384,7 @@ vcc_kind_t VCC_HandleKind(vcc_type_t fmt);
 void VCC_PrintCName(struct vsb *vsb, const char *b, const char *e);
 struct symbol *VCC_MkSym(struct vcc *tl, const char *b, vcc_ns_t, vcc_kind_t,
     int, int);
+struct symbol *VCC_MkSymAlias(struct vcc *tl, const char *, const char *);
 
 struct symxref { const char *name; };
 extern const struct symxref XREF_NONE[1];

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -320,6 +320,14 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 			break;
 		tn = tn1;
 	}
+	if (sym != NULL && sym->kind == SYM_ALIAS) {
+		assert(ns == SYM_MAIN);
+		st = vcc_symtab_str(tl->syms[ns->id], sym->eval_priv, NULL, ID);
+		AN(st);
+		st2 = st;
+		sym = vcc_sym_in_tab(tl, st, SYM_NONE, sym->lorev, sym->hirev);
+		AN(sym);
+	}
 	if (sym != NULL && sym->kind == SYM_VMOD && e->partial)
 		e = SYMTAB_EXISTING;
 	if (sym != NULL && e->partial) {
@@ -447,6 +455,29 @@ VCC_MkSym(struct vcc *tl, const char *b, vcc_ns_t ns, vcc_kind_t kind,
 	sym = vcc_new_symbol(tl, st, kind, vlo, vhi);
 	AN(sym);
 	sym->noref = 1;
+	return (sym);
+}
+
+struct symbol *
+VCC_MkSymAlias(struct vcc *tl, const char *alias, const char *name)
+{
+	struct symbol *sym_alias, *sym;
+	struct symtab *st;
+
+	AN(tl);
+	AN(alias);
+	AN(name);
+
+	st = vcc_symtab_str(tl->syms[SYM_MAIN->id], name, NULL, ID);
+	AN(st);
+	sym = vcc_sym_in_tab(tl, st, SYM_NONE, VCL_LOW, VCL_HIGH);
+	AN(sym);
+	assert(sym->kind != SYM_ALIAS);
+	sym_alias = VCC_MkSym(tl, alias, SYM_MAIN, SYM_ALIAS, sym->lorev,
+	    sym->hirev);
+	AN(sym_alias);
+	sym_alias->eval_priv = strdup(name);
+	AN(sym_alias->eval_priv);
 	return (sym);
 }
 

--- a/vmod/vmod_cookie.c
+++ b/vmod/vmod_cookie.c
@@ -451,7 +451,7 @@ vmod_get_string(VRT_CTX, struct vmod_priv *priv)
 }
 
 VCL_STRING
-vmod_format_rfc1123(VRT_CTX, VCL_TIME ts, VCL_DURATION duration)
+vmod_format_date(VRT_CTX, VCL_TIME ts, VCL_DURATION duration)
 {
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);

--- a/vmod/vmod_cookie.vcc
+++ b/vmod/vmod_cookie.vcc
@@ -132,7 +132,7 @@ Example::
 
 
 
-$Function STRING format_rfc1123(TIME now, DURATION timedelta)
+$Function STRING format_date(TIME now, DURATION timedelta)
 
 Get a RFC1123 formatted date string suitable for inclusion in a
 Set-Cookie response header.
@@ -145,7 +145,7 @@ Example::
 	sub vcl_deliver {
 	    # Set a userid cookie on the client that lives for 5 minutes.
 	    set resp.http.Set-Cookie = "userid=" + req.http.userid +
-	        "; Expires=" + cookie.format_rfc1123(now, 5m) + "; httpOnly";
+	        "; Expires=" + cookie.format_date(now, 5m) + "; httpOnly";
 	}
 
 $Function STRING get(PRIV_TASK, STRING cookiename)
@@ -254,3 +254,8 @@ Example::
 	    cookie.set("cookie1", "value1");
 	    std.log("cookie1 value is: " + cookie.get("cookie1"));
 	}
+
+DEPRECATED
+==========
+
+$Alias format_rfc1123 format_date

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -374,3 +374,10 @@ $Object caller(SUB)
 $Method VOID .call()
 
 $Method SUB .xsub()
+
+DEPRECATED
+==========
+
+$Alias .bar obj.foo
+
+Bar was wrong, it was definitely foo.


### PR DESCRIPTION
Their sole purpose is to resolve to another symbol. The script expects aliases to be defined like this in the RST docs:

    my.alias ``VCL <= 4.1``

        Type: DEPRECATED

        Alias of: something.else

        A little description is still necessary.

This should facilitate renaming variables in the future. One thing we could do is to have libvcc warn about deprecated aliases (subject to a new `vcc_err_alias` parameter too) to make this visible not just in the manual.

There is no `DEPRECATED` type in addition to the new `SYM_ALIAS` kind, this is a purely cosmetic suggestion.

Deprecated aliases should probably have a high VCL version limit like in the example above, `generate.py` doesn't enforce it so far.

Aliases have zero runtime cost, since ultimately the aliased symbol is used at compile time instead of the alias itself. Renaming a variable and keeping the old name as an alias will result in VRT breakage.

---

This is the VCL counterpart of #3753, and the first variable to be renamed this way is `req.esi_level`.