### PR TITLE
param: New experimental parameter

### DIFF
--- a/bin/varnishd/cache/cache_pool.c
+++ b/bin/varnishd/cache/cache_pool.c
@@ -197,7 +197,7 @@ pool_poolherder(void *priv)
 				continue;
 			}
 		} else if (nwq > cache_param->wthread_pools &&
-				DO_DEBUG(DBG_DROP_POOLS)) {
+				EXPERIMENTAL(EXPERIMENTAL_DROP_POOLS)) {
 			Lck_Lock(&pool_mtx);
 			pp = VTAILQ_FIRST(&pools);
 			CHECK_OBJ_NOTNULL(pp, POOL_MAGIC);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -570,6 +570,7 @@ void SMP_Ready(void);
 #endif
 
 #define FEATURE(x)	COM_FEATURE(cache_param->feature_bits, x)
+#define EXPERIMENTAL(x)	COM_EXPERIMENTAL(cache_param->experimental_bits, x)
 #define DO_DEBUG(x)	COM_DO_DEBUG(cache_param->debug_bits, x)
 
 #define DSL(debug_bit, id, ...)					\

--- a/bin/varnishd/common/common_param.h
+++ b/bin/varnishd/common/common_param.h
@@ -52,6 +52,18 @@ COM_DO_DEBUG(const volatile uint8_t *p, enum debug_bits x)
 	return (p[(unsigned)x>>3] & (0x80U >> ((unsigned)x & 7)));
 }
 
+enum experimental_bits {
+#define EXPERIMENTAL_BIT(U, l, d) EXPERIMENTAL_##U,
+#include "tbl/experimental_bits.h"
+       EXPERIMENTAL_Reserved
+};
+
+static inline int
+COM_EXPERIMENTAL(const volatile uint8_t *p, enum experimental_bits x)
+{
+	return (p[(unsigned)x>>3] & (0x80U >> ((unsigned)x & 7)));
+}
+
 enum feature_bits {
 #define FEATURE_BIT(U, l, d) FEATURE_##U,
 #include "tbl/feature_bits.h"
@@ -64,7 +76,6 @@ COM_FEATURE(const volatile uint8_t *p, enum feature_bits x)
 	return (p[(unsigned)x>>3] & (0x80U >> ((unsigned)x & 7)));
 }
 
