### PR TITLE
build: Centralize suffix .c.vsc make rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ EXTRA_DIST = \
 	varnishapi.pc.in \
 	varnish.m4 \
 	varnish-legacy.m4 \
+	vsc.am \
 	vtc.am \
 	wflags.py
 

--- a/configure.ac
+++ b/configure.ac
@@ -645,6 +645,7 @@ AC_SUBST(pkgsysconfdir)
 # VMOD variables
 AC_SUBST(vmoddir, [$\(pkglibdir\)/vmods])
 AC_SUBST(VMODTOOL, [$\(top_srcdir\)/lib/libvcc/vmodtool.py])
+AC_SUBST(VSCTOOL, [$\(top_srcdir\)/lib/libvsc/vsctool.py])
 
 # Check for linker script support
 gl_LD_VERSION_SCRIPT

--- a/configure.ac
+++ b/configure.ac
@@ -644,7 +644,7 @@ AC_SUBST(pkgsysconfdir)
 
 # VMOD variables
 AC_SUBST(vmoddir, [$\(pkglibdir\)/vmods])
-AC_SUBST(vmodtool, [$\(top_srcdir\)/lib/libvcc/vmodtool.py])
+AC_SUBST(VMODTOOL, [$\(top_srcdir\)/lib/libvcc/vmodtool.py])
 
 # Check for linker script support
 gl_LD_VERSION_SCRIPT

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -78,8 +78,8 @@ PFX.h vmod_XXX.rst vmod_XXX.man.rst: PFX.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-PFX.c: $(vmodtool) $(srcdir)/VCC
-\t@PYTHON@ $(vmodtool) $(vmodtoolargs_XXX) $(srcdir)/VCC
+PFX.c: $(VMODTOOL) $(srcdir)/VCC
+\t@PYTHON@ $(VMODTOOL) $(vmodtoolargs_XXX) $(srcdir)/VCC
 \ttouch PFX.c
 
 clean-local: clean-vmod-XXX

--- a/lib/libvsc/Makefile.am
+++ b/lib/libvsc/Makefile.am
@@ -1,5 +1,7 @@
 #
 
+include $(top_srcdir)/vsc.am
+
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_builddir)/include
@@ -14,19 +16,7 @@ VSC_SRC = \
 	VSC_smu.vsc \
 	VSC_vbe.vsc
 
-VSC_GEN_C	= $(VSC_SRC:.vsc=.c)
-VSC_GEN_H	= $(VSC_SRC:.vsc=.h)
-
-$(VSC_GEN_C): vsctool.py
-
-.vsc.c:
-	$(PYTHON) $(srcdir)/vsctool.py -ch $<
-
 noinst_LTLIBRARIES = libvsc.la
 libvsc_la_SOURCES = $(VSC_SRC)
 
-dist_pkgdata_SCRIPTS = \
-	vsctool.py
-
-BUILT_SOURCES	= $(VSC_GEN_C)
-CLEANFILES	= $(VSC_GEN_C) $(VSC_GEN_H)
+dist_pkgdata_SCRIPTS = vsctool.py

--- a/vmod/Makefile.am
+++ b/vmod/Makefile.am
@@ -2,6 +2,7 @@
 
 TESTS = @VMOD_TESTS@
 
+include $(top_srcdir)/vsc.am
 include $(top_srcdir)/vtc.am
 
 EXTRA_DIST = $(TESTS)
@@ -33,18 +34,9 @@ include $(srcdir)/automake_boilerplate_vtc.am
 # Post-boilerplate tweaks
 #
 
-.vsc.c: $(top_srcdir)/lib/libvsc/vsctool.py
-	$(PYTHON) $(top_srcdir)/lib/libvsc/vsctool.py -c $<
+VSC_SRC = VSC_debug.vsc
 
-.vsc.h: $(top_srcdir)/lib/libvsc/vsctool.py
-	$(PYTHON) $(top_srcdir)/lib/libvsc/vsctool.py -h $<
-
-EXTRA_DIST += VSC_debug.vsc
-nodist_libvmod_debug_la_SOURCES += \
-	VSC_debug.c \
-	VSC_debug.h
-
-vmod_debug.c: VSC_debug.c VSC_debug.h
+libvmod_debug_la_SOURCES += $(VSC_SRC)
 
 # Allow Vmod_wrong*_Data to be exported
 vmod_debug_symbols_regex = 'Vmod_.*_Data'

