### PR TITLE
circleci: Update packages on archlinux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,8 @@ jobs:
                     tar \
                     sudo
             elif [ << parameters.dist >> = archlinux ]; then
-                pacman -Sy --noconfirm \
+                pacman -Syu --noconfirm
+                pacman -S --noconfirm \
                     ca-certificates \
                     cpio \
                     git \


### PR DESCRIPTION
We see linking failures sometimes, so hopefully that solves those.