### PR TITLE
shmlog: Avoid allocating vsl_reclen bytes in VSLv()

### DIFF
--- a/bin/varnishd/cache/cache_shmlog.c
+++ b/bin/varnishd/cache/cache_shmlog.c
@@ -294,13 +294,13 @@ VSLv(enum VSL_tag_e tag, vxid_t vxid, const char *fmt, va_list ap)
 
 	if (strchr(fmt, '%') == NULL) {
 		vslr(tag, vxid, fmt, strlen(fmt) + 1);
-	} else {
-		n = vsnprintf(buf, mlen, fmt, ap);
-		n = vmin_t(unsigned, n, mlen - 1);
-		buf[n++] = '\0'; /* NUL-terminated */
-		vslr(tag, vxid, buf, n);
+		return;
 	}
 
+	n = vsnprintf(buf, mlen, fmt, ap);
+	n = vmin_t(unsigned, n, mlen - 1);
+	buf[n++] = '\0'; /* NUL-terminated */
+	vslr(tag, vxid, buf, n);
 }
 
 void

--- a/bin/varnishd/cache/cache_shmlog.c
+++ b/bin/varnishd/cache/cache_shmlog.c
@@ -342,6 +342,11 @@ VSLs(enum VSL_tag_e tag, vxid_t vxid, const struct strands *s)
 
 	mlen = cache_param->vsl_reclen;
 
+	if (s->n == 1 && s->p[0] != NULL) {
+		vslr(tag, vxid, s->p[0], strlen(s->p[0]) + 1);
+		return;
+	}
+
 	n = strands_cat(buf, sizeof buf, s);
 
 	if (n <= sizeof buf) {


### PR DESCRIPTION
When vsl_reclen increases to a large value, like 8kB to hold long ReqURL
or *Header:Cookie records, making such an allocation on the stack could
jump over a 4kB guard page. The underlying printf call could also result
in significant stack usage. Both factors could result in hard to debug
segmentation faults.

Instead, we can opportunistically print to a reasonably-sized buffer,
and fall back to printing directly inside the VSL segment when a record
is too large for the buffer. At this point we know the full record size
and we can adjust it to vsl_reclen.

This is inspired by a different patch from @mbgrydeland targeting the
6.0 branch.