### PR TITLE
Invalidate vxid caches when the vxid wraps

### DIFF
--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -68,6 +68,7 @@ extern const struct req_step R_STP_RECV[1];
 struct vxid_pool {
 	uint32_t		next;
 	uint32_t		count;
+	uint32_t		gen;
 };
 
 /*--------------------------------------------------------------------

--- a/bin/varnishtest/tests/r03775.vtc
+++ b/bin/varnishtest/tests/r03775.vtc
@@ -1,0 +1,39 @@
+varnishtest "test that vxid caches are not reused after a wrap"
+
+barrier b1 cond 2
+barrier b2 cond 2
+
+varnish v1 -vcl {
+	backend proforma none;
+
+	sub vcl_recv {
+		return (synth(200));
+	}
+} -start
+
+# vxid wrap at 1<<30, assign the first worker the last chunk
+# 1073676288 == (1<<30) - (2 * 32768)
+varnish v1 -cliok "debug.xid 1073676288 32768"
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.x-varnish == 1073676290
+	barrier b1 sync
+	barrier b2 sync
+	txreq
+	rxresp
+	expect resp.http.x-varnish == 32769
+} -start
+
+barrier b1 sync
+
+client c2 {
+	txreq
+	rxresp
+	expect resp.http.x-varnish == 1
+	barrier b2 sync
+} -start
+
+client c1 -wait
+client c2 -wait


### PR DESCRIPTION
To avoid vxid clashes, we add a vxid generation number which is increased every time the global vxid counter wraps.

Any vxid caches from a previous generation are invalidated.

This patch should fix #3775 if the latest hypothesis is correct that transaction inconsistencies in the vsl reader are caused by vxid clashes due to vxid caching on the varnishd side.

Implementation notes:

- The global generation counter value is deliberately read outside the lock to keep the performance impact minimal. It should not matter if an outdated value is read momentarily, because the time scale of vxids is some orders of magintudes larger than that of SMP cache inconsistencies.

- This implementation invalidates vxid caches earlier than it absolutely needed to, but I decided to go with this idea for its simplicity in contrast to calculating a distance between the global vxid base and the cached value.