### PR TITLE
param: Optionally pass a duration unit to timeouts

### DIFF
--- a/bin/varnishtest/tests/b00042.vtc
+++ b/bin/varnishtest/tests/b00042.vtc
@@ -4,6 +4,7 @@ varnish v1 -vcl {backend be none;} -start
 
 
 varnish v1 -clierr 106	"param.set default_ttl -1"
+varnish v1 -clierr 106	{param.set acceptor_sleep_decay "0.42 is not a number"}
 varnish v1 -clierr 106	"param.set acceptor_sleep_max 20"
 varnish v1 -cliok	"param.set prefer_ipv6 off"
 varnish v1 -cliok	"param.set prefer_ipv6 no"

--- a/bin/varnishtest/tests/b00042.vtc
+++ b/bin/varnishtest/tests/b00042.vtc
@@ -4,6 +4,10 @@ varnish v1 -vcl {backend be none;} -start
 
 
 varnish v1 -clierr 106	"param.set default_ttl -1"
+varnish v1 -clierr 106	"param.set default_ttl 1x"
+varnish v1 -cliok	"param.set default_ttl 1s"
+varnish v1 -clierr 106	{param.set default_ttl "1 x"}
+varnish v1 -cliok	{param.set default_ttl "1 s"}
 varnish v1 -clierr 106	{param.set acceptor_sleep_decay "0.42 is not a number"}
 varnish v1 -clierr 106	"param.set acceptor_sleep_max 20"
 varnish v1 -cliok	"param.set prefer_ipv6 off"

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -385,13 +385,16 @@ PARAM_SIMPLE(
 	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* def */	"10.000",
+	/* def */	"10s",
 	/* units */	"seconds",
 	/* descr */
 	"Default grace period.  We will deliver an object this long after "
 	"it has expired, provided another thread is attempting to get a "
 	"new copy.",
-	/* flags */	OBJ_STICKY
+	/* flags */	OBJ_STICKY,
+	/* dyn_min_reason */	NULL,
+	/* dyn_max_reason */	NULL,
+	/* dyn_def_reason */	"10s"
 )
 
 PARAM_SIMPLE(
@@ -399,14 +402,17 @@ PARAM_SIMPLE(
 	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* def */	"0.000",
+	/* def */	"0s",
 	/* units */	"seconds",
 	/* descr */
 	"Default keep period.  We will keep a useless object around this "
 	"long, making it available for conditional backend fetches.  That "
 	"means that the object will be removed from the cache at the end "
 	"of ttl+grace+keep.",
-	/* flags */	OBJ_STICKY
+	/* flags */	OBJ_STICKY,
+	/* dyn_min_reason */	NULL,
+	/* dyn_max_reason */	NULL,
+	/* dyn_def_reason */	"0s"
 )
 
 PARAM_SIMPLE(
@@ -414,12 +420,15 @@ PARAM_SIMPLE(
 	/* type */	timeout,
 	/* min */	"0.000",
 	/* max */	NULL,
-	/* def */	"120.000",
+	/* def */	"2m",
 	/* units */	"seconds",
 	/* descr */
 	"The TTL assigned to objects if neither the backend nor the VCL "
 	"code assigns one.",
-	/* flags */	OBJ_STICKY
+	/* flags */	OBJ_STICKY,
+	/* dyn_min_reason */	NULL,
+	/* dyn_max_reason */	NULL,
+	/* dyn_def_reason */	"2m"
 )
 
 PARAM_SIMPLE(


### PR DESCRIPTION
Allowing units is much more convenient and keeping them optional
maintains compatibility. On the other hand, changing the defaults
for default_ttl and default_grace has no impact on the generated
RST.

Keeping track of the user input could help since default values
are "washed" like user input, without resorting to a dynamic
default.

Refs #3756