### PR TITLE
Prepare for 7.3.0

### DIFF
--- a/bin/varnishtest/tests/m00003.vtc
+++ b/bin/varnishtest/tests/m00003.vtc
@@ -96,7 +96,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so "\x03"
 varnish v1 -errvcl {VMOD wants ABI version 1.0} { import wrong; }
 
 #############################################################
-# NB: in the tests below "16" should track VRT_MAJOR_VERSION
+# NB: in the tests below "17" should track VRT_MAJOR_VERSION
 
 filewrite ${tmpdir}/libvmod_wrong.so "VMOD_JSON_SPEC\x02"
 filewrite -a ${tmpdir}/libvmod_wrong.so {
@@ -108,7 +108,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
-	    "16",
+	    "17",
 	    "0"
 	], [
 	    "$FOOBAR"
@@ -128,7 +128,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
-	    "16",
+	    "17",
 	    "0"
 	]
     ]
@@ -146,7 +146,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
-	    "16",
+	    "17",
 	    "0"
 	], [
 	    "$CPROTO"
@@ -168,7 +168,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
 	    "Vmod_vmod_std_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
-	    "16",
+	    "17",
 	    "0"
 	], [
 	    "$CPROTO", "/* blabla */"

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_PREREQ(2.69)
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
-Copyright (c) 2006-2022 Varnish Software])
+Copyright (c) 2006-2023 Varnish Software])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [trunk], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [7.3.0], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -31,9 +31,9 @@ http://varnish-cache.org/docs/trunk/whats-new/index.html and via
 individual releases. These documents are updated as part of the
 release process.
 
-===============================
-Varnish Cache NEXT (2023-03-15)
-===============================
+================================
+Varnish Cache 7.3.0 (2023-03-15)
+================================
 
 * The macro ``WS_TASK_ALLOC_OBJ`` as been added to handle the common
   case of allocating mini objects on a workspace.

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -42,7 +42,7 @@ Longer listings like example command output and VCL look like this::
     $ /opt/varnish/sbin/varnishd -V
     varnishd (varnish-trunk revision 1234567)
     Copyright (c) 2006 Verdens Gang AS
-    Copyright (c) 2006-2022 Varnish Software
+    Copyright (c) 2006-2023 Varnish Software
 
 
 .. For maintainers:

--- a/doc/sphinx/whats-new/changes-7.3.rst
+++ b/doc/sphinx/whats-new/changes-7.3.rst
@@ -1,15 +1,11 @@
-**Note: This is a working document for a future release, with running
-updates for changes in the development branch. For changes in the
-released versions of Varnish, see:** :ref:`whats-new-index`
+.. _whatsnew_changes_7.3:
 
-.. _whatsnew_changes_CURRENT:
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Changes in Varnish **$NEXT_RELEASE**
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+Changes in Varnish **7.3**
+%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 For information about updating your current Varnish deployment to the
-new version, see :ref:`whatsnew_upgrading_CURRENT`.
+new version, see :ref:`whatsnew_upgrading_7.3`.
 
 A more detailed and technical account of changes in Varnish, with
 links to issues that have been fixed and pull requests that have been

--- a/doc/sphinx/whats-new/index.rst
+++ b/doc/sphinx/whats-new/index.rst
@@ -1,5 +1,5 @@
 ..
-	Copyright (c) 2013-2022 Varnish Software AS
+	Copyright (c) 2013-2023 Varnish Software AS
 	SPDX-License-Identifier: BSD-2-Clause
 	See LICENSE file for full text of license
 
@@ -13,18 +13,14 @@ This section describes the changes and improvements between different
 versions of Varnish, and what upgrading between the different versions
 entail.
 
-Varnish **$NEXT_RELEASE**
--------------------------
-
-**Note: These are working documents for a future release, with running
-updates for changes in the development branch. For changes in the
-released versions of Varnish, see the chapters listed below.**
+Varnish 7.3
+-----------
 
 .. toctree::
    :maxdepth: 2
 
-   changes-trunk
-   upgrading-trunk
+   changes-7.3
+   upgrading-7.3
 
 Varnish **7.2**
 ---------------

--- a/doc/sphinx/whats-new/upgrading-7.3.rst
+++ b/doc/sphinx/whats-new/upgrading-7.3.rst
@@ -1,34 +1,8 @@
-**Note: This is a working document for a future release, with running
-updates for changes in the development branch. For changes in the
-released versions of Varnish, see:** :ref:`whats-new-index`
+.. _whatsnew_upgrading_7.3:
 
-.. _whatsnew_upgrading_CURRENT:
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Upgrading to Varnish **$NEXT_RELEASE**
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-**XXX: how to upgrade from previous deployments to this
-version. Limited to work that has to be done for an upgrade, new
-features are listed in "Changes". Explicitly mention what does *not*
-have to be changed, especially in VCL. May include, but is not limited
-to:**
-
-* Elements of VCL that have been removed or are deprecated, or whose
-  semantics have changed.
-
-* -p parameters that have been removed or are deprecated, or whose
-  semantics have changed.
-
-* Changes in the CLI.
-
-* Changes in the output or interpretation of stats or the log, including
-  changes affecting varnishncsa/-hist/-top.
-
-* Changes that may be necessary in VTCs or in the use of varnishtest.
-
-* Changes in public APIs that may require changes in VMODs or VAPI/VUT
-  clients.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Upgrading to Varnish **7.3**
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 New VSL format
 ==============

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -46,7 +46,7 @@
 #  error "include vdef.h before vrt.h"
 #endif
 
-#define VRT_MAJOR_VERSION	16U
+#define VRT_MAJOR_VERSION	17U
 
 #define VRT_MINOR_VERSION	0U
 
@@ -57,7 +57,7 @@
  * Whenever something is deleted or changed in a way which is not
  * binary/load-time compatible, increment MAJOR version
  *
- * NEXT (2023-03-15)
+ * 17.0 (2023-03-15)
  *	VXID is 64 bit
  *	[cache.h] http_GetRange() changed
  *	exp_close added to struct vrt_backend_probe

--- a/lib/libvarnish/version.c
+++ b/lib/libvarnish/version.c
@@ -76,7 +76,7 @@ VCS_String(const char *which)
 		    ")"
 		    "\n"
 		    "Copyright (c) 2006 Verdens Gang AS\n"
-		    "Copyright (c) 2006-2022 Varnish Software\n"
+		    "Copyright (c) 2006-2023 Varnish Software\n"
 		);
 	default:
 		WRONG("Wrong argument to VCS_String");


### PR DESCRIPTION
Reviewers must check the following items:

- [ ] Release notes are complete (major release only)
- [ ] Release notes no longer target trunk (major release only)
- [ ] The change log is populated
- [ ] The VRT history in `include/vrt.h` is populated
- [ ] The VRT history refers to the next VRT version
- [ ] The macro `VRT_MAJOR_VERSION` was updated if applicable
- [ ] The macro `VRT_MINOR_VERSION` was updated if applicable
- [ ] The new VRT version follows releases guidelines
- [ ] The new VRT version matches the one from the VRT history
- [ ] Bundled `devicedetect.vcl` was updated (major release only)
- [ ] Running `./autogen.des && make distcheck` succeeds
- [ ] The version in `configure.ac` is correct
- [ ] The copyright notice in `configure.ac` covers the current year
- [ ] The copyright output in `lib/libvarnish/version.c` covers the current year
- [ ] There are no other changes than the ones listed above
