### PR TITLE
build: Require an explicit --with-jemalloc to use it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,6 +387,7 @@ workflows:
           name: build_centos_7
           dist: centos
           release: "7"
+          extra_conf: --with-jemalloc
       - build:
           name: build_centos_stream
           prefix: quay.io/centos/

--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -180,8 +180,12 @@ varnishd_LDADD = \
 	$(top_builddir)/lib/libvarnish/libvarnish.la \
 	$(top_builddir)/lib/libvsc/libvsc.la \
 	$(top_builddir)/lib/libvgz/libvgz.la \
-	@JEMALLOC_LDADD@ \
 	${DL_LIBS} ${PTHREAD_LIBS} ${NET_LIBS} ${RT_LIBS} ${LIBM}
+
+if WITH_JEMALLOC
+varnishd_CFLAGS += ${JEMALLOC_CFLAGS}
+varnishd_LDADD += ${JEMALLOC_LIBS}
+endif
 
 if WITH_UNWIND
 varnishd_CFLAGS += -DUNW_LOCAL_ONLY ${LIBUNWIND_CFLAGS}

--- a/configure.ac
+++ b/configure.ac
@@ -352,24 +352,19 @@ AM_COND_IF([ENABLE_WORKSPACE_EMULATOR], [
               [Define to 1 if the workspace emulator is enabled])
 ])
 
-# Use jemalloc on Linux
-JEMALLOC_LDADD=
+# --with-jemalloc
 AC_ARG_WITH([jemalloc],
-            [AS_HELP_STRING([--with-jemalloc],
-              [use jemalloc memory allocator.  Default is yes on Linux,  no elsewhere])],
-            [],
-            [with_jemalloc=check])
+	[AS_HELP_STRING([--with-jemalloc],
+		[use jemalloc memory allocator. Default is no.])],
+		[PKG_CHECK_MODULES([JEMALLOC], [jemalloc],
+			[have_jemalloc=yes], [have_jemalloc=no])],
+	[with_jemalloc=no])
 
-case $target in
-    *-*-linux*)
-        if test "x$with_jemalloc" != xno; then
-            AC_CHECK_LIB([jemalloc], [malloc_conf],
-                  [JEMALLOC_LDADD="-ljemalloc"],
-                  [AC_MSG_WARN([No system jemalloc found, using system malloc])])
-	fi
-	;;
-esac
-AC_SUBST(JEMALLOC_LDADD)
+if test "$with_jemalloc" = yes && test "$have_jemalloc" != yes; then
+        AC_MSG_ERROR([Could not find jemalloc])
+fi
+
+AM_CONDITIONAL([WITH_JEMALLOC], [test "$have_jemalloc" = yes])
 
 AC_CHECK_FUNCS([setproctitle])
 


### PR DESCRIPTION
This removes the automatic check made only on Linux systems for jemalloc now that operating systems we care about ship a much more recent version than the 3.6 that is known to work really well with Varnish on x86_64 hardware.

Of the platforms we provide packages for, only Ubuntu 18.04 (bionic) and RHEL 7 (via EPEL) ship jemalloc 3.6.0 and the rest already moved on to a 5.x series.

It appears that jemalloc 3.6 on aarch64 results in unstable Varnish workloads while jemalloc 5 is known to generate a lot of waste with its default configuration with a highly threaded workload like Varnish would operate, based on feedback we have seen over years.

From now on, jemalloc is found via pkg-config, only if it is explicitly requested at configure time. With explicit opt-in, the Linux-only check is gone and we solely rely on pkg-config to find the library. This can of course be overriden as usual at configure time:

    ./configure --with-jemalloc JEMALLOC_CFLAGS=... JEMALLOC_LIBS=...

Or, if you don't like long command lines, via environment variables.

Refs #3867
Refs #3879