### PR TITLE
fix client_req double count with waitlist

### DIFF
--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -386,10 +386,10 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 		} else if (st == H1PROC) {
 			req->task->func = http1_req;
 			req->task->priv = req;
-			wrk->stats->client_req++;
 			CNT_Embark(wrk, req);
 			if (CNT_Request(req) == REQ_FSM_DISEMBARK)
 				return;
+			wrk->stats->client_req++;
 			AZ(req->top->vcl0);
 			req->task->func = NULL;
 			req->task->priv = NULL;

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -540,8 +540,8 @@ h2_do_req(struct worker *wrk, void *priv)
 	THR_SetRequest(req);
 	CNT_Embark(wrk, req);
 
-	wrk->stats->client_req++;
 	if (CNT_Request(req) != REQ_FSM_DISEMBARK) {
+		wrk->stats->client_req++;
 		assert(!WS_IsReserved(req->ws));
 		AZ(req->top->vcl0);
 		h2 = r2->h2sess;

--- a/bin/varnishtest/tests/c00013.vtc
+++ b/bin/varnishtest/tests/c00013.vtc
@@ -47,6 +47,7 @@ client c2 {
 client c1 -wait
 
 varnish v1 -vsl_catchup
+varnish v1 -expect client_req == 2
 varnish v1 -expect busy_sleep >= 1
 varnish v1 -expect busy_wakeup >= 1
 varnish v1 -stop

--- a/bin/varnishtest/tests/t02009.vtc
+++ b/bin/varnishtest/tests/t02009.vtc
@@ -29,3 +29,5 @@ client c1 {
 	} -run
 	stream 1 -wait
 } -run
+
+varnish v1 -expect client_req == 2


### PR DESCRIPTION
Fixes an issue where client_req counter does not account for waiting list re-embarks.

This issue was discovered by https://github.com/sirn