### PR TITLE
Ci update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,14 +176,15 @@ jobs:
                     ;;
             esac
 
-            set -x
-            echo "FROM $IMG" > Dockerfile
-            echo "ADD make-$EXT-packages.sh /usr/bin/" >> Dockerfile
-            echo "CMD make-$EXT-packages.sh" >> Dockerfile
-
             cp .circleci/make-$EXT-packages.sh .
-            docker build -t docker_img .
-            docker run --rm -it -e PARAM_DIST=$(echo "<< parameters.platform >>" | cut -d: -f1) -e PARAM_RELEASE=$(echo "<< parameters.platform >>" | cut -d: -f2) -v$(pwd):/varnish-cache docker_img
+            docker run \
+              --rm \
+              -it \
+              -e PARAM_DIST=$(echo "<< parameters.platform >>" | cut -d: -f1) \
+              -e PARAM_RELEASE=$(echo "<< parameters.platform >>" | cut -d: -f2) \
+              -v$(pwd):/varnish-cache \
+              $IMG \
+              /varnish-cache/make-$EXT-packages.sh
       - run:
           name: List created packages
           command: find ./packages -type f

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,8 +160,8 @@ jobs:
             mkdir -p packages
             case "<< parameters.platform >>" in
                 debian:*|ubuntu:*)  EXT=deb ;;
-                centos:*)         EXT=rpm ;;
-                alpine:*)         EXT=apk ;;
+                centos:*|fedora:*)  EXT=rpm ;;
+                alpine:*)           EXT=apk ;;
                 *)
                     echo "unrecognized platform: << parameters.platform >>"
                     exit 1
@@ -209,7 +209,7 @@ jobs:
     working_directory: /workspace
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: 20.10.11
       - run:
           name: Install docker
           command: yum install -y docker
@@ -220,16 +220,13 @@ jobs:
             docker create --name workspace -v /workspace << parameters.dist >>:<< parameters.release >> /bin/true
             docker cp /workspace workspace:/
             docker run --volumes-from workspace -w /workspace << parameters.dist >>:<< parameters.release >> sh -c '
-            if [ << parameters.dist >> = centos ]; then
-                if [ << parameters.release >> = 8 ]; then
-                    dnf install -y "dnf-command(config-manager)"
-                    yum config-manager --set-enabled powertools
-                    yum install -y diffutils python3-sphinx
-                else
-                    yum install -y python-sphinx
+            if [ << parameters.dist >> = centos -o << parameters.dist >> = fedora ]; then
+                yum groupinstall -y "Development Tools"
+                if [ << parameters.dist >> = centos ]; then
+                  yum install -y epel-release
                 fi
-                yum install -y epel-release
                 yum install -y \
+                    cpio \
                     automake \
                     git \
                     jemalloc-devel \
@@ -239,6 +236,7 @@ jobs:
                     make \
                     pcre2-devel \
                     python3 \
+                    python-sphinx \
                     sudo
             elif [ << parameters.dist >> = debian -o << parameters.dist >> = ubuntu ]; then
                 export DEBIAN_FRONTEND=noninteractive
@@ -297,7 +295,7 @@ jobs:
 
             if [ << parameters.dist >> = archlinux ]; then
                 useradd varnish
-            elif [ << parameters.dist >> = centos ]; then
+            elif [ << parameters.dist >> = centos -o << parameters.dist >> = fedora ]; then
             	adduser varnish
             else
             	adduser --disabled-password --gecos "" varnish
@@ -349,9 +347,13 @@ workflows:
           dist: centos
           release: "7"
       - distcheck:
-          name: distcheck_centos_8
-          dist: centos
-          release: "8"
+          name: distcheck_fedora_stable
+          dist: fedora
+          release: latest
+      - distcheck:
+          name: distcheck_fedora_rawhide
+          dist: fedora
+          release: rawhide
       - distcheck:
           name: distcheck_debian_buster
           dist: debian
@@ -397,6 +399,7 @@ workflows:
                 - debian:stretch
                 - centos:7
                 - centos:8
+                - fedora:latest
                 - alpine:3
               rclass:
                 - arm.medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,6 @@ jobs:
                     ;;
             esac
 
-            cp .circleci/make-$EXT-packages.sh .
             docker run \
               --rm \
               -it \
@@ -184,7 +183,7 @@ jobs:
               -e PARAM_RELEASE=$(echo "<< parameters.platform >>" | cut -d: -f2) \
               -v$(pwd):/varnish-cache \
               $IMG \
-              /varnish-cache/make-$EXT-packages.sh
+              /varnish-cache/.circleci/make-$EXT-packages.sh
       - run:
           name: List created packages
           command: find ./packages -type f

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,6 @@ workflows:
   version: 2
   commit:
     jobs:
-      - dist
       - distcheck:
           name: distcheck_centos_7
           dist: centos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ workflows:
           dist: centos
           release: "7"
       - distcheck:
-          name: distcheck_fedora_stable
+          name: distcheck_fedora_latest
           dist: fedora
           release: latest
       - distcheck:

--- a/.circleci/make-rpm-packages.sh
+++ b/.circleci/make-rpm-packages.sh
@@ -13,13 +13,13 @@ elif [ -z "$PARAM_DIST" ]; then
     exit 1
 fi
 
-yum install -y epel-release
 
 if [ "$PARAM_DIST" = centos ]; then
-  if [ "$PARAM_RELEASE" = 8 ]; then
-      dnf install -y 'dnf-command(config-manager)'
-      yum config-manager --set-enabled powertools
-  fi
+    if [ "$PARAM_RELEASE" = 8 ]; then
+        dnf install -y 'dnf-command(config-manager)'
+        yum config-manager --set-enabled powertools
+    fi
+    yum install -y epel-release
 fi
 
 yum install -y rpm-build yum-utils


### PR DESCRIPTION
move things around a bit, but most importantly removes `centos:8` in favor of `fedora:latest`