### PR TITLE
Prepare for 7.1.0

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -167,7 +167,7 @@ Resp_Setup_Deliver(struct req *req)
 	http_PrintfHeader(h, "Age: %.0f",
 	    floor(fmax(0., req->t_prev - oc->t_origin)));
 
-	http_SetHeader(h, "Via: 1.1 varnish (Varnish/7.0)");
+	http_SetHeader(h, "Via: 1.1 varnish (Varnish/7.1)");
 
 	if (cache_param->http_gzip_support &&
 	    ObjCheckFlag(req->wrk, oc, OF_GZIPED) &&

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_PREREQ(2.69)
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
-Copyright (c) 2006-2021 Varnish Software])
+Copyright (c) 2006-2022 Varnish Software])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [trunk], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [7.1.0], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -31,9 +31,9 @@ http://varnish-cache.org/docs/trunk/whats-new/index.html and via
 individual releases. These documents are updated as part of the
 release process.
 
-===============================
-Varnish Cache NEXT (2022-03-15)
-===============================
+================================
+Varnish Cache 7.1.0 (2022-03-15)
+================================
 
 * The ``cookie.format_rfc1123()`` function was renamed to
   ``cookie.format_date()``, and the former was retained as a

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -42,7 +42,7 @@ Longer listings like example command output and VCL look like this::
     $ /opt/varnish/sbin/varnishd -V
     varnishd (varnish-trunk revision 1234567)
     Copyright (c) 2006 Verdens Gang AS
-    Copyright (c) 2006-2021 Varnish Software
+    Copyright (c) 2006-2022 Varnish Software
 
 
 .. For maintainers:

--- a/doc/sphinx/whats-new/changes-7.1.rst
+++ b/doc/sphinx/whats-new/changes-7.1.rst
@@ -1,15 +1,11 @@
-**Note: This is a working document for a future release, with running
-updates for changes in the development branch. For changes in the
-released versions of Varnish, see:** :ref:`whats-new-index`
+.. _whatsnew_changes_7.1:
 
-.. _whatsnew_changes_CURRENT:
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Changes in Varnish **$NEXT_RELEASE**
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+Changes in Varnish **7.1**
+%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 For information about updating your current Varnish deployment to the
-new version, see :ref:`whatsnew_upgrading_CURRENT`.
+new version, see :ref:`whatsnew_upgrading_7.1`.
 
 A more detailed and technical account of changes in Varnish, with
 links to issues that have been fixed and pull requests that have been
@@ -112,9 +108,9 @@ VMODs
 New :ref:`std.strftime()` function for UTC formatting.
 
 It is now possible to declare deprecated aliases of VMOD functions and object
-methods, just like VCL aliases. The ``cookie.format_rfc1123()`` was renamed to
-:ref:`cookie.format_date()`, and the former was retained as a deprecated alias
-of the latter for compatibility.
+methods, just like VCL aliases. The ``cookie.format_rfc1123()`` function was
+renamed to :ref:`cookie.format_date()`, and the former was retained as a
+deprecated alias of the latter for compatibility.
 
 Deprecated VMOD aliases have no runtime overhead, they are reified at VCL
 compile time.

--- a/doc/sphinx/whats-new/index.rst
+++ b/doc/sphinx/whats-new/index.rst
@@ -1,5 +1,5 @@
 ..
-	Copyright (c) 2013-2020 Varnish Software AS
+	Copyright (c) 2013-2022 Varnish Software AS
 	SPDX-License-Identifier: BSD-2-Clause
 	See LICENSE file for full text of license
 
@@ -13,18 +13,14 @@ This section describes the changes and improvements between different
 versions of Varnish, and what upgrading between the different versions
 entail.
 
-Varnish **$NEXT_RELEASE**
--------------------------
-
-**Note: These are working documents for a future release, with running
-updates for changes in the development branch. For changes in the
-released versions of Varnish, see the chapters listed below.**
+Varnish **7.1**
+---------------
 
 .. toctree::
    :maxdepth: 2
 
-   changes-trunk
-   upgrading-trunk
+   changes-7.1
+   upgrading-7.1
 
 Varnish 7.0
 -----------

--- a/doc/sphinx/whats-new/upgrading-7.1.rst
+++ b/doc/sphinx/whats-new/upgrading-7.1.rst
@@ -1,34 +1,8 @@
-**Note: This is a working document for a future release, with running
-updates for changes in the development branch. For changes in the
-released versions of Varnish, see:** :ref:`whats-new-index`
+.. _whatsnew_upgrading_7.1:
 
-.. _whatsnew_upgrading_CURRENT:
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Upgrading to Varnish **$NEXT_RELEASE**
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-**XXX: how to upgrade from previous deployments to this
-version. Limited to work that has to be done for an upgrade, new
-features are listed in "Changes". Explicitly mention what does *not*
-have to be changed, especially in VCL. May include, but is not limited
-to:**
-
-* Elements of VCL that have been removed or are deprecated, or whose
-  semantics have changed.
-
-* -p parameters that have been removed or are deprecated, or whose
-  semantics have changed.
-
-* Changes in the CLI.
-
-* Changes in the output or interpretation of stats or the log, including
-  changes affecting varnishncsa/-hist/-top.
-
-* Changes that may be necessary in VTCs or in the use of varnishtest.
-
-* Changes in public APIs that may require changes in VMODs or VAPI/VUT
-  clients.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Upgrading to Varnish **7.1**
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 varnishd
 ========

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -53,7 +53,7 @@
  * Whenever something is deleted or changed in a way which is not
  * binary/load-time compatible, increment MAJOR version
  *
- * Next (2022-03-15)
+ * 15.0 (2022-03-15)
  *	VRT_r_req_transport() added
  *	VRT_Assign_Backend() added
  *	VRT_StaticDirector() added

--- a/lib/libvarnish/version.c
+++ b/lib/libvarnish/version.c
@@ -74,7 +74,7 @@ VCS_String(const char *which)
 		    ")"
 		    "\n"
 		    "Copyright (c) 2006 Verdens Gang AS\n"
-		    "Copyright (c) 2006-2021 Varnish Software\n"
+		    "Copyright (c) 2006-2022 Varnish Software\n"
 		);
 	default:
 		WRONG("Wrong argument to VCS_String");


### PR DESCRIPTION
Small changes to the release process document so far:

https://github.com/varnishcache/varnish-cache/wiki/Release-procedure/_compare/1828e403030ed12ccfe4a00c8d65fa28f4fc5727...b11b98093a9cd87af2dede6c0161d5ada101e143