### PR TITLE
Define Z_PREFIX to prevent collisions with zlib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,8 @@ AC_SUBST([PACKAGE_BRANCH])
 AC_DEFINE_UNQUOTED([PACKAGE_BRANCH], ["$PACKAGE_BRANCH"],
 	[Define the branch of this package.])
 
+CFLAGS="$CFLAGS -DZ_PREFIX"
+
 # save command line CFLAGS for use in VCC_CC (to pass through things like -m64)
 # and make distcheck configure
 OCFLAGS="$CFLAGS"


### PR DESCRIPTION
Trying to use zlib from a vmod would lead to conflicts because the varnish-defined zlib symbols were found first.