### PR TITLE
vut: Extract SIGHUP handling out of daemon mode

### DIFF
--- a/bin/varnishlog/varnishlog.c
+++ b/bin/varnishlog/varnishlog.c
@@ -148,7 +148,7 @@ main(int argc, char * const *argv)
 	if (optind != argc)
 		VUT_Usage(vut, &vopt_spec, 1);
 
-	if (vut->D_opt && !LOG.w_arg)
+	if (vut->H_opt && !LOG.w_arg)
 		VUT_Error(vut, 1, "Missing -w option");
 
 	if (vut->D_opt && !strcmp(LOG.w_arg, "-"))
@@ -171,7 +171,7 @@ main(int argc, char * const *argv)
 	if (LOG.w_arg) {
 		openout(LOG.a_opt);
 		AN(LOG.fo);
-		if (vut->D_opt)
+		if (vut->H_opt)
 			vut->sighup_f = rotateout;
 	} else
 		LOG.fo = stdout;

--- a/bin/varnishlog/varnishlog_options.h
+++ b/bin/varnishlog/varnishlog_options.h
@@ -56,11 +56,12 @@
 	VOPT("w:", "[-w <filename>]", "Output filename",		\
 	    "Redirect output to file. The file will be overwritten"	\
 	    " unless the -a option was specified. If the application"	\
-	    " receives a SIGHUP in daemon mode the file will be "	\
-	    " reopened allowing the old one to be rotated away. The"	\
-	    " file can then be read by varnishlog and other tools with"	\
-	    " the -r option, unless the -A option was specified. This"	\
-	    " option is required when running in daemon mode. If the"	\
+	    " application runs as a daemon (-D option) or adds a"	\
+	    " SIGHUP handler (-H option), the -w option is required"	\
+	    " and the file will be reopened allowing the old one to be"	\
+	    " rotated away when a HUP signal is received. The file can" \
+	    " then be read by varnishlog and other tools with the -r"	\
+	    " option, unless the -A option was specified. If the"	\
 	    " filename is -, varnishlog writes to the standard output"	\
 	    " and cannot work as a daemon."				\
 	)
@@ -75,6 +76,7 @@ VUT_GLOBAL_OPT_D
 VSL_OPT_E
 VUT_OPT_g
 VUT_OPT_h
+VUT_OPT_H
 VSL_OPT_i
 VSL_OPT_I
 VUT_OPT_k

--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -1217,7 +1217,7 @@ main(int argc, char * const *argv)
 	if (optind != argc)
 		VUT_Usage(vut, &vopt_spec, 1);
 
-	if (vut->D_opt && !CTX.w_arg)
+	if (vut->H_opt && !CTX.w_arg)
 		VUT_Error(vut, 1, "Missing -w option");
 
 	if (vut->D_opt && !strcmp(CTX.w_arg, "-"))
@@ -1239,7 +1239,7 @@ main(int argc, char * const *argv)
 	if (CTX.w_arg) {
 		openout(CTX.a_opt);
 		AN(CTX.fo);
-		if (vut->D_opt)
+		if (vut->H_opt)
 			vut->sighup_f = rotateout;
 	} else
 		CTX.fo = stdout;

--- a/bin/varnishncsa/varnishncsa_options.h
+++ b/bin/varnishncsa/varnishncsa_options.h
@@ -61,9 +61,10 @@
 	VOPT("w:", "[-w <filename>]", "Output filename",		\
 	    "Redirect output to file. The file will be overwritten"	\
 	    " unless the -a option was specified. If the application"	\
-	    " receives a SIGHUP in daemon mode the file will be"	\
-	    " reopened allowing the old one to be rotated away. This"	\
-	    " option is required when running in daemon mode. If the"	\
+	    " application runs as a daemon (-D option) or adds a"	\
+	    " SIGHUP handler (-H option), the -w option is required"	\
+	    " and the file will be reopened allowing the old one to be"	\
+	    " rotated away when a HUP signal is received. If the"	\
 	    " filename is -, varnishncsa writes to the standard output"	\
 	    " and cannot work as a daemon."				\
 	)
@@ -102,6 +103,7 @@ NCSA_OPT_F
 NCSA_OPT_f
 NCSA_OPT_g
 VUT_OPT_h
+VUT_OPT_H
 NCSA_OPT_j
 VSL_OPT_L
 VUT_OPT_n

--- a/bin/varnishtest/tests/u00003.vtc
+++ b/bin/varnishtest/tests/u00003.vtc
@@ -24,11 +24,6 @@ varnish v1 -vcl+backend {
 	}
 } -start
 
-shell {
-	varnishncsa -n ${v1_name} -D -P ${tmpdir}/ncsa.pid \
-		-w ${tmpdir}/ncsa.log -R 100/s
-}
-
 process p1 -winsz 25 200 {varnishncsa -n ${v1_name}} -start
 
 delay 1
@@ -40,27 +35,21 @@ client c1 {
 	rxresp
 } -run
 
