### PR TITLE
heritage: Remove unset params::[gu]id fields

### DIFF
--- a/bin/varnishd/common/common_param.h
+++ b/bin/varnishd/common/common_param.h
@@ -140,9 +140,5 @@ struct params {
 #undef ptyp_vsl_mask
 #undef ptyp_vsl_reclen
 
-	/* Unprivileged user / group */
-	uid_t			uid;
-	gid_t			gid;
-
 	struct vre_limits	vre_limits;
 };

--- a/bin/varnishd/mgt/mgt_vcc.c
+++ b/bin/varnishd/mgt/mgt_vcc.c
@@ -259,10 +259,6 @@ mgt_vcc_touchfile(const char *fn, struct vsb *sb)
 		VSB_printf(sb, "Failed to create %s: %s", fn, VAS_errtxt(errno));
 		return (2);
 	}
-	if (fchown(i, mgt_param.uid, mgt_param.gid) != 0)
-		if (geteuid() == 0)
-			VSB_printf(sb, "Failed to change owner on %s: %s\n",
-			    fn, VAS_errtxt(errno));
 	closefd(&i);
 	return (0);
 }


### PR DESCRIPTION
They are shared with the cache process but are never used. Only the VCC
process uses them, but they are never set. This specific fchown(2) call
in the VCC process was probably a no-op in the first place: since the
fields are never set this is transferring ownership to root:root and if
that succeeded the process was already root in the first place. If it
failed, we never see the error message since we lacked root privileges.

When this fchown(2) call is made (multiple times) the files are created
by a VCC process that already dropped privileges, if applicable, via the
jail system. So the VJ_fix_fd() replacement may also be a no-op.