### PR TITLE
Don't send If-Modified-Since if Last-Modified is a weak validator

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -880,6 +880,8 @@ unsigned RFC2616_Req_Gzip(const struct http *);
 int RFC2616_Do_Cond(const struct req *sp);
 void RFC2616_Weaken_Etag(struct http *hp);
 void RFC2616_Vary_AE(struct http *hp);
+const char * RFC2616_Strong_LM(struct http *hp, struct worker *wrk,
+    struct objcore *oc);
 
 /*
  * We want to cache the most recent timestamp in wrk->lastused to avoid

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -274,7 +274,7 @@ vbf_stp_mkbereq(struct worker *wrk, struct busyobj *bo)
 	    ObjCheckFlag(bo->wrk, bo->stale_oc, OF_IMSCAND) &&
 	    (bo->stale_oc->boc != NULL || ObjGetLen(wrk, bo->stale_oc) != 0)) {
 		AZ(bo->stale_oc->flags & (OC_F_HFM|OC_F_PRIVATE));
-		q = HTTP_GetHdrPack(bo->wrk, bo->stale_oc, H_Last_Modified);
+		q = RFC2616_Strong_LM(NULL, wrk, bo->stale_oc);
 		if (q != NULL)
 			http_PrintfHeader(bo->bereq0,
 			    "If-Modified-Since: %s", q);
@@ -700,7 +700,7 @@ vbf_stp_fetch(struct worker *wrk, struct busyobj *bo)
 
 	if (!(oc->flags & OC_F_HFM) &&
 	    http_IsStatus(bo->beresp, 200) && (
-	      http_GetHdr(bo->beresp, H_Last_Modified, NULL) ||
+	      RFC2616_Strong_LM(bo->beresp, NULL, NULL) != NULL ||
 	      http_GetHdr(bo->beresp, H_ETag, NULL)))
 		ObjSetFlag(bo->wrk, oc, OF_IMSCAND, 1);
 

--- a/bin/varnishd/cache/cache_rfc2616.c
+++ b/bin/varnishd/cache/cache_rfc2616.c
@@ -356,3 +356,36 @@ RFC2616_Vary_AE(struct http *hp)
 		http_SetHeader(hp, "Vary: Accept-Encoding");
 	}
 }
+
+/*--------------------------------------------------------------------*/
+
+const char *
+RFC2616_Strong_LM(struct http *hp, struct worker *wrk, struct objcore *oc)
+{
+	const char *p = NULL, *e = NULL;
+	vtim_real lm, d;
+
+	CHECK_OBJ_ORNULL(wrk, WORKER_MAGIC);
+	CHECK_OBJ_ORNULL(oc, OBJCORE_MAGIC);
+	CHECK_OBJ_ORNULL(hp, HTTP_MAGIC);
+
+	if (hp != NULL) {
+		http_GetHdr(hp, H_Last_Modified, &p);
+		http_GetHdr(hp, H_Date, &e);
+	} else if (wrk != NULL && oc != NULL) {
+		p = HTTP_GetHdrPack(wrk, oc, H_Last_Modified);
+		e = HTTP_GetHdrPack(wrk, oc, H_Date);
+	}
+
+	if (p == NULL || e == NULL)
+		return (NULL);
+
+	lm = VTIM_parse(p);
+	d = VTIM_parse(e);
+
+	/* The cache entry includes a Date value which is at least one second
+	 * after the Last-Modified value.
+	 * [RFC9110 8.8.2.2-6.2]
+	 */
+	return ((lm && d && lm + 1 <= d) ? p : NULL);
+}

