### PR TITLE
Add a utility macro to allocate mini-objects on the workspace

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -850,6 +850,15 @@ const char *WS_Printf(struct ws *ws, const char *fmt, ...) v_printflike_(2, 3);
 void WS_VSB_new(struct vsb *, struct ws *);
 char *WS_VSB_finish(struct vsb *, struct ws *, size_t *);
 
+/* WS utility */
+#define WS_TASK_ALLOC_OBJ(ctx, ptr, magic) do {			\
+	ptr = WS_Alloc((ctx)->ws, sizeof *(ptr));		\
+	if ((ptr) == NULL)					\
+		VRT_fail(ctx, "Out of workspace for " #magic);	\
+	else							\
+		INIT_OBJ(ptr, magic);				\
+} while(0)
+
 /* cache_rfc2616.c */
 void RFC2616_Ttl(struct busyobj *, vtim_real now, vtim_real *t_origin,
     float *ttl, float *grace, float *keep);

--- a/vmod/vmod_cookie.c
+++ b/vmod/vmod_cookie.c
@@ -187,13 +187,10 @@ vmod_set(VRT_CTX, struct vmod_priv *priv, VCL_STRING name, VCL_STRING value)
 		return;
 	}
 
-	cookie = WS_Alloc(ctx->ws, sizeof *cookie);
-	if (cookie == NULL) {
-		VSLb(ctx->vsl, SLT_Error,
-		    "cookie: unable to get storage for cookie");
+	WS_TASK_ALLOC_OBJ(ctx, cookie, VMOD_COOKIE_ENTRY_MAGIC);
+	if (cookie == NULL)
 		return;
-	}
-	INIT_OBJ(cookie, VMOD_COOKIE_ENTRY_MAGIC);
+
 	cookie->name = WS_Printf(ctx->ws, "%s", name);
 	cookie->value = WS_Printf(ctx->ws, "%s", value);
 	if (cookie->name == NULL || cookie->value == NULL) {

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -943,12 +943,9 @@ xyzzy_catflap(VRT_CTX, VCL_ENUM type)
 	req = ctx->req;
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	XXXAZ(req->vcf);
-	req->vcf = WS_Alloc(req->ws, sizeof *req->vcf);
-	if (req->vcf == NULL) {
-		VRT_fail(ctx, "WS_Alloc failed in debug.catflap()");
+	WS_TASK_ALLOC_OBJ(ctx, req->vcf, VCF_MAGIC);
+	if (req->vcf == NULL)
 		return;
-	}
-	INIT_OBJ(req->vcf, VCF_MAGIC);
 	if (type == VENUM(first) || type == VENUM(miss)) {
 		req->vcf->func = xyzzy_catflap_simple;
 		req->vcf->priv = TRUST_ME(type);

--- a/vmod/vmod_directors_shard.c
+++ b/vmod/vmod_directors_shard.c
@@ -924,13 +924,10 @@ shard_param_task_l(VRT_CTX, const void *id, const char *who,
 		return (p);
 	}
 
-	p = WS_Alloc(ctx->ws, sizeof *p);
-	if (p == NULL) {
-		shard_fail(ctx, who, "%s", "WS_Alloc failed");
+	WS_TASK_ALLOC_OBJ(ctx, p, VMOD_SHARD_SHARD_PARAM_MAGIC);
+	if (p == NULL)
 		return (NULL);
-	}
 	task->priv = p;
-	INIT_OBJ(p, VMOD_SHARD_SHARD_PARAM_MAGIC);
 	p->vcl_name = who;
 	p->scope = SCOPE_TASK;
 

--- a/vmod/vmod_directors_shard_cfg.c
+++ b/vmod/vmod_directors_shard_cfg.c
@@ -127,13 +127,9 @@ shard_change_get(VRT_CTX, struct sharddir * const shardd)
 		return (change);
 	}
 
-	change = WS_Alloc(ctx->ws, sizeof(*change));
-	if (change == NULL) {
-		shard_fail(ctx, shardd->name, "%s", "could not get workspace");
+	WS_TASK_ALLOC_OBJ(ctx, change, SHARD_CHANGE_MAGIC);
+	if (change == NULL)
 		return (NULL);
-	}
-
-	INIT_OBJ(change, SHARD_CHANGE_MAGIC);
 	change->vsl = ctx->vsl;
 	change->shardd = shardd;
 	VSTAILQ_INIT(&change->tasks);
@@ -159,13 +155,9 @@ shard_change_task_add(VRT_CTX, struct shard_change *change,
 
 	CHECK_OBJ_NOTNULL(change, SHARD_CHANGE_MAGIC);
 
-	task = WS_Alloc(ctx->ws, sizeof(*task));
-	if (task == NULL) {
-		shard_fail(ctx, change->shardd->name, "%s",
-		    "could not get workspace for task");
+	WS_TASK_ALLOC_OBJ(ctx, task, SHARD_CHANGE_TASK_MAGIC);
+	if (task == NULL)
 		return (NULL);
-	}
-	INIT_OBJ(task, SHARD_CHANGE_TASK_MAGIC);
 	task->task = task_e;
 	task->priv = priv;
 	VSTAILQ_INSERT_TAIL(&change->tasks, task, list);


### PR DESCRIPTION
isn't this something we would have wanted all along?

This simplifies the common pattern to allocate/initialize a miniobj on the workspace to

```c
	WS_TASK_ALLOC_OBJ(ctx, myobj, MYOBJ_MAGIC);
	if (myobj == NULL)
		return (error);
```