### PR TITLE
vcc: Teach HEADER symbols to accept constant strings

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -634,6 +634,32 @@ VRT_SetHdr(VRT_CTX, VCL_HEADER hs, const char *pfx, VCL_STRANDS s)
 	http_SetHeader(hp, b);
 }
 
+VCL_VOID
+VRT_SetHeader(VRT_CTX, VCL_HEADER hs, const char *hdr)
+{
+	VCL_HTTP hp;
+	unsigned wl, hl;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	AN(hs);
+	AN(hs->what);
+	AN(hdr);
+
+	hl = strlen(hdr);
+	wl = hs->what[0];
+	assert(hl > wl);
+	AZ(strncasecmp(hs->what + 1, hdr, wl));
+	hp = VRT_selecthttp(ctx, hs->where);
+	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
+
+	if (FEATURE(FEATURE_VALIDATE_HEADERS) && !validhdr(hdr + wl)) {
+		VRT_fail(ctx, "Bad static header %s", hdr);
+		return;
+	}
+	http_Unset(hp, hs->what);
+	http_SetHeader(hp, hdr);
+}
+
 /*--------------------------------------------------------------------*/
 
 VCL_VOID

--- a/bin/varnishtest/tests/b00040.vtc
+++ b/bin/varnishtest/tests/b00040.vtc
@@ -35,7 +35,7 @@ logexpect l1 -v v1 -g raw {
 	expect * 1012 BogoHeader {Header has ctrl char 0x0d}
 	expect * 1014 BogoHeader {Header has ctrl char 0x0d}
 	expect * 1016 BogoHeader {Missing header name:.*}
-	expect * 1018 VCL_Error  {Bad header foo:}
+	expect * 1018 VCL_Error  {Bad static header foo:}
 } -start
 
 client c1 {

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -65,6 +65,7 @@
  *	BODY can either be a BLOB or a STRANDS, but only a STRANDS
  *	can take a non-NULL const char * prefix. The changes to BODY
  *	assignments doesn't break the ABI or the API.
+ *	VRT_SetHeader() added
  *
  * 14.0 (2021-09-15)
  *	VIN_n_Arg() no directly returns the directory name.
@@ -646,6 +647,7 @@ VCL_VOID VRT_hit_for_pass(VRT_CTX, VCL_DURATION);
 VCL_BOOL VRT_ValidHdr(VRT_CTX, VCL_STRANDS);
 VCL_VOID VRT_UnsetHdr(VRT_CTX, VCL_HEADER);
 VCL_VOID VRT_SetHdr(VRT_CTX, VCL_HEADER, const char *pfx, VCL_STRANDS);
+VCL_VOID VRT_SetHeader(VRT_CTX, VCL_HEADER, const char *);
 VCL_VOID VRT_handling(VRT_CTX, unsigned hand);
 unsigned VRT_handled(VRT_CTX);
 VCL_VOID VRT_fail(VRT_CTX, const char *fmt, ...) v_printflike_(2,3);

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -151,6 +151,7 @@ vcc_assign_edit(struct vsb *vsb, struct symbol *sym, const struct assign *ap)
 static void v_matchproto_(sym_act_f)
 vcc_act_set(struct vcc *tl, struct token *t, struct symbol *sym)
 {
+	const char *const_assign = NULL;
 	const struct assign *ap;
 	struct vsb *vsb;
 	vcc_type_t type;
@@ -181,7 +182,11 @@ vcc_act_set(struct vcc *tl, struct token *t, struct symbol *sym)
 	AN(vsb);
 	vcc_assign_edit(vsb, sym, ap);
 	AZ(VSB_finish(vsb));
-	vcc_ExprEdit(tl, type, VSB_data(vsb), NULL);
+
+	if (ap->oper == '=')
+		const_assign = sym->const_assign;
+
+	vcc_ExprEdit(tl, type, VSB_data(vsb), const_assign);
 	VSB_destroy(&vsb);
 	SkipToken(tl, ';');
 }

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -348,6 +348,7 @@ char *TlDup(struct vcc *tl, const char *s);
 
 /* vcc_expr.c */
 void vcc_Expr(struct vcc *tl, vcc_type_t typ);
+void vcc_ExprEdit(struct vcc *tl, vcc_type_t typ, const char *, const char *);
 sym_act_f vcc_Act_Call;
 sym_act_f vcc_Act_Obj;
 void vcc_Expr_Init(struct vcc *tl);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -200,6 +200,7 @@ struct symbol {
 	unsigned			w_methods;
 	const char			*uname;
 	unsigned			u_methods;
+	const char			*const_assign;
 };
 
 VTAILQ_HEAD(tokenhead, token);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -120,7 +120,6 @@ struct type {
 	vcc_type_t		multype;
 	int			stringform;
 	int			bodyform;
-	int			noindent;
 };
 
 #define VCC_TYPE(UC, lc)	extern const struct type UC[1];

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1510,13 +1510,42 @@ vcc_expr_typecheck(struct vcc *tl, struct expr **e, vcc_type_t fmt,
 void
 vcc_Expr(struct vcc *tl, vcc_type_t fmt)
 {
-	struct expr *e = NULL;
+
+	vcc_ExprEdit(tl, fmt, NULL, NULL);
+}
+
+void
+vcc_ExprEdit(struct vcc *tl, vcc_type_t fmt, const char *var_edit,
+    const char *const_edit)
+{
+	struct expr *e = NULL, *e1 = NULL;
+	const char *edit = NULL;
 
 	assert(fmt != VOID);
 	assert(fmt != STRINGS);
 	vcc_expr0(tl, &e, fmt);
 	ERRCHK(tl);
 	assert(e->fmt == fmt);
+	if (const_edit != NULL)
+		AN(var_edit);
+
+	if (e->constant & EXPR_VAR) {
+		if (e->constant_expr != NULL) {
+			edit = const_edit;
+			e1 = e->constant_expr;
+		}
+	} else {
+		edit = const_edit;
+		e1 = e;
+	}
+
+	if (edit == NULL) {
+		edit = var_edit;
+		e1 = e;
+	}
+
+	if (edit != NULL)
+		e = vcc_expr_edit(tl, e1->fmt, edit, e1, NULL);
 
 	vcc_expr_fmt(tl->fb, tl->indent, e);
 	VSB_cat(tl->fb, "\n");

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -252,10 +252,8 @@ vcc_expr_fmt(struct vsb *d, int ind, const struct expr *e1)
 	char *p;
 	int i;
 
-	if (!e1->fmt->noindent) {
-		for (i = 0; i < ind; i++)
-			VSB_putc(d, ' ');
-	}
+	for (i = 0; i < ind; i++)
+		VSB_putc(d, ' ');
 	p = VSB_data(e1->vsb);
 	while (*p != '\0') {
 		if (*p == '\n') {

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -85,7 +85,6 @@ const struct type BLOB[1] = {{
 const struct type BODY[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"BODY",
-	.noindent =		1,
 }};
 
 const struct type BOOL[1] = {{

--- a/lib/libvcc/vcc_var.c
+++ b/lib/libvcc/vcc_var.c
@@ -96,5 +96,10 @@ vcc_Var_Wildcard(struct vcc *tl, struct symbol *parent, struct symbol *sym)
 	VSB_printf(vsb, "VRT_UnsetHdr(ctx, %s)", sym->rname);
 	AZ(VSB_finish(vsb));
 	sym->uname = TlDup(tl, VSB_data(vsb));
+	VSB_clear(vsb);
+	VSB_printf(vsb, "VRT_SetHeader(ctx, %s, \"%s: \" \v1);",
+	    sym->rname, sym->name);
+	AZ(VSB_finish(vsb));
+	sym->const_assign = TlDup(tl, VSB_data(vsb));
 	VSB_destroy(&vsb);
 }


### PR DESCRIPTION
Static strings are unfortunately copied into workspace simply because
they don't belong to it. Since it is safe to reference a static string,
or at the very least a string that is guaranteed to outlive a VCL
transaction since in this case it has the same scope as the VCL shared
object, we can bypass the regular STRANDS assignment.

When a transaction runs out of workspace, fails and goes to vcl_synth,
we don't want to fail again because of a static VCL assignment of the
content-type and retry-after headers from the built-in VCL.

Refs #3765