--- a/bin/varnishtest/tests/b00002.vtc
+++ b/bin/varnishtest/tests/b00002.vtc
@@ -3,7 +3,7 @@ varnishtest "Check that a pass transaction works"
 server s1 {
 	rxreq
 	expect req.proto == HTTP/1.1
-	txresp -hdr "Cache-Control: max-age=120" -hdr "Connection: close" -body "012345\n"
+	txresp -hdr "Cache-Control: max-age=120" -hdr "Connection: close" -nodate -body "012345\n"
 } -start
 
 varnish v1 -arg "-sTransient=default,1m" -vcl+backend {

--- a/bin/varnishtest/tests/b00037.vtc
+++ b/bin/varnishtest/tests/b00037.vtc
@@ -13,7 +13,7 @@ varnish v1 -vsl_catchup
 varnish v1 -expect client_req_400 == 1
 
 client c1 {
-	txreq -method POST -hdr "Content-Length: 12" -bodylen 12
+	txreq -method POST -hdr "Content-Length: 12" -hdr "Content-Length: 12" -bodylen 12
 	rxresp
 	expect resp.status == 400
 } -run

--- a/bin/varnishtest/tests/b00079.vtc
+++ b/bin/varnishtest/tests/b00079.vtc
@@ -1,0 +1,83 @@
+varnishtest "Test backend IMS with weak and strong LM"
+
+server s1 {
+	rxreq
+	txresp -hdr "Last-Modified: Wed, 11 Sep 2013 13:36:55 GMT" -nodate -body "1"
+
+	# When origin does not send a Date, varnish inserts one, prompting IMS
+	rxreq
+	expect req.http.if-modified-since == "Wed, 11 Sep 2013 13:36:55 GMT"
+	txresp -status 304 -hdr "Last-Modified: Wed, 11 Sep 2013 13:36:55 GMT" \
+		-hdr "Date: Wed, 11 Sep 2013 13:36:55 GMT" \
+
+	# LM was the same as Date
+	rxreq
+	expect req.http.if-modified-since == <undef>
+	txresp -hdr "Last-Modified: Wed, 11 Sep 2013 13:36:55 GMT" \
+		-hdr "Date: Wed, 11 Sep 2013 13:36:56 GMT" \
+		-body "2"
+
+	# LM was one second older than Date
+	rxreq
+	expect req.http.if-modified-since == "Wed, 11 Sep 2013 13:36:55 GMT"
+	txresp -status 304 -hdr "Last-Modified: Wed, 11 Sep 2013 13:36:55 GMT" \
+		-hdr "Date: Wed, 11 Sep 2013 13:36:55 GMT" \
+		-hdr {ETag: "foo"}
+
+	# LM was the same as Date, but we had an ETag, prompting INM
+	rxreq
+	expect req.http.if-modified-since == <undef>
+	expect req.http.if-none-match == {"foo"}
+	txresp -status 304 -hdr "Last-Modified: Wed, 11 Sep 2013 13:36:55 GMT" \
+		-hdr "Date: Wed, 11 Sep 2013 13:36:55 GMT" \
+		-hdr {ETag: "foo"}
+} -start
+
+varnish v1 -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.ttl = 1ms;
+		set beresp.grace = 0s;
+		set beresp.keep = 1m;
+		set beresp.http.was-304 = beresp.was_304;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.body == "1"
+	expect resp.http.was-304 == "false"
+
+	delay 0.1
+
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.body == "1"
+	expect resp.http.was-304 == "true"
+
+	delay 0.1
+
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.body == "2"
+	expect resp.http.was-304 == "false"
+
+	delay 0.1
+
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.body == "2"
+	expect resp.http.was-304 == "true"
+
+	delay 0.1
+
+	txreq
+	rxresp
+	expect resp.status == 200
+	expect resp.body == "2"
+	expect resp.http.was-304 == "true"
+} -run

--- a/bin/varnishtest/tests/c00036.vtc
+++ b/bin/varnishtest/tests/c00036.vtc
@@ -2,13 +2,13 @@ varnishtest "Backend close retry"
 
 server s1 -repeat 1 {
 	rxreq
-	txresp -bodylen 5
+	txresp -nodate -bodylen 5
 
 	rxreq
 	accept
 
 	rxreq
-	txresp -bodylen 6
+	txresp -nodate -bodylen 6
 
 } -start
 

