### PR TITLE
build: Add -mno-omit-leaf-frame-pointer to sanitizer CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -316,7 +316,7 @@ if test "x$UBSAN_FLAGS$TSAN_FLAGS$ASAN_FLAGS$MSAN_FLAGS" != "x"; then
 	AC_DEFINE([ENABLE_SANITIZER], [1],
 		[Define to 1 if any sanitizer is enabled.])
 	SAN_FLAGS="$ASAN_FLAGS $UBSAN_FLAGS $TSAN_FLAGS $MSAN_FLAGS"
-	SAN_CFLAGS="$SAN_FLAGS -fPIC -fPIE -fno-omit-frame-pointer"
+	SAN_CFLAGS="$SAN_FLAGS -fPIC -fPIE -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
 	SAN_LDFLAGS=
 	save_CFLAGS=$CFLAGS
 	CFLAGS="${CFLAGS} -Werror=unused-command-line-argument"


### PR DESCRIPTION
According to the GCC manual on -fno-omit-frame-pointer:

> Note that -fno-omit-frame-pointer doesn't guarantee the frame pointer
> is used in all functions.  Several targets always omit the frame
> pointer in leaf functions.

And what is says about -m[no-]omit-leaf-frame-pointer:

> -momit-leaf-frame-pointer
> -mno-omit-leaf-frame-pointer
>
> Omit or keep the frame pointer in leaf functions.  The former behavior
> is the default.

So we should probably prevent both.