### PR TITLE
Honor H2 request limits

### DIFF
--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -140,6 +140,7 @@ struct h2_req {
 	VTAILQ_ENTRY(h2_req)		list;
 	int64_t				t_window;
 	int64_t				r_window;
+	uint64_t			req_len;
 
 	/* Where to wake this stream up */
 	struct worker			*wrk;

--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -141,6 +141,7 @@ struct h2_req {
 	int64_t				t_window;
 	int64_t				r_window;
 	uint64_t			req_len;
+	char				hpack_err;
 
 	/* Where to wake this stream up */
 	struct worker			*wrk;
@@ -227,7 +228,7 @@ struct h2h_decode {
 void h2h_decode_init(const struct h2_sess *h2);
 h2_error h2h_decode_fini(const struct h2_sess *h2);
 h2_error h2h_decode_bytes(struct h2_sess *h2, const uint8_t *ptr,
-    size_t len);
+    size_t len, struct h2_req *r2);
 
 /* cache_http2_send.c */
 void H2_Send_Get(struct worker *, struct h2_sess *, struct h2_req *);

--- a/bin/varnishd/http2/cache_http2_hpack.c
+++ b/bin/varnishd/http2/cache_http2_hpack.c
@@ -263,7 +263,7 @@ h2h_decode_fini(const struct h2_sess *h2)
  * H2E_PROTOCOL_ERROR: Malformed header or duplicate pseudo-header.
  */
 h2_error
-h2h_decode_bytes(struct h2_sess *h2, const uint8_t *in, size_t in_l)
+h2h_decode_bytes(struct h2_sess *h2, const uint8_t *in, size_t in_l, struct h2_req *r2)
 {
 	struct http *hp;
 	struct h2h_decode *d;
@@ -335,6 +335,8 @@ h2h_decode_bytes(struct h2_sess *h2, const uint8_t *in, size_t in_l)
 			    d->out_u);
 			if (d->error)
 				break;
+			if (d->out_u > cache_param->http_req_hdr_len)
+				r2->hpack_err = 1;
 			d->error = h2h_addhdr(hp, d->out, d->namelen, d->out_u);
 			if (d->error)
 				break;


### PR DESCRIPTION
This PR honors h2 request limits for http_req_size,  http_req_hdr_len, and h2_max_header_list_size 
Fixes #3709