--- a/bin/varnishtest/tests/l00004.vtc
+++ b/bin/varnishtest/tests/l00004.vtc
@@ -4,7 +4,7 @@ server s1 {
 	rxreq
 	expect req.url == "/"
 	expect req.http.test == "yes"
-	txresp -body "fdsa"
+	txresp -nodate -body "fdsa"
 } -start
 
 varnish v1 -vcl+backend {

--- a/bin/varnishtest/tests/l00005.vtc
+++ b/bin/varnishtest/tests/l00005.vtc
@@ -3,7 +3,7 @@ varnishtest "Test backend fetch byte counters"
 server s1 {
 	rxreq
 	expect req.url == "/1"
-	txresp -bodylen 1000
+	txresp -nodate -bodylen 1000
 
 	rxreq
 	expect req.url == "/2"

--- a/bin/varnishtest/tests/r00498.vtc
+++ b/bin/varnishtest/tests/r00498.vtc
@@ -3,7 +3,7 @@ varnishtest "very very very long return header"
 server s1 {
 	rxreq
 	expect req.url == "/"
-	txresp -hdr "Location: ${string,repeat,8136,1}" -body {foo}
+	txresp -hdr "Location: ${string,repeat,8136,1}" -nodate -body {foo}
 } -start
 
 varnish v1 -vcl+backend {

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -786,6 +786,9 @@ http_tx_parse_args(char * const *av, struct vtclog *vl, struct http *hp,
 		} else if (!strcmp(*av, "-nohost")) {
 			nohost = 1;
 		} else if (!strcmp(*av, "-hdr")) {
+			if (!strncasecmp(av[1], "Content-Length:", 15) ||
+			    !strncasecmp(av[1], "Transfer-Encoding:", 18))
+				nolen = 1;
 			if (!strncasecmp(av[1], "Host:", 5))
 				nohost = 1;
 			VSB_printf(hp->vsb, "%s%s", av[1], nl);


### PR DESCRIPTION
This PR changes backend revalidations to only send If-Modified-Since if the Last-Modified header is at least one second older than the Date header, to prevent revalidating content that changed within the same second.

varnishtest servers now send a Date header by default, unless `-nodate` is specified. While in the neighborhood, `-nolen` was adjusted to behave similar to `-nohost` and `-nodate`.

RFC9110 states (this is not new, but some of the wording has changed over time):

> A Last-Modified time, when used as a validator in a request, is implicitly weak unless it is possible to deduce that it is strong, using the following rules:
> 
> (...)
> 
> - The validator is being compared by an intermediate cache to the validator stored in its cache entry for the representation, and
> - That cache entry includes a Date value which is at least one second after the Last-Modified value and the cache has reason to believe that they were generated by the same clock or that there is enough difference between the Last-Modified and Date values to make clock synchronization issues unlikely.

https://www.rfc-editor.org/rfc/rfc9110#section-8.8.2.2-6.2

So Last-Modified is a weak validator, unless the response also contains a Date header that is at least one second more recent than the Last-Modified header. What should we do when we only have a weak validator?

> Strong validators are usable for all conditional requests, including cache validation, partial content ranges, and "lost update" avoidance. Weak validators are only usable when the client does not require exact equality with previously obtained representation data, such as when validating a cache entry or limiting a web traversal to recent changes.

https://www.rfc-editor.org/rfc/rfc9110#section-8.8.1-10

The RFC is a bit vague here, but notice that it really only talks about what a **client** can do with a weak validator, this section of the RFC distinguishes between clients and intermediary caches. So Varnish should not stop a client from using a weak Last-Modified as a validator, since the client may know that it is fine to do so. Varnish does not have this knowlege.

Going back 15 years, we find some discussion on the topic of weak validators:

> The reason for this is the abstraction "weak validator" itself. While "validator" is a good abstraction from the details of Last-Modified and Etag, and also "strong validator" is quite clear, this can't work for "weak".
> 
> "weak validator" tries do build a common abstraction from two different, completely unrelated kinds of "weakness".
> 
> Weak etags: the weakness is not to guarantee byte-equivalence, but they guarantee semantic equivalence. Of course, the server needs some concept of semantic equivalence build in, to use weak etags. (Oh, and it would be fine, if the client would have the same idea about semantics.)
> 
> Last-Modified date: the weakness is the limited time resolution. It is unreliable (or not a validator at all), unless it meets some extra conditions. There is no concept of semantic equivalence whatsoever.

https://trac.ietf.org/trac/httpbis/ticket/101

The intent seems to be that a weak ETag indicates semantic equivalence, and can thus be used for cache revalidation. A weak Last-Modified does not indicate semantic equivalence, so we cannot use it for cache revalidation. 