### PR TITLE
release: Prep work before the next release

### DIFF
--- a/doc/sphinx/whats-new/changes-trunk.rst
+++ b/doc/sphinx/whats-new/changes-trunk.rst
@@ -164,4 +164,12 @@ Custom backend implementations are now in charge of printing headers, which
 avoids duplicates when a custom implementation relied on ``http_*()`` that
 would also log the headers being set up.
 
+The ``VRT_new_backend*()`` functions take an additional backend argument, the
+optional via backend. It can not be a custom backend implementation, but it
+can be a director resolving a native backend.
+
+There is a new ``authority`` field for via backends in ``struct vrt_backend``.
+
+There is a new ``exp_close`` field in ``struct vrt_backend_probe``.
+
 *eof*

--- a/doc/sphinx/whats-new/changes-trunk.rst
+++ b/doc/sphinx/whats-new/changes-trunk.rst
@@ -25,8 +25,32 @@ Parameters
 
 **XXX changes in -p parameters**
 
+There is a new parameter ``transit_buffer`` disabled by default to limit the
+amount of storage used for uncacheable responses. This is useful in situations
+where slow clients may consume large but uncacheable objects, to prevent them
+from filling up storage too fast at the expense of cacheable resources. When
+transit buffer is enabled, a client request will effectively hold its backend
+connection open until the client response delivery completes.
+
 Other changes in varnishd
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to classic Unix-domain sockets, abstract sockets can now be used
+on Linux. Instead of an absolute path, the syntax ``-a @name`` can be used to
+bind the abstract socket called ``name``.
+
+Weak ``Last-Modified`` headers are no longer candidates for revalidation. This
+means that a subsequent fetch will not, when such a stale object is available,
+include an ``If-Modified-Since`` header. A weak ``Last-Modified`` header does
+not prevent ``Etag`` revalidation.
+
+A cache hit on an object being streamed no longer prevents delivery of partial
+responses (status code 206) to range requests.
+
+Response status codes other than 200 and 204 are now considered errors for ESI
+fragments. The default behavior was changed, errors are no longer delivered by
+default. The feature flag ``esi_include_onerror`` can be raised to allow a
+backend to specify whether to continue.
 
 Changes to VCL
 ==============
@@ -36,8 +60,43 @@ VCL variables
 
 **XXX new, deprecated or removed variables, or changed semantics**
 
+The variables ``req.xid``, ``bereq.xid`` and ``sess.xid`` are now integers
+instead of strings, but should remain usable without a VCL change in a string
+context.
+
+Transit buffer can be controlled per fetch with the ``beresp.transit_buffer``
+variable.
+
 Other changes to VCL
 ~~~~~~~~~~~~~~~~~~~~
+
+Backends have a new ``.via`` attribute referencing another backend::
+
+    backend detour {
+        .host = "...";
+    }
+
+    backend destination {
+        .host = "...";
+        .via = detour;
+    }
+
+Attempting a connection for ``destination`` connects to ``detour`` with a
+PROXYv2 protocol header targeting ``destination``'s address. Optionally, the
+``destination`` backend could use the other new ``.authority`` attribute to
+define an authority TLV in the PROXYv2 header.
+
+Backends can connect to abstract sockets on linux::
+
+    backend abstract {
+        .path = "@name";
+    }
+
+This is the same syntax as the ``varnishd -a`` command line option.
+
+Probes have a new ``.expect_close`` attribute defaulting to ``true``, matching
+the current behavior. Setting it to ``false`` will defer final checks until
+after the probe times out.
 
 VMODs
 =====
@@ -49,10 +108,26 @@ varnishlog
 
 **XXX changes concerning varnishlog(1) and/or vsl(7)**
 
+The in-memory and on-disk format of VSL records changed to allow 64bit VXID
+numbers. The new binary format is not compatible with previous versions, and
+log dumps performed with a previous Varnish release are no longer readable
+from now on.
+
+The VXID range is limited to ``VRT_INTEGER`` to fit in VCL the variables
+``req.xid``, ``bereq.xid`` and ``sess.xid``.
+
+A ``ReqStart`` record is emitted for bad requests, allowing ``varnishncsa`` to
+find the client IP address.
+
 varnishadm
 ==========
 
 **XXX changes concerning varnishadm(1) and/or varnish-cli(7)**
+
+The ``debug.xid`` command generally used by ``varnishtest`` used to set up the
+current VXID. As the intent usually is to set up the next VXID, this forced to
+set an off-by-one value. To simplify its usage it now sets up the next VXID
+directly.
 
 varnishstat
 ===========
@@ -64,10 +139,29 @@ varnishtest
 
 **XXX changes concerning varnishtest(1) and/or vtc(7)**
 
+It is now possible to send special keys NPAGE, PPAGE, HOME and END to a
+process.
+
+The ``-nolen`` option is implied for ``txreq`` and ``txresp`` when either
+``Content-Length`` or ``Transfer-Encoding`` headers are present.
+
+A new ``stream.peer_window`` variable similar to ``stream.window`` is
+available for HTTP/2 checks.
+
 Changes for developers and VMOD authors
 =======================================
 
 **XXX changes concerning VRT, the public APIs, source code organization,
 builds etc.**
