### PR TITLE
Optimize VRE_sub() by avoiding VSB_putc()

### DIFF
--- a/lib/libvarnish/vre.c
+++ b/lib/libvarnish/vre.c
@@ -276,7 +276,7 @@ VRE_sub(const vre_t *code, const char *subject, const char *replacement,
 	txt groups[10];
 	size_t count;
 	int i, offset = 0;
-	const char *s;
+	const char *s, *e;
 	unsigned x;
 
 	CHECK_OBJ_NOTNULL(code, VRE_MAGIC);
@@ -301,21 +301,21 @@ VRE_sub(const vre_t *code, const char *subject, const char *replacement,
 		/* Copy prefix to match */
 		s = subject + offset;
 		VSB_bcat(vsb, s, pdiff(s, groups[0].b));
-		for (s = replacement; *s != '\0'; s++ ) {
-			if (*s != '\\' || s[1] == '\0') {
-				VSB_putc(vsb, *s);
+		for (s = e = replacement; *e != '\0'; e++ ) {
+			if (*e != '\\' || e[1] == '\0')
 				continue;
-			}
-			s++;
-			if (isdigit(*s)) {
-				x = *s - '0';
+			VSB_bcat(vsb, s, pdiff(s, e));
+			s = ++e;
+			if (isdigit(*e)) {
+				s++;
+				x = *e - '0';
 				if (x >= count)
 					continue;
 				VSB_bcat(vsb, groups[x].b, Tlen(groups[x]));
 				continue;
 			}
-			VSB_putc(vsb, *s);
 		}
+		VSB_bcat(vsb, s, pdiff(s, e));
 		offset = pdiff(subject, groups[0].e);
 		if (!all)
 			break;


### PR DESCRIPTION
This patch optimizes substitutions to relevant extent as shown by the percentiles of execution times in microseconds from the test detailed below:

unpatched:

 10% | 20% | 30% | 40% | 50% | 60% | 70% | 80%  | 90%
 --- | --- | --- | --- | --- | --- | --- | --- | --- |
12.8219 | 12.8650 | 12.9070 | 12.9506 | 13.0225 | 19.2838 | 19.4100 | 19.5714 | 22.7865

patched:

 10% | 20% | 30% | 40% | 50% | 60% | 70% | 80%  | 90%
 --- | --- | --- | --- | --- | --- | --- | --- | --- |
 8.5710 |  8.6090 |  8.6390 |  8.6676 |  8.7020 |  8.8440 |  9.1669 | 10.3150 | 11.0061 

test vcl:

```
vcl 4.1;

backend none none;

import std;
sub perf {
	set beresp.http.Snafu8 =
	    regsub(beresp.http.Foobar, "(b)(a)(r)(f)", "0123456789abcdef0123456789abcdef\4\3\2p0123456789abcdef0123456789abcdef");
	set beresp.http.Snafu8 =
	    regsub(beresp.http.Foobar, "(b)(a)(r)(f)", "0123456789abcdef0123456789abcdef\4\3\2p0123456789abcdef0123456789abcdef");
	set beresp.http.Snafu8 =
	    regsub(beresp.http.Foobar, "(b)(a)(r)(f)", "0123456789abcdef0123456789abcdef\4\3\2p0123456789abcdef0123456789abcdef");
	set beresp.http.Snafu8 =
	    regsub(beresp.http.Foobar, "(b)(a)(r)(f)", "0123456789abcdef0123456789abcdef\4\3\2p0123456789abcdef0123456789abcdef");
	set beresp.http.Snafu8 =
	    regsub(beresp.http.Foobar, "(b)(a)(r)(f)", "0123456789abcdef0123456789abcdef\4\3\2p0123456789abcdef0123456789abcdef");
}

sub vcl_backend_error {
	set beresp.http.foobar = "_barf_";
	set beresp.http.perf = std.timed_call(perf) * 1000 * 1000;
}
```

```
curl -sI localhost:8080/{1..1000}| grep perf | awk '{ print $NF }' >/tmp/times
```

R:

```
d <- as.numeric(readLines("/tmp/times"))
quantile(d, probs = seq(.1, .9, by = .1))
```