### PR TITLE
tcp_keepidle socket option support for macOs.

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -105,10 +105,12 @@ static struct sock_opt {
 
 	SOCK_OPT(IPPROTO_TCP, TCP_NODELAY, int)
 
-#ifdef HAVE_TCP_KEEP
+#if defined(HAVE_TCP_KEEP)
 	SOCK_OPT(IPPROTO_TCP, TCP_KEEPIDLE, int)
 	SOCK_OPT(IPPROTO_TCP, TCP_KEEPCNT, int)
 	SOCK_OPT(IPPROTO_TCP, TCP_KEEPINTVL, int)
+#elif defined(HAVE_TCP_KEEPALIVE)
+	SOCK_OPT(IPPROTO_TCP, TCP_KEEPALIVE, int)
 #endif
 
 #undef SOCK_OPT
@@ -206,13 +208,16 @@ vca_sock_opt_init(void)
 		NEW_VAL(SO_RCVTIMEO, so, tv,
 		    VTIM_timeval(cache_param->timeout_idle));
 		SET_VAL(TCP_NODELAY, so, i, enable_tcp_nodelay);
-#ifdef HAVE_TCP_KEEP
+#if defined(HAVE_TCP_KEEP)
 		NEW_VAL(TCP_KEEPIDLE, so, i,
 		    (int)cache_param->tcp_keepalive_time);
 		NEW_VAL(TCP_KEEPCNT, so, i,
 		    (int)cache_param->tcp_keepalive_probes);
 		NEW_VAL(TCP_KEEPINTVL, so, i,
 		    (int)cache_param->tcp_keepalive_intvl);
+#elif defined(HAVE_TCP_KEEPALIVE)
+		NEW_VAL(TCP_KEEPALIVE, so, i,
+		    (int)cache_param->tcp_keepalive_time);
 #endif
 	}
 	return (chg);

--- a/bin/varnishd/mgt/mgt_param_tcp.c
+++ b/bin/varnishd/mgt/mgt_param_tcp.c
@@ -49,7 +49,7 @@
 
 #include "vtcp.h"
 
-#ifdef HAVE_TCP_KEEP
+#if defined(HAVE_TCP_KEEP) || defined(HAVE_TCP_KEEPALIVE)
 
 static void
 tcp_probe(int sock, int nam, const char *param, unsigned def)
@@ -75,9 +75,13 @@ tcp_keep_probes(void)
 	if (err != NULL)
 		ARGV_ERR("Could not probe TCP keepalives: %s", err);
 	assert(s > 0);
+#ifdef HAVE_TCP_KEEP
 	tcp_probe(s, TCP_KEEPIDLE, "tcp_keepalive_time",	600);
 	tcp_probe(s, TCP_KEEPCNT, "tcp_keepalive_probes",	5);
 	tcp_probe(s, TCP_KEEPINTVL, "tcp_keepalive_intvl",	5);
+#else
+	tcp_probe(s, TCP_KEEPALIVE, "tcp_keepalive_time",	600);
+#endif
 	closefd(&s);
 }
 #endif
@@ -85,7 +89,7 @@ tcp_keep_probes(void)
 void
 MCF_TcpParams(void)
 {
-#ifdef HAVE_TCP_KEEP
+#if defined(HAVE_TCP_KEEP) || defined(HAVE_TCP_KEEPALIVE)
 	tcp_keep_probes();
 #endif
 }

--- a/configure.ac
+++ b/configure.ac
@@ -589,6 +589,32 @@ return (0);
   ])
 if test "$ac_cv_have_tcp_keep" = yes; then
    AC_DEFINE([HAVE_TCP_KEEP], [1], [Define if OS supports TCP_KEEP* socket options])
+else
+   # Check TCP_KEEPALIVE on macOs which uses seconds as idle time unit like TCP_KEEPIDLE
+   AC_CACHE_CHECK([for TCP_KEEPALIVE socket option],
+     [ac_cv_have_tcp_keepalive],
+     [AC_RUN_IFELSE(
+     [AC_LANG_PROGRAM([[
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <errno.h>
+    ]],[[
+int s = socket(AF_INET, SOCK_STREAM, 0);
+int i = 5;
+if (s < 0)
+  return (1);
+if (setsockopt(s, IPPROTO_TCP, TCP_KEEPALIVE, &i, sizeof i))
+  return (1);
+return 0;
+    ]])],
+    [ac_cv_have_tcp_keepalive=yes],
+    [ac_cv_have_tcp_keepalive=no])
+  ])
+  if test "$ac_cv_have_tcp_keepalive" = yes; then
+     AC_DEFINE([HAVE_TCP_KEEPALIVE], [1], [Define if OS supports TCP_KEEPALIVE socket option])
+  fi
 fi
 LIBS="${save_LIBS}"
 


### PR DESCRIPTION
TCP_KEEPALIVE is the TCP_KEEPIDLE's equivalent and uses seconds
 for the idle time.