### PR TITLE
circleci: Revamp Ubuntu jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,10 +393,15 @@ workflows:
           name: distcheck_fedora_rawhide
           dist: fedora
           release: rawhide
+      # latest debian uses sanitizers
       - distcheck:
           name: distcheck_debian_buster
           dist: debian
           release: buster
+      - distcheck:
+          name: distcheck_debian_bullseye
+          dist: debian
+          release: bullseye
           extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator
       # oldest ubuntu goes 32bit
       - distcheck:
@@ -437,8 +442,8 @@ workflows:
                 - ubuntu:bionic
                 - ubuntu:focal
                 - ubuntu:jammy
-                - debian:bullseye
                 - debian:buster
+                - debian:bullseye
                 - debian:stretch
                 - centos:7
                 - centos:stream

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,11 +398,20 @@ workflows:
           dist: debian
           release: buster
           extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator
+      # oldest ubuntu goes 32bit
       - distcheck:
           name: distcheck_ubuntu_bionic
           prefix: i386/
           dist: ubuntu
           release: bionic
+      - distcheck:
+          name: distcheck_ubuntu_focal
+          dist: ubuntu
+          release: focal
+      - distcheck:
+          name: distcheck_ubuntu_jammy
+          dist: ubuntu
+          release: jammy
       - distcheck:
           name: distcheck_alpine
           dist: alpine
@@ -427,6 +436,7 @@ workflows:
               platform:
                 - ubuntu:bionic
                 - ubuntu:focal
+                - ubuntu:jammy
                 - debian:bullseye
                 - debian:buster
                 - debian:stretch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,10 @@ jobs:
       release:
         description: the release name (stretch|buster|bionic|focal)
         type: string
+      check:
+        description: the check to perform during the build
+        default: distcheck
+        type: string
       extra_conf:
         description: platform-specific configure arguments
         default: ""
@@ -343,7 +347,7 @@ jobs:
                 << parameters.extra_conf >>
             sudo -u varnish \
                 --preserve-env=ASAN_OPTIONS,LSAN_OPTIONS,TSAN_OPTIONS,UBSAN_OPTIONS \
-                make distcheck VERBOSE=1 -j 4 -k \
+                make << parameters.check >> VERBOSE=1 -j 4 -k \
                 DISTCHECK_CONFIGURE_FLAGS="<< pipeline.parameters.configure_args >> \
                 << parameters.extra_conf >>"
             '
@@ -385,10 +389,12 @@ workflows:
           name: distcheck_almalinux_8
           dist: almalinux
           release: "8"
+      # fedora is our witness
       - distcheck:
           name: distcheck_fedora_latest
           dist: fedora
           release: latest
+          check: witness
       - distcheck:
           name: distcheck_fedora_rawhide
           dist: fedora

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
           root: .
           paths:
             - "packages"
-  distcheck:
+  build:
     parameters:
       prefix:
         description: the container image prefix (repository or architecture)
@@ -210,8 +210,8 @@ jobs:
       release:
         description: the release name (stretch|buster|bionic|focal)
         type: string
-      check:
-        description: the check to perform during the build
+      make_target:
+        description: the make target to execute during the build
         default: distcheck
         type: string
       extra_conf:
@@ -229,7 +229,7 @@ jobs:
           command: yum install -y docker
       - checkout
       - run:
-          name: Extract and distcheck
+          name: Extract and build
           command: |
             docker create --name workspace -v /workspace << parameters.prefix >><< parameters.dist >>:<< parameters.release >> /bin/true
             docker cp /workspace workspace:/
@@ -347,7 +347,7 @@ jobs:
                 << parameters.extra_conf >>
             sudo -u varnish \
                 --preserve-env=ASAN_OPTIONS,LSAN_OPTIONS,TSAN_OPTIONS,UBSAN_OPTIONS \
-                make << parameters.check >> VERBOSE=1 -j 4 -k \
+                make << parameters.make_target >> VERBOSE=1 -j 4 -k \
                 DISTCHECK_CONFIGURE_FLAGS="<< pipeline.parameters.configure_args >> \
                 << parameters.extra_conf >>"
             '
@@ -376,60 +376,60 @@ workflows:
         - << pipeline.parameters.build-pkgs >>
         - << pipeline.parameters.dist-url >>
     jobs:
-      - distcheck:
-          name: distcheck_centos_7
+      - build:
+          name: build_centos_7
           dist: centos
           release: "7"
-      - distcheck:
-          name: distcheck_centos_stream
+      - build:
+          name: build_centos_stream
           prefix: quay.io/centos/
           dist: centos
           release: stream
