### PR TITLE
high watermarks for workspaces iteration 2

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -467,6 +467,7 @@ vca_make_session(struct worker *wrk, void *arg)
 	req->htc->rfd = &sp->fd;
 
 	SES_SetTransport(wrk, sp, req, wa->acceptlsock->transport);
+	WS_ReportSize(wrk->aws, 0);	// XXX correct?
 	WS_Release(wrk->aws, 0);
 }
 

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -679,7 +679,7 @@ HSH_Purge(struct worker *wrk, struct objhead *oh, vtim_real ttl_now,
 	CHECK_OBJ_NOTNULL(oh, OBJHEAD_MAGIC);
 
 	n_max = WS_ReserveLumps(wrk->aws, sizeof *ocp);
-	if (n_max < 2) {
+	if (n_max <= 2) {
 		/* No space on the workspace. Give it a stack buffer of 2
 		 * elements, which is the minimum for the algorithm
 		 * below. */
@@ -726,6 +726,8 @@ HSH_Purge(struct worker *wrk, struct objhead *oh, vtim_real ttl_now,
 			/* No eligible objcores found. We are finished. */
 			break;
 		}
+		if (n_max > 2)
+			WS_ReportSize(wrk->aws, n * sizeof *ocp);
 
 		j = n;
 		if (oc != NULL) {

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -551,6 +551,7 @@ http_CollectHdrSep(struct http *hp, hdr_t hdr, const char *sep)
 				http_fail(hp);
 				VSLbs(hp->vsl, SLT_LostHeader,
 				    TOSTRAND(hdr + 1));
+				WS_Report(hp->ws, b + x);
 				WS_Release(hp->ws, 0);
 				return;
 			}
@@ -573,6 +574,7 @@ http_CollectHdrSep(struct http *hp, hdr_t hdr, const char *sep)
 		if (b + lsep + x >= e) {
 			http_fail(hp);
 			VSLbs(hp->vsl, SLT_LostHeader, TOSTRAND(hdr + 1));
+			WS_Report(hp->ws, b + lsep + x);
 			WS_Release(hp->ws, 0);
 			return;
 		}
@@ -588,6 +590,7 @@ http_CollectHdrSep(struct http *hp, hdr_t hdr, const char *sep)
 	*b = '\0';
 	hp->hd[f].b = WS_Reservation(hp->ws);
 	hp->hd[f].e = b;
+	WS_Report(hp->ws, b + 1);
 	WS_ReleaseP(hp->ws, b + 1);
 }
 

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -240,7 +240,14 @@ Req_Rollback(VRT_CTX)
 	WS_Rollback(req->ws, req->ws_req);
 }
 
-/*----------------------------------------------------------------------
+static void
+req_ws_report(struct vsl_log *vsl, const struct ws *ws, const char *name)
+{
+	VSLb(vsl, SLT_Debug, "ws highwater %s %s %zu", name,
+	     WS_Atleast(ws) ? ">=" : "=", WS_Highwater(ws));
+}
+
+/*--------------------------- -------------------------------------------
  * TODO: remove code duplication with cnt_recv_prep
  */
 
@@ -263,6 +270,10 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 
 	/* Charge and log byte counters */
 	if (req->vsl->wid) {
+		req_ws_report(req->vsl, req->ws, "client");
+		req_ws_report(req->vsl, req->sp->ws, "session");
+		req_ws_report(req->vsl, wrk->aws, "thread");
+
 		Req_AcctLogCharge(wrk->stats, req);
 		if (req->vsl->wid != sp->vxid)
 			VSL_End(req->vsl);

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -529,12 +529,14 @@ VRT_UpperLowerStrands(VRT_CTX, VCL_STRANDS s, int up)
 	}
 	assert(b <= e);
 	if (!copy) {
+		WS_ReportSize(ctx->ws, 0);
 		WS_Release(ctx->ws, 0);
 		return (q);
 	}
 	assert(b < e);
 	*b++ = '\0';
 	assert(b <= e);
+	WS_Report(ctx->ws, b);
 	WS_ReleaseP(ctx->ws, b);
 	return (r);
 }
@@ -630,7 +632,9 @@ VRT_SetHdr(VRT_CTX, VCL_HEADER hs, const char *pfx, VCL_STRANDS s)
 		WS_Release(hp->ws, 0);
 		return;
 	}
-	WS_ReleaseP(hp->ws, strchr(p, '\0') + 1);
+	p = strchr(p, '\0') + 1;
+	WS_Report(hp->ws, p);
+	WS_ReleaseP(hp->ws, p);
 	http_Unset(hp, hs->what);
 	http_SetHeader(hp, b);
 }

