### PR TITLE
vsc: Always perform volatile access to VSC values

### DIFF
--- a/include/vapi/vsc.h
+++ b/include/vapi/vsc.h
@@ -171,7 +171,7 @@ VSC_Value(const struct VSC_point * const pt)
 {
 	uint64_t val;
 
-	val = *pt->ptr;
+	val =  *(const volatile uint64_t*)pt->ptr;
 	if (!pt->raw && pt->semantics == 'g' && val > INT64_MAX)
 		val = 0;
 	return (val);


### PR DESCRIPTION
From @asadsa92's recent review of #3483:

> Any side-effect to get rid off the volatile pointer?

There used to be two locations where `pt->ptr` was dereferenced as a
volatile pointer and considering the effective volatility of VSCs we
should probably generalize it in VSC_Value() where it was centralized.