### PR TITLE
Fixed build on i386 macOS with clang-11

### DIFF
--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -389,7 +389,7 @@ cmd_http_expect_pattern(CMD_ARGS)
 		if (*p != t)
 			vtc_fatal(hp->vl,
 			    "EXPECT PATTERN FAIL @%zd should 0x%02x is 0x%02x",
-			    p - hp->body, t, *p);
+			    (ssize_t) (p - hp->body), t, *p);
 		t += 1;
 		t &= ~0x08;
 	}


### PR DESCRIPTION
Apparently, clang11 on i386 macOS uses `int` instead of `ssize_t` for `a- b` where bot `a` and `b` is `char`. It leads to an error:
```
vtc_http.c:392:8: error: format specifies type 'ssize_t' (aka 'long') but the argument has type 'int' [-Werror,-Wformat]
                            p - hp->body, t, *p);
                            ^~~~~~~~~~~~
```

See https://build.macports.org/builders/ports-10.6_i386-builder/builds/64402/steps/install-port/logs/stdio as example of such error.