--- a/vmod/automake_boilerplate_blob.am
+++ b/vmod/automake_boilerplate_blob.am
@@ -34,8 +34,8 @@ vcc_blob_if.h vmod_blob.rst vmod_blob.man.rst: vcc_blob_if.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-vcc_blob_if.c: $(vmodtool) $(srcdir)/vmod_blob.vcc
-	@PYTHON@ $(vmodtool) $(vmodtoolargs_blob) $(srcdir)/vmod_blob.vcc
+vcc_blob_if.c: $(VMODTOOL) $(srcdir)/vmod_blob.vcc
+	@PYTHON@ $(VMODTOOL) $(vmodtoolargs_blob) $(srcdir)/vmod_blob.vcc
 	touch vcc_blob_if.c
 
 clean-local: clean-vmod-blob

--- a/vmod/automake_boilerplate_cookie.am
+++ b/vmod/automake_boilerplate_cookie.am
@@ -27,8 +27,8 @@ vcc_cookie_if.h vmod_cookie.rst vmod_cookie.man.rst: vcc_cookie_if.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-vcc_cookie_if.c: $(vmodtool) $(srcdir)/vmod_cookie.vcc
-	@PYTHON@ $(vmodtool) $(vmodtoolargs_cookie) $(srcdir)/vmod_cookie.vcc
+vcc_cookie_if.c: $(VMODTOOL) $(srcdir)/vmod_cookie.vcc
+	@PYTHON@ $(VMODTOOL) $(vmodtoolargs_cookie) $(srcdir)/vmod_cookie.vcc
 	touch vcc_cookie_if.c
 
 clean-local: clean-vmod-cookie

--- a/vmod/automake_boilerplate_debug.am
+++ b/vmod/automake_boilerplate_debug.am
@@ -30,8 +30,8 @@ vcc_debug_if.h vmod_debug.rst vmod_debug.man.rst: vcc_debug_if.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-vcc_debug_if.c: $(vmodtool) $(srcdir)/vmod_debug.vcc
-	@PYTHON@ $(vmodtool) $(vmodtoolargs_debug) $(srcdir)/vmod_debug.vcc
+vcc_debug_if.c: $(VMODTOOL) $(srcdir)/vmod_debug.vcc
+	@PYTHON@ $(VMODTOOL) $(vmodtoolargs_debug) $(srcdir)/vmod_debug.vcc
 	touch vcc_debug_if.c
 
 clean-local: clean-vmod-debug

--- a/vmod/automake_boilerplate_directors.am
+++ b/vmod/automake_boilerplate_directors.am
@@ -37,8 +37,8 @@ vcc_directors_if.h vmod_directors.rst vmod_directors.man.rst: vcc_directors_if.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-vcc_directors_if.c: $(vmodtool) $(srcdir)/vmod_directors.vcc
-	@PYTHON@ $(vmodtool) $(vmodtoolargs_directors) $(srcdir)/vmod_directors.vcc
+vcc_directors_if.c: $(VMODTOOL) $(srcdir)/vmod_directors.vcc
+	@PYTHON@ $(VMODTOOL) $(vmodtoolargs_directors) $(srcdir)/vmod_directors.vcc
 	touch vcc_directors_if.c
 
 clean-local: clean-vmod-directors

--- a/vmod/automake_boilerplate_proxy.am
+++ b/vmod/automake_boilerplate_proxy.am
@@ -27,8 +27,8 @@ vcc_proxy_if.h vmod_proxy.rst vmod_proxy.man.rst: vcc_proxy_if.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-vcc_proxy_if.c: $(vmodtool) $(srcdir)/vmod_proxy.vcc
-	@PYTHON@ $(vmodtool) $(vmodtoolargs_proxy) $(srcdir)/vmod_proxy.vcc
+vcc_proxy_if.c: $(VMODTOOL) $(srcdir)/vmod_proxy.vcc
+	@PYTHON@ $(VMODTOOL) $(vmodtoolargs_proxy) $(srcdir)/vmod_proxy.vcc
 	touch vcc_proxy_if.c
 
 clean-local: clean-vmod-proxy

--- a/vmod/automake_boilerplate_purge.am
+++ b/vmod/automake_boilerplate_purge.am
@@ -27,8 +27,8 @@ vcc_purge_if.h vmod_purge.rst vmod_purge.man.rst: vcc_purge_if.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-vcc_purge_if.c: $(vmodtool) $(srcdir)/vmod_purge.vcc
-	@PYTHON@ $(vmodtool) $(vmodtoolargs_purge) $(srcdir)/vmod_purge.vcc
+vcc_purge_if.c: $(VMODTOOL) $(srcdir)/vmod_purge.vcc
+	@PYTHON@ $(VMODTOOL) $(vmodtoolargs_purge) $(srcdir)/vmod_purge.vcc
 	touch vcc_purge_if.c
 
 clean-local: clean-vmod-purge

