### PR TITLE
Drop ban_mtx during STV_BanExport()

### DIFF
--- a/bin/varnishd/cache/cache_ban.c
+++ b/bin/varnishd/cache/cache_ban.c
@@ -344,8 +344,10 @@ ban_export(void)
 		AZ(VSB_bcat(vsb, b->spec, ban_len(b->spec)));
 	AZ(VSB_finish(vsb));
 	assert(VSB_len(vsb) == ln);
+	Lck_Unlock(&ban_mtx);
 	STV_BanExport((const uint8_t *)VSB_data(vsb), VSB_len(vsb));
 	VSB_destroy(&vsb);
+	Lck_Lock(&ban_mtx);
 	VSC_C_main->bans_persisted_bytes =
 	    bans_persisted_bytes = ln;
 	VSC_C_main->bans_persisted_fragmentation =
@@ -361,7 +363,6 @@ ban_export(void)
 void
 ban_info_new(const uint8_t *ban, unsigned len)
 {
-	/* XXX martin pls review if ban_mtx needs to be held */
 	Lck_AssertHeld(&ban_mtx);
 	if (STV_BanInfoNew(ban, len))
 		ban_export();
@@ -370,7 +371,6 @@ ban_info_new(const uint8_t *ban, unsigned len)
 void
 ban_info_drop(const uint8_t *ban, unsigned len)
 {
-	/* XXX martin pls review if ban_mtx needs to be held */
 	Lck_AssertHeld(&ban_mtx);
 	if (STV_BanInfoDrop(ban, len))
 		ban_export();

--- a/bin/varnishd/cache/cache_ban_build.c
+++ b/bin/varnishd/cache/cache_ban_build.c
@@ -373,9 +373,6 @@ BAN_Commit(struct ban_proto *bp)
 	if (b->flags & BANS_FLAG_REQ)
 		VSC_C_main->bans_req++;
 
-	if (bi != NULL)
-		ban_info_new(b->spec, ln);	/* Notify stevedores */
-
 	if (cache_param->ban_dups) {
 		/* Hunt down duplicates, and mark them as completed */
 		for (bi = VTAILQ_NEXT(b, list); bi != NULL;
@@ -387,8 +384,12 @@ BAN_Commit(struct ban_proto *bp)
 			}
 		}
 	}
+
 	if (!(b->flags & BANS_FLAG_REQ))
 		ban_kick_lurker();
+
+	if (bi != NULL)
+		ban_info_new(b->spec, ln);	/* Notify stevedores */
 	Lck_Unlock(&ban_mtx);
 
 	BAN_Abandon(bp);


### PR DESCRIPTION
This change is to drop the ban mutex while stevedores are munging on the serialized ban list.

While I would value his feedback, it is my understanding that @mbgrydeland does no longer use this code.

Description from the commit message:
----

Stevedores now need to be prepared to potentially receive multiple export calls in parallel.

Why is this change safe?

`ban_export()` needs to hold the lock while serializing the ban list into the VSB, but once that is done, it can drop the lock.

Other call sites are:

* `BAN_Commit()` -> `ban_info_new()`

  Because our new ban `b` could be concurrently removed by another thread while the lock is dropped, we move the dup check to before the `ban_info_new()` call.

  This should also have the added benefit of potentially (not) exporting more bans as completed.

* `ban_cleantail()` -> `ban_info_drop()`

  Each iteration of the loop starts with the last ban, and the now removed ban b has been moved to the freelist, so there is no concurrent access possible any more while the lock is dropped.

* `BAN_Compile()`, `BAN_Shutdown()`

  Called during init / fini, no concurrency here.

Other than that, we should really batch ban_export calls, especially for `ban_cleantail()`...