### PR TITLE
Deal with backends that don't close connections

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -357,8 +357,11 @@ vbp_poke(struct vbp_target *vt)
 		}
 		i = poll(pfd, 1, tmo);
 		if (i <= 0) {
-			if (!i)
+			if (!i) {
+				if (!vt->exp_close)
+					break;
 				errno = ETIMEDOUT;
+			}
 			bprintf(vt->resp_buf, "Poll error %d (%s)",
 			    errno, VAS_errtxt(errno));
 			i = -1;

--- a/bin/varnishtest/tests/c00113.vtc
+++ b/bin/varnishtest/tests/c00113.vtc
@@ -1,0 +1,31 @@
+varnishtest "probe expect close"
+
+server s0 {
+	rxreq
+	txresp
+	expect_close
+} -dispatch
+
+varnish v1 -vcl+backend {
+	probe default {
+		.window = 1;
+		.threshold = 1;
+		.timeout = 1s;
+		.interval = 0.1s;
+	}
+} -start
+
+varnish v2 -vcl+backend {
+	probe default {
+		.window = 1;
+		.threshold = 1;
+		.timeout = 1s;
+		.interval = 0.1s;
+		.expect_close = false;
+	}
+} -start
+
+delay 2
+
+varnish v1 -cliexpect sick backend.list
+varnish v2 -cliexpect healthy backend.list

--- a/bin/varnishtest/tests/c00113.vtc
+++ b/bin/varnishtest/tests/c00113.vtc
@@ -12,6 +12,7 @@ varnish v1 -vcl+backend {
 		.threshold = 1;
 		.timeout = 1s;
 		.interval = 0.1s;
+		.expect_close = true;
 	}
 } -start
 

--- a/bin/varnishtest/tests/v00005.vtc
+++ b/bin/varnishtest/tests/v00005.vtc
@@ -32,6 +32,17 @@ varnish v1 -vcl {
 	}
 }
 
