### PR TITLE
http1: Emit ReqStart on bad requests

### DIFF
--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -44,6 +44,7 @@
 #include "cache/cache_transport.h"
 #include "cache_http1.h"
 
+#include "common/heritage.h"
 #include "vtcp.h"
 
 static const char H1NEWREQ[] = "HTTP1::NewReq";
@@ -245,6 +246,7 @@ http1_abort(struct req *req, uint16_t status)
 static int
 http1_dissect(struct worker *wrk, struct req *req)
 {
+	const char *ci, *cp, *endpname;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
@@ -271,6 +273,15 @@ http1_dissect(struct worker *wrk, struct req *req)
 		    (int)(req->htc->rxbuf_e - req->htc->rxbuf_b),
 		    req->htc->rxbuf_b);
 		wrk->stats->client_req_400++;
+
+		ci = SES_Get_String_Attr(req->sp, SA_CLIENT_IP);
+		cp = SES_Get_String_Attr(req->sp, SA_CLIENT_PORT);
+		CHECK_OBJ_NOTNULL(req->sp->listen_sock, LISTEN_SOCK_MAGIC);
+		endpname = req->sp->listen_sock->name;
+		AN(endpname);
+
+		VSLb(req->vsl, SLT_ReqStart, "%s %s %s", ci, cp, endpname);
+
 		req->doclose = SC_RX_JUNK;
 		http1_abort(req, 400);
 		return (-1);

--- a/bin/varnishtest/tests/u00003.vtc
+++ b/bin/varnishtest/tests/u00003.vtc
@@ -45,7 +45,7 @@ delay 1
 shell "mv ${tmpdir}/ncsa.log ${tmpdir}/ncsa.old.log"
 shell "kill -HUP `cat ${tmpdir}/ncsa.pid`"
 
-client c1 {
+client c2 {
 	txreq -url /2
 	rxresp
 } -run
@@ -167,5 +167,19 @@ process p2 {varnishncsa -t 5 -n nonexistent} -start
 delay 1
 process p2 -expect-exit 1 -kill INT -wait
 shell {grep -q "VSM: Attach interrupted" ${p2_err}}
+
+# IP address for bad requests
+
+client c3 {
+	txreq -url "/bad path"
+	rxresp
+	expect resp.status == 400
+} -run
+
+varnish v1 -vsl_catchup
+
+shell -expect ${localhost} {
+	varnishncsa -n ${v1_name} -d -q 'RespStatus == 400'
+}
 
 # ESI coverage in e00003.vtc


### PR DESCRIPTION
It makes no sense to emit this just before we end the transaction, except to help varnishncsa find the client IP address.