-delay 1
-
-shell "mv ${tmpdir}/ncsa.log ${tmpdir}/ncsa.old.log"
-shell "kill -HUP `cat ${tmpdir}/ncsa.pid`"
-
-client c1 {
+client c2 {
 	txreq -url /2
 	rxresp
 } -run
 
 delay 1
 
-shell "kill `cat ${tmpdir}/ncsa.pid`"
-
-# default formatter and rotation
-shell -match {${localhost} - user \[../.../20[1-9][0-9]:..:..:.. (?#
+# default formatter
+shell -match {^${localhost} - user \[../.../20[1-9][0-9]:..:..:.. (?#
 )[+-]....\] "GET http://${localhost}/1\?foo=bar HTTP/1.1" 200 100 "-" "-"
 ${localhost} - - \[../.../20[1-9][0-9]:..:..:.. [+-]....\] (?#
-)"GET http://${localhost}/1\?foo=bar HTTP/1.1" 404 \d+ "-" "-"$} \
-	"cat ${tmpdir}/ncsa.old.log"
-shell "grep -q /2 ${tmpdir}/ncsa.log"
+)"GET http://${localhost}/1\?foo=bar HTTP/1.1" 404 \d+ "-" "-"
+${localhost} - - \[../.../20[1-9][0-9]:..:..:.. [+-]....\] (?#
+)"GET http://${localhost}/2 HTTP/1.1" - - "-" "-"$} \
+	"varnishncsa -n ${v1_name} -d"
 
 # command line
 shell -match "Usage: .*varnishncsa <options>" \
@@ -168,4 +157,5 @@ delay 1
 process p2 -expect-exit 1 -kill INT -wait
 shell {grep -q "VSM: Attach interrupted" ${p2_err}}
 
+# HUP coverage in u00020.vtc
 # ESI coverage in e00003.vtc

--- a/bin/varnishtest/tests/u00006.vtc
+++ b/bin/varnishtest/tests/u00006.vtc
@@ -12,12 +12,6 @@ process p1 {
 	exec varnishlog -n ${v1_name} -g raw -u -A -w -
 } -start
 
-shell {
-	exec varnishlog -n ${v1_name} -D -P ${tmpdir}/vlog.pid \
-	    -w ${tmpdir}/vlog.bin -R 10/s \
-	    -i RespStatus -i ReqURL -i BereqURL
-}
-
 shell -match "Usage: .*varnishlog <options>" \
 	"varnishlog -h"
 shell -expect "Copyright (c) 2006 Verdens Gang AS" \
@@ -138,9 +132,6 @@ client c1 {
 
 delay 1
 
-shell "mv ${tmpdir}/vlog.bin ${tmpdir}/vlog.bin~"
-shell "kill -HUP `cat ${tmpdir}/vlog.pid`"
-
 client c1 {
 	txreq -url /bar
 	rxresp
@@ -148,7 +139,10 @@ client c1 {
 
 delay 1
 
-shell "kill `cat ${tmpdir}/vlog.pid`"
+shell {
+	varnishlog -n ${v1_name} -d -w vlog.bin~ -q 'vxid <= 1002'
+	varnishlog -n ${v1_name} -d -w vlog.bin  -q 'vxid >  1002'
+}
 
 shell -match {^\*[ ]+<< Request\s+>>[ ]+1001[ ]+
 -[ ]+1001 ReqURL[ ]+c /foo
@@ -172,4 +166,5 @@ shell "echo foobar > ${tmpdir}/foo"
 shell -err -expect "Not a VSL file: ${tmpdir}/foo" \
 	"varnishlog -r ${tmpdir}/foo"
 
+# HUP coverage in u00020.vtc
 # ESI coverage in e00003.vtc

--- a/bin/varnishtest/tests/u00020.vtc
+++ b/bin/varnishtest/tests/u00020.vtc
@@ -1,0 +1,89 @@
+varnishtest "VUT SIGHUP handler"
+
+server s0 {
+	rxreq
+	txresp
+} -dispatch
+
+varnish v1 -vcl+backend {} -start
+
+shell {
+	varnishlog  -n ${v1_name} -D -P ${tmpdir}/vlog.pid \
+		-w ${tmpdir}/vlog_daemon.vsl
+
+	varnishncsa -n ${v1_name} -D -P ${tmpdir}/ncsa.pid \
+		-w ${tmpdir}/ncsa_daemon.log -F '%r %s'
+}
+
+process pvlog {
+	exec varnishlog  -n ${v1_name} -H -w vlog_hup.vsl
+} -start
+
+process pncsa {
+	exec varnishncsa -n ${v1_name} -H -w ncsa_hup.log -F '%r %s'
+} -start
+
+delay 1
+
+client c1 {
+	txreq
+	rxresp
+
+	txreq -method POST
+	rxresp
+} -run
+
+delay 1
+
+shell {
+	mv vlog_daemon.vsl vlog_daemon_old.vsl
+	mv ncsa_daemon.log ncsa_daemon_old.log
+
+	mv vlog_hup.vsl vlog_hup_old.vsl
+	mv ncsa_hup.log ncsa_hup_old.log
+
+	kill -HUP $(cat vlog.pid) $(cat ncsa.pid) ${pvlog_pid} ${pncsa_pid}
+}
+
+delay 1
+
+client c2 {
+	txreq -method PIPE
+	rxresp
+} -run
+
+delay 1
+
+shell { kill $(cat vlog.pid) $(cat ncsa.pid) }
+
+process pvlog -stop
+process pncsa -stop
+
+shell {
+	set -e
+
+	cat >expected_old.txt <<- EOF
+	GET http://127.0.0.1/ HTTP/1.1 200
+	POST http://127.0.0.1/ HTTP/1.1 200
+	EOF
+
+	cat >expected.txt <<- EOF
+	PIPE http://127.0.0.1/ HTTP/1.1 -
+	EOF
+
+	varnishncsa -F '%r %s' -r vlog_daemon_old.vsl -w vlog_daemon_old.log
+	varnishncsa -F '%r %s' -r vlog_daemon.vsl -w vlog_daemon.log
+
+	varnishncsa -F '%r %s' -r vlog_hup_old.vsl -w vlog_hup_old.log
+	varnishncsa -F '%r %s' -r vlog_hup.vsl -w vlog_hup.log
+
+	diff -u expected_old.txt vlog_daemon_old.log
+	diff -u expected_old.txt ncsa_daemon_old.log
+	diff -u expected.txt vlog_daemon.log
+	diff -u expected.txt ncsa_daemon.log
+
+	diff -u expected_old.txt vlog_hup_old.log
+	diff -u expected_old.txt ncsa_hup_old.log
+	diff -u expected.txt vlog_hup.log
+	diff -u expected.txt ncsa_hup.log
+}

--- a/include/vut.h
+++ b/include/vut.h
@@ -47,6 +47,7 @@ struct VUT {
 	int		d_opt;
 	int		D_opt;
 	int		g_arg;
+	int		H_opt;
 	int		k_arg;
 	char		*n_arg;
 	char		*P_arg;

--- a/include/vut_options.h
+++ b/include/vut_options.h
@@ -33,7 +33,12 @@
 
 #define VUT_GLOBAL_OPT_D						\
 	VOPT("D", "[-D]", "Daemonize",					\
-	    "Daemonize."						\
+	    "Daemonize. This implies the -H option."			\
+	)
+
+#define VUT_OPT_H						\
+	VOPT("H", "[-H]", "Add SIGHUP handler",				\
+	    "Add a signal handler for HUP signals."			\
 	)
 
 #define VUT_GLOBAL_OPT_P						\

--- a/lib/libvarnishapi/Makefile.am
+++ b/lib/libvarnishapi/Makefile.am
@@ -8,7 +8,7 @@ AM_CPPFLAGS = \
 
 lib_LTLIBRARIES = libvarnishapi.la
 
-libvarnishapi_la_LDFLAGS = $(AM_LDFLAGS) -version-info 3:0:0
+libvarnishapi_la_LDFLAGS = $(AM_LDFLAGS) -version-info 4:0:0
 
 libvarnishapi_la_SOURCES = \
 	../../include/vcs_version.h \

--- a/lib/libvarnishapi/libvarnishapi.map
+++ b/lib/libvarnishapi/libvarnishapi.map
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2011-2020 Varnish Software AS
+ * Copyright (c) 2011-2022 Varnish Software AS
  * All rights reserved.
  *
  * Author: Tollef Fog Heen <tfheen@varnish-software.com>
@@ -147,7 +147,10 @@ LIBVARNISHAPI_3.0 {	/* 2021-09-15 release */
 		VTIM_sleep;
 		VTIM_timespec;
 		VTIM_timeval;
+};
 
+LIBVARNISHAPI_4.0 {	/* 202?-??-15 release */
+    global:
 	# vut.c
 		VUT_Arg;
 		VUT_Error;

--- a/lib/libvarnishapi/vut.c
+++ b/lib/libvarnishapi/vut.c
@@ -169,6 +169,10 @@ VUT_Arg(struct VUT *vut, int opt, const char *arg)
 	case 'D':
 		/* Daemon mode */
 		vut->D_opt = 1;
+		/* FALLTHROUGH */
+	case 'H':
+		/* SIGHUP handler */
+		vut->H_opt = 1;
 		return (1);
 	case 'g':
 		/* Grouping */
@@ -423,7 +427,7 @@ VUT_Main(struct VUT *vut)
 			if (vut->sighup_f != NULL)
 				i = vut->sighup_f(vut);
 			else
-				i = 1;
+				i = !vut->H_opt;
 			if (i)
 				break;
 		}


### PR DESCRIPTION
This allows VUTs to either ignore SIGHUP or react to it without daemonizing. This is useful in a linux container to avoid forking a new process when the doctrine is one process per container.

As a result varnishlog and varnishncsa now rotate logs when the -H option is used. Daemonizing implies adding a SIGHUP handler.

Coverage of both varnishncsa and varnishlog was moved to a new dedicated u20 test case to slightly simplify u3 and u6.

This changes the layout of struct VUT and as a result is breaking the ABI.

---

I'm opening this pull request on behalf of @Creamen to solve containers issues with log rotation. I slightly tweaked the change, added test coverage and took care of soname housekeeping.