### PR TITLE
Install vnum.h

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -66,6 +66,7 @@ nobase_pkginclude_HEADERS += \
 	vcl.h \
 	vcs.h \
 	vmod_abi.h \
+	vnum.h \
 	vqueue.h \
 	vre.h \
 	vre_pcre2.h \
@@ -98,7 +99,6 @@ nobase_noinst_HEADERS = \
 	vjsn.h \
 	vlu.h \
 	vmb.h \
-	vnum.h \
 	vpf.h \
 	vsc_priv.h \
 	vsl_priv.h \


### PR DESCRIPTION
Do we need many words?
I think it's equally useful as `vtim.h` and should be available to vmods.