### PR TITLE
Release 7.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.69)
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
 Copyright (c) 2006-2022 Varnish Software])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [trunk], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [7.2.0], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -31,9 +31,9 @@ http://varnish-cache.org/docs/trunk/whats-new/index.html and via
 individual releases. These documents are updated as part of the
 release process.
 
-===============================
-Varnish Cache NEXT (2022-09-15)
-===============================
+================================
+Varnish Cache 7.2.0 (2022-09-15)
+================================
 
 * Functions ``VRT_AddVDP()``, ``VRT_AddVFP()``, ``VRT_RemoveVDP()`` and
   ``VRT_RemoveVFP()`` are deprecated.

--- a/doc/sphinx/whats-new/changes-7.2.rst
+++ b/doc/sphinx/whats-new/changes-7.2.rst
@@ -1,15 +1,11 @@
-**Note: This is a working document for a future release, with running
-updates for changes in the development branch. For changes in the
-released versions of Varnish, see:** :ref:`whats-new-index`
+.. _whatsnew_changes_7.2:
 
-.. _whatsnew_changes_CURRENT:
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Changes in Varnish **$NEXT_RELEASE**
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+Changes in Varnish **7.2**
+%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 For information about updating your current Varnish deployment to the
-new version, see :ref:`whatsnew_upgrading_CURRENT`.
+new version, see :ref:`whatsnew_upgrading_7.2`.
 
 A more detailed and technical account of changes in Varnish, with
 links to issues that have been fixed and pull requests that have been

--- a/doc/sphinx/whats-new/index.rst
+++ b/doc/sphinx/whats-new/index.rst
@@ -13,18 +13,14 @@ This section describes the changes and improvements between different
 versions of Varnish, and what upgrading between the different versions
 entail.
 
-Varnish **$NEXT_RELEASE**
--------------------------
-
-**Note: These are working documents for a future release, with running
-updates for changes in the development branch. For changes in the
-released versions of Varnish, see the chapters listed below.**
+Varnish **7.2**
+---------------
 
 .. toctree::
    :maxdepth: 2
 
-   changes-trunk
-   upgrading-trunk
+   changes-7.2
+   upgrading-7.2
 
 Varnish **7.1**
 ---------------

--- a/doc/sphinx/whats-new/upgrading-7.2.rst
+++ b/doc/sphinx/whats-new/upgrading-7.2.rst
@@ -1,12 +1,8 @@
-**Note: This is a working document for a future release, with running
-updates for changes in the development branch. For changes in the
-released versions of Varnish, see:** :ref:`whats-new-index`
+.. _whatsnew_upgrading_7.2:
 
-.. _whatsnew_upgrading_CURRENT:
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Upgrading to Varnish **$NEXT_RELEASE**
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Upgrading to Varnish **7.2**
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 varnishd
 ========

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -57,7 +57,7 @@
  * Whenever something is deleted or changed in a way which is not
  * binary/load-time compatible, increment MAJOR version
  *
- * NEXT (2022-09-15)
+ * 16.0 (2022-09-15)
  *	VMOD C-prototypes moved into JSON
  *	VRT_AddVDP() deprecated
  *	VRT_AddVFP() deprecated


### PR DESCRIPTION
Reviewers must check the following items:

- [x] Release notes are complete (major release only)
- [x] Release notes no longer target trunk (major release only)
- [x] The change log is populated
- [x] The VRT history in `include/vrt.h` is populated
- [x] The VRT history refers to the next VRT version
- [x] The macro `VRT_MAJOR_VERSION` was updated if applicable
- [x] The macro `VRT_MINOR_VERSION` was updated if applicable
- [x] The new VRT version follows releases guidelines
- [x] The new VRT version matches the one from the VRT history
- [x] Bundled `devicedetect.vcl` was updated (major release only)
- [x] Running `./autogen.des && make distcheck` succeeds
- [x] The version in `configure.ac` is correct
- [x] The copyright notice in `configure.ac` covers the current year
- [x] The copyright output in `lib/libvarnish/version.c` covers the current year
- [x] There are no other changes than the ones listed above