### PR TITLE
build: Revisit zlib C flags one more time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -249,19 +249,14 @@ LIBS="${save_LIBS}"
 
 AC_CHECK_DECL([__SUNPRO_C], [SUNCC="yes"], [SUNCC="no"])
 
-if test "$SUNCC" = "yes" ; then
-	CFLAGS="${CFLAGS} -errwarn=%all,no%E_EMPTY_TRANSLATION_UNIT"
-else
-	CFLAGS="${CFLAGS} -Werror"
-fi
-
 # zlib-specific flags
-libvgz_extra_cflags="-Wno-error=strict-prototypes -Wno-unknown-warning-option"
+VGZ_CFLAGS="-Wno-error=strict-prototypes -Wno-unknown-warning-option"
 
 dnl https://github.com/madler/zlib/issues/633
-libvgz_extra_cflags="$libvgz_extra_cflags -Wno-error=deprecated-non-prototype"
+AX_CHECK_COMPILE_FLAG([-Wno-error=deprecated-non-prototype],
+	[VGZ_CFLAGS="$VGZ_CFLAGS -Wno-error=deprecated-non-prototype"])
 
-AC_SUBST(libvgz_extra_cflags)
+AC_SUBST(VGZ_CFLAGS)
 
 # Support for visibility attribute (zlib)
 AC_CACHE_CHECK([whether we have support for visibility attributes],

--- a/lib/libvgz/Makefile.am
+++ b/lib/libvgz/Makefile.am
@@ -3,7 +3,7 @@
 AM_CFLAGS = $(AM_LT_CFLAGS) \
 	-D_LARGEFILE64_SOURCE=1 \
 	-DZLIB_CONST \
-	$(libvgz_extra_cflags)
+	$(VGZ_CFLAGS)
 
 AM_LDFLAGS = $(AM_LT_LDFLAGS)
 


### PR DESCRIPTION
Trying to fix the build for clang 15 actually broke the build for GCC.

The -Werror that was initially set after saving CFLAGS was meant to be part of NO_VIZ test. We turn warnings into errors later in the configure script so at this point we shouldn't care about it. If we really do, we can move this check below the line where -Werror is set.

GCC chokes on -Wno-error=deprecated-non-prototype so instead we add it conditionally.

To match the naming convention everywhere else, libvgz_extra_cflags was renamed to VGZ_CFLAGS.

Refs 118fd10c9e81920e0c31906c2bf5c62a3f25cd5b

---

Opening a pull request this time, to make sure it passes CI first.