--- a/bin/varnishd/cache/cache_wrk.c
+++ b/bin/varnishd/cache/cache_wrk.c
@@ -282,6 +282,7 @@ Pool_Task_Arg(struct worker *wrk, enum task_prio prio, task_func_t *func,
 	AZ(wrk2->task->func);
 	assert(arg_len <= WS_ReserveSize(wrk2->aws, arg_len));
 	memcpy(WS_Reservation(wrk2->aws), arg, arg_len);
+	WS_ReportSize(wrk2->aws, arg_len);
 	wrk2->task->func = func;
 	wrk2->task->priv = WS_Reservation(wrk2->aws);
 	Lck_Unlock(&pp->mtx);

--- a/bin/varnishd/cache/cache_ws_common.c
+++ b/bin/varnishd/cache/cache_ws_common.c
@@ -111,6 +111,7 @@ WS_Printf(struct ws *ws, const char *fmt, ...)
 		WS_MarkOverflow(ws);
 		p = NULL;
 	} else {
+		WS_ReportSize(ws, v + 1);
 		WS_Release(ws, v + 1);
 	}
 	return (p);
@@ -149,15 +150,18 @@ char *
 WS_VSB_finish(struct vsb *vsb, struct ws *ws, size_t *szp)
 {
 	char *p;
+	size_t sz;
 
 	AN(vsb);
 	WS_Assert(ws);
 	if (!VSB_finish(vsb)) {
 		p = VSB_data(vsb);
 		if (p == ws->f) {
-			WS_Release(ws, VSB_len(vsb) + 1);
+			sz = VSB_len(vsb) + 1;
+			WS_ReportSize(ws, sz);
+			WS_Release(ws, sz);
 			if (szp != NULL)
-				*szp = VSB_len(vsb);
+				*szp = sz - 1;
 			VSB_fini(vsb);
 			return (p);
 		}

--- a/bin/varnishtest/tests/l00004.vtc
+++ b/bin/varnishtest/tests/l00004.vtc
@@ -49,7 +49,7 @@ varnish v1 -vcl+backend {
 logexpect l1 -v v1 -g request {
 	expect 0 1001	Begin		"^req .* rxreq"
 	expect * =	PipeAcct	"^49 60 4 42$"
-	expect 0 =	End
+	expect 4 =	End
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/o00006.vtc
+++ b/bin/varnishtest/tests/o00006.vtc
@@ -17,7 +17,7 @@ logexpect l1 -v v1 -g raw {
 	expect 0 =	SessClose	"RX_JUNK"
 } -start
 
-varnish v1 -cliok "param.set workspace_session 480"
+varnish v1 -cliok "param.set workspace_session 488"
 
 client c1 {
 	# PROXY2 with CRC32C TLV

--- a/tools/magic_check.sh
+++ b/tools/magic_check.sh
@@ -45,7 +45,7 @@ tr '[:upper:]' '[:lower:]' |
 sort |
 uniq -c |
 sort |
-awk '$1 != 1 || $2 !~ /^0x[0-9a-f]*$/ || length($2) !~ /^(4|10)$/' |
+awk '$1 != 1 || $2 !~ /^0x[0-9a-f]*$/ || length($2) !~ /^(4|6|10)$/' |
 while read -r COUNT MAGIC
 do
 	if [ $COUNT -eq 1 ]


### PR DESCRIPTION
This is the continuation of #3285 based on the [bugwash feedback](https://github.com/varnishcache/varnish-cache/pull/3285#issuecomment-644143679).

It is submitted as a draft PR to gather feedback first before spending more time on the missing bits, which are:
* finish a proper user reporting interface, I would suggest a new `SLT_Resource` for resource consumption tracking.
* add reporting for the backend side
* complete the tracking of used space from reservations, such that `at_least` does not show up for varnish-cache any more.

I am particularly interested in feedback on the changes to the ws interface: Is this the way we want to go?

Primary commit message:

----

We add tracking of a "high water" pointer to workspaces.

It is tracked automatically for normal allocations and is preserved across resets.

For reservations, the used space needs to be tracked explicitly. If explicit tracking is missing, the "at least" flag is raised if the reserved space exceeded the high water mark.

This could be done more intelligently, "at least" could be cleared if a following allocation exceeds a previous reservation, but the way to go is to have proper reporting.

For user reporting, a prototypical VSL is implemented as `SLT_Debug`, for example:

```
**** v1    vsl|       1001 Debug           c ws highwater client = 77684
**** v1    vsl|       1001 Debug           c ws highwater session = 120
**** v1    vsl|       1001 Debug           c ws highwater thread = 2360
````

With the "at least" flag present, `=` is replaced by `>=` as in this example:

```
*** v1    vsl|       1027 Debug           c ws highwater client >= 77761
```

To avoid `struct ws` to grow by another pointer size, the magic value is reduced to a uint16_t to make room for the flags.