--- a/vmod/automake_boilerplate_std.am
+++ b/vmod/automake_boilerplate_std.am
@@ -30,8 +30,8 @@ vcc_std_if.h vmod_std.rst vmod_std.man.rst: vcc_std_if.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-vcc_std_if.c: $(vmodtool) $(srcdir)/vmod_std.vcc
-	@PYTHON@ $(vmodtool) $(vmodtoolargs_std) $(srcdir)/vmod_std.vcc
+vcc_std_if.c: $(VMODTOOL) $(srcdir)/vmod_std.vcc
+	@PYTHON@ $(VMODTOOL) $(vmodtoolargs_std) $(srcdir)/vmod_std.vcc
 	touch vcc_std_if.c
 
 clean-local: clean-vmod-std

--- a/vmod/automake_boilerplate_unix.am
+++ b/vmod/automake_boilerplate_unix.am
@@ -28,8 +28,8 @@ vcc_unix_if.h vmod_unix.rst vmod_unix.man.rst: vcc_unix_if.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-vcc_unix_if.c: $(vmodtool) $(srcdir)/vmod_unix.vcc
-	@PYTHON@ $(vmodtool) $(vmodtoolargs_unix) $(srcdir)/vmod_unix.vcc
+vcc_unix_if.c: $(VMODTOOL) $(srcdir)/vmod_unix.vcc
+	@PYTHON@ $(VMODTOOL) $(vmodtoolargs_unix) $(srcdir)/vmod_unix.vcc
 	touch vcc_unix_if.c
 
 clean-local: clean-vmod-unix

--- a/vmod/automake_boilerplate_vtc.am
+++ b/vmod/automake_boilerplate_vtc.am
@@ -27,8 +27,8 @@ vcc_vtc_if.h vmod_vtc.rst vmod_vtc.man.rst: vcc_vtc_if.c
 
 # A doc-change will not update mtime on the .h and .c files, so a
 # touch(1) is necessary to signal that vmodtool was in fact run.
-vcc_vtc_if.c: $(vmodtool) $(srcdir)/vmod_vtc.vcc
-	@PYTHON@ $(vmodtool) $(vmodtoolargs_vtc) $(srcdir)/vmod_vtc.vcc
+vcc_vtc_if.c: $(VMODTOOL) $(srcdir)/vmod_vtc.vcc
+	@PYTHON@ $(VMODTOOL) $(vmodtoolargs_vtc) $(srcdir)/vmod_vtc.vcc
 	touch vcc_vtc_if.c
 
 clean-local: clean-vmod-vtc

--- a/vsc.am
+++ b/vsc.am
@@ -1,0 +1,14 @@
+# Generic rule to generate C code from VSC files. VSC files must be listed
+# in the $(VSC_SRC) variable.
+
+VSC_GEN = $(VSC_SRC:.vsc=.c) $(VSC_SRC:.vsc=.h)
+
+$(VSC_GEN): $(top_srcdir)/lib/libvsc/vsctool.py
+
+.vsc.c:
+	$(AM_V_GEN) $(PYTHON) $(top_srcdir)/lib/libvsc/vsctool.py -ch $<
+
+clean-local: vsc-clean
+
+vsc-clean:
+	rm -f $(VSC_GEN)

--- a/vsc.am
+++ b/vsc.am
@@ -1,12 +1,13 @@
 # Generic rule to generate C code from VSC files. VSC files must be listed
-# in the $(VSC_SRC) variable.
+# in the $(VSC_SRC) variable. The $(VSCTOOL) variable must point to the
+# location of vsctool.py, normally set up by varnish.m4 at configure time.
 
 VSC_GEN = $(VSC_SRC:.vsc=.c) $(VSC_SRC:.vsc=.h)
 
-$(VSC_GEN): $(top_srcdir)/lib/libvsc/vsctool.py
+$(VSC_GEN): $(VSCTOOL)
 
 .vsc.c:
-	$(AM_V_GEN) $(PYTHON) $(top_srcdir)/lib/libvsc/vsctool.py -ch $<
+	$(AM_V_GEN) $(PYTHON) $(VSCTOOL) -ch $<
 
 clean-local: vsc-clean
 

--- a/vtc.am
+++ b/vtc.am
@@ -11,7 +11,7 @@
 VTC_LOG_COMPILER = $(top_builddir)/bin/varnishtest/varnishtest -v -i
 TEST_EXTENSIONS = .vtc
 
-check-am: vtc-check-tests
+check-local: vtc-check-tests
 
 vtc-check-tests:
 	@mkdir -p tests ; \


### PR DESCRIPTION
The new vsc.am file takes care of most of the logic, and include sites only need to reference sources as such.