### PR TITLE
build: Implement "proper" maintainer programs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,7 +405,7 @@ workflows:
           name: build_fedora_latest
           dist: fedora
           release: latest
-          make_target: witness
+          make_target: witness.dot
       - build:
           name: build_fedora_rawhide
           dist: fedora

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,7 +81,7 @@ gcov_digest:
 witness.dot: all
 	$(MAKE) check AM_VTC_LOG_FLAGS=-pdebug=+witness
 	$(AM_V_GEN) $(srcdir)/tools/witness.sh witness.dot bin/varnishtest/ \
-		lib/libvmod_*/
+		vmod/
 
 .dot.svg:
 	$(AM_V_GEN) $(DOT) -Tsvg $< >$@

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,19 +84,8 @@ witness.dot: all
 		lib/libvmod_*/
 
 .dot.svg:
-if ! HAVE_DOT
-	@echo ==================================================
-	@echo You need graphviz installed to generate svg output
-	@echo ==================================================
-	@false
-else
 	$(AM_V_GEN) $(DOT) -Tsvg $< >$@
-endif
 
-if HAVE_DOT
 witness: witness.svg
-else
-witness: witness.dot
-endif
 
 .PHONY: cscope witness.dot

--- a/configure.ac
+++ b/configure.ac
@@ -79,16 +79,9 @@ if test "x$RST2HTML" = "xno"; then
      [rst2html not found - (Weird, we found rst2man?!)])
 fi
 
-AC_ARG_WITH([dot],
-  AS_HELP_STRING([--with-dot=PATH],
-		 [Location of the dot tool from graphviz (auto)]),
-  [DOT="$withval"],
-  [AC_CHECK_PROGS(DOT, [dot], [no])
-   if test "x$DOT" = "xno"; then
-     AC_MSG_WARN(
-       [dot not found - build will fail if svg files are out of date.])
-   fi])
-AM_CONDITIONAL(HAVE_DOT,[test "x$DOT" != "xno"])
+AC_ARG_VAR([DOT], [The dot program from graphviz to build SVG graphics])
+AM_MISSING_PROG([DOT], [dot])
+AC_CHECK_PROGS([DOT], [dot])
 
 # Define VMOD flags
 _VARNISH_VMOD_LDFLAGS

--- a/doc/graphviz/Makefile.am
+++ b/doc/graphviz/Makefile.am
@@ -35,10 +35,8 @@ SVGS = \
 	cache_req_fsm.svg \
 	cache_fetch.svg
 
-if HAVE_DOT
 CLEANFILES = \
 	$(PDFS)
-endif
 
 pdf: $(PDFS)
 
@@ -46,31 +44,10 @@ html: $(SVGS) link_srcdir
 
 # XXX does not fit onto a4 unless in landscape
 cache_fetch.pdf: cache_fetch.dot
-if ! HAVE_DOT
-	@echo ==================================================
-	@echo You need graphviz installed to generate pdf output
-	@echo ==================================================
-	@false
-else
-	@DOT@ -Tpdf -Gsize=$(SIZE) -Grotate=90 $< >$@
-endif
+	$(AM_V_GEN) $(DOT) -Tpdf -Gsize=$(SIZE) -Grotate=90 $< >$@
 
 .dot.pdf:
-if ! HAVE_DOT
-	@echo ==================================================
-	@echo You need graphviz installed to generate pdf output
-	@echo ==================================================
-	@false
-else
-	@DOT@ -Tpdf -Gsize=$(SIZE) $< >$@
-endif
+	$(AM_V_GEN) $(DOT) -Tpdf -Gsize=$(SIZE) $< >$@
 
 .dot.svg:
-if ! HAVE_DOT
-	@echo ==================================================
-	@echo You need graphviz installed to generate svg output
-	@echo ==================================================
-	@false
-else
-	@DOT@ -Tsvg $< >$@
-endif
+	$(AM_V_GEN) $(DOT) -Tsvg $< >$@


### PR DESCRIPTION
There is a bunch of programs that are not strictly needed when building from a release "dist" archive, because we ship the deliverables. For example we should not require `rst2man` because pre-built manual pages are present in the dist archive, and likewise, we shouldn't need sphinx-build since we ship the HTML documentation.

One problem with how we deal with documentation however is that we generate some of them from programs we compile at build time, so we need to avoid updating such targets unless they actually change. This shouldn't be difficult.

There is however a maintainer program that goes one step further: not only do we ship SVGs in dist archives, we also check them in. So even when working from a git clone (as opposed to rebuilding from a dist archive) we don't require a working graphviz installation.

The first maintainer program promoted to the relevant autotools macros is dot(1) since it's the easiest one to deal with. The first actual patch makes a +6-47 diff to result in the same behavior, modulus a slightly different configure command line (when applicable) and a slightly different error message when dot(1) is needed but missing.

I'd like to take care of the other maintainer programs after the March release, meanwhile, please check that it does not just work on my machine. The macros I used are all old enough to satisfy our autoconf and automake minimum versions.