### PR TITLE
h2: Make requests walk away from the waiting list

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -485,11 +485,13 @@ struct req {
 	void			*transport_priv;
 
 	VTAILQ_ENTRY(req)	w_list;
+	VTAILQ_ENTRY(req)	t_list;
 
 	struct objcore		*body_oc;
 
-	/* The busy objhead we sleep on */
+	/* The busy objhead we sleep on, referenced up to twice */
 	struct objhead		*hash_objhead;
+	struct objhead		*transport_objhead;
 
 	/* Built Vary string == workspace reservation */
 	uint8_t			*vary_b;

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -47,7 +47,7 @@
 #include "vgz.h"
 
 static vtr_deliver_f ved_deliver;
-static vtr_reembark_f ved_reembark;
+static vtr_waitlist_f ved_reembark;
 
 static const uint8_t gzip_hdr[] = {
 	0x1f, 0x8b, 0x08,
@@ -91,7 +91,7 @@ static const struct transport VED_transport = {
 
 /*--------------------------------------------------------------------*/
 
-static void v_matchproto_(vtr_reembark_f)
+static void v_matchproto_(vtr_waitlist_f)
 ved_reembark(struct worker *wrk, struct req *req)
 {
 	struct ecx *ecx;

--- a/bin/varnishd/cache/cache_objhead.h
+++ b/bin/varnishd/cache/cache_objhead.h
@@ -76,3 +76,4 @@ unsigned HSH_Purge(struct worker *, struct objhead *, vtim_real ttl_now,
     vtim_dur ttl, vtim_dur grace, vtim_dur keep);
 struct objcore *HSH_Private(const struct worker *wrk);
 void HSH_Cancel(struct worker *, struct objcore *, struct boc *);
+void HSH_WalkAway(struct worker *wrk, struct objhead **ohp, struct req *req);

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -44,7 +44,6 @@ typedef void vtr_sess_panic_f (struct vsb *, const struct sess *);
 typedef void vtr_req_panic_f (struct vsb *, const struct req *);
 typedef void vtr_req_fail_f (struct req *, stream_close_t);
 typedef void vtr_waitlist_f (struct worker *, struct req *);
-typedef void vtr_reembark_f (struct worker *, struct req *);
 typedef int vtr_minimal_response_f (struct req *, uint16_t status);
 
 struct transport {
@@ -65,8 +64,8 @@ struct transport {
 	vtr_sess_panic_f		*sess_panic;
 	vtr_req_panic_f			*req_panic;
 	vtr_waitlist_f			*top_waitlist;
-	vtr_reembark_f			*top_reembark;
-	vtr_reembark_f			*reembark;
+	vtr_waitlist_f			*top_reembark;
+	vtr_waitlist_f			*reembark;
 	vtr_minimal_response_f		*minimal_response;
 
 	VTAILQ_ENTRY(transport)		list;

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -43,6 +43,7 @@ typedef void vtr_req_body_f (struct req *);
 typedef void vtr_sess_panic_f (struct vsb *, const struct sess *);
 typedef void vtr_req_panic_f (struct vsb *, const struct req *);
 typedef void vtr_req_fail_f (struct req *, stream_close_t);
+typedef void vtr_waitlist_f (struct worker *, struct req *);
 typedef void vtr_reembark_f (struct worker *, struct req *);
 typedef int vtr_minimal_response_f (struct req *, uint16_t status);
 
@@ -63,6 +64,8 @@ struct transport {
 	vtr_deliver_f			*deliver;
 	vtr_sess_panic_f		*sess_panic;
 	vtr_req_panic_f			*req_panic;
+	vtr_waitlist_f			*top_waitlist;
+	vtr_reembark_f			*top_reembark;
 	vtr_reembark_f			*reembark;
 	vtr_minimal_response_f		*minimal_response;
 

--- a/bin/varnishd/hash/hash_slinger.h
+++ b/bin/varnishd/hash/hash_slinger.h
@@ -52,7 +52,7 @@ struct hash_slinger {
 };
 
 enum lookup_e {
-	HSH_CONTINUE,
+	HSH_WALKAWAY,
 	HSH_MISS,
 	HSH_BUSY,
 	HSH_HIT,

--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -134,6 +134,7 @@ struct h2_req {
 	int				counted;
 	struct h2_sess			*h2sess;
 	struct req			*req;
+	VTAILQ_HEAD(, req)		waitinglist;
 	double				t_send;
 	double				t_winupd;
 	pthread_cond_t			*cond;

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -159,6 +159,7 @@ h2_new_req(struct h2_sess *h2, unsigned stream, struct req *req)
 	r2->r_window = h2->local_settings.initial_window_size;
 	r2->t_window = h2->remote_settings.initial_window_size;
 	req->transport_priv = r2;
+	VTAILQ_INIT(&r2->waitinglist);
 	Lck_Lock(&h2->sess->mtx);
 	if (stream)
 		h2->open_streams++;
@@ -182,6 +183,7 @@ h2_del_req(struct worker *wrk, struct h2_req *r2)
 	ASSERT_RXTHR(h2);
 	sp = h2->sess;
 	Lck_Lock(&sp->mtx);
+	assert(VTAILQ_EMPTY(&r2->waitinglist));
 	assert(h2->refcnt > 0);
 	--h2->refcnt;
 	/* XXX: PRIORITY reshuffle */

--- a/bin/varnishtest/tests/t02023.vtc
+++ b/bin/varnishtest/tests/t02023.vtc
@@ -1,0 +1,66 @@
+varnishtest "Dying h2 session with stream on waiting list"
+
+barrier b1 cond 2
+barrier b2 cond 2
+barrier b3 cond 2
+
+server s1 {
+	rxreq
+	barrier b1 sync
+	barrier b3 sync
+	txresp
+} -start
+
+varnish v1 -cliok "param.set thread_pools 1"
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.set debug +waitinglist"
+varnish v1 -cliok "param.set debug +syncvsl"
+varnish v1 -vcl+backend {} -start
+
+logexpect l1 -v v1 -g raw {
+	expect * 1003 Debug "on waiting list"
+} -start
+
+logexpect l2 -v v1 {
+	expect * 1003	Debug		"walking away"
+	expect 0 =	Debug		"off waiting list"
+	expect * =	Timestamp	"^Waitinglist: "
+	expect 0 =	Error		"The client is going away"
+} -start
+
+client c1 {
+	stream 1 {
+		txreq
+		barrier b1 sync
+	} -run
+	stream 3 {
+		txreq
+	} -run
+	stream 5 {
+		barrier b2 sync
+		txsettings
+	} -run
+	stream 0 {
+		rxgoaway
+		expect goaway.laststream == 3
+		expect goaway.err == PROTOCOL_ERROR
+	} -run
+} -start
+
+logexpect l1 -wait
+barrier b2 sync
+
+logexpect l2 -wait
+barrier b3 sync
+
+server s1 -wait
+
+varnish v1 -expect busy_killed == 1
+
+client c2 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -expect cache_hit == 1

--- a/bin/varnishtest/tests/t02024.vtc
+++ b/bin/varnishtest/tests/t02024.vtc
@@ -1,0 +1,90 @@
+varnishtest "Dying h2 session with ESI stream on waiting list"
+
+barrier b1 cond 2
+barrier b2 cond 2
+barrier b3 cond 2
+
+server s1 {
+	rxreq
+	expect req.url == "/esi"
+	barrier b1 sync
+	barrier b3 sync
+	txresp -hdr "included: esi" -body hello
+} -start
+
+server s2 {
+	rxreq
+	expect req.url == "/"
+	txresp -body {<esi:include src="/esi"/><esi:include src="/esi"/><esi:include src="/esi"/>}
+} -start
+
+varnish v1 -cliok "param.set thread_pools 1"
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.set debug +waitinglist"
+varnish v1 -cliok "param.set debug +syncvsl"
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.url == "/") {
+			set req.backend_hint = s2;
+		}
+	}
+	sub vcl_backend_response {
+		set beresp.do_esi = !beresp.http.included;
+	}
+} -start
+
+logexpect l1 -v v1 -g raw {
+	expect * 1006 Debug "on waiting list"
+} -start
+
+logexpect l2 -v v1 -g raw {
+	expect * 1006 Debug "walking away"
+	expect 0 1006 Debug "off waiting list"
+} -start
+
+# c1 will block during a backend fetch
+client c1 {
+	txreq -url "/esi"
+	rxresp
+	expect resp.body == hello
+} -start
+
+barrier b1 sync
+
+client c2 {
+	stream 1 {
+		txreq
+	} -run
+	stream 3 {
+		barrier b2 sync
+		# bork the session
+		txsettings
+	} -run
+	stream 0 {
+		rxgoaway
+		expect goaway.laststream == 1
+		expect goaway.err == PROTOCOL_ERROR
+	} -run
+} -start
+
+logexpect l1 -wait
+barrier b2 sync
+
+logexpect l2 -wait
+barrier b3 sync
+
+client c1 -wait
+client c2 -wait
+server s1 -wait
+server s2 -wait
+
+varnish v1 -expect busy_killed == 1
+varnish v1 -expect cache_hit == 0
+
+client c3 {
+	txreq
+	rxresp
+	expect resp.body == hellohellohello
+} -run
+
+varnish v1 -expect cache_hit == 4

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -40,6 +40,7 @@ REQ_FLAG(is_hit,		0, 0, "")
 REQ_FLAG(waitinglist,		0, 0, "")
 REQ_FLAG(want100cont,		0, 0, "")
 REQ_FLAG(late100cont,		0, 0, "")
+REQ_FLAG(walkaway,		0, 0, "")
 #define REQ_BEREQ_FLAG(lower, vcl_r, vcl_w, doc) \
 	REQ_FLAG(lower, vcl_r, vcl_w, doc)
 #include "tbl/req_bereq_flags.h"

--- a/lib/libvsc/VSC_main.vsc
+++ b/lib/libvsc/VSC_main.vsc
@@ -319,10 +319,11 @@
 	Number of requests taken off the busy object sleep list and rescheduled.
 
 .. varnish_vsc:: busy_killed
+	:group: wrk
 	:oneliner:	Number of requests killed after sleep on busy objhdr
 
 	Number of requests killed from the busy object sleep list due to
-	lack of resources.
+	the client going away.
 
 .. varnish_vsc:: sess_queued
 	:oneliner:	Sessions queued for thread


### PR DESCRIPTION
When a session goes to the cleanup step, it will indefinitely try to
kill all the streams until those stuck in a waiting list reembark a
thread. This can lead to clients timing out, closing the h2 session,
and opening a new h2 session for the exact same requests. This can
artifically inflate the number of dead tasks in a waiting list with
generous backend timeouts.

To avoid that, an h2 stream will keep a list of requests currently
in a waiting list and make them walk away quietly during cleanup.
An h2 stream would normally only have one request running at any
time but this may no longer be true with modules like vmod_pesi.

---

See https://varnish-cache.org/lists/pipermail/varnish-misc/2022-July/027160.html

This is equivalent to what we have in Varnish Enterprise that I
mentioned in this thread. It does not solve the problem described
in the email thread, because we have no path to walk away from
an HTTP/1 request (pun intended).

I believe we could potentially solve the HTTP/1 case if we involved
a waiter that would only care about closed connections, ignoring
incoming data that I believe trigger a wake up today.

I am convinced that I managed a better design than the original
attempt, and I'm looking forward to reviews. Unfortunately, I will
miss the next two bugwash meetings.