### PR TITLE
gzip: We can't work with a standalone zlib

### DIFF
--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -645,7 +645,7 @@ ved_gzgz_init(VRT_CTX, struct vdp_ctx *vdc, void **priv, struct objcore *oc)
  * in VDP_bytes(), but ved_bytes() covers it.
  *
  * To avoid unnecessary chunks downstream, it would be nice to re-structure the
- * code to intendify the last block, send VDP_END/VDP_FLUSH for that one and
+ * code to identify the last block, send VDP_END/VDP_FLUSH for that one and
  * VDP_NULL for anything before it.
  */
 

--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -97,7 +97,7 @@ vfp_vep_callback(struct vfp_ctx *vc, void *priv, ssize_t l, enum vgz_flag flg)
 		}
 		VGZ_Obuf(vef->vgz, ptr, dl);
 		i = VGZ_Gzip(vef->vgz, &dp, &dl, flg);
-		VGZ_UpdateObj(vc, vef->vgz, VUA_UPDATE);
+		VGZ_UpdateObj(vc, vef->vgz, i);
 		if (dl > 0) {
 			vef->tot += dl;
 			VFP_Extend(vc, dl, VFP_OK);
@@ -145,7 +145,7 @@ vfp_esi_end(struct vfp_ctx *vc, struct vef_priv *vef,
 
 	if (vef->vgz != NULL) {
 		if (retval == VFP_END)
-			VGZ_UpdateObj(vc, vef->vgz, VUA_END_GZIP);
+			VGZ_UpdateObj(vc, vef->vgz, VGZ_END);
 		if (VGZ_Destroy(&vef->vgz) != VGZ_END)
 			retval = VFP_Error(vc,
 			    "ESI+Gzip Failed at the very end");

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -264,7 +264,7 @@ VGZ_Gzip(struct vgz *vg, const void **pptr, ssize_t *plen, enum vgz_flag flags)
 	case VGZ_ALIGN:		zflg = Z_SYNC_FLUSH; break;
 	case VGZ_RESET:		zflg = Z_FULL_FLUSH; break;
 	case VGZ_FINISH:	zflg = Z_FINISH; break;
-	default:		INCOMPL();
+	default:		WRONG("Invalid VGZ flag");
 	}
 	i = deflate(&vg->vz, zflg);
 	if (i == Z_OK || i == Z_STREAM_END) {

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -212,26 +212,20 @@ VGZ_ObufFull(const struct vgz *vg)
 /*--------------------------------------------------------------------*/
 
 static enum vgzret_e
-VGZ_Gunzip(struct vgz *vg, const void **pptr, ssize_t *plen,
-    enum vgz_flag flags)
+VGZ_Gunzip(struct vgz *vg, const void **pptr, ssize_t *plen)
 {
-	int i, zflg;
+	int i;
 	ssize_t l;
 	const uint8_t *before;
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
-	switch (flags) {
-	case VGZ_NORMAL:	zflg = Z_NO_FLUSH; break;
-	case VGZ_ALIGN:		zflg = Z_BLOCK; break;
-	default:		WRONG("Invalid VGZ flag");
-	}
 
 	*pptr = NULL;
 	*plen = 0;
 	AN(vg->vz.next_out);
 	AN(vg->vz.avail_out);
 	before = vg->vz.next_out;
-	i = inflate(&vg->vz, zflg);
+	i = inflate(&vg->vz, 0);
 	if (i == Z_OK || i == Z_STREAM_END) {
 		*pptr = before;
 		l = (const uint8_t *)vg->vz.next_out - before;
@@ -381,7 +375,7 @@ vdp_gunzip_bytes(struct vdp_ctx *vdx, enum vdp_action act, void **priv,
 
 	VGZ_Ibuf(vg, ptr, len);
 	do {
-		vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_NORMAL);
+		vr = VGZ_Gunzip(vg, &dp, &dl);
 		if (vr == VGZ_END && !VGZ_IbufEmpty(vg)) {
 			VSLb(vg->vsl, SLT_Gzip, "G(un)zip error: %d (%s)",
 			     vr, "junk after VGZ_END");
@@ -580,7 +574,7 @@ vfp_gunzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 			VGZ_Ibuf(vg, vg->m_buf, l);
 		}
 		if (!VGZ_IbufEmpty(vg) || vp == VFP_END) {
-			vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_NORMAL);
+			vr = VGZ_Gunzip(vg, &dp, &dl);
 			if (vr == VGZ_END && !VGZ_IbufEmpty(vg))
 				return (VFP_Error(vc, "Junk after gzip data"));
 			if (vr < VGZ_OK)
@@ -684,7 +678,7 @@ vfp_testgunzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 		VGZ_Ibuf(vg, p, *lp);
 		do {
 			VGZ_Obuf(vg, vg->m_buf, vg->m_sz);
-			vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_NORMAL);
+			vr = VGZ_Gunzip(vg, &dp, &dl);
 			if (vr == VGZ_END && !VGZ_IbufEmpty(vg))
 				return (VFP_Error(vc, "Junk after gzip data"));
 			if (vr < VGZ_OK)

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -414,21 +414,26 @@ const struct vdp VDP_gunzip = {
 void
 VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 {
+	z_bounds bounds;
 	char *p;
 	intmax_t ii;
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
 	if (e < VGZ_OK)
 		return;
-	ii = vg->vz.start_bit + vg->vz.last_bit + vg->vz.stop_bit;
+	if (vg->dir == VGZ_GZ)
+		assert(Z_OK == deflateBlockBounds(&vg->vz, &bounds));
+	else
+		assert(Z_OK == inflateBlockBounds(&vg->vz, &bounds));
+	ii = bounds.init_block + bounds.last_block + bounds.last_bit;
 	if (e != VGZ_END && ii == vg->bits)
 		return;
 	vg->bits = ii;
 	p = ObjSetAttr(vc->wrk, vc->oc, OA_GZIPBITS, 32, NULL);
 	AN(p);
-	vbe64enc(p, vg->vz.start_bit);
-	vbe64enc(p + 8, vg->vz.last_bit);
-	vbe64enc(p + 16, vg->vz.stop_bit);
+	vbe64enc(p, bounds.init_block);
+	vbe64enc(p + 8, bounds.last_block);
+	vbe64enc(p + 16, bounds.last_bit);
 	if (e != VGZ_END)
 		return;
 	if (vg->dir == VGZ_GZ)
@@ -445,17 +450,22 @@ VGZ_Destroy(struct vgz **vgp)
 {
 	struct vgz *vg;
 	enum vgzret_e vr;
+	z_bounds bounds;
 	int i;
 
 	TAKE_OBJ_NOTNULL(vg, vgp, VGZ_MAGIC);
 	AN(vg->id);
+	if (vg->dir == VGZ_GZ)
+		assert(Z_OK == deflateBlockBounds(&vg->vz, &bounds));
+	else
+		assert(Z_OK == inflateBlockBounds(&vg->vz, &bounds));
 	VSLb(vg->vsl, SLT_Gzip, "%s %jd %jd %jd %jd %jd",
 	    vg->id,
 	    (intmax_t)vg->vz.total_in,
 	    (intmax_t)vg->vz.total_out,
-	    (intmax_t)vg->vz.start_bit,
-	    (intmax_t)vg->vz.last_bit,
-	    (intmax_t)vg->vz.stop_bit);
+	    (intmax_t)bounds.init_block,
+	    (intmax_t)bounds.last_block,
+	    (intmax_t)bounds.last_bit);
 	if (vg->dir == VGZ_GZ)
 		i = deflateEnd(&vg->vz);
 	else

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -272,7 +272,7 @@ VGZ_Gzip(struct vgz *vg, const void **pptr, ssize_t *plen, enum vgz_flag flags)
 	AN(vg->vz.avail_out);
 	before = vg->vz.next_out;
 	switch (flags) {
-	case VGZ_NORMAL:	zflg = Z_BLOCK; break;
+	case VGZ_NORMAL:	zflg = Z_NO_FLUSH; break;
 	case VGZ_ALIGN:		zflg = Z_SYNC_FLUSH; break;
 	case VGZ_RESET:		zflg = Z_FULL_FLUSH; break;
 	case VGZ_FINISH:	zflg = Z_FINISH; break;
@@ -417,16 +417,13 @@ const struct vdp VDP_gunzip = {
 
 /*--------------------------------------------------------------------*/
 
-#include <stdio.h>
-
 void
 VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 {
 	char *p;
 	intmax_t ii;
 	size_t bits;
-	int bi_valid;
-	unsigned type, pending;
+	unsigned type;
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
 
@@ -443,14 +440,6 @@ VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 			vg->last_bit = bits;
 		} else if ((type & 0xc0) != 0x40)
 			vg->stop_bit = bits;
-	} else {
-		assert(deflatePending(&vg->vz, &pending, &bi_valid) == Z_OK);
-		bits = (vg->vz.total_out + pending) * 8 + bi_valid;
-		assert(vg->vz.start_bit == 0 || vg->vz.start_bit == 80);
-		fprintf(stderr,
-		    "%s z=%p start=%lu stop=%lu last=%lu bits=%zu\n",
-		    __func__, &vg->vz,
-		    vg->vz.start_bit, vg->vz.stop_bit, vg->vz.last_bit, bits);
 	}
 
 	ii = vg->vz.start_bit + vg->vz.last_bit + vg->vz.stop_bit;

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -212,20 +212,26 @@ VGZ_ObufFull(const struct vgz *vg)
 /*--------------------------------------------------------------------*/
 
 static enum vgzret_e
-VGZ_Gunzip(struct vgz *vg, const void **pptr, ssize_t *plen)
+VGZ_Gunzip(struct vgz *vg, const void **pptr, ssize_t *plen,
+    enum vgz_flag flags)
 {
-	int i;
+	int i, zflg;
 	ssize_t l;
 	const uint8_t *before;
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
+	switch (flags) {
+	case VGZ_NORMAL:	zflg = Z_NO_FLUSH; break;
+	case VGZ_ALIGN:		zflg = Z_BLOCK; break;
+	default:		WRONG("Invalid VGZ flag");
+	}
 
 	*pptr = NULL;
 	*plen = 0;
 	AN(vg->vz.next_out);
 	AN(vg->vz.avail_out);
 	before = vg->vz.next_out;
-	i = inflate(&vg->vz, 0);
+	i = inflate(&vg->vz, zflg);
 	if (i == Z_OK || i == Z_STREAM_END) {
 		*pptr = before;
 		l = (const uint8_t *)vg->vz.next_out - before;
@@ -375,7 +381,7 @@ vdp_gunzip_bytes(struct vdp_ctx *vdx, enum vdp_action act, void **priv,
 
 	VGZ_Ibuf(vg, ptr, len);
 	do {
-		vr = VGZ_Gunzip(vg, &dp, &dl);
+		vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_NORMAL);
 		if (vr == VGZ_END && !VGZ_IbufEmpty(vg)) {
 			VSLb(vg->vsl, SLT_Gzip, "G(un)zip error: %d (%s)",
 			     vr, "junk after VGZ_END");
@@ -564,7 +570,7 @@ vfp_gunzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 			VGZ_Ibuf(vg, vg->m_buf, l);
 		}
 		if (!VGZ_IbufEmpty(vg) || vp == VFP_END) {
-			vr = VGZ_Gunzip(vg, &dp, &dl);
+			vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_NORMAL);
 			if (vr == VGZ_END && !VGZ_IbufEmpty(vg))
 				return (VFP_Error(vc, "Junk after gzip data"));
 			if (vr < VGZ_OK)
@@ -668,7 +674,7 @@ vfp_testgunzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 		VGZ_Ibuf(vg, p, *lp);
 		do {
 			VGZ_Obuf(vg, vg->m_buf, vg->m_sz);
-			vr = VGZ_Gunzip(vg, &dp, &dl);
+			vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_NORMAL);
 			if (vr == VGZ_END && !VGZ_IbufEmpty(vg))
 				return (VFP_Error(vc, "Junk after gzip data"));
 			if (vr < VGZ_OK)

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -272,7 +272,7 @@ VGZ_Gzip(struct vgz *vg, const void **pptr, ssize_t *plen, enum vgz_flag flags)
 	AN(vg->vz.avail_out);
 	before = vg->vz.next_out;
 	switch (flags) {
-	case VGZ_NORMAL:	zflg = Z_NO_FLUSH; break;
+	case VGZ_NORMAL:	zflg = Z_BLOCK; break;
 	case VGZ_ALIGN:		zflg = Z_SYNC_FLUSH; break;
 	case VGZ_RESET:		zflg = Z_FULL_FLUSH; break;
 	case VGZ_FINISH:	zflg = Z_FINISH; break;
@@ -417,13 +417,16 @@ const struct vdp VDP_gunzip = {
 
 /*--------------------------------------------------------------------*/
 
+#include <stdio.h>
+
 void
 VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 {
 	char *p;
 	intmax_t ii;
 	size_t bits;
-	unsigned type;
+	int bi_valid;
+	unsigned type, pending;
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
 
@@ -440,6 +443,14 @@ VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 			vg->last_bit = bits;
 		} else if ((type & 0xc0) != 0x40)
 			vg->stop_bit = bits;
+	} else {
+		assert(deflatePending(&vg->vz, &pending, &bi_valid) == Z_OK);
+		bits = (vg->vz.total_out + pending) * 8 + bi_valid;
+		assert(vg->vz.start_bit == 0 || vg->vz.start_bit == 80);
+		fprintf(stderr,
+		    "%s z=%p start=%lu stop=%lu last=%lu bits=%zu\n",
+		    __func__, &vg->vz,
+		    vg->vz.start_bit, vg->vz.stop_bit, vg->vz.last_bit, bits);
 	}
 
 	ii = vg->vz.start_bit + vg->vz.last_bit + vg->vz.stop_bit;

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -66,11 +66,6 @@ struct vgz {
 	intmax_t		bits;
 
 	z_stream		vz;
-
-	size_t			pull_len;
-	size_t			start_bit;	/* first deflate block */
-	size_t			stop_bit;	/* after last deflate block */
-	size_t			last_bit;
 };
 
 static const char *
@@ -184,7 +179,6 @@ VGZ_Ibuf(struct vgz *vg, const void *ptr, ssize_t len)
 	AZ(vg->vz.avail_in);
 	vg->vz.next_in = TRUST_ME(ptr);
 	vg->vz.avail_in = len;
-	vg->pull_len += len;
 }
 
 int
@@ -422,26 +416,10 @@ VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 {
 	char *p;
 	intmax_t ii;
-	size_t bits;
-	unsigned type;
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
-
-	if (vg->dir == VGZ_UN) {
-		/* NB: vgz.h contains the explanation on how inflate() is
-		 * affected by the Z_BLOCK flag. That is where * the magic
-		 * values 0x80, 0x40 and 0x07 come from.
-		 */
-		type = vg->vz.data_type;
-		bits = ((vg->pull_len - vg->vz.avail_in) << 3) - (type & 0x07);
-		if ((type & 0xc0) == 0x80) {
-			if (vg->start_bit == 0)
-				vg->start_bit = bits;
-			vg->last_bit = bits;
-		} else if ((type & 0xc0) != 0x40)
-			vg->stop_bit = bits;
-	}
-
+	if (e < VGZ_OK)
+		return;
 	ii = vg->vz.start_bit + vg->vz.last_bit + vg->vz.stop_bit;
 	if (e != VGZ_END && ii == vg->bits)
 		return;
@@ -457,12 +435,6 @@ VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 		vbe64enc(p + 24, vg->vz.total_in);
 	if (vg->dir == VGZ_UN)
 		vbe64enc(p + 24, vg->vz.total_out);
-
-	if (vg->dir == VGZ_UN) {
-		assert(vg->start_bit == vg->vz.start_bit);
-		assert(vg->stop_bit == vg->vz.stop_bit);
-		assert(vg->last_bit == vg->vz.last_bit);
-	}
 }
 
 /*--------------------------------------------------------------------
@@ -702,15 +674,15 @@ vfp_testgunzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 		VGZ_Ibuf(vg, p, *lp);
 		do {
 			VGZ_Obuf(vg, vg->m_buf, vg->m_sz);
-			vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_ALIGN);
+			vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_NORMAL);
 			if (vr == VGZ_END && !VGZ_IbufEmpty(vg))
 				return (VFP_Error(vc, "Junk after gzip data"));
-			VGZ_UpdateObj(vc, vg, vr);
 			if (vr < VGZ_OK)
 				return (VFP_Error(vc,
 				    "Invalid Gzip data: %s", vgz_msg(vg)));
 		} while (!VGZ_IbufEmpty(vg));
 	}
+	VGZ_UpdateObj(vc, vg, vr);
 	if (vp == VFP_END && vr != VGZ_END)
 		return (VFP_Error(vc, "tGunzip failed"));
 	return (vp);

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -66,6 +66,11 @@ struct vgz {
 	intmax_t		bits;
 
 	z_stream		vz;
+
+	size_t			pull_len;
+	size_t			start_bit;	/* first deflate block */
+	size_t			stop_bit;	/* after last deflate block */
+	size_t			last_bit;
 };
 
 static const char *
@@ -179,6 +184,7 @@ VGZ_Ibuf(struct vgz *vg, const void *ptr, ssize_t len)
 	AZ(vg->vz.avail_in);
 	vg->vz.next_in = TRUST_ME(ptr);
 	vg->vz.avail_in = len;
+	vg->pull_len += len;
 }
 
 int
@@ -416,10 +422,26 @@ VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 {
 	char *p;
 	intmax_t ii;
+	size_t bits;
+	unsigned type;
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
-	if (e < VGZ_OK)
-		return;
+
+	if (vg->dir == VGZ_UN) {
+		/* NB: vgz.h contains the explanation on how inflate() is
+		 * affected by the Z_BLOCK flag. That is where * the magic
+		 * values 0x80, 0x40 and 0x07 come from.
+		 */
+		type = vg->vz.data_type;
+		bits = ((vg->pull_len - vg->vz.avail_in) << 3) - (type & 0x07);
+		if ((type & 0xc0) == 0x80) {
+			if (vg->start_bit == 0)
+				vg->start_bit = bits;
+			vg->last_bit = bits;
+		} else if ((type & 0xc0) != 0x40)
+			vg->stop_bit = bits;
+	}
+
 	ii = vg->vz.start_bit + vg->vz.last_bit + vg->vz.stop_bit;
 	if (e != VGZ_END && ii == vg->bits)
 		return;
@@ -435,6 +457,12 @@ VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 		vbe64enc(p + 24, vg->vz.total_in);
 	if (vg->dir == VGZ_UN)
 		vbe64enc(p + 24, vg->vz.total_out);
+
+	if (vg->dir == VGZ_UN) {
+		assert(vg->start_bit == vg->vz.start_bit);
+		assert(vg->stop_bit == vg->vz.stop_bit);
+		assert(vg->last_bit == vg->vz.last_bit);
+	}
 }
 
 /*--------------------------------------------------------------------
@@ -674,15 +702,15 @@ vfp_testgunzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 		VGZ_Ibuf(vg, p, *lp);
 		do {
 			VGZ_Obuf(vg, vg->m_buf, vg->m_sz);
-			vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_NORMAL);
+			vr = VGZ_Gunzip(vg, &dp, &dl, VGZ_ALIGN);
 			if (vr == VGZ_END && !VGZ_IbufEmpty(vg))
 				return (VFP_Error(vc, "Junk after gzip data"));
+			VGZ_UpdateObj(vc, vg, vr);
 			if (vr < VGZ_OK)
 				return (VFP_Error(vc,
 				    "Invalid Gzip data: %s", vgz_msg(vg)));
 		} while (!VGZ_IbufEmpty(vg));
 	}
-	VGZ_UpdateObj(vc, vg, vr);
 	if (vp == VFP_END && vr != VGZ_END)
 		return (VFP_Error(vc, "tGunzip failed"));
 	return (vp);

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -406,14 +406,16 @@ const struct vdp VDP_gunzip = {
 /*--------------------------------------------------------------------*/
 
 void
-VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgz_ua_e e)
+VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgzret_e e)
 {
 	char *p;
 	intmax_t ii;
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
+	if (e < VGZ_OK)
+		return;
 	ii = vg->vz.start_bit + vg->vz.last_bit + vg->vz.stop_bit;
-	if (e == VUA_UPDATE && ii == vg->bits)
+	if (e != VGZ_END && ii == vg->bits)
 		return;
 	vg->bits = ii;
 	p = ObjSetAttr(vc->wrk, vc->oc, OA_GZIPBITS, 32, NULL);
@@ -421,9 +423,11 @@ VGZ_UpdateObj(const struct vfp_ctx *vc, struct vgz *vg, enum vgz_ua_e e)
 	vbe64enc(p, vg->vz.start_bit);
 	vbe64enc(p + 8, vg->vz.last_bit);
 	vbe64enc(p + 16, vg->vz.stop_bit);
-	if (e == VUA_END_GZIP)
+	if (e != VGZ_END)
+		return;
+	if (vg->dir == VGZ_GZ)
 		vbe64enc(p + 24, vg->vz.total_in);
-	if (e == VUA_END_GUNZIP)
+	if (vg->dir == VGZ_UN)
 		vbe64enc(p + 24, vg->vz.total_out);
 }
 
@@ -620,7 +624,7 @@ vfp_gzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 			if (vr < VGZ_OK)
 				return (VFP_Error(vc, "Gzip failed"));
 			if (dl > 0) {
-				VGZ_UpdateObj(vc, vg, VUA_UPDATE);
+				VGZ_UpdateObj(vc, vg, vr);
 				*lp = dl;
 				assert(dp == p);
 				return (VFP_OK);
@@ -631,7 +635,7 @@ vfp_gzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 
 	if (vr != VGZ_END)
 		return (VFP_Error(vc, "Gzip failed"));
-	VGZ_UpdateObj(vc, vg, VUA_END_GZIP);
+	VGZ_UpdateObj(vc, vg, VGZ_END);
 	return (VFP_END);
 }
 
@@ -672,11 +676,10 @@ vfp_testgunzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 				    "Invalid Gzip data: %s", vgz_msg(vg)));
 		} while (!VGZ_IbufEmpty(vg));
 	}
-	VGZ_UpdateObj(vc, vg, VUA_UPDATE);
+	VGZ_UpdateObj(vc, vg, vr);
 	if (vp == VFP_END) {
 		if (vr != VGZ_END)
 			return (VFP_Error(vc, "tGunzip failed"));
-		VGZ_UpdateObj(vc, vg, VUA_END_GUNZIP);
 	}
 	return (vp);
 }

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -30,7 +30,7 @@
  * Interaction with the linvgz (zlib) library.
  *
  * The zlib library pollutes namespace a LOT when you include the "vgz.h"
- * (aka (zlib.h") file so we contain the damage by vectoring all access
+ * (aka ("zlib.h") file so we contain the damage by vectoring all access
  * to libz through this source file.
  *
  * The API defined by this file, will also insulate the rest of the code,

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -677,10 +677,8 @@ vfp_testgunzip_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *p,
 		} while (!VGZ_IbufEmpty(vg));
 	}
 	VGZ_UpdateObj(vc, vg, vr);
-	if (vp == VFP_END) {
-		if (vr != VGZ_END)
-			return (VFP_Error(vc, "tGunzip failed"));
-	}
+	if (vp == VFP_END && vr != VGZ_END)
+		return (VFP_Error(vc, "tGunzip failed"));
 	return (vp);
 }
 

--- a/bin/varnishd/cache/cache_vgz.h
+++ b/bin/varnishd/cache/cache_vgz.h
@@ -55,10 +55,4 @@ enum vgzret_e VGZ_Gzip(struct vgz *, const void **, ssize_t *len,
 // enum vgzret_e VGZ_Gunzip(struct vgz *, const void **, ssize_t *len);
 enum vgzret_e VGZ_Destroy(struct vgz **);
 
-enum vgz_ua_e {
-	VUA_UPDATE,		// Update start/stop/last bits if changed
-	VUA_END_GZIP,		// Record uncompressed size
-	VUA_END_GUNZIP,		// Record uncompressed size
-};
-
-void VGZ_UpdateObj(const struct vfp_ctx *, struct vgz*, enum vgz_ua_e);
+void VGZ_UpdateObj(const struct vfp_ctx *, struct vgz*, enum vgzret_e);

--- a/bin/varnishtest/tests/e00022.vtc
+++ b/bin/varnishtest/tests/e00022.vtc
@@ -29,9 +29,9 @@ varnish v1 -cliok "param.set gzip_memlevel 1"
 
 logexpect l1 -v v1 -g vxid {
 	expect * * Fetch_Body
-	expect 0 = ESI_xmlerror {^ERR after 24 ESI 1.0 <esi:include> element nested in <esi:remove>$}
-	expect 0 = ESI_xmlerror {^ERR after 24 ESI 1.0 Nested <!--esi element in <esi:remove>$}
-	expect 0 = Gzip         {^G}
+	expect * = ESI_xmlerror {^ERR after 24 ESI 1.0 <esi:include> element nested in <esi:remove>$}
+	expect * = ESI_xmlerror {^ERR after 24 ESI 1.0 Nested <!--esi element in <esi:remove>$}
+	expect * = Gzip         {^G}
 	expect 0 = Gzip         {^U}
 	expect 0 = BackendClose
 } -start

--- a/bin/varnishtest/tests/e00022.vtc
+++ b/bin/varnishtest/tests/e00022.vtc
@@ -29,9 +29,9 @@ varnish v1 -cliok "param.set gzip_memlevel 1"
 
 logexpect l1 -v v1 -g vxid {
 	expect * * Fetch_Body
-	expect * = ESI_xmlerror {^ERR after 24 ESI 1.0 <esi:include> element nested in <esi:remove>$}
-	expect * = ESI_xmlerror {^ERR after 24 ESI 1.0 Nested <!--esi element in <esi:remove>$}
-	expect * = Gzip         {^G}
+	expect 0 = ESI_xmlerror {^ERR after 24 ESI 1.0 <esi:include> element nested in <esi:remove>$}
+	expect 0 = ESI_xmlerror {^ERR after 24 ESI 1.0 Nested <!--esi element in <esi:remove>$}
+	expect 0 = Gzip         {^G}
 	expect 0 = Gzip         {^U}
 	expect 0 = BackendClose
 } -start

--- a/lib/libvgz/deflate.c
+++ b/lib/libvgz/deflate.c
@@ -512,8 +512,6 @@ int ZEXPORT deflateGetDictionary (strm, dictionary, dictLength)
 
 #endif /* NOVGZ */
 
-#include <stdio.h>
-
 /* ========================================================================= */
 int ZEXPORT deflateResetKeep (strm)
     z_streamp strm;
@@ -1077,10 +1075,8 @@ int ZEXPORT deflate (strm, flush)
 #endif /* NOVGZ */
 #endif
 
-    if (strm->start_bit == 0) {
+    if (strm->start_bit == 0)
         strm->start_bit = (strm->total_out + s->pending) * 8 + s->bi_valid;
-        fprintf(stderr, "%s z=%p start=%lu\n", __func__, strm, strm->start_bit);
-    }
 
     /* Start a new block or continue the current one.
      */

--- a/lib/libvgz/deflate.c
+++ b/lib/libvgz/deflate.c
@@ -576,8 +576,6 @@ int ZEXPORT deflateSetHeader (strm, head)
     return Z_OK;
 }
 
-#endif
-
 /* ========================================================================= */
 int ZEXPORT deflatePending (strm, pending, bits)
     unsigned *pending;
@@ -591,8 +589,6 @@ int ZEXPORT deflatePending (strm, pending, bits)
         *bits = strm->state->bi_valid;
     return Z_OK;
 }
-
-#ifdef NOVGZ
 
 /* ========================================================================= */
 int ZEXPORT deflatePrime (strm, bits, value)

--- a/lib/libvgz/deflate.c
+++ b/lib/libvgz/deflate.c
@@ -576,6 +576,8 @@ int ZEXPORT deflateSetHeader (strm, head)
     return Z_OK;
 }
 
+#endif
+
 /* ========================================================================= */
 int ZEXPORT deflatePending (strm, pending, bits)
     unsigned *pending;
@@ -589,6 +591,8 @@ int ZEXPORT deflatePending (strm, pending, bits)
         *bits = strm->state->bi_valid;
     return Z_OK;
 }
