### PR TITLE
bereq: Also unset a cached req body

### DIFF
--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 
 #include "cache_varnishd.h"
+#include "cache_objhead.h"
 #include "cache_transport.h"
 #include "common/heritage.h"
 
@@ -595,6 +596,11 @@ VRT_u_bereq_body(VRT_CTX)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+	if (ctx->bo->bereq_body != NULL) {
+		HSH_DerefObjCore(ctx->bo->wrk, &ctx->bo->bereq_body, 0);
+		http_Unset(ctx->bo->bereq, H_Content_Length);
+	}
+
 	if (ctx->bo->req != NULL) {
 		CHECK_OBJ(ctx->bo->req, REQ_MAGIC);
 		ctx->bo->req = NULL;

--- a/bin/varnishtest/tests/v00068.vtc
+++ b/bin/varnishtest/tests/v00068.vtc
@@ -1,0 +1,33 @@
+varnishtest "unset bereq.body with cached req body"
+
+server s1 {
+	rxreq
+	expect req.method == "GET"
+	expect req.http.Content-Length == <undef>
+	txresp
+
+	rxreq
+	expect req.method == "GET"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_recv {
+		std.cache_req_body(2KB);
+	}
+	sub vcl_backend_fetch {
+		unset bereq.body;
+	}
+} -start
+
+client c1 {
+	txreq -body "fine"
+	rxresp
+	expect resp.status == 200
+
+	txreq
+	rxresp
+	expect resp.status == 200
+} -run


### PR DESCRIPTION
From an Enterprise ticket, trying to unset a cached request body currently accomplishes nothing.

The body can be sent after the first request (without Content-Length), and the body bytes become a part of the next request.