### PR TITLE
range: Move more parsing to http_GetRange()

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -640,7 +640,8 @@ int http_GetHdrField(const struct http *hp, hdr_t,
 double http_GetHdrQ(const struct http *hp, hdr_t, const char *field);
 ssize_t http_GetContentLength(const struct http *hp);
 ssize_t http_GetContentRange(const struct http *hp, ssize_t *lo, ssize_t *hi);
-const char * http_GetRange(const struct http *hp, ssize_t *lo, ssize_t *hi);
+const char * http_GetRange(const struct http *hp, ssize_t *lo, ssize_t *hi,
+    ssize_t len);
 uint16_t http_GetStatus(const struct http *hp);
 int http_IsStatus(const struct http *hp, int);
 void http_SetStatus(struct http *to, uint16_t status, const char *reason);

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -958,7 +958,7 @@ http_GetContentRange(const struct http *hp, ssize_t *lo, ssize_t *hi)
 }
 
 const char *
-http_GetRange(const struct http *hp, ssize_t *lo, ssize_t *hi)
+http_GetRange(const struct http *hp, ssize_t *lo, ssize_t *hi, ssize_t len)
 {
 	ssize_t tmp_lo, tmp_hi;
 	const char *b, *t;
@@ -1003,6 +1003,26 @@ http_GetRange(const struct http *hp, ssize_t *lo, ssize_t *hi)
 		b++;
 	if (*b != '\0')
 		return ("Trailing stuff");
+
+	assert(*lo >= -1);
+	assert(*hi >= -1);
+
+	if (len <= 0)
+		return (NULL);			// Allow 200 response
+
+	if (*lo < 0) {
+		assert(*hi > 0);
+		*lo = len - *hi;
+		if (*lo < 0)
+			*lo = 0;
+		*hi = len - 1;
+	} else if (len >= 0 && (*hi >= len || *hi < 0)) {
+		*hi = len - 1;
+	}
+
+	if (*lo >= len)
+		return ("low range beyond object");
+
 	return (NULL);
 }
 

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -960,15 +960,15 @@ http_GetContentRange(const struct http *hp, ssize_t *lo, ssize_t *hi)
 const char *
 http_GetRange(const struct http *hp, ssize_t *lo, ssize_t *hi)
 {
-	ssize_t tmp;
+	ssize_t tmp_lo, tmp_hi;
 	const char *b, *t;
 
 	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
 
 	if (lo == NULL)
-		lo = &tmp;
+		lo = &tmp_lo;
 	if (hi == NULL)
-		hi = &tmp;
+		hi = &tmp_hi;
 
 	*lo = *hi = -1;
 

--- a/bin/varnishd/cache/cache_range.c
+++ b/bin/varnishd/cache/cache_range.c
@@ -115,13 +115,6 @@ vrg_dorange(struct req *req, void **priv)
 	if (low < 0 || high < 0)
 		return (NULL);		// Allow 200 response
 
-	/*
-	 * else (bo != NULL) {
-	 *    We assume that the client knows what it's doing and trust
-	 *    that both low and high make sense.
-	 * }
-	 */
-
 	if (req->resp_len >= 0) {
 		http_PrintfHeader(req->resp, "Content-Range: bytes %jd-%jd/%jd",
 		    (intmax_t)low, (intmax_t)high, (intmax_t)req->resp_len);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -58,6 +58,7 @@
  * binary/load-time compatible, increment MAJOR version
  *
  * NEXT (2023-03-15)
+ *	[cache.h] http_GetRange() changed
  * 16.0 (2022-09-15)
  *	VMOD C-prototypes moved into JSON
  *	VRT_AddVDP() deprecated


### PR DESCRIPTION
This came up on the enterprise side, the need to move more parsing free of side effects to `http_GetRange()`. It changes the function signature but I'm not sure whether it qualifies as VRT material.