+
+#ifdef NOVGZ
 
 /* ========================================================================= */
 int ZEXPORT deflatePrime (strm, bits, value)

--- a/lib/libvgz/deflate.c
+++ b/lib/libvgz/deflate.c
@@ -530,6 +530,7 @@ int ZEXPORT deflateResetKeep (strm)
     s = (deflate_state *)strm->state;
     s->pending = 0;
     s->pending_out = s->pending_buf;
+    zmemzero(&s->bounds, sizeof s->bounds);
 
     if (s->wrap < 0) {
         s->wrap = -s->wrap; /* was made negative by deflate(..., Z_FINISH); */
@@ -777,6 +778,19 @@ uLong ZEXPORT deflateBound(strm, sourceLen)
 }
 
 #endif /* NOVGZ */
+
+/* ========================================================================= */
+int ZEXPORT deflateBlockBounds (strm, dest)
+    z_streamp strm;
+    z_boundsp dest;
+{
+    deflate_state *s;
+    if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
+    s = strm->state;
+    if (dest != Z_NULL)
+        memcpy(dest, &s->bounds, sizeof *dest);
+    return Z_OK;
+}
 
 /* =========================================================================
  * Put a short in the pending buffer. The 16-bit value is put in MSB order.
@@ -1071,8 +1085,10 @@ int ZEXPORT deflate (strm, flush)
 #endif /* NOVGZ */
 #endif
 