-
 struct poolparam {
 	unsigned		min_pool;
 	unsigned		max_pool;
@@ -75,6 +86,7 @@ struct poolparam {
 
 PARAM_BITMAP(vsl_mask_t,	256);
 PARAM_BITMAP(debug_t,		DBG_Reserved);
+PARAM_BITMAP(experimental_t,	EXPERIMENTAL_Reserved);
 PARAM_BITMAP(feature_t,		FEATURE_Reserved);
 #undef PARAM_BITMAP
 
@@ -114,5 +126,6 @@ struct params {
 
 	vsl_mask_t		vsl_mask;
 	debug_t			debug_bits;
+	experimental_t		experimental_bits;
 	feature_t		feature_bits;
 };

--- a/bin/varnishd/common/common_param.h
+++ b/bin/varnishd/common/common_param.h
@@ -71,10 +71,12 @@ struct poolparam {
 	vtim_dur		max_age;
 };
 
+#define PARAM_BITMAP(name, len) typedef uint8_t name[(len + 7)>>3]
 
-typedef uint8_t vsl_mask_t[256>>3];
-typedef uint8_t debug_t[(DBG_Reserved+7)>>3];
-typedef uint8_t feature_t[(FEATURE_Reserved+7)>>3];
+PARAM_BITMAP(vsl_mask_t,	256);
+PARAM_BITMAP(debug_t,		DBG_Reserved);
+PARAM_BITMAP(feature_t,		FEATURE_Reserved);
+#undef PARAM_BITMAP
 
 struct params {
 

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -244,5 +244,6 @@ extern const char *mgt_vmod_path;
 #error "Keep pthreads out of in manager process"
 #endif
 
-#define MGT_FEATURE(x)	COM_FEATURE(mgt_param.feature_bits, x)
-#define MGT_DO_DEBUG(x)	COM_DO_DEBUG(mgt_param.debug_bits, x)
+#define MGT_FEATURE(x)		COM_FEATURE(mgt_param.feature_bits, x)
+#define MGT_EXPERIMENTAL(x)	COM_EXPERIMENTAL(mgt_param.experimental_bits, x)
+#define MGT_DO_DEBUG(x)		COM_DO_DEBUG(mgt_param.debug_bits, x)

--- a/bin/varnishd/mgt/mgt_param_bits.c
+++ b/bin/varnishd/mgt/mgt_param_bits.c
@@ -64,7 +64,7 @@ bit(uint8_t *p, unsigned no, enum bit_do act)
 
 static int
 bit_tweak(struct vsb *vsb, uint8_t *p, unsigned l, const char *arg,
-    const char * const *tags, const char *desc, const char *sign)
+    const char * const *tags, const char *desc, char sign)
 {
 	int i, n;
 	unsigned j;
@@ -94,7 +94,7 @@ bit_tweak(struct vsb *vsb, uint8_t *p, unsigned l, const char *arg,
 			return (-1);
 		}
 		assert(j < l);
-		if (s[0] == *sign)
+		if (s[0] == sign)
 			(void)bit(p, j, BSET);
 		else
 			(void)bit(p, j, BCLR);
@@ -141,7 +141,7 @@ tweak_vsl_mask(struct vsb *vsb, const struct parspec *par, const char *arg)
 			(void)bit(mgt_param.vsl_mask, SLT_ExpKill, BSET);
 		} else {
 			return (bit_tweak(vsb, mgt_param.vsl_mask,
-			    SLT__Reserved, arg, VSL_tags, "VSL tag", "-"));
+			    SLT__Reserved, arg, VSL_tags, "VSL tag", '-'));
 		}
 	} else {
 		if (arg == JSON_FMT)
@@ -184,7 +184,7 @@ tweak_debug(struct vsb *vsb, const struct parspec *par, const char *arg)
 			    0, sizeof mgt_param.debug_bits);
 		} else {
 			return (bit_tweak(vsb, mgt_param.debug_bits,
-			    DBG_Reserved, arg, debug_tags, "debug bit", "+"));
+			    DBG_Reserved, arg, debug_tags, "debug bit", '+'));
 		}
 	} else {
 		if (arg == JSON_FMT)
@@ -228,7 +228,7 @@ tweak_experimental(struct vsb *vsb, const struct parspec *par, const char *arg)
 		} else {
 			return (bit_tweak(vsb, mgt_param.experimental_bits,
 			    EXPERIMENTAL_Reserved, arg, experimental_tags,
-			    "experimental bit", "+"));
+			    "experimental bit", '+'));
 		}
 	} else {
 		if (arg == JSON_FMT)
@@ -278,7 +278,7 @@ tweak_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
 		} else {
 			return (bit_tweak(vsb, mgt_param.feature_bits,
 			    FEATURE_Reserved, arg, feature_tags,
-			    "feature bit", "+"));
+			    "feature bit", '+'));
 		}
 	} else {
 		if (arg == JSON_FMT)

--- a/bin/varnishd/mgt/mgt_param_bits.c
+++ b/bin/varnishd/mgt/mgt_param_bits.c
@@ -115,7 +115,12 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 	const char *s;
 	unsigned j;
 
-	(void)par;
+	if (arg != NULL && !strcmp(arg, "default") &&
+	    strcmp(par->def, "none")) {
+		memset(p, 0, l >> 3);
+		return (tweak_generic_bits(vsb, par, par->def, p, l, tags,
+		    desc, sign));
+	}
 
 	if (arg != NULL && arg != JSON_FMT) {
 		if (sign == '+' && !strcmp(arg, "none"))
@@ -152,26 +157,6 @@ static const char * const VSL_tags[256] = {
 static int v_matchproto_(tweak_t)
 tweak_vsl_mask(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
-
-	if (arg != NULL && !strcmp(arg, "default")) {
-		memset(mgt_param.vsl_mask, 0, sizeof mgt_param.vsl_mask);
-		(void)bit(mgt_param.vsl_mask, SLT_VCL_trace, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_WorkThread, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_Hash, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_VfpAcct, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_VdpAcct, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_H2TxBody, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_H2TxHdr, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_H2RxBody, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_H2RxHdr, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_ObjHeader, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_ObjProtocol, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_ObjReason, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_ObjStatus, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_Debug, BSET);
-		(void)bit(mgt_param.vsl_mask, SLT_ExpKill, BSET);
-		return (0);
-	}
 
 	return (tweak_generic_bits(vsb, par, arg, mgt_param.vsl_mask,
 	    SLT__Reserved, VSL_tags, "VSL tag", '-'));
@@ -227,14 +212,6 @@ static int v_matchproto_(tweak_t)
 tweak_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 
-	if (arg != NULL && !strcmp(arg, "default")) {
-		memset(mgt_param.feature_bits, 0,
-		    sizeof mgt_param.feature_bits);
-		(void)bit(mgt_param.feature_bits,
-		    FEATURE_VALIDATE_HEADERS, BSET);
-		return (0);
-	}
-
 	return (tweak_generic_bits(vsb, par, arg, mgt_param.feature_bits,
 	    FEATURE_Reserved, feature_tags, "feature bit", '+'));
 }
@@ -245,14 +222,32 @@ tweak_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
 
 struct parspec VSL_parspec[] = {
 	{ "vsl_mask", tweak_vsl_mask, NULL,
-		NULL, NULL, "default",
+		NULL, NULL,
+		/* default */
+		"-Debug,"
+		"-ExpKill,"
+		"-H2RxBody,"
+		"-H2RxHdr,"
+		"-H2TxBody,"
+		"-H2TxHdr,"
+		"-Hash,"
+		"-ObjHeader,"
+		"-ObjProtocol,"
+		"-ObjReason,"
+		"-ObjStatus,"
+		"-VCL_trace,"
+		"-VdpAcct,"
+		"-VfpAcct,"
+		"-WorkThread",
 		NULL,
 		"Mask individual VSL messages from being logged.\n"
 		"\tdefault\tSet default value\n"
 		"\nUse +/- prefix in front of VSL tag name to unmask/mask "
 		"individual VSL messages." },
 	{ "debug", tweak_debug, NULL,
-		NULL, NULL, "none",
+		NULL, NULL,
+		/* default */
+		"none",
 		NULL,
 		"Enable/Disable various kinds of debugging.\n"
 		"\tnone\tDisable all debugging\n\n"
@@ -261,7 +256,9 @@ struct parspec VSL_parspec[] = {
 #include "tbl/debug_bits.h"
 		},
 	{ "experimental", tweak_experimental, NULL,
-		NULL, NULL, "none",
+		NULL, NULL,
+		/* default */
+		"none",
 		NULL,
 		"Enable/Disable experimental features.\n"
 		"\tnone\tDisable all experimental features\n\n"
@@ -270,7 +267,9 @@ struct parspec VSL_parspec[] = {
 #include "tbl/experimental_bits.h"
 		},
 	{ "feature", tweak_feature, NULL,
-		NULL, NULL, "default",
+		NULL, NULL,
+		/* default */
+		"+validate_headers",
 		NULL,
 		"Enable/Disable various minor features.\n"
 		"\tdefault\tSet default value\n"

--- a/bin/varnishd/mgt/mgt_param_bits.c
+++ b/bin/varnishd/mgt/mgt_param_bits.c
@@ -120,29 +120,29 @@ tweak_vsl_mask(struct vsb *vsb, const struct parspec *par, const char *arg)
 	const char *s;
 	(void)par;
 
+	if (arg != NULL && !strcmp(arg, "default")) {
+		memset(mgt_param.vsl_mask, 0, sizeof mgt_param.vsl_mask);
+		(void)bit(mgt_param.vsl_mask, SLT_VCL_trace, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_WorkThread, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_Hash, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_VfpAcct, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_VdpAcct, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_H2TxBody, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_H2TxHdr, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_H2RxBody, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_H2RxHdr, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_ObjHeader, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_ObjProtocol, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_ObjReason, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_ObjStatus, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_Debug, BSET);
+		(void)bit(mgt_param.vsl_mask, SLT_ExpKill, BSET);
+		return (0);
+	}
+
 	if (arg != NULL && arg != JSON_FMT) {
-		if (!strcmp(arg, "default")) {
-			memset(mgt_param.vsl_mask,
-			    0, sizeof mgt_param.vsl_mask);
-			(void)bit(mgt_param.vsl_mask, SLT_VCL_trace, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_WorkThread, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_Hash, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_VfpAcct, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_VdpAcct, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_H2TxBody, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_H2TxHdr, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_H2RxBody, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_H2RxHdr, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_ObjHeader, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_ObjProtocol, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_ObjReason, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_ObjStatus, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_Debug, BSET);
-			(void)bit(mgt_param.vsl_mask, SLT_ExpKill, BSET);
-		} else {
-			return (bit_tweak(vsb, mgt_param.vsl_mask,
-			    SLT__Reserved, arg, VSL_tags, "VSL tag", '-'));
-		}
+		return (bit_tweak(vsb, mgt_param.vsl_mask,
+		    SLT__Reserved, arg, VSL_tags, "VSL tag", '-'));
 	} else {
 		if (arg == JSON_FMT)
 			VSB_putc(vsb, '"');
@@ -266,13 +266,16 @@ tweak_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
 	unsigned j;
 	(void)par;
 
+	if (arg != NULL && !strcmp(arg, "default")) {
+		memset(mgt_param.feature_bits, 0,
+		    sizeof mgt_param.feature_bits);
+		(void)bit(mgt_param.feature_bits,
+		    FEATURE_VALIDATE_HEADERS, BSET);
+		return (0);
+	}
+
 	if (arg != NULL && arg != JSON_FMT) {
-		if (!strcmp(arg, "default")) {
-			memset(mgt_param.feature_bits,
-			    0, sizeof mgt_param.feature_bits);
-			(void)bit(mgt_param.feature_bits,
-			    FEATURE_VALIDATE_HEADERS, BSET);
-		} else if (!strcmp(arg, "none")) {
+		if (!strcmp(arg, "none")) {
 			memset(mgt_param.feature_bits,
 			    0, sizeof mgt_param.feature_bits);
 		} else {

--- a/bin/varnishtest/tests/c00080.vtc
+++ b/bin/varnishtest/tests/c00080.vtc
@@ -9,7 +9,7 @@ server s1 {
 
 varnish v1 -vcl+backend {} -start
 
-varnish v1 -cliok "param.set debug +drop_pools"
+varnish v1 -cliok "param.set experimental +drop_pools"
 varnish v1 -cliok "param.set debug +slow_acceptor"
 varnish v1 -cliok "param.set thread_pools 1"
 
@@ -40,7 +40,7 @@ server s1 {
 
 varnish v2 -arg "-Wpoll" -vcl+backend {} -start
 
-varnish v2 -cliok "param.set debug +drop_pools"
+varnish v2 -cliok "param.set experimental +drop_pools"
 varnish v2 -cliok "param.set debug +slow_acceptor"
 varnish v2 -cliok "param.set thread_pools 1"
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -13,6 +13,7 @@ nobase_pkginclude_HEADERS = \
 	tbl/body_status.h \
 	tbl/cli_cmds.h \
 	tbl/debug_bits.h \
+	tbl/experimental_bits.h \
 	tbl/feature_bits.h \
 	tbl/h2_error.h \
 	tbl/h2_frames.h \

--- a/include/tbl/experimental_bits.h
+++ b/include/tbl/experimental_bits.h
@@ -1,8 +1,8 @@
 /*-
- * Copyright (c) 2012 Varnish Software AS
+ * Copyright (c) 2022 Varnish Software AS
  * All rights reserved.
  *
- * Author: Poul-Henning Kamp <phk@phk.freebsd.dk>
+ * Author: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -27,31 +27,13 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * Fields in the debug parameter
+ * Fields in the experimental parameter
  *
  */
 
 /*lint -save -e525 -e539 */
 
-DEBUG_BIT(REQ_STATE,		req_state,	"VSL Request state engine")
-DEBUG_BIT(WORKSPACE,		workspace,	"VSL Workspace operations")
-DEBUG_BIT(WAITINGLIST,		waitinglist,	"VSL Waitinglist events")
-DEBUG_BIT(SYNCVSL,		syncvsl,	"Make VSL synchronous")
-DEBUG_BIT(HASHEDGE,		hashedge,	"Edge cases in Hash")
-DEBUG_BIT(VCLREL,		vclrel,		"Rapid VCL release")
-DEBUG_BIT(LURKER,		lurker,		"VSL Ban lurker")
-DEBUG_BIT(ESI_CHOP,		esi_chop,	"Chop ESI fetch to bits")
-DEBUG_BIT(FLUSH_HEAD,		flush_head,	"Flush after http1 head")
-DEBUG_BIT(VTC_MODE,		vtc_mode,	"Varnishtest Mode")
-DEBUG_BIT(WITNESS,		witness,	"Emit WITNESS lock records")
-DEBUG_BIT(VSM_KEEP,		vsm_keep,	"Keep the VSM file on restart")
-DEBUG_BIT(SLOW_ACCEPTOR,	slow_acceptor,	"Slow down Acceptor")
-DEBUG_BIT(H2_NOCHECK,		h2_nocheck,	"Disable various H2 checks")
-DEBUG_BIT(VMOD_SO_KEEP,		vmod_so_keep,	"Keep copied VMOD libraries")
-DEBUG_BIT(PROCESSORS,		processors,	"Fetch/Deliver processors")
-DEBUG_BIT(PROTOCOL,		protocol,	"Protocol debugging")
-DEBUG_BIT(VCL_KEEP,		vcl_keep,	"Keep VCL C and so files")
-DEBUG_BIT(LCK,			lck,		"Additional lock statistics")
-#undef DEBUG_BIT
+EXPERIMENTAL_BIT(DROP_POOLS,	drop_pools,	"Drop thread pools")
+#undef EXPERIMENTAL_BIT
 
 /*lint -restore */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1737,6 +1737,23 @@ PARAM(
 )
 
 /* actual location mgt_param_bits.c*/
+/* see tbl/experimental_bits.h */
+PARAM(
+	/* name */	experimental,
+	/* type */	experimental,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* def */	NULL,
+	/* units */	NULL,
+	/* descr */
+	"Enable/Disable experimental features.\n"
+	"	none	Disable all experimental features\n"
+	"\n"
+	"Use +/- prefix to set/reset individual bits:\n"
+	"	drop_pools	Drop thread pools\n"
+)
+
+/* actual location mgt_param_bits.c*/
 /* See tbl/feature_bits.h */
 PARAM(
 	/* name */	feature,


### PR DESCRIPTION
This parameter should ease the introduction of features that may later
be removed without being considered a breaking change. For features that
get promoted to either being always present or behind the feature param,
it sends a clear signal regarding when we consider a feature ready for
production. This could have been useful for HTTP/2 support for example.

The first experimental feature is the ability to drop thread pools,
which was behind the debug param.

Having EXPERIMENTAL in the code takes a lot of real estate, but exp is
already established as short for expiry.

---

I omitted this patch since there is already a lot to review for a single new parameter:

```diff
diff --git i/include/tbl/params.h w/include/tbl/params.h
--- i/include/tbl/params.h
+++ w/include/tbl/params.h
@@ -1695,6 +1695,7 @@ PARAM_PCRE2(
            "Deprecated alias for the " #nm " parameter.")
 
 PARAM_ALIAS(deprecated_dummy, debug)
+PARAM_ALIAS(simonvik, experimental)
 
 #  undef PARAM_ALIAS
 #  undef PARAM_ALL
```