-      - distcheck:
-          name: distcheck_almalinux_8
+      - build:
+          name: build_almalinux_8
           dist: almalinux
           release: "8"
       # fedora is our witness
-      - distcheck:
-          name: distcheck_fedora_latest
+      - build:
+          name: build_fedora_latest
           dist: fedora
           release: latest
-          check: witness
-      - distcheck:
-          name: distcheck_fedora_rawhide
+          make_target: witness
+      - build:
+          name: build_fedora_rawhide
           dist: fedora
           release: rawhide
       # latest debian uses sanitizers
-      - distcheck:
-          name: distcheck_debian_buster
+      - build:
+          name: build_debian_buster
           dist: debian
           release: buster
-      - distcheck:
-          name: distcheck_debian_bullseye
+      - build:
+          name: build_debian_bullseye
           dist: debian
           release: bullseye
           extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator
       # oldest ubuntu goes 32bit
-      - distcheck:
-          name: distcheck_ubuntu_bionic
+      - build:
+          name: build_ubuntu_bionic
           prefix: i386/
           dist: ubuntu
           release: bionic
-      - distcheck:
-          name: distcheck_ubuntu_focal
+      - build:
+          name: build_ubuntu_focal
           dist: ubuntu
           release: focal
-      - distcheck:
-          name: distcheck_ubuntu_jammy
+      - build:
+          name: build_ubuntu_jammy
           dist: ubuntu
           release: jammy
-      - distcheck:
-          name: distcheck_alpine
+      - build:
+          name: build_alpine
           dist: alpine
           release: "latest"
           #extra_conf: --without-jemalloc
-      - distcheck:
-          name: distcheck_archlinux
+      - build:
+          name: build_archlinux
           dist: archlinux
           release: base-devel
   packaging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,12 @@ jobs:
             centos|almalinux|fedora)
                 yum groupinstall -y "Development Tools"
                 case "<< parameters.dist >>:<< parameters.release >>" in
+                    almalinux:9)
+                        dnf install -y "dnf-command(config-manager)"
+                        yum config-manager --set-enabled crb
+                        yum install -y diffutils
+                        yum install -y epel-release
+                        ;;
                     centos:stream|almalinux:8)
                         dnf install -y "dnf-command(config-manager)"
                         yum config-manager --set-enabled powertools
@@ -389,6 +395,10 @@ workflows:
           name: build_almalinux_8
           dist: almalinux
           release: "8"
+      - build:
+          name: build_almalinux_9
+          dist: almalinux
+          release: "9"
       # fedora is our witness
       - build:
           name: build_fedora_latest
@@ -454,6 +464,7 @@ workflows:
                 - centos:7
                 - centos:stream
                 - almalinux:8
+                - almalinux:9
                 - fedora:latest
                 - alpine:3
               rclass:

--- a/.circleci/make-deb-packages.sh
+++ b/.circleci/make-deb-packages.sh
@@ -12,10 +12,10 @@ echo "PARAM_DIST: $PARAM_DIST"
 
 
 if [ -z "$PARAM_RELEASE" ]; then
-    echo "Env variable PARAM_RELEASE is not set! For example PARAM_RELEASE=8, for CentOS 8"
+    echo "Env variable PARAM_RELEASE is not set! For example PARAM_RELEASE=focal for Ubuntu 20.04"
     exit 1
 elif [ -z "$PARAM_DIST" ]; then
-    echo "Env variable PARAM_DIST is not set! For example PARAM_DIST=centos"
+    echo "Env variable PARAM_DIST is not set! For example PARAM_DIST=debian"
     exit 1
 fi
 

--- a/.circleci/make-rpm-packages.sh
+++ b/.circleci/make-rpm-packages.sh
@@ -14,6 +14,11 @@ elif [ -z "$PARAM_DIST" ]; then
 fi
 
 case "$PARAM_DIST:$PARAM_RELEASE" in
+    almalinux:9)
+        dnf install -y 'dnf-command(config-manager)'
+        yum config-manager --set-enabled crb
+        yum install -y epel-release
+        ;;
     centos:stream|almalinux:8)
         dnf install -y 'dnf-command(config-manager)'
         yum config-manager --set-enabled powertools


### PR DESCRIPTION
Use their version number as the image tag instead of the code name for
clarity. Add a packaging job for the incoming Ubuntu 22.04, and add
distcheck jobs for Ubuntu 20.04 and 22.04 with a comment explaining
which Ubuntu is arbitrarily selected for 32bit builds.

Also, stop pretending that CentOS is a dpkg-based distribution, we are
not fooling anyone.