### PR TITLE
Add vcc_feature trace to control generation of VCL_trace logs

### DIFF
--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -62,14 +62,13 @@ VPI_wrk_init(struct worker *wrk, void *p, size_t spc)
 }
 
 void
-VPI_count(VRT_CTX, unsigned u)
+VPI_trace(VRT_CTX, unsigned u)
 {
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->vcl, VCL_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->vcl->conf, VCL_CONF_MAGIC);
 	assert(u < ctx->vcl->conf->nref);
-	ctx->vpi->ref = u;
 	if (ctx->vsl != NULL)
 		VSLb(ctx->vsl, SLT_VCL_trace, "%s %u %u.%u.%u",
 		    ctx->vcl->loaded_name, u, ctx->vcl->conf->ref[u].source,

--- a/bin/varnishtest/tests/c00005.vtc
+++ b/bin/varnishtest/tests/c00005.vtc
@@ -9,7 +9,7 @@ server s1 {
 	txresp -body "2222\n"
 } -start
 
-varnish v1 -arg "-p vsl_mask=+VCL_trace"
+varnish v1 -arg "-p vcc_feature=+trace"
 
 varnish v1 -errvcl {Name acl1 must have type 'acl'.} {
 	sub vcl_recv {

--- a/bin/varnishtest/tests/c00054.vtc
+++ b/bin/varnishtest/tests/c00054.vtc
@@ -9,7 +9,7 @@ server s1 {
 varnish v1 -vcl+backend {} -start
 
 varnish v1 -cliok "param.show vsl_mask"
-varnish v1 -cliok "param.set vsl_mask +VCL_trace"
+varnish v1 -cliok "param.set vsl_mask -VCL_trace"
 varnish v1 -cliok "param.show vsl_mask"
 varnish v1 -cliok "param.set vsl_mask -WorkThread,-TTL"
 varnish v1 -cliok "param.show vsl_mask"

--- a/bin/varnishtest/tests/r02413.vtc
+++ b/bin/varnishtest/tests/r02413.vtc
@@ -1,11 +1,11 @@
-varnishtest "Test vcl_trace"
+varnishtest "Test vcc_feature trace"
 
 server s1 {
 	rxreq
 	txresp
 } -start
 
-varnish v1 -arg "-p vsl_mask=+VCL_trace" -vcl+backend {
+varnish v1 -arg "-p vcc_feature=+trace" -vcl+backend {
 	sub vcl_deliver {
 		set resp.http.vcl = "vclA";
 	}

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -39,6 +39,16 @@ Varnish Cache NEXT (2022-09-15)
   semi-colon (``';'``) at the end of the string. This could break VCL relying
   on the previous incorrect behavior.
 
+* VCL tracing now needs to be explicitly activated by setting the
+  ``vcc_feature +trace`` parameter. Only then will ``VCL_trace`` log
+  records be generated for that VCL.
+
+  Consequently, ``VCL_trace`` has been removed from the default
+  ``vsl_mask``, so whenever a VCL compiled with the ``trace`` VCC
+  feature enabled runs, the log records will be emitted by
+  default. ``vsl_mask`` can still be used to filter ``VCL_trace``
+  records.
+
 ================================
 Varnish Cache 7.1.0 (2022-03-15)
 ================================

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1789,7 +1789,6 @@ PARAM_BITS(
 	"-ObjProtocol,"
 	"-ObjReason,"
 	"-ObjStatus,"
-	"-VCL_trace,"
 	"-VdpAcct,"
 	"-VfpAcct,"
 	"-WorkThread",

--- a/include/tbl/vcc_feature_bits.h
+++ b/include/tbl/vcc_feature_bits.h
@@ -45,6 +45,10 @@ VCC_FEATURE_BIT(UNSAFE_PATH,		unsafe_path,
     "Allow '/' in vmod & include paths. Allow 'import ... from ...'."
 )
 
+VCC_FEATURE_BIT(TRACE,			trace,
+    "Enable VCL tracing."
+)
+
 #undef VCC_FEATURE_BIT
 
 /*lint -restore */

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -63,8 +63,12 @@ struct wrk_vpi {
 	unsigned	ref;	// index into (struct vpi_ref)[]
 };
 
-
-void VPI_count(VRT_CTX, unsigned);
+#define VPI_count(ctx, max, u) \
+	do {							\
+		assert(u < max);				\
+		(ctx)->vpi->ref = u;				\
+	} while(0)
+void VPI_trace(VRT_CTX, unsigned);
 void VPI_vcl_fini(VRT_CTX);
 
 int VPI_Vmod_Init(VRT_CTX, struct vmod **hdl, unsigned nbr, void *ptr, int len,

--- a/lib/libvcc/vcc_parse.c
+++ b/lib/libvcc/vcc_parse.c
@@ -47,9 +47,11 @@ static void vcc_Compound(struct vcc *tl);
 	tl->indent -= INDENT;	\
 } while (0)
 
-#define C(tl, sep)	do {					\
-	Fb(tl, 1, "VPI_count(ctx, %u)%s\n", ++tl->cnt, sep);	\
-	tl->t->cnt = tl->cnt;					\
+#define C(tl, sep)	do {						\
+	Fb(tl, 1, "VPI_count(ctx, VGC_NREFS, %u)%s\n", ++tl->cnt, sep); \
+	if (tl->trace)							\
+		Fb(tl, 1, "VPI_trace(ctx, %u)%s\n", tl->cnt, sep);	\
+	tl->t->cnt = tl->cnt;						\
 } while (0)
 
 /*--------------------------------------------------------------------


### PR DESCRIPTION
To potentially emit `VCL_trace` VSL records, we called `VPI_count()` from VGC for, in the extreme, every line of VCL.

For a normal setup, `VPI_count()` would call into VSL only to find out that `VCL_trace` is masked and not have any effect.

Issuing two additional function calls for each line of VCL obviously is something we should avoid unless there is a real benefit.

Under the assumption that the `VCL_trace` facility is used rarely, we add the `trace` vcc feature which must explicitly be enabled before loading a VCL to enable tracing. This should have no relevant impact for common installations and, if tracing is required, re-loading the vcl to enable tracing is quick and easy.

The benefit of this change is that we can turn `VPI_count()`, which tracks an approximation of our position in VCL processing, into a macro, reducing the overhead from the above mentioned two function calls to a single address write (one of the two lines of `VPI_count()` is an assertion on constant values which can (and usually will) be eliminated by compilers).