### PR TITLE
Polish contrib Makefile

### DIFF
--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,5 +1,7 @@
 #
 
+include $(top_srcdir)/vtc.am
+
 if !WITH_CONTRIB
 dist_noinst_SCRIPTS = \
 	varnishstatdiff
@@ -9,7 +11,6 @@ dist_bin_SCRIPTS = \
 
 TESTS = @CONTRIB_TESTS@
 
-include $(top_srcdir)/vtc.am
 endif
 
 EXTRA_DIST = @CONTRIB_TESTS@


### PR DESCRIPTION
Avoid this warning:

```
autoreconf2.69: running: automake --add-missing --copy --no-force vtc.am:12: warning: 'TEST_EXTENSIONS' cannot have conditional contents
contrib/Makefile.am:12:   'vtc.am' included from here
```

Always defining the tests even if contrib is not built should not cause any harm.