+
+There is a new convenience macro ``WS_TASK_ALLOC_OBJ()`` to allocate objects
+from the current tasks' workspace.
+
+The ``NO_VXID`` macro can be used to explicitly log records outside of a
+transaction.
+
+Custom backend implementations are now in charge of printing headers, which
+avoids duplicates when a custom implementation relied on ``http_*()`` that
+would also log the headers being set up.
 
 *eof*

--- a/doc/sphinx/whats-new/upgrading-trunk.rst
+++ b/doc/sphinx/whats-new/upgrading-trunk.rst
@@ -30,4 +30,37 @@ to:**
 * Changes in public APIs that may require changes in VMODs or VAPI/VUT
   clients.
 
+New VSL format
+==============
+
+The binary format of Varnish logs changed to increase the space for VXIDs from
+32 bits to 64. This is not a change that older versions of the Varnish logging
+utilities can understand, and the new utilities can also not process old logs.
+
+There is no conversion tool from the old format to the new one, so this should
+become a problem only when raw logs are stored for future processing. If old
+binary logs need to remain usable, the only solution is to use a compatible
+Varnish version and at the time of this release, the 6.0 branch is the only
+one without an EOL date.
+
+Via backends
+============
+
+The new backend argument to the ``VRT_new_backend*()`` functions is optional
+and ``NULL`` can be passed to match the previous behavior.
+
+suckaddr
+========
+
+The following functions return or accept ``const`` pointers from now on:
+
+- ``VSA_Clone()``
+- ``VSA_getsockname()``
+- ``VSA_getpeername()``
+- ``VSA_free()``
+- ``VSA_Malloc()``
+- ``VSA_Build*()``
+- ``VSS_ResolveOne()``
+- ``VSS_ResolveFirst()``
+
 *eof*

--- a/include/vapi/vsl_int.h
+++ b/include/vapi/vsl_int.h
@@ -104,7 +104,7 @@
 #define VSL_WRAPMARKER	(((uint32_t)SLT__Reserved << 24) | 0x575757) /* "WWW" */
 
 /*
- * The identifiers in shmlogtag are "SLT_" + XML tag.  A script may be run
+ * The identifiers in shmlogtag are "SLT_" + VSL tag.  A script may be run
  * on this file to extract the table rather than handcode it
  */
 #define SLT__MAX 256

--- a/include/vsl_priv.h
+++ b/include/vsl_priv.h
@@ -58,7 +58,7 @@
  */
 
 struct VSL_head {
-#define VSL_HEAD_MARKER		"VSLHEAD1"	/* Incr. as version# */
+#define VSL_HEAD_MARKER		"VSLHEAD2"	/* Incr. as version# */
 	char			marker[8];
 	ssize_t			segsize;
 	unsigned		segment_n;

--- a/lib/libvarnishapi/vsl.c
+++ b/lib/libvarnishapi/vsl.c
@@ -413,8 +413,8 @@ VSL_PrintTransactions(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 FILE*
 VSL_WriteOpen(struct VSL_data *vsl, const char *name, int append, int unbuf)
 {
-	const char head[] = VSL_FILE_ID;
 	FILE* f;
+
 	if (!strcmp(name, "-"))
 		f = stdout;
 	else
@@ -426,7 +426,8 @@ VSL_WriteOpen(struct VSL_data *vsl, const char *name, int append, int unbuf)
 	if (unbuf)
 		setbuf(f, NULL);
 	if (ftell(f) == 0 || f == stdout) {
-		if (fwrite(head, 1, sizeof head, f) != sizeof head) {
+		if (fwrite(VSL_FILE_ID, 1, sizeof VSL_FILE_ID, f) !=
+		    sizeof VSL_FILE_ID) {
 			vsl_diag(vsl, "%s", strerror(errno));
 			(void)fclose(f);
 			return (NULL);

--- a/lib/libvarnishapi/vsl_api.h
+++ b/lib/libvarnishapi/vsl_api.h
@@ -31,7 +31,9 @@
  *
  */
 
-#define VSL_FILE_ID			"VSL"
+static const char			vsl_file_id[] = {'V', 'S', 'L', '2'};
+
+#define VSL_FILE_ID			(vsl_file_id)
 
 /*lint -esym(534, vsl_diag) */
 int vsl_diag(struct VSL_data *vsl, const char *fmt, ...) v_printflike_(2, 3);

--- a/lib/libvarnishapi/vsl_cursor.c
+++ b/lib/libvarnishapi/vsl_cursor.c
@@ -527,7 +527,7 @@ VSL_CursorFile(struct VSL_data *vsl, const char *name, unsigned options)
 	struct vslc_file *c;
 	int fd;
 	int close_fd = 0;
-	char buf[] = VSL_FILE_ID;
+	char buf[sizeof VSL_FILE_ID];
 	ssize_t i;
 
 	CHECK_OBJ_NOTNULL(vsl, VSL_MAGIC);


### PR DESCRIPTION
This is currently work in progress, but I plan to cover a first sweep of:

- [x] VSL (in)compatibility
- [x] initial release notes
- [x] initial upgrade notes
- [x] VRT history
- [x] libvarnishapi review
- [ ] gc SLTs?