-    if (strm->start_bit == 0)
+    if (s->bounds.init_block == 0) {
         strm->start_bit = (strm->total_out + s->pending) * 8 + s->bi_valid;
+        s->bounds.init_block = DEFLATE_BITS(s);
+    }
 
     /* Start a new block or continue the current one.
      */

--- a/lib/libvgz/deflate.c
+++ b/lib/libvgz/deflate.c
@@ -512,6 +512,8 @@ int ZEXPORT deflateGetDictionary (strm, dictionary, dictLength)
 
 #endif /* NOVGZ */
 
+#include <stdio.h>
+
 /* ========================================================================= */
 int ZEXPORT deflateResetKeep (strm)
     z_streamp strm;
@@ -1075,8 +1077,10 @@ int ZEXPORT deflate (strm, flush)
 #endif /* NOVGZ */
 #endif
 
-    if (strm->start_bit == 0)
+    if (strm->start_bit == 0) {
         strm->start_bit = (strm->total_out + s->pending) * 8 + s->bi_valid;
+        fprintf(stderr, "%s z=%p start=%lu\n", __func__, strm, strm->start_bit);
+    }
 
     /* Start a new block or continue the current one.
      */

--- a/lib/libvgz/deflate.h
+++ b/lib/libvgz/deflate.h
@@ -268,7 +268,11 @@ typedef struct internal_state {
      * updated to the new high water mark.
      */
 
+    z_bounds bounds;
+    /* Track the bit positions of the first and last block of a stream. */
 } FAR deflate_state;
