### PR TITLE
param: New vcc_feature bits parameter

### DIFF
--- a/bin/varnishd/common/common_param.h
+++ b/bin/varnishd/common/common_param.h
@@ -76,6 +76,18 @@ COM_FEATURE(const volatile uint8_t *p, enum feature_bits x)
 	return (p[(unsigned)x>>3] & (0x80U >> ((unsigned)x & 7)));
 }
 
+enum vcc_feature_bits {
+#define VCC_FEATURE_BIT(U, l, d) VCC_FEATURE_##U,
+#include "tbl/vcc_feature_bits.h"
+       VCC_FEATURE_Reserved
+};
+
+static inline int
+COM_VCC_FEATURE(const volatile uint8_t *p, enum vcc_feature_bits x)
+{
+	return (p[(unsigned)x>>3] & (0x80U >> ((unsigned)x & 7)));
+}
+
 struct poolparam {
 	unsigned		min_pool;
 	unsigned		max_pool;
@@ -88,6 +100,7 @@ PARAM_BITMAP(vsl_mask_t,	256);
 PARAM_BITMAP(debug_t,		DBG_Reserved);
 PARAM_BITMAP(experimental_t,	EXPERIMENT_Reserved);
 PARAM_BITMAP(feature_t,		FEATURE_Reserved);
+PARAM_BITMAP(vcc_feature_t,	VCC_FEATURE_Reserved);
 #undef PARAM_BITMAP
 
 struct params {
@@ -104,6 +117,7 @@ struct params {
 #define ptyp_thread_pool_min	unsigned
 #define ptyp_timeout		vtim_dur
 #define ptyp_uint		unsigned
+#define ptyp_vcc_feature	vcc_feature_t
 #define ptyp_vsl_buffer		unsigned
 #define ptyp_vsl_mask		vsl_mask_t
 #define ptyp_vsl_reclen		unsigned

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -236,8 +236,6 @@ extern char *mgt_cc_cmd_def;
 extern char *mgt_cc_warn;
 extern const char *mgt_vcl_path;
 extern const char *mgt_vmod_path;
-#define MGT_VCC(t, n, cc) extern t mgt_vcc_ ## n;
-#include <tbl/mgt_vcc.h>
 
 #if defined(PTHREAD_CANCELED) || defined(PTHREAD_MUTEX_DEFAULT)
 #error "Keep pthreads out of in manager process"

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -246,3 +246,4 @@ extern const char *mgt_vmod_path;
 #define MGT_FEATURE(x)		COM_FEATURE(mgt_param.feature_bits, x)
 #define MGT_EXPERIMENT(x)	COM_EXPERIMENT(mgt_param.experimental_bits, x)
 #define MGT_DO_DEBUG(x)		COM_DO_DEBUG(mgt_param.debug_bits, x)
+#define MGT_VCC_FEATURE(x)	COM_VCC_FEATURE(mgt_param.vcc_feature_bits, x)

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -84,6 +84,7 @@ tweak_t tweak_thread_pool_min;
 tweak_t tweak_thread_pool_max;
 tweak_t tweak_timeout;
 tweak_t tweak_uint;
+tweak_t tweak_vcc_feature;
 tweak_t tweak_vsl_buffer;
 tweak_t tweak_vsl_mask;
 tweak_t tweak_vsl_reclen;

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -762,3 +762,21 @@ tweak_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
 	return (tweak_generic_bits(vsb, par, arg, mgt_param.feature_bits,
 	    FEATURE_Reserved, feature_tags, "feature bit", '+'));
 }
+
+/*--------------------------------------------------------------------
+ * The vcc_feature parameter
+ */
+
+static const char * const vcc_feature_tags[] = {
+#  define VCC_FEATURE_BIT(U, l, d) [VCC_FEATURE_##U] = #l,
+#  include "tbl/vcc_feature_bits.h"
+       NULL
+};
+
+int v_matchproto_(tweak_t)
+tweak_vcc_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
+{
+
+	return (tweak_generic_bits(vsb, par, arg, mgt_param.vcc_feature_bits,
+	    VCC_FEATURE_Reserved, vcc_feature_tags, "vcc_feature bit", '+'));
+}

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -36,6 +36,7 @@
 
 #include <limits.h>
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -776,7 +777,20 @@ static const char * const vcc_feature_tags[] = {
 int v_matchproto_(tweak_t)
 tweak_vcc_feature(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
+	const struct parspec *orig;
+	char buf[32];
+	int val;
 
+	if (arg != NULL && arg != JSON_FMT &&
+	    strcmp(par->name, "vcc_feature")) {
+		orig = TRUST_ME(par->priv);
+		val = parse_boolean(vsb, arg);
+		if (val < 0)
+			return (-1);
+		bprintf(buf, "%c%s", val ? '+' : '-',
+		    par->name + strlen("vcc_"));
+		return (tweak_vcc_feature(vsb, orig, buf));
+	}
 	return (tweak_generic_bits(vsb, par, arg, mgt_param.vcc_feature_bits,
 	    VCC_FEATURE_Reserved, vcc_feature_tags, "vcc_feature bit", '+'));
 }

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -565,9 +565,15 @@ tweak_storage(struct vsb *vsb, const struct parspec *par, const char *arg)
 int v_matchproto_(tweak_t)
 tweak_alias(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
+	const struct parspec *orig;
+	struct parspec alias[1];
 
-	par = TRUST_ME(par->priv);
-	return (par->func(vsb, par, arg));
+	orig = TRUST_ME(par->priv);
+	AN(orig);
+	memcpy(alias, orig, sizeof *orig);
+	alias->name = par->name;
+	alias->priv = TRUST_ME(orig);
+	return (alias->func(vsb, alias, arg));
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -152,33 +152,43 @@ tweak_double(struct vsb *vsb, const struct parspec *par, const char *arg)
 
 /*--------------------------------------------------------------------*/
 
+static int
+parse_boolean(struct vsb *vsb, const char *arg)
+{
+
+	if (!strcasecmp(arg, "off"))
+		return (0);
+	if (!strcasecmp(arg, "disable"))
+		return (0);
+	if (!strcasecmp(arg, "no"))
+		return (0);
+	if (!strcasecmp(arg, "false"))
+		return (0);
+	if (!strcasecmp(arg, "on"))
+		return (1);
+	if (!strcasecmp(arg, "enable"))
+		return (1);
+	if (!strcasecmp(arg, "yes"))
+		return (1);
+	if (!strcasecmp(arg, "true"))
+		return (1);
+
+	VSB_cat(vsb, "use \"on\" or \"off\"\n");
+	return (-1);
+}
+
 int v_matchproto_(tweak_t)
 tweak_boolean(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
 	volatile unsigned *dest;
+	int val;
 
 	dest = par->priv;
 	if (arg != NULL && arg != JSON_FMT) {
-		if (!strcasecmp(arg, "off"))
-			*dest = 0;
-		else if (!strcasecmp(arg, "disable"))
-			*dest = 0;
-		else if (!strcasecmp(arg, "no"))
-			*dest = 0;
-		else if (!strcasecmp(arg, "false"))
-			*dest = 0;
-		else if (!strcasecmp(arg, "on"))
-			*dest = 1;
-		else if (!strcasecmp(arg, "enable"))
-			*dest = 1;
-		else if (!strcasecmp(arg, "yes"))
-			*dest = 1;
-		else if (!strcasecmp(arg, "true"))
-			*dest = 1;
-		else {
-			VSB_cat(vsb, "use \"on\" or \"off\"\n");
+		val = parse_boolean(vsb, arg);
+		if (val < 0)
 			return (-1);
-		}
+		*dest = val;
 	} else if (arg == JSON_FMT) {
 		VSB_printf(vsb, "%s", *dest ? "true" : "false");
 	} else {

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -68,8 +68,6 @@ char *mgt_cc_cmd_def;
 char *mgt_cc_warn;
 const char *mgt_vcl_path;
 const char *mgt_vmod_path;
-#define MGT_VCC(t, n, cc) t mgt_vcc_ ## n;
-#include <tbl/mgt_vcc.h>
 
 #define VGC_SRC		"vgc.c"
 #define VGC_LIB		"vgc.so"
@@ -108,9 +106,9 @@ run_vcc(void *priv)
 	VCC_VCL_path(vcc, mgt_vcl_path);
 	VCC_VMOD_path(vcc, mgt_vmod_path);
 
-#define MGT_VCC(type, name, camelcase)			\
-	VCC_ ## camelcase (vcc, mgt_vcc_ ## name);
-#include "tbl/mgt_vcc.h"
+#define VCC_FEATURE_BIT(U, l, d)			\
+	VCC_Opt_ ## l(vcc, MGT_VCC_FEATURE(VCC_FEATURE_ ## U));
+#include "tbl/vcc_feature_bits.h"
 
 	STV_Foreach(stv)
 		VCC_Predef(vcc, "VCL_STEVEDORE", stv->ident);

--- a/bin/varnishtest/tests/b00025.vtc
+++ b/bin/varnishtest/tests/b00025.vtc
@@ -1,6 +1,6 @@
 varnishtest "more backends"
 
-varnish v1 -arg "-p vcc_err_unref=off" -vcl {
+varnish v1 -arg "-p vcc_feature=-err_unref" -vcl {
 	backend d0 { .host = "${bad_backend}"; }
 	backend d1 { .host = "${bad_backend}"; }
 	backend d2 { .host = "${bad_backend}"; }

--- a/bin/varnishtest/tests/b00058.vtc
+++ b/bin/varnishtest/tests/b00058.vtc
@@ -2,7 +2,7 @@ varnishtest "Test backend definition documentation examples"
 
 feature cmd {getent hosts localhost && getent services http}
 
-varnish v1 -arg "-p vcc_err_unref=off" -vcl {
+varnish v1 -arg "-p vcc_feature=-err_unref" -vcl {
 	backend b1 {.host = "127.0.0.1";}
 	backend b2 {.host = "[::1]:8080";}
 	backend b3 {.host = "localhost:8081";}

--- a/bin/varnishtest/tests/b00078.vtc
+++ b/bin/varnishtest/tests/b00078.vtc
@@ -19,3 +19,9 @@ shell -err {
 shell -err {
 	varnishadm -n ${v1_name} "param.show -j" | grep deprecated_dummy
 }
+
+# temporary aliases
+
+varnish v1 -cliexpect vcc_feature "param.show vcc_allow_inline_c"
+varnish v1 -cliexpect vcc_feature "param.show vcc_err_unref"
+varnish v1 -cliexpect vcc_feature "param.show vcc_unsafe_path"

--- a/bin/varnishtest/tests/b00078.vtc
+++ b/bin/varnishtest/tests/b00078.vtc
@@ -1,14 +1,12 @@
 varnishtest "deprecated parameters"
 
+varnish v1 -arg "-b none" -start
+
+# permanent alias
+
 varnish v1 -cliok "param.set debug +syncvsl"
-
-shell -expect "+syncvsl" {
-	varnishadm -n ${v1_name} "param.show deprecated_dummy"
-}
-
-shell -expect "+syncvsl" {
-	varnishadm -n ${v1_name} "param.show -j deprecated_dummy"
-}
+varnish v1 -cliexpect "[+]syncvsl" "param.show deprecated_dummy"
+varnish v1 -cliexpect "[+]syncvsl" "param.show -j deprecated_dummy"
 
 shell -err {
 	varnishadm -n ${v1_name} "param.show" | grep deprecated_dummy

--- a/bin/varnishtest/tests/c00052.vtc
+++ b/bin/varnishtest/tests/c00052.vtc
@@ -7,13 +7,13 @@ server s1 {
 
 varnish v1
 
-varnish v1 -cliok "param.set vcc_allow_inline_c true"
+varnish v1 -cliok "param.set vcc_feature +allow_inline_c"
 
 varnish v1 -vcl+backend {
 	C{ /*...*/ }C
 }
 
-varnish v1 -cliok "param.set vcc_allow_inline_c false"
+varnish v1 -cliok "param.set vcc_feature -allow_inline_c"
 
 varnish v1 -errvcl {Inline-C not allowed} {
 	backend default {
@@ -31,7 +31,7 @@ varnish v1 -errvcl {Inline-C not allowed} {
 	}
 }
 
-varnish v1 -cliok "param.set vcc_allow_inline_c true"
+varnish v1 -cliok "param.set vcc_feature +allow_inline_c"
 
 varnish v1 -vcl+backend {
 	sub vcl_recv {

--- a/bin/varnishtest/tests/c00053.vtc
+++ b/bin/varnishtest/tests/c00053.vtc
@@ -11,7 +11,7 @@ varnish v1 -vcl+backend {
 	include "${tmpdir}/_.c00053";
 }
 
-varnish v1 -cliok "param.set vcc_unsafe_path off"
+varnish v1 -cliok "param.set vcc_feature -unsafe_path"
 
 varnish v1 -errvcl {' is unsafe} {
 	backend default { .host = "${s1_sock}"; }
@@ -28,7 +28,7 @@ shell "rm -f ${tmpdir}/_.c00053"
 
 # Testing of include +glob
 
-varnish v1 -cliok "param.set vcc_unsafe_path on"
+varnish v1 -cliok "param.set vcc_feature +unsafe_path"
 
 varnish v1 -errvcl "glob pattern matched no files." {
 	vcl 4.0;

--- a/bin/varnishtest/tests/c00057.vtc
+++ b/bin/varnishtest/tests/c00057.vtc
@@ -11,7 +11,7 @@ server s1 {
 
 varnish v1 \
 	-arg "-p feature=+no_coredump" \
-	-arg "-p vcc_allow_inline_c=true" \
+	-arg "-p vcc_feature=+allow_inline_c" \
 	-arg "-p thread_pool_stack=128k" \
 	-vcl+backend {
 	C{
@@ -66,7 +66,7 @@ varnish v1 -expectexit 0x40
 
 varnish v2 \
 	-arg "-p feature=+no_coredump" \
-	-arg "-p vcc_allow_inline_c=true" \
+	-arg "-p vcc_feature=+allow_inline_c" \
 	-vcl+backend {
 
 	C{

--- a/bin/varnishtest/tests/m00000.vtc
+++ b/bin/varnishtest/tests/m00000.vtc
@@ -157,7 +157,7 @@ varnish v1 -errvcl {Failed initialization} {
 	}
 }
 
-varnish v1 -cliok "param.set vcc_allow_inline_c on"
+varnish v1 -cliok "param.set vcc_feature +allow_inline_c"
 varnish v1 -vcl {
 	import vtc;
 

--- a/bin/varnishtest/tests/m00008.vtc
+++ b/bin/varnishtest/tests/m00008.vtc
@@ -29,7 +29,7 @@ varnish v1 -vcl+backend {
 	import std;
 }
 
-varnish v1 -cliok "param.set vcc_unsafe_path off"
+varnish v1 -cliok "param.set vcc_feature -unsafe_path"
 
 varnish v1 -errvcl {'import ... from path ...' is unsafe.} {
 	backend default { .host = "${s1_sock}"; }
@@ -43,7 +43,7 @@ varnish v1 -vcl+backend {
 	import std;
 }
 
-varnish v1 -cliok "param.set vcc_unsafe_path on"
+varnish v1 -cliok "param.set vcc_feature +unsafe_path"
 
 varnish v1 -cliok "param.set vmod_path /nowhere:/else"
 

--- a/bin/varnishtest/tests/r00742.vtc
+++ b/bin/varnishtest/tests/r00742.vtc
@@ -5,7 +5,7 @@ server s1 {
 	txresp
 } -start
 
-varnish v1 -cliok "param.set vcc_allow_inline_c true" -vcl+backend {
+varnish v1 -cliok "param.set vcc_feature +allow_inline_c" -vcl+backend {
 	C{
 	#include <stdio.h>
 	}C

--- a/bin/varnishtest/tests/r00911.vtc
+++ b/bin/varnishtest/tests/r00911.vtc
@@ -1,4 +1,4 @@
-varnishtest "vcc_err_unref should also cover subs"
+varnishtest "vcc_feature::err_unref should also cover subs"
 
 server s1 {
 	rxreq
@@ -6,7 +6,7 @@ server s1 {
 	txresp -body "foobar"
 } -start
 
-varnish v1 -arg "-p vcc_err_unref=false" -vcl+backend {
+varnish v1 -arg "-p vcc_feature=-err_unref" -vcl+backend {
 	sub foobar {
 		set req.http.foobar = "foobar";
 	}

--- a/bin/varnishtest/tests/r01406.vtc
+++ b/bin/varnishtest/tests/r01406.vtc
@@ -5,7 +5,7 @@ server s1 {
 	txresp
 } -start
 
-varnish v1 -arg "-p vcc_allow_inline_c=true" -vcl+backend {
+varnish v1 -arg "-p vcc_feature=+allow_inline_c" -vcl+backend {
 	import std ;
 
 	C{

--- a/bin/varnishtest/tests/r01504.vtc
+++ b/bin/varnishtest/tests/r01504.vtc
@@ -1,6 +1,6 @@
 varnishtest "unreferenced or null acls"
 
-varnish v1 -arg "-p vcc_err_unref=off" -vcl {
+varnish v1 -arg "-p vcc_feature=-err_unref" -vcl {
 	import vtc;
 	backend s1 {
 		.host = "${bad_backend}";

--- a/bin/varnishtest/tests/r01562.vtc
+++ b/bin/varnishtest/tests/r01562.vtc
@@ -12,7 +12,7 @@ server s2 {
 	txresp -status 200 -hdr "Foo: Foo" -body "56"
 } -start
 
-varnish v1 -cliok "param.set vcc_allow_inline_c true" -vcl+backend {
+varnish v1 -cliok "param.set vcc_feature +allow_inline_c" -vcl+backend {
 	sub vcl_recv {
 		return (pass);
 	}

--- a/bin/varnishtest/tests/r02976.vtc
+++ b/bin/varnishtest/tests/r02976.vtc
@@ -9,7 +9,7 @@ server s1 -repeat 5 { # probe requests
 	txresp
 } -start
 
-varnish v1 -cliok {param.set vcc_err_unref off}
+varnish v1 -cliok {param.set vcc_feature -err_unref}
 
 varnish v1 -vcl {
 	backend b1 {

--- a/bin/varnishtest/tests/r03159.vtc
+++ b/bin/varnishtest/tests/r03159.vtc
@@ -12,7 +12,7 @@ shell {
 
 process p1 -winsz 100 80 -log {
 	varnishd -F -n "${tmpdir}/t" -a "${tmpdir}/sock" \
-	    -p vcc_err_unref=off -f "${tmpdir}/unref.vcl" \
+	    -p vcc_feature=-err_unref -f "${tmpdir}/unref.vcl" \
 	    -l 2m 2>&1
 } -start
 

--- a/bin/varnishtest/tests/v00019.vtc
+++ b/bin/varnishtest/tests/v00019.vtc
@@ -28,7 +28,7 @@ varnish v1 -errvcl {Unterminated string, starting at} {
 	"
 }
 
-varnish v1 -cliok "param.set vcc_allow_inline_c true" -vcl {
+varnish v1 -cliok "param.set vcc_feature +allow_inline_c" -vcl {
 	backend b { .host = "${localhost}"; }
 	sub vcl_recv { C{ int i; (void)i; }C }
 }

--- a/bin/varnishtest/tests/v00020.vtc
+++ b/bin/varnishtest/tests/v00020.vtc
@@ -1,6 +1,6 @@
 varnishtest "VCL compiler coverage test: vcc_parse.c & vcc_expr.c"
 
-varnish v1 -cliok "param.set vcc_allow_inline_c true" -vcl {
+varnish v1 -cliok "param.set vcc_feature +allow_inline_c" -vcl {
 	backend b { .host = "${localhost}"; }
 	C{
 	#include <stdio.h>
@@ -310,7 +310,7 @@ varnish v1 -errvcl {Not available in subroutine 'vcl_recv'.} {
 	}
 }
 
-varnish v1 -cliok "param.set vcc_err_unref off"
+varnish v1 -cliok "param.set vcc_feature -err_unref"
 
 varnish v1 -errvcl {Impossible Subroutine} {
 	backend b { .host = "127.0.0.1"; }
@@ -319,7 +319,7 @@ varnish v1 -errvcl {Impossible Subroutine} {
 	}
 }
 
-varnish v1 -cliok "param.set vcc_err_unref on"
+varnish v1 -cliok "param.set vcc_feature +err_unref"
 
 varnish v1 -errvcl {
 ('<vcl.inline>' Line 4 Pos 44) -- (Pos 49)

--- a/bin/varnishtest/tests/v00031.vtc
+++ b/bin/varnishtest/tests/v00031.vtc
@@ -1,18 +1,18 @@
-varnishtest "param vcc_err_unref"
+varnishtest "param vcc_feature::err_unref"
 
 varnish v1 -errvcl {Unused backend c, defined:} {
 	backend b { .host = "${localhost}"; }
 	backend c { .host = "${localhost}"; }
 }
 
-varnish v1 -cliok "param.set vcc_err_unref false"
+varnish v1 -cliok "param.set vcc_feature -err_unref"
 
 varnish v1 -vcl {
 	backend b { .host = "${localhost}"; }
 	backend c { .host = "${localhost}"; }
 }
 
-varnish v1 -cliok "param.set vcc_err_unref true"
+varnish v1 -cliok "param.set vcc_feature +err_unref"
 
 varnish v1 -errvcl {Unused backend c, defined:} {
 	backend b { .host = "${localhost}"; }

--- a/bin/varnishtest/tests/v00060.vtc
+++ b/bin/varnishtest/tests/v00060.vtc
@@ -44,7 +44,7 @@ client c1 {
 	expect resp.status == 503
 } -run
 
-varnish v1 -cliok "param.set vcc_err_unref off"
+varnish v1 -cliok "param.set vcc_feature -err_unref"
 varnish v1 -vcl {
 	backend bad { .host = "${bad_backend}"; }
 	backend nil none;

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -32,6 +32,7 @@ nobase_pkginclude_HEADERS = \
 	tbl/sess_attr.h \
 	tbl/sess_close.h \
 	tbl/symbol_kind.h \
+	tbl/vcc_feature_bits.h \
 	tbl/vcl_returns.h \
 	tbl/vcl_states.h \
 	tbl/vhd_fsm.h \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -23,7 +23,6 @@ nobase_pkginclude_HEADERS = \
 	tbl/http_headers.h \
 	tbl/http_response.h \
 	tbl/locks.h \
-	tbl/mgt_vcc.h \
 	tbl/obj_attr.h \
 	tbl/oc_exp_flags.h \
 	tbl/oc_flags.h \

--- a/include/libvcc.h
+++ b/include/libvcc.h
@@ -39,9 +39,9 @@ void VCC_VMOD_path(struct vcc *, const char *);
 void VCC_Predef(struct vcc *, const char *type, const char *name);
 void VCC_VCL_Range(unsigned *, unsigned *);
 
-#define MGT_VCC(t, n, cc)					\
-	void VCC_ ## cc (struct vcc *, t);
-#include "tbl/mgt_vcc.h"
+#define VCC_FEATURE_BIT(U, l, d)				\
+	void VCC_Opt_ ## l(struct vcc *, unsigned);
+#include "tbl/vcc_feature_bits.h"
 
 int VCC_Compile(struct vcc *, struct vsb **,
     const char *, const char *, const char *, const char *);

--- a/include/tbl/mgt_vcc.h
+++ b/include/tbl/mgt_vcc.h
@@ -1,9 +1,0 @@
-/*
- * This file is in the public domain
- *
- */
-
-MGT_VCC(unsigned, allow_inline_c, Allow_InlineC)
-MGT_VCC(unsigned, err_unref,      Err_Unref)
-MGT_VCC(unsigned, unsafe_path,    Unsafe_Path)
-#undef MGT_VCC

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1787,6 +1787,24 @@ PARAM_POST
 
 PARAM_PRE
 PARAM_BITS(
+	/* name */	vcc_feature,
+	/* fld */	vcc_feature_bits,
+	/* def */
+	"+err_unref,"
+	"+unsafe_path",
+	/* descr */
+	"Enable/Disable various VCC behaviors.\n"
+	"\tdefault\tSet default value\n"
+	"\tnone\tDisable all behaviors.\n\n"
+	"Use +/- prefix to enable/disable individual behavior:")
+#ifdef PARAM_ALL
+#  define VCC_FEATURE_BIT(U, l, d) "\n\t" #l "\t" d
+#  include "tbl/vcc_feature_bits.h"
+#endif
+PARAM_POST
+
+PARAM_PRE
+PARAM_BITS(
 	/* name */	vsl_mask,
 	/* fld */	vsl_mask,
 	/* def */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1635,38 +1635,6 @@ PARAM_STRING(
 )
 
 /*--------------------------------------------------------------------
- * VCC parameters
- */
-
-#  define PARAM_VCC(nm, def, descr)					\
-	PARAM_PRE							\
-	PARAM(, , nm, tweak_boolean, &mgt_ ## nm, NULL, NULL, def,	\
-	    "bool", descr)						\
-	PARAM_POST
-
-PARAM_VCC(
-	/* name */	vcc_err_unref,
-	/* def */	"on",
-	/* descr */
-	"Unreferenced VCL objects result in error."
-)
-
-PARAM_VCC(
-	/* name */	vcc_allow_inline_c,
-	/* def */	"off",
-	/* descr */
-	"Allow inline C code in VCL."
-)
-
-PARAM_VCC(
-	/* name */	vcc_unsafe_path,
-	/* def */	"on",
-	/* descr */
-	"Allow '/' in vmod & include paths.\n"
-	"Allow 'import ... from ...'."
-)
-
-/*--------------------------------------------------------------------
  * PCRE2 parameters
  */
 
@@ -1723,12 +1691,14 @@ PARAM_PCRE2(
 	    "Deprecated alias for the " #nm " parameter.")	\
 	PARAM_POST
 
-PARAM_ALIAS(deprecated_dummy, debug)
+PARAM_ALIAS(deprecated_dummy,	debug)
+PARAM_ALIAS(vcc_err_unref,	vcc_feature)
+PARAM_ALIAS(vcc_allow_inline_c,	vcc_feature)
+PARAM_ALIAS(vcc_unsafe_path,	vcc_feature)
 
 #  undef PARAM_ALIAS
 #  undef PARAM_PCRE2
 #  undef PARAM_STRING
-#  undef PARAM_VCC
 #endif /* defined(PARAM_ALL) */
 
 /*--------------------------------------------------------------------

--- a/include/tbl/vcc_feature_bits.h
+++ b/include/tbl/vcc_feature_bits.h
@@ -1,0 +1,50 @@
+/*-
+ * Copyright (c) 2022 Varnish Software AS
+ * All rights reserved.
+ *
+ * Author: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * Fields in the vcc parameter
+ *
+ */
+
+/*lint -save -e525 -e539 */
+
+VCC_FEATURE_BIT(ERR_UNREF,		err_unref,
+    "Unreferenced VCL objects result in error."
+)
+
+VCC_FEATURE_BIT(ALLOW_INLINE_C,		allow_inline_c,
+    "Allow inline C code in VCL."
+)
+
+VCC_FEATURE_BIT(UNSAFE_PATH,		unsafe_path,
+    "Allow '/' in vmod & include paths. Allow 'import ... from ...'."
+)
+
+#undef VCC_FEATURE_BIT
+
+/*lint -restore */

--- a/include/tbl/vsl_tags.h
+++ b/include/tbl/vsl_tags.h
@@ -291,7 +291,7 @@ SLTM(VCL_acl, 0, "VCL ACL check results",
 	"The format is::\n\n"
 	"\t%s %s [%s [fixed: %s]]\n"
 	"\t|  |   |          |\n"
-	"\t|  |   |          +- Fixed entry (see vcc_acl_pedantic parameter)\n"
+	"\t|  |   |          +- Fixed entry (see acl +pedantic flag)\n"
 	"\t|  |   +------------ Matching entry (only for MATCH)\n"
 	"\t|  +---------------- Name of the ACL\n"
 	"\t+-------------------- MATCH or NO_MATCH\n"

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -921,13 +921,13 @@ VCC_VMOD_path(struct vcc *vcc, const char *str)
  * Configure settings
  */
 
-#define MGT_VCC(type, name, camelcase)				\
-	void VCC_ ## camelcase (struct vcc *vcc, type val)	\
+#define VCC_FEATURE_BIT(U, l, d)				\
+	void VCC_Opt_ ## l(struct vcc *vcc, unsigned val)	\
 	{							\
 		CHECK_OBJ_NOTNULL(vcc, VCC_MAGIC);		\
-		vcc->name = val;				\
+		vcc->l = val;					\
 	}
-#include "tbl/mgt_vcc.h"
+#include "tbl/vcc_feature_bits.h"
 
 /*--------------------------------------------------------------------
  * Configure settings

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -250,8 +250,8 @@ struct vcc {
 	char			*builtin_vcl;
 	struct vfil_path	*vcl_path;
 	struct vfil_path	*vmod_path;
-#define MGT_VCC(t, n, cc) t n;
-#include <tbl/mgt_vcc.h>
+#define VCC_FEATURE_BIT(U, l, d) unsigned l;
+#include <tbl/vcc_feature_bits.h>
 
 	struct symtab		*syms[VCC_NAMESPACE__MAX];
 

--- a/vmod/tests/blob_b00011.vtc
+++ b/vmod/tests/blob_b00011.vtc
@@ -5,7 +5,7 @@ varnishtest "VMOD blob workspace overflow conditions"
 # Since not all of them may be called by all VCLs we also need to ensure this
 # will not result in a compilation failure.
 
-varnish v1 -cliok "param.set vcc_err_unref off"
+varnish v1 -cliok "param.set vcc_feature -err_unref"
 varnish v1 -cliok "param.set debug +syncvsl"
 
 shell {


### PR DESCRIPTION
With #3789 merged I quickly put together the `vcc_feature` parameter discussed in #3269.

Building on top of the parameter alias infrastructure, the existing parameters are still available:

- `vcc_err_unref`
- `vcc_allow_inline_c`
- `vcc_unsafe_path`

They are now bit flags with the same name (without the `vcc_` prefix) in the `vcc_feature` parameter. This should ease the transition and not mandate a major version bump.