### PR TITLE
Add a private pointer to struct vdp

### DIFF
--- a/bin/varnishd/cache/cache_filter.h
+++ b/bin/varnishd/cache/cache_filter.h
@@ -122,6 +122,7 @@ struct vdp {
 	vdp_init_f		*init;
 	vdp_bytes_f		*bytes;
 	vdp_fini_f		*fini;
+	const void		*priv1;
 };
 
 struct vdp_entry {

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -58,6 +58,7 @@
  * binary/load-time compatible, increment MAJOR version
  *
  * NEXT (2023-09-15)
+ *	[cache_filter.h] struct vdp gained priv1 member
  * 17.0 (2023-03-15)
  *	VXID is 64 bit
  *	[cache.h] http_GetRange() changed


### PR DESCRIPTION
to facilitate custom filter parametrization:

VMOD filters are likely to use the same init/bytes/fini callbacks for many vcl objects, which differ only in their parameters. It would be helpful to have a place to stash a per VCL private pointer.