+# Check expect_close definition
+varnish v1 -vcl {
+	backend b1 {
+		.host = "${localhost}";
+		.probe = {
+			.url = "/";
+			.expect_close = false;
+		}
+	}
+}
+
 # Check redefinition
 varnish v1 -errvcl {Probe request redefinition at:} {
 	backend b1 {

--- a/bin/varnishtest/tests/v00005.vtc
+++ b/bin/varnishtest/tests/v00005.vtc
@@ -43,6 +43,16 @@ varnish v1 -errvcl {Expected "true" or "false"} {
 	}
 }
 
+varnish v1 -errvcl {Expected ID got '1'} {
+	backend b1 {
+		.host = "${localhost}";
+		.probe = {
+			.url = "/";
+			.expect_close = 1;
+		}
+	}
+}
+
 # Check redefinition
 varnish v1 -errvcl {Probe request redefinition at:} {
 	backend b1 {

--- a/bin/varnishtest/tests/v00005.vtc
+++ b/bin/varnishtest/tests/v00005.vtc
@@ -33,12 +33,12 @@ varnish v1 -vcl {
 }
 
 # Check expect_close definition
-varnish v1 -vcl {
+varnish v1 -errvcl {Expected "true" or "false"} {
 	backend b1 {
 		.host = "${localhost}";
 		.probe = {
 			.url = "/";
-			.expect_close = false;
+			.expect_close = faux;
 		}
 	}
 }

--- a/doc/sphinx/reference/vcl-probe.rst
+++ b/doc/sphinx/reference/vcl-probe.rst
@@ -95,6 +95,19 @@ The expected HTTP status, defaults to ``200``::
 
     .expected_response = 418;
 
+Attribute ``.expect_close``
+---------------------------
+
+Whether or not to expect the backend to close the TCP connection.
+
+Accepts ``true`` or ``false``, defaults to ``true``::
+
+    .expect_close = false;
+
+Note that probing takes more time when backend does not close the connection.
+Even when ``expect_close`` is set to ``false``, probe will still wait until timeout is
+reached before processing the response.
+
 Attribute ``.timeout``
 ----------------------
 

--- a/doc/sphinx/reference/vcl-probe.rst
+++ b/doc/sphinx/reference/vcl-probe.rst
@@ -104,9 +104,9 @@ Accepts ``true`` or ``false``, defaults to ``true``::
 
     .expect_close = false;
 
-Note that probing takes more time when backend does not close the connection.
-Even when ``expect_close`` is set to ``false``, probe will still wait until timeout is
-reached before processing the response.
+Warning: when the backend does not close the connection,
+setting ``expect_close`` to ``false`` makes probe tasks wait until
+they time out before inspecting the response.
 
 Attribute ``.timeout``
 ----------------------

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -60,6 +60,7 @@
  * NEXT (2023-03-15)
  *	VXID is 64 bit
  *	[cache.h] http_GetRange() changed
+ *	exp_close added to struct vrt_backend_probe
  * 16.0 (2022-09-15)
  *	VMOD C-prototypes moved into JSON
  *	VRT_AddVDP() deprecated
@@ -589,7 +590,8 @@ struct vrt_backend {
 	unsigned			exp_status;		\
 	unsigned			window;			\
 	unsigned			threshold;		\
-	unsigned			initial;
+	unsigned			initial;		\
+	unsigned			exp_close;
 
 #define VRT_BACKEND_PROBE_HANDLE()		\
 	do {					\
@@ -599,6 +601,7 @@ struct vrt_backend {
 		DN(window);			\
 		DN(threshold);			\
 		DN(initial);			\
+		DN(exp_close);			\
 	} while (0)
 
 struct vrt_backend_probe {

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -183,7 +183,7 @@ vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **namep)
 	const struct token *t_field;
 	const struct token *t_did = NULL, *t_window = NULL, *t_threshold = NULL;
 	struct token *t_initial = NULL;
-	unsigned window, threshold, initial, status;
+	unsigned window, threshold, initial, status, exp_close;
 	char buf[32];
 	const char *name;
 	double t;
@@ -197,6 +197,7 @@ vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **namep)
 	    "?window",
 	    "?threshold",
 	    "?initial",
+	    "?expect_close",
 	    NULL);
 
 	SkipToken(tl, '{');
@@ -216,6 +217,7 @@ vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **namep)
 	threshold = 0;
 	initial = 0;
 	status = 0;
+	exp_close = 1;
 	while (tl->t->tok != '}') {
 
 		vcc_IsField(tl, &t_field, fs);
@@ -273,6 +275,9 @@ vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **namep)
 			t_threshold = tl->t;
 			threshold = vcc_UintVal(tl);
 			ERRCHK(tl);
+		} else if (vcc_IdIs(t_field, "expect_close")) {
+			exp_close = vcc_BoolVal(tl);
+			ERRCHK(tl);
 		} else {
 			vcc_ErrToken(tl, t_field);
 			vcc_ErrWhere(tl, t_field);
@@ -321,6 +326,7 @@ vcc_ParseProbeSpec(struct vcc *tl, const struct symbol *sym, char **namep)
 		Fh(tl, 0, "\t.initial = ~0U,\n");
 	if (status > 0)
 		Fh(tl, 0, "\t.exp_status = %u,\n", status);
+	Fh(tl, 0, "\t.exp_close = %u,\n", exp_close);
 	Fh(tl, 0, "}};\n");
 	SkipToken(tl, '}');
 }

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -448,6 +448,7 @@ double vcc_DurationUnit(struct vcc *);
 void vcc_ByteVal(struct vcc *, VCL_INT *);
 void vcc_Duration(struct vcc *tl, double *);
 uint64_t vcc_UintVal(struct vcc *tl);
+uint8_t vcc_BoolVal(struct vcc *tl);
 int vcc_IsFlag(struct vcc *tl);
 int vcc_IsFlagRaw(struct vcc *, const struct token *, const struct token *);
 char *vcc_Dup_be(const char *b, const char *e);

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -286,6 +286,28 @@ Resolve_Sockaddr(struct vcc *tl,
 }
 
 /*--------------------------------------------------------------------
+* Recognize boolean const "true" or "false"
+*/
+
+uint8_t
+vcc_BoolVal(struct vcc *tl)
+{
+	struct symbol* sym;
+
+	if (tl->t->tok != ID) {
+		Expect(tl, ID);
+		return (0);
+	}
+	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_NONE, SYMTAB_EXISTING, XREF_NONE);
+	if (sym == NULL || sym->type != BOOL) {
+		VSB_cat(tl->sb, "Expected \"true\" or \"false\"\n");
+		vcc_ErrWhere(tl, tl->t);
+		return (0);
+	}
+	return (sym->eval_priv != NULL);
+}
+
+/*--------------------------------------------------------------------
  * Recognize and convert units of duration, return seconds.
  */
 

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -301,7 +301,6 @@ vcc_BoolVal(struct vcc *tl)
 	sym = VCC_SymbolGet(tl, SYM_MAIN, SYM_NONE, SYMTAB_EXISTING, XREF_NONE);
 	if (sym == NULL || sym->type != BOOL) {
 		VSB_cat(tl->sb, "Expected \"true\" or \"false\"\n");
-		vcc_ErrWhere(tl, tl->t);
 		return (0);
 	}
 	return (sym->eval_priv != NULL);


### PR DESCRIPTION
Add "expect_close" parameter to probe to deal with backends that are considered sick because they don't close the TCP connection after sending the response. 
The new parameter accepts the value true or false, and defaults to true for backward compatibility.