### PR TITLE
vsc: New MAIN.shm_bytes* counters

### DIFF
--- a/bin/varnishd/cache/cache_shmlog.c
+++ b/bin/varnishd/cache/cache_shmlog.c
@@ -193,6 +193,7 @@ vsl_get(unsigned len, unsigned records, unsigned flushes)
 	VSC_C_main->shm_writes++;
 	VSC_C_main->shm_flushes += flushes;
 	VSC_C_main->shm_records += records;
+	VSC_C_main->shm_bytes += VSL_BYTES(VSL_OVERHEAD + VSL_WORDS(len));
 
 	/* Wrap if necessary */
 	if (VSL_END(vsl_ptr, len) >= vsl_end)

--- a/bin/varnishtest/tests/l00006.vtc
+++ b/bin/varnishtest/tests/l00006.vtc
@@ -1,0 +1,18 @@
+varnishtest "Check shmlog stats"
+
+server s1 {
+    rxreq
+    txresp
+} -start
+
+varnish v1 -vcl+backend "" -start
+
+client c1 {
+    txreq
+    rxresp
+} -run
+
+varnish v1 -vsl_catchup
+varnish v1 -expect shm_writes > 0
+varnish v1 -expect shm_records > 0
+varnish v1 -expect shm_bytes > 0

--- a/lib/libvsc/VSC_main.vsc
+++ b/lib/libvsc/VSC_main.vsc
@@ -703,6 +703,14 @@
 	of the shared memory log, cycling back to the beginning.
 
 
+.. varnish_vsc:: shm_bytes
+	:level:	diag
+	:format: bytes
+	:oneliner:	SHM bytes
+
+	Number of bytes written to the shared memory log.
+
+
 .. varnish_vsc:: backend_req
 	:oneliner:	Backend requests made
 

--- a/lib/libvsc/VSC_main.vsc
+++ b/lib/libvsc/VSC_main.vsc
@@ -670,25 +670,37 @@
 	:level:	diag
 	:oneliner:	SHM records
 
+	Number of log records written to the shared memory log.
+
 
 .. varnish_vsc:: shm_writes
 	:level:	diag
 	:oneliner:	SHM writes
+
+	Number of individual writes to the shared memory log. A single
+	write may batch multiple records for bufferred tasks.
 
 
 .. varnish_vsc:: shm_flushes
 	:level:	diag
 	:oneliner:	SHM flushes due to overflow
 
+	Number of writes performed before the end of a bufferred task
+	because adding a record to a batch would exceed vsl_buffer.
 
 .. varnish_vsc:: shm_cont
 	:level:	diag
-	:oneliner:	SHM MTX contention
+	:oneliner:	SHM lock contention
+
+	Number of times a write had to wait for the lock.
 
 
 .. varnish_vsc:: shm_cycles
 	:level:	diag
-	:oneliner:	SHM cycles through buffer
+	:oneliner:	SHM cycles through VSL space
+
+	Number of times a write of log records would reach past the end
+	of the shared memory log, cycling back to the beginning.
 
 
 .. varnish_vsc:: backend_req


### PR DESCRIPTION
We have various stat counters for the shared memory log (shmlog),
but nothing to give us the number of bytes used (consumed).  To
address this, add new stat counters to the shmlog:

    shm_bytes
        Total number of bytes used in the shared memory log.
        This includes bytes unused when we wrap.

    shm_bytes_wrap
        Number of bytes unused when we wrap.

Signed-off-by: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>

---

I'm submitting this change on behalf of @drodden from @varnish, and I bundled an additional trivial patch.