### PR TITLE
esi: Implement <esi:include onerror="continue"/>

### DIFF
--- a/bin/varnishd/cache/cache_esi.h
+++ b/bin/varnishd/cache/cache_esi.h
@@ -39,7 +39,8 @@
 #define	VEC_S1	(0x60 + 1)
 #define	VEC_S2	(0x60 + 2)
 #define	VEC_S8	(0x60 + 8)
-#define	VEC_INCL	'I'
+#define	VEC_INCL_ABRT	'I'
+#define	VEC_INCL_CONT	'i'
 
 typedef ssize_t vep_callback_t(struct vfp_ctx *, void *priv, ssize_t l,
     enum vgz_flag flg);

--- a/bin/varnishd/cache/cache_esi.h
+++ b/bin/varnishd/cache/cache_esi.h
@@ -39,8 +39,8 @@
 #define	VEC_S1	(0x60 + 1)
 #define	VEC_S2	(0x60 + 2)
 #define	VEC_S8	(0x60 + 8)
-#define	VEC_INCL_ABRT	'I'
-#define	VEC_INCL_CONT	'i'
+#define	VEC_IA	(0x40 + 9)
+#define	VEC_IC	(0x60 + 9)
 
 typedef ssize_t vep_callback_t(struct vfp_ctx *, void *priv, ssize_t l,
     enum vgz_flag flg);

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -379,11 +379,11 @@ ved_vdp_esi_bytes(struct vdp_ctx *vdx, enum vdp_action act, void **priv,
 				Debug("SKIP1(%d)\n", (int)ecx->l);
 				ecx->state = 4;
 				break;
-			case VEC_INCL_ABRT:
+			case VEC_IA:
 				ecx->abrt =
 				    FEATURE(FEATURE_ESI_INCLUDE_ONERROR);
 				/* FALLTHROUGH */
-			case VEC_INCL_CONT:
+			case VEC_IC:
 				ecx->p++;
 				q = (void*)strchr((const char*)ecx->p, '\0');
 				AN(q);

--- a/bin/varnishd/cache/cache_esi_parse.c
+++ b/bin/varnishd/cache/cache_esi_parse.c
@@ -514,7 +514,7 @@ vep_do_include(struct vep_state *vep, enum dowhat what)
 	l = VSB_len(vep->include_src);
 	h = 0;
 
-	incl = vep->include_continue ? VEC_INCL_CONT : VEC_INCL_ABRT;
+	incl = vep->include_continue ? VEC_IC : VEC_IA;
 
 	if (l > 7 && !memcmp(p, "http://", 7)) {
 		h = p + 7;

--- a/bin/varnishtest/tests/e00035.vtc
+++ b/bin/varnishtest/tests/e00035.vtc
@@ -1,0 +1,50 @@
+varnishtest "ESI fragment fetch fail"
+
+server s1 {
+	rxreq
+	expect req.url == "/abort"
+	txresp -hdr {surrogate-control: content="ESI/1.0"} \
+	    -body {before <esi:include src="/fail"/> after}
+
+	rxreq
+	expect req.url == "/fail"
+	txresp -hdr "content-length: 100" -nolen
+	delay 0.1
+} -start
+
+varnish v1 -cliok "param.set feature +esi_disable_xml_check"
+varnish v1 -cliok "param.set feature +esi_include_onerror"
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.do_esi = beresp.http.surrogate-control ~ "ESI/1.0";
+		unset beresp.http.surrogate-control;
+	}
+} -start
+
+client c1 {
+	txreq -url "/abort"
+	non_fatal
+	rxresp
+	expect resp.body == "before "
+} -run
+
+server s1 -wait
+
+server s1 {
+	rxreq
+	expect req.url == "/continue"
+	txresp -hdr {surrogate-control: content="ESI/1.0"} \
+	    -body {before <esi:include src="/fail" onerror="continue"/> after}
+
+	rxreq
+	expect req.url == "/fail"
+	txresp -hdr "content-length: 100" -nolen
+	delay 0.1
+} -start
+
+client c1 {
+	fatal
+	txreq -url "/continue"
+	rxresp
+	expect resp.body == "before  after"
+} -run

--- a/include/tbl/feature_bits.h
+++ b/include/tbl/feature_bits.h
@@ -70,6 +70,10 @@ FEATURE_BIT(ESI_REMOVE_BOM,		esi_remove_bom,
     "Ignore UTF-8 BOM in ESI bodies."
 )
 
+FEATURE_BIT(ESI_INCLUDE_ONERROR,	esi_include_onerror,
+    "Parse the onerror attribute of <esi:include> tags."
+)
+
 FEATURE_BIT(WAIT_SILO,			wait_silo,
     "Wait for persistent silos to completely load before serving requests."
 )


### PR DESCRIPTION
This changes the default behavior of includes, matching the ESI language specification. The onerror attribute seems to only accept one value, so in its absence a failed ESI fragment delivery aborts the top request delivery.

In addition, it breaks the ESI object attribute format for persisted caches.

---

This is OK for trunk to change the default behavior and objattr format, but for the 6.0 LTS branch we would need to gate this behind a feature flag. I'm wondering whether this is fine to have such an `esi_include_onerror` flag in 6.0 that does not exist in trunk.