+
+#define DEFLATE_BITS(s) ((s->strm->total_out + s->pending) * 8 + s->bi_valid)
 
 /* Output a byte on the stream.
  * IN assertion: there is enough room in pending_buf.

--- a/lib/libvgz/inflate.c
+++ b/lib/libvgz/inflate.c
@@ -141,6 +141,7 @@ z_streamp strm;
     state->lencode = state->distcode = state->next = state->codes;
     state->sane = 1;
     state->back = -1;
+    zmemzero(&state->bounds, sizeof state->bounds);
     Tracev((stderr, "inflate: reset\n"));
     return Z_OK;
 }
@@ -274,6 +275,18 @@ int value;
 }
 
 #endif /* NOVGZ */
+
+int ZEXPORT inflateBlockBounds (strm, dest)
+    z_streamp strm;
+    z_boundsp dest;
+{
+    struct inflate_state FAR *state;
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    if (dest != Z_NULL)
+        memcpy(dest, &state->bounds, sizeof *dest);
+    return Z_OK;
+}
 
 /*
    Return state with length and distance decoding tables and index sizes set to
@@ -870,18 +883,23 @@ int flush;
             if (flush == Z_BLOCK || flush == Z_TREES) goto inf_leave;
                 /* fallthrough */
         case TYPEDO:
-            if (strm->start_bit == 0)
+            if (state->bounds.init_block == 0) {
                 strm->start_bit = 8 * (strm->total_in + in - have) - bits;
+		state->bounds.init_block = INFLATE_BITS(strm, in - have, bits);
+	    }
             if (state->last) {
                 strm->stop_bit = 8 * (strm->total_in + in - have) - bits;
+		state->bounds.last_bit = INFLATE_BITS(strm, in - have, bits);
                 BYTEBITS();
                 state->mode = CHECK;
                 break;
             }
             NEEDBITS(3);
             state->last = BITS(1);
-            if (state->last)
+            if (state->last) {
                 strm->last_bit = 8 * (strm->total_in + in - have) - bits;
+		state->bounds.last_block = INFLATE_BITS(strm, in - have, bits);
+	    }
             DROPBITS(1);
             switch (BITS(2)) {
             case 0:                             /* stored block */

--- a/lib/libvgz/inflate.c
+++ b/lib/libvgz/inflate.c
@@ -885,11 +885,11 @@ int flush;
         case TYPEDO:
             if (state->bounds.init_block == 0) {
                 strm->start_bit = 8 * (strm->total_in + in - have) - bits;
-		state->bounds.init_block = INFLATE_BITS(strm, in - have, bits);
-	    }
+                state->bounds.init_block = INFLATE_BITS(strm, in - have, bits);
+            }
             if (state->last) {
                 strm->stop_bit = 8 * (strm->total_in + in - have) - bits;
-		state->bounds.last_bit = INFLATE_BITS(strm, in - have, bits);
+                state->bounds.last_bit = INFLATE_BITS(strm, in - have, bits);
                 BYTEBITS();
                 state->mode = CHECK;
                 break;
@@ -898,8 +898,8 @@ int flush;
             state->last = BITS(1);
             if (state->last) {
                 strm->last_bit = 8 * (strm->total_in + in - have) - bits;
-		state->bounds.last_block = INFLATE_BITS(strm, in - have, bits);
-	    }
+                state->bounds.last_block = INFLATE_BITS(strm, in - have, bits);
+            }
             DROPBITS(1);
             switch (BITS(2)) {
             case 0:                             /* stored block */

--- a/lib/libvgz/inflate.h
+++ b/lib/libvgz/inflate.h
@@ -123,4 +123,8 @@ struct inflate_state {
     int sane;                   /* if false, allow invalid distance too far */
     int back;                   /* bits back of last unprocessed length/lit */
     unsigned was;               /* initial length of match */
+    z_bounds bounds;            /* track the bit positions of the first and */
+        /*last block of a stream. */
 };
+
+#define INFLATE_BITS(strm, bytes, bits) (8 * (strm->total_in + bytes) - bits)

--- a/lib/libvgz/trees.c
+++ b/lib/libvgz/trees.c
@@ -866,9 +866,11 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
     ulg stored_len;   /* length of input block */
     int last;         /* one if this is the last block for a file */
 {
-    if (last)
+    if (last) {
         s->strm->last_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
+        s->bounds.last_block = DEFLATE_BITS(s);
+    }
 
     send_bits(s, (STORED_BLOCK<<1)+last, 3);    /* send block type */
     bi_windup(s);        /* align on byte boundary */
@@ -883,9 +885,11 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
     s->bits_sent += 2*16;
     s->bits_sent += stored_len<<3;
 #endif
-    if (last)
+    if (last) {
         s->strm->stop_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
+        s->bounds.last_bit = DEFLATE_BITS(s);
+    }
 }
 
 /* ===========================================================================
@@ -925,9 +929,11 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
     ulg opt_lenb, static_lenb; /* opt_len and static_len in bytes */
     int max_blindex = 0;  /* index of last bit length code of non zero freq */
 
-    if (last)
+    if (last) {
         s->strm->last_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
+        s->bounds.last_block = DEFLATE_BITS(s);
+    }
 
     /* Build the Huffman trees unless a stored block is forced */
     if (s->level > 0) {
@@ -1011,6 +1017,7 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
     if (last) {
         s->strm->stop_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
+        s->bounds.last_bit = DEFLATE_BITS(s);
         bi_windup(s);
 #ifdef ZLIB_DEBUG
         s->compressed_len += 7;  /* align on byte boundary */

--- a/lib/libvgz/trees.c
+++ b/lib/libvgz/trees.c
@@ -36,6 +36,8 @@
 
 #include "deflate.h"
 
+#include <stdio.h>
+
 #ifdef ZLIB_DEBUG
 #  include <ctype.h>
 #endif
@@ -866,9 +868,12 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
     ulg stored_len;   /* length of input block */
     int last;         /* one if this is the last block for a file */
 {
-    if (last)
+    if (last) {
         s->strm->last_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
+        fprintf(stderr, "%s z=%p last=%lu\n",
+	    __func__, s->strm, s->strm->last_bit);
+    }
 
     send_bits(s, (STORED_BLOCK<<1)+last, 3);    /* send block type */
     bi_windup(s);        /* align on byte boundary */
@@ -883,9 +888,12 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
     s->bits_sent += 2*16;
     s->bits_sent += stored_len<<3;
 #endif
-    if (last)
+    if (last) {
         s->strm->stop_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
+        fprintf(stderr, "%s z=%p stop=%lu\n",
+	    __func__, s->strm, s->strm->stop_bit);
+    }
 }
 
 /* ===========================================================================
@@ -925,9 +933,12 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
     ulg opt_lenb, static_lenb; /* opt_len and static_len in bytes */
     int max_blindex = 0;  /* index of last bit length code of non zero freq */
 
-    if (last)
+    if (last) {
         s->strm->last_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
+        fprintf(stderr, "%s z=%p last=%lu\n",
+	    __func__, s->strm, s->strm->last_bit);
+    }
 
     /* Build the Huffman trees unless a stored block is forced */
     if (s->level > 0) {
@@ -1011,6 +1022,8 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
     if (last) {
         s->strm->stop_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
+        fprintf(stderr, "%s z=%p stop=%lu\n",
+	    __func__, s->strm, s->strm->stop_bit);
         bi_windup(s);
 #ifdef ZLIB_DEBUG
         s->compressed_len += 7;  /* align on byte boundary */

--- a/lib/libvgz/trees.c
+++ b/lib/libvgz/trees.c
@@ -36,8 +36,6 @@
 
 #include "deflate.h"
 
-#include <stdio.h>
-
 #ifdef ZLIB_DEBUG
 #  include <ctype.h>
 #endif
@@ -868,12 +866,9 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
     ulg stored_len;   /* length of input block */
     int last;         /* one if this is the last block for a file */
 {
-    if (last) {
+    if (last)
         s->strm->last_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
-        fprintf(stderr, "%s z=%p last=%lu\n",
-	    __func__, s->strm, s->strm->last_bit);
-    }
 
     send_bits(s, (STORED_BLOCK<<1)+last, 3);    /* send block type */
     bi_windup(s);        /* align on byte boundary */
@@ -888,12 +883,9 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
     s->bits_sent += 2*16;
     s->bits_sent += stored_len<<3;
 #endif
-    if (last) {
+    if (last)
         s->strm->stop_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
-        fprintf(stderr, "%s z=%p stop=%lu\n",
-	    __func__, s->strm, s->strm->stop_bit);
-    }
 }
 
 /* ===========================================================================
@@ -933,12 +925,9 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
     ulg opt_lenb, static_lenb; /* opt_len and static_len in bytes */
     int max_blindex = 0;  /* index of last bit length code of non zero freq */
 
-    if (last) {
+    if (last)
         s->strm->last_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
-        fprintf(stderr, "%s z=%p last=%lu\n",
-	    __func__, s->strm, s->strm->last_bit);
-    }
 
     /* Build the Huffman trees unless a stored block is forced */
     if (s->level > 0) {
@@ -1022,8 +1011,6 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
     if (last) {
         s->strm->stop_bit =
            (s->strm->total_out + s->pending) * 8 + s->bi_valid;
-        fprintf(stderr, "%s z=%p stop=%lu\n",
-	    __func__, s->strm, s->strm->stop_bit);
         bi_windup(s);
 #ifdef ZLIB_DEBUG
         s->compressed_len += 7;  /* align on byte boundary */

--- a/lib/libvgz/vgz.h
+++ b/lib/libvgz/vgz.h
@@ -106,8 +106,8 @@ typedef struct z_stream_s {
 
 #define VGZ_EXTENSIONS 1
     uLong   start_bit;	/* Bit pos of first deflate block */
+    uLong   last_bit;	/* Bit pos of last deflate block */
     uLong   stop_bit;	/* Bit pos after last deflate block */
-    uLong   last_bit;	/* Bit pos of 'last' bit */
 } z_stream;
 
 typedef z_stream FAR *z_streamp;

--- a/lib/libvgz/vgz.h
+++ b/lib/libvgz/vgz.h
@@ -113,6 +113,17 @@ typedef struct z_stream_s {
 typedef z_stream FAR *z_streamp;
 
 /*
+     deflate block boundaries information obtained from zlib routines.
+*/
+typedef struct z_bounds_s {
+    uLong   init_block; /* bit position of the initial deflate block */
+    uLong   last_block; /* bit position of the last deflate block */
+    uLong   last_bit;   /* bit position after the last deflate block */
+} z_bounds;
+
+typedef z_bounds FAR *z_boundsp;
+
+/*
      gzip header information passed to and from zlib routines.  See RFC 1952
   for more details on the meanings of these fields.
 */
@@ -777,6 +788,13 @@ ZEXTERN uLong ZEXPORT deflateBound OF((z_streamp strm,
    than Z_FINISH or Z_NO_FLUSH are used.
 */
 
+ZEXTERN int ZEXPORT deflateBlockBounds OF((z_streamp strm,
+                                           z_boundsp dest));
+/*
+     TODO:
+   description.
+*/
+
 ZEXTERN int ZEXPORT deflatePending OF((z_streamp strm,
                                        unsigned *pending,
                                        int *bits));
@@ -1176,6 +1194,13 @@ ZEXTERN int ZEXPORT inflateBackEnd OF((z_streamp strm));
 
      inflateBackEnd() returns Z_OK on success, or Z_STREAM_ERROR if the stream
    state was inconsistent.
+*/
+
+ZEXTERN int ZEXPORT inflateBlockBounds OF((z_streamp strm,
+                                           z_boundsp dest));
+/*
+     TODO:
+   description.
 */
 
 ZEXTERN uLong ZEXPORT zlibCompileFlags OF((void));


### PR DESCRIPTION
Below is the commit message of the last patch in this series. Reviewing the previous patches may or may not be needed to build enough context to digest this one. Despite this definitive failure at working with a standalone zlib, I think there are a couple patches we can cherry-pick in trunk.

More comments after the commit message.

> Unlike the inflate() API that lands itself nicely to figuring block
> boundaries, I have come to the conclusion that this is impossible for
> its deflate() counterpart.
> 
> I proceeded similarly to inflate():
> 
> - find how and when boundaries are registered
> - port the formula to varnishd's code
> - see what boundaries we operate on outside zlib
> 
> What I found is that we keep track of the start, stop and last bit
> positions deep in the inflate code. The start bit is not a problem for
> us, it is guaranteed to always be 80 bits, the initial 10B gzip header.
> We know for a fact that gzip streams we generate never have anything
> extra. This is verified by an assertion.
> 
> Porting the formula was trivial using the deflatePending() function
> and it turns out to be essential to figure boundaries out.
> 
> The problem I initially suspected was that one call to deflate() could
> result into multiple blocks being output, as the structure of the code
> suggests in the trees.c file. This poor man's tracing confirms that we
> can't achieve from the outside what our patched zlib does.
> 
> Output example:
> 
>     $ ./varnishtest -i tests/c00034.vtc | grep z= | sed 's/.*said//'
>     z_deflate z=0x7fca7d016040 start=80
>     VGZ_UpdateObj z=0x7fca7d016040 start=80 stop=0 last=0 bits=80
>     z__tr_flush_block z=0x7fca7d016040 last=80
>     z__tr_flush_block z=0x7fca7d016040 stop=196
>     VGZ_UpdateObj z=0x7fca7d016040 start=80 stop=196 last=80 bits=264
>     VGZ_UpdateObj z=0x7fca7d016040 start=80 stop=196 last=80 bits=264
> 
> We know that we can hard-code the start bit to 80, and we could maybe
> capture the last bit (80) but unlike the inflate() code there doesn't
> seem to be state we could inspect to inform this need. On the inflate()
> side we can rely on the z_stream::data_type field, but here it seems to
> solely contain Z_BINARY or Z_TEXT (if not Z_UNKNOWN) and no special bits
> like in inflate mode.
> 
> After adding the Z_BLOCK flag in this patch, the situation does not
> improve:
> 
>     $ ./varnishtest -i tests/c00034.vtc | grep z= | sed 's/.*said//'
>     z_deflate z=0x7ff0e6416040 start=80
>     VGZ_UpdateObj z=0x7ff0e6416040 start=80 stop=0 last=0 bits=196
>     z__tr_flush_block z=0x7ff0e6416040 last=196
>     z__tr_flush_block z=0x7ff0e6416040 stop=220
>     VGZ_UpdateObj z=0x7ff0e6416040 start=80 stop=220 last=196 bits=288
>     VGZ_UpdateObj z=0x7ff0e6416040 start=80 stop=220 last=196 bits=288
> 
> First, we get a chance to run VGZ_UpdateObj() after the initial header
> and before the first block is written. So we can first record the start
> at 80, so we gain nothing. Once again, we get a chance to capture the
> last bit at 196 (instead of 80) but have no state to inspect to confirm
> whether we should do that. By the time we come back the stop bit has
> already been recorded and we already went past it. We also can't infer
> the stop bit of the stream as `total_out * 8 - 64` (where 64 is the
> number of bits needed for the CRC32 and ISIZE fields at the end of a
> block) because the compressed payload of a block may not have a bit size
> that is a multiple of 8.
> 
> Even worse, we artifically force the block boundary and end up with a
> larger gzip stream altogether.
> 
> And that is just a simplistic test case when it comes to gzip. Another
> one like v00004.vtc shows an even bleaker picture. And if we aren't even
> close to making a gzip test case pass, there's no hope for ESI assembly
> of multiple fragments compressed (or not) independently.

After it came up one time too many I decided to try @madler's suggestion on how to find block boundaries without patching zlib.

See https://github.com/madler/zlib/issues/189 for some context.

The way it works is that varnishd tries to find the gzip block boundaries we care about, and then compares notes with libvgz (read: asserts). We could get away with a standalone zlib for gunzip operations, but not for compression.

Now that I have a good understanding of what our patched zlib (libvgz) does, and now that I am convinced that doing so without our downstream patch is impossible, I plan to reopen the aforementioned issue to explain precisely what it is that we do. One problem I see with our patch is that the ESI assembly of maybe-compressed fragments is done completely outside of zlib, so adding this block boundaries tracking feature in zlib could be a hard sell without APIs to make use of this tracking.

Regardless of the outcome, we should probably cherry-pick the relevant commits and clearly document why we have libvgz today.