### PR TITLE
Vip4: add $Restrict in vcc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ cscope.*out
 /include/vmod_abi.h
 /include/tbl/vcl_returns.h
 /include/tbl/vrt_stv_var.h
+/include/tbl/vcl_context.h
 /include/vcs_version.h
 /lib/libvcc/vcc_fixed_token.c
 /lib/libvcc/vcc_obj.c

--- a/bin/varnishtest/tests/b00016.vtc
+++ b/bin/varnishtest/tests/b00016.vtc
@@ -9,9 +9,6 @@ varnish v1 -vcl+backend {
 	import directors;
 
 	sub vcl_recv {
-		if (req.url == "/lookup") {
-			set req.http.foo = directors.lookup("s1");
-		}
 		return (pass);
 	}
 
@@ -24,10 +21,6 @@ client c1 {
 	txreq -url "/"
 	rxresp
 	expect resp.http.X-Backend-Name == "s1"
-	txreq -url "/lookup"
-	rxresp
-	expect resp.status == 503
-	expect resp.reason == "VCL failed"
 } -run
 
 varnish v1 -vcl+backend {
@@ -55,3 +48,17 @@ client c1 {
 	expect resp.http.X-Director-Name == "bar"
 	expect resp.http.X-Backend-Name == "s1"
 } -run
+
+varnish v1 -errvcl "Not available in subroutine 'vcl_recv'" {
+	import directors;
+
+	backend dummy None;
+
+	sub vcl_recv {
+		if (req.url == "/lookup") {
+			set req.http.foo = directors.lookup("s1");
+		}
+		return (pass);
+	}
+
+}

--- a/bin/varnishtest/tests/c00055.vtc
+++ b/bin/varnishtest/tests/c00055.vtc
@@ -17,9 +17,7 @@ varnish v1 -vcl+backend {
 	import std;
 
 	sub vcl_recv {
-		if (req.url != "/wrong-sub") {
-			set req.http.stored = std.cache_req_body(1KB);
-		}
+		set req.http.stored = std.cache_req_body(1KB);
 		return (pass);
 	}
 
@@ -30,15 +28,6 @@ varnish v1 -vcl+backend {
 		set resp.http.stored = req.http.stored;
 	}
 
-	sub vcl_backend_fetch {
-		if (bereq.url == "/wrong-sub") {
-			if (std.cache_req_body(1KB)) {
-				return (error(200));
-			} else {
-				return (error(503));
-			}
-		}
-	}
 } -start
 
 varnish v1 -cliok "param.set debug +syncvsl"
@@ -63,13 +52,6 @@ client c2 {
 
 logexpect l1 -wait
 
-# wrong calling context
-client c3 {
-	txreq -url "/wrong-sub"
-	rxresp
-	expect resp.status == 503
-} -run
-
 delay .1
 
 varnish v1 -expect MGT.child_died == 0
@@ -92,13 +74,3 @@ client c5 {
 	txreq -req POST -hdr "Content-Length: 1025"
 	expect_close
 } -run
-
-varnish v1 -errvcl {req.body can only be cached in vcl_recv} {
-	import std;
-	backend none none;
-	sub vcl_init {
-		if (! std.cache_req_body(1KB)) {
-			return (fail);
-		}
-	}
-}

--- a/bin/varnishtest/tests/m00055.vtc
+++ b/bin/varnishtest/tests/m00055.vtc
@@ -1,0 +1,59 @@
+varnishtest "Test $Restrict scope"
+
+feature topbuild
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+
+varnish v1 -arg "-pvmod_path=${tmpdir}" -vcl+backend {} -start
+
+
+filewrite ${tmpdir}/libvmod_wrong.so "VMOD_JSON_SPEC\x02"
+filewrite -a ${tmpdir}/libvmod_wrong.so {
+[
+	[
+	    "$VMOD",
+	    "1.0",
+	    "wrong",
+	    "Vmod_vmod_wrong_Func",
+	    "0000000000000000000000000000000000000000000000000000000000000000",
+	    "0000000000000000000000000000000000000000000000000000000000000000",
+	    "17",
+	    "0"
+	],
+	[
+	    "$CPROTO",
+	    "struct Vmod_vmod_wrong_Func {",
+	    "",
+	    "}"
+	],
+	[
+	    "$FUNC",
+	    "test",
+	    [
+			[
+				"VOID"
+			],
+	    "Vmod_vmod_wrong_Func.test",
+	    ""
+	    ]
+	],
+	[
+	    "$RESTRICT",
+	    [
+			"vcl_recv",
+			"foo",
+			"deliver"
+	    ]
+	]
+]
+}
+
+filewrite -a ${tmpdir}/libvmod_wrong.so "\x03"
+
+varnish v1 -errvcl {invalid scope for $Restrict: foo} { import wrong; }
+
+shell "rm -f ${tmpdir}/libvmod_wrong.so ${tmpdir}wrong.vcl"

--- a/bin/varnishtest/tests/r02339.vtc
+++ b/bin/varnishtest/tests/r02339.vtc
@@ -9,46 +9,12 @@ varnish v1 -cliok "param.set thread_pools 1"
 varnish v1 -cliok "param.set vsl_mask +ExpKill"
 varnish v1 -vcl+backend {
 	import purge;
-	import vtc;
 
-	sub vcl_recv {
-		if (req.url == "recv") { purge.hard(); }
-		if (req.url == "pass") { return (pass); }
-		if (req.url == "purge") { return (purge); }
-		if (req.url == "synth") { return (synth(200)); }
-	}
-	sub vcl_hash {
-		if (req.url == "hash") { purge.hard(); }
-	}
 	sub vcl_miss {
 		if (req.url == "miss") { purge.hard(); }
 	}
 	sub vcl_hit {
 		if (req.url == "hit") { purge.hard(); }
-	}
-	sub vcl_purge {
-		if (req.url == "purge") { purge.hard(); }
-	}
-	sub vcl_pass {
-		if (req.url == "pass") { purge.hard(); }
-	}
-	sub vcl_deliver {
-		if (req.url == "deliver") { purge.hard(); }
-	}
-	sub vcl_synth {
-		if (req.url == "synth") { purge.hard(); }
-	}
-	sub vcl_backend_fetch {
-		if (bereq.url == "fetch") { purge.hard(); }
-		if (bereq.url == "error") {
-			set bereq.backend = vtc.no_backend();
-		}
-	}
-	sub vcl_backend_error {
-		if (bereq.url == "error") { purge.hard(); }
-	}
-	sub vcl_backend_response {
-		if (bereq.url == "response") { purge.hard(); }
 	}
 } -start
 
@@ -70,34 +36,6 @@ logexpect l1 -v v1 {
 	expect * 1004	VCL_call	MISS
 	expect 0 =	VCL_return	fetch
 
-	expect * 1007	VCL_call	RECV
-	expect 0 =	VCL_Error	purge
-	expect 0 =	VCL_return	fail
-
-	expect * 1009	VCL_call	HASH
-	expect 0 =	VCL_Error	purge
-	expect 0 =	VCL_return	fail
-
-	expect * 1011	VCL_call	PURGE
-	expect 0 =	VCL_Error	purge
-
-	expect * 1013	VCL_call	PASS
-	expect 0 =	VCL_Error	purge
-
-	expect * 1015	VCL_call	DELIVER
-	expect 0 =	VCL_Error	purge
-
-	expect * 1018	VCL_call	SYNTH
-	expect 0 =	VCL_Error	purge
-
-	expect * 1021	VCL_call	BACKEND_FETCH
-	expect 0 =	VCL_Error	purge
-
-	expect * 1024	VCL_call	BACKEND_ERROR
-	expect 0 =	VCL_Error	purge
-
-	expect * 1027	VCL_call	BACKEND_RESPONSE
-	expect 0 =	VCL_Error	purge
 } -start
 
 client c1 {
@@ -117,67 +55,58 @@ client c1 {
 logexpect l0 -wait
 logexpect l2 -wait
 
-client c1 {
-	txreq -url recv
-	rxresp
-	expect resp.status == 503
-	expect_close
-} -run
+varnish v1 -errvcl "Not available in subroutine 'vcl_purge'" {
+	import purge;
 
-client c1 {
-	txreq -url hash
-	rxresp
-	expect resp.status == 503
-	expect_close
-} -run
+	sub vcl_purge {
+		if (req.url == "purge") { purge.hard(); }
+	}
+}
 
-client c1 {
-	txreq -url purge
-	rxresp
-	expect resp.status == 503
-	expect_close
-} -run
+varnish v1 -errvcl "Not available in subroutine 'vcl_pass'" {
+	import purge;
 
-client c1 {
-	txreq -url pass
-	rxresp
-	expect resp.status == 503
-	expect_close
-} -run
+	sub vcl_pass {
+		if (req.url == "pass") { purge.hard(); }
+	}
+}
 
-client c1 {
-	txreq -url deliver
-	rxresp
-	expect resp.status == 503
-	expect_close
-} -run
+varnish v1 -errvcl "Not available in subroutine 'vcl_deliver'" {
+	import purge;
 
-client c1 {
-	txreq -url synth
-	rxresp
-	expect resp.status == 500
-	expect_close
-} -run
+	sub vcl_deliver {
+		if (req.url == "deliver") { purge.hard(); }
+	}
+}
 
-client c1 {
-	txreq -url fetch
-	rxresp
-	expect resp.status == 503
-	expect_close
-} -run
+varnish v1 -errvcl "Not available in subroutine 'vcl_synth'" {
+	import purge;
 
-client c1 {
-	txreq -url error
-	rxresp
-	expect resp.status == 503
-	expect_close
-} -run
+	sub vcl_synth {
+		if (req.url == "synth") { purge.hard(); }
+	}
+}
 
-client c1 {
-	txreq -url response
-	rxresp
-	expect resp.status == 503
-	expect_close
-} -run
+varnish v1 -errvcl "Not available in subroutine 'vcl_backend_fetch'" {
+	import purge;
 
-logexpect l1 -wait
+	sub vcl_backend_fetch {
+		if (bereq.url == "fetch") { purge.hard(); }
+	}
+}
+
+varnish v1 -errvcl "Not available in subroutine 'vcl_backend_error'" {
+	import purge;
+
+	sub vcl_backend_error {
+		if (bereq.url == "error") { purge.hard(); }
+	}
+}
+
+varnish v1 -errvcl "Not available in subroutine 'vcl_backend_response'" {
+	import purge;
+
+	sub vcl_backend_response {
+		if (bereq.url == "response") { purge.hard(); }
+	}
+}

--- a/bin/varnishtest/tests/v00043.vtc
+++ b/bin/varnishtest/tests/v00043.vtc
@@ -98,10 +98,7 @@ varnish v1 -cliok "param.set debug +syncvsl" -vcl+backend {
 	}
 
 	sub vcl_backend_fetch {
-		if (bereq.url == "/fail") {
-			# dynamic priv not checked at compile time
-			o2.test_priv_top("only works on client side");
-		}
+
 	}
 
 	sub vcl_backend_response {
@@ -126,8 +123,3 @@ client c1 {
 
 varnish v1 -expect client_req == 2
 
-client c2 {
-	txreq -url /fail
-	rxresp
-	expect resp.status == 503
-} -run

--- a/bin/varnishtest/tests/v00051.vtc
+++ b/bin/varnishtest/tests/v00051.vtc
@@ -538,3 +538,30 @@ logexpect l1 -v v1 -g raw {
 
 varnish v1 -cliok "vcl.discard vcl10"
 logexpect l1 -wait
+
+#######################################################################
+# Fail vcl - debug.client_ip function restricted to client and backend
+
+varnish v1 -errvcl {Not available in subroutine 'vcl_init'} {
+	import debug;
+
+	sub vcl_init {
+		debug.client_ip();
+    }
+}
+
+#######################################################################
+# Fail vcl - obj.test_priv_top method restricted to client
+
+varnish v1 -errvcl {Not available in subroutine 'vcl_backend_response'} {
+	import debug;
+
+	sub vcl_init {
+		new test_obj = debug.obj("bar");
+	}
+
+	sub vcl_backend_response {
+		set beresp.http.foo = test_obj.test_priv_top();
+	}
+}
+

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -264,6 +264,19 @@ managing instances, in particular their memory management. As the
 lifetime of object instances is the vcl, they will usually be
 allocated from the heap.
 
+Functions and Methods scope restriction
+---------------------------------------
+
+The ``$Restrict`` stanza offers a way to limit the scope of the preceding vmod function
+or method, so that they can only be called from restricted vcl call sites.
+It must only appear after a ``$Method`` or ``$Function`` and has the following syntax::
+
+    $Restrict scope1 [scope2 ...]
+
+Possible scope values are:
+backend, client, housekeeping, recv, pipe, pass, hash, purge, miss, hit,
+deliver, synth, backend_fetch, backend_response, backend_error, init, fini
+
 Deprecated Aliases
 ------------------
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -35,6 +35,7 @@ nobase_pkginclude_HEADERS = \
 	tbl/symbol_kind.h \
 	tbl/vcc_feature_bits.h \
 	tbl/vcl_returns.h \
+	tbl/vcl_context.h \
 	tbl/vcl_states.h \
 	tbl/vhd_fsm.h \
 	tbl/vhd_fsm_funcs.h \

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -708,6 +708,20 @@ fo.close()
 
 #######################################################################
 
+fo = open(join(buildroot, "include/tbl/vcl_context.h"), "w")
+file_header(fo)
+
+for i in returns:
+    fo.write("\nVCL_CTX(vcl_%s,%s)" % (i[0],i[0].upper()))
+fo.write("\nVCL_CTX(backend, TASK_B)")
+fo.write("\nVCL_CTX(client, TASK_C)")
+fo.write("\nVCL_CTX(housekeeping, TASK_H)")
+fo.write("\n")
+fo.write("\n#undef VCL_CTX")
+fo.write("\n")
+fo.close()
+
+#######################################################################
 
 def restrict(fo, spec):
     d = dict()

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -547,6 +547,7 @@ vcc_ParseImport(struct vcc *tl)
 			msym->import = vsym->import;
 			msym->vmod_name = vsym->vmod_name;
 			vcc_VmodSymbols(tl, msym);
+			AZ(tl->err);
 			// XXX: insert msym in sideways ?
 			vcc_vim_destroy(&vim);
 			return;
@@ -559,6 +560,7 @@ vcc_ParseImport(struct vcc *tl)
 	msym->import = vim;
 	msym->vmod_name = TlDup(tl, vim->name);
 	vcc_VmodSymbols(tl, msym);
+	ERRCHK(tl);
 
 	vcc_emit_setup(tl, vim);
 }

--- a/lib/libvcc/vcc_vmod.h
+++ b/lib/libvcc/vcc_vmod.h
@@ -35,6 +35,7 @@
 	STANZA(FUNC, func, SYM_FUNC) \
 	STANZA(METHOD, method, SYM_METHOD) \
 	STANZA(OBJ, obj, SYM_OBJECT) \
-	STANZA(VMOD, vmod, SYM_NONE)
+	STANZA(VMOD, vmod, SYM_NONE) \
+	STANZA(RESTRICT, restrict, SYM_NONE)
 
 void vcc_VmodSymbols(struct vcc *tl, const struct symbol *sym);

--- a/vmod/tests/directors_c00015.vtc
+++ b/vmod/tests/directors_c00015.vtc
@@ -16,8 +16,6 @@ varnish v1 -vcl {
 	if (req.url == "/1") {
 	    set req.backend_hint = shard.backend(
 	      param=blob.decode(HEX, encoded=""));
-	} else if (req.url == "/2") {
-	    p.set(by=HASH);
 	}
     }
 } -start
@@ -30,9 +28,6 @@ logexpect l1 -v v1 -g raw -d 1 {
 logexpect l2 -v v1 -g raw {
     expect * 1001 VCL_Error {vmod_directors: shard shard: .backend.key_blob. param invalid}
 } -start
-logexpect l3 -v v1 -g raw {
-    expect * 1003 VCL_Error {vmod_directors: shard p: shard_param.set.. may only be used in vcl_init and in backend/pipe context}
-} -start
 
 client c1 {
     txreq -url "/1"
@@ -41,15 +36,8 @@ client c1 {
     expect_close
 } -run
 
-client c1 {
-    txreq -url "/2"
-    rxresp
-    expect resp.status == 503
-    expect_close
-} -run
 
 logexpect l2 -wait
-logexpect l3 -wait
 
 varnish v1 -errvcl {shard .associate param invalid} {
     import directors;
@@ -204,5 +192,24 @@ varnish v1 -errvcl {vmod_directors: shard shard: .remove_backend(): either backe
     sub vcl_init {
 	new shard = directors.shard();
 	shard.remove_backend();
+    }
+}
+
+varnish v1 -errvcl "Not available in subroutine 'vcl_recv'" {
+    import directors;
+    import blob;
+
+    backend dummy None;
+
+    sub vcl_init {
+        new shard = directors.shard();
+	    new p = directors.shard_param();
+	    p.set(by=BLOB, key_blob=blob.decode(HEX, encoded=""));
+    }
+
+    sub vcl_recv {
+	    if (req.url == "/2") {
+	        p.set(by=HASH);
+	    }
     }
 }

--- a/vmod/tests/std_c00001.vtc
+++ b/vmod/tests/std_c00001.vtc
@@ -358,7 +358,7 @@ varnish v1 -errvcl {Not available in subroutine 'vcl_pipe'} {
 # We would want to remove req from vcl_pipe, but that could break
 # vmods, so we fail specifically at runtime
 
-varnish v1 -vcl {
+varnish v1 -errvcl {Not available in subroutine 'vcl_pipe'} {
 	import std;
 
 	backend proforma None;
@@ -371,9 +371,3 @@ varnish v1 -vcl {
 	}
 }
 
-client c7 {
-	txreq -url /
-	rxresp
-	expect resp.status == 503
-	expect resp.reason == "VCL failed"
-} -run

--- a/vmod/tests/unix_c00000.vtc
+++ b/vmod/tests/unix_c00000.vtc
@@ -58,7 +58,7 @@ logexpect l1 -v v1 -d 1 -c {
 } -run
 
 
-varnish v1 -errvcl {vmod unix failure: may not be called in vcl_init or vcl_fini} {
+varnish v1 -errvcl {Not available in subroutine 'vcl_init'} {
 	import unix;
 	import std;
 	backend b None;
@@ -68,7 +68,7 @@ varnish v1 -errvcl {vmod unix failure: may not be called in vcl_init or vcl_fini
 	}
 }
 
-varnish v1 -errvcl {vmod unix failure: may not be called in vcl_init or vcl_fini} {
+varnish v1 -errvcl {Not available in subroutine 'vcl_init'} {
 	import unix;
 	import std;
 	backend b None;
@@ -78,7 +78,7 @@ varnish v1 -errvcl {vmod unix failure: may not be called in vcl_init or vcl_fini
 	}
 }
 
-varnish v1 -errvcl {vmod unix failure: may not be called in vcl_init or vcl_fini} {
+varnish v1 -errvcl {Not available in subroutine 'vcl_init'} {
 	import unix;
 	import std;
 	backend b None;
@@ -88,7 +88,7 @@ varnish v1 -errvcl {vmod unix failure: may not be called in vcl_init or vcl_fini
 	}
 }
 
-varnish v1 -errvcl {vmod unix failure: may not be called in vcl_init or vcl_fini} {
+varnish v1 -errvcl {Not available in subroutine 'vcl_init'} {
 	import unix;
 	import std;
 	backend b None;

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -123,6 +123,8 @@ $Method STRING .test_priv_top(STRING s="")
 
 Test per-object priv_top via VRT_priv_top()
 
+$Restrict client
+
 $Function VOID rot104()
 
 Try to register the rot52 filter again. This should always fail
@@ -285,6 +287,8 @@ $Function VOID catflap(ENUM {miss, first, last} type)
 
 Test the HSH_Lookup catflap
 
+$Restrict client
+
 $Function BYTES stk()
 
 Return an approximation of the amount of stack used.
@@ -293,6 +297,8 @@ This function is by no means guaranteed to work cross platform and
 should now only be used for diagnostic purposes.
 
 0B is returned if no sensible value can be determined.
+
+$Restrict client
 
 $Function VOID vcl_prevent_cold(PRIV_VCL)
 
@@ -316,6 +322,8 @@ Set the client socket' send buffer size to *sndbuf*. The previous, desired
 and actual values appear in the logs. Not currently implemented for backend
 transactions.
 
+$Restrict client backend
+
 $Function VOID store_ip(IP)
 
 Store an IP address to be later found by ``debug.get_ip()`` in the same
@@ -336,9 +344,13 @@ $Function STRING client_ip()
 
 Get the stringified client ip from the session attr
 
+$Restrict client backend
+
 $Function STRING client_port()
 
 Get the stringified client port from the session attr
+
+$Restrict client backend
 
 $Function VOID fail_task_fini()
 

--- a/vmod/vmod_directors.c
+++ b/vmod/vmod_directors.c
@@ -48,12 +48,7 @@
 VCL_BACKEND
 VPFX(lookup)(VRT_CTX, VCL_STRING name)
 {
-	if ((ctx->method & VCL_MET_TASK_H) == 0) {
-		VRT_fail(ctx,
-		    "lookup() may only be called from vcl_init / vcl_fini");
-		return (NULL);
-	}
-
+	AN(ctx->method & VCL_MET_TASK_H);
 	return (VRT_LookupDirector(ctx, name));
 }
 

--- a/vmod/vmod_directors.vcc
+++ b/vmod/vmod_directors.vcc
@@ -650,7 +650,7 @@ Reset the parameter set to default values as documented for
 * backend context and in ``vcl_pipe {}``, resets the parameter set for
   this backend request to the VCL defaults
 
-This method may not be used in client context other than ``vcl_pipe {}``.
+$Restrict vcl_pipe backend housekeeping
 
 $Method VOID .set(
 	[ ENUM {HASH, URL, KEY, BLOB} by ],
@@ -670,7 +670,7 @@ Change the given parameters of a parameter set as documented for
   for this backend request, keeping the defaults set for this VCL for
   unspecified arguments.
 
-This method may not be used in client context other than ``vcl_pipe {}``.
+$Restrict vcl_pipe backend housekeeping
 
 $Method STRING .get_by()
 
@@ -706,16 +706,16 @@ shard director using this parameter object would use. See
 
 $Method BLOB .use()
 
-This method may only be used in backend context and in ``vcl_pipe {}``.
-
 For use with the *param* argument of `xshard.backend()`_
 to associate this shard parameter set with a shard director.
+
+$Restrict vcl_pipe backend housekeeping
 
 $Function BACKEND lookup(STRING)
 
 Lookup a backend by its name.
 
-This function can only be used from ``vcl_init{}`` and  ``vcl_fini{}``.
+$Restrict housekeeping
 
 ACKNOWLEDGEMENTS
 ================

--- a/vmod/vmod_proxy.vcc
+++ b/vmod/vmod_proxy.vcc
@@ -45,6 +45,8 @@ Example::
 
 	set req.http.alpn = proxy.alpn();
 
+$Restrict client
+
 $Function STRING authority()
 
 Extract authority attribute. This corresponds to SNI from a TLS
@@ -53,6 +55,8 @@ connection.
 Example::
 
 	set req.http.authority = proxy.authority();
+
+$Restrict client
 
 $Function BOOL is_ssl()
 
@@ -64,15 +68,21 @@ Example::
 		set req.http.ssl-version = proxy.ssl_version();
 	}
 
+$Restrict client
+
 $Function BOOL client_has_cert_sess()
 
 Report if the client provided a certificate at least once over the TLS
 session this connection belongs to.
 
+$Restrict client
+
 $Function BOOL client_has_cert_conn()
 
 Report if the client provided a certificate over the current
 connection.
+
+$Restrict client
 
 $Function INT ssl_verify_result()
 
@@ -86,6 +96,8 @@ Example::
 		set req.http.ssl-verify = "ok";
 	}
 
+$Restrict client
+
 $Function STRING ssl_version()
 
 Extract SSL version attribute.
@@ -94,12 +106,16 @@ Example::
 
 	set req.http.ssl-version = proxy.ssl_version();
 
+$Restrict client
+
 $Function STRING client_cert_cn()
 
 Extract the common name attribute of the client certificate's.
 
 Example::
 	set req.http.cert-cn = proxy.client_cert_cn();
+
+$Restrict client
 
 $Function STRING ssl_cipher()
 
@@ -109,6 +125,8 @@ Example::
 
 	set req.http.ssl-cipher = proxy.ssl_cipher();
 
+$Restrict client
+
 $Function STRING cert_sign()
 
 Extract the certificate signature algorithm attribute.
@@ -117,6 +135,8 @@ Example::
 
 	set req.http.cert-sign = proxy.cert_sign();
 
+$Restrict client
+
 $Function STRING cert_key()
 
 Extract the certificate key algorithm attribute.
@@ -124,6 +144,8 @@ Extract the certificate key algorithm attribute.
 Example::
 
 	set req.http.cert-key = proxy.cert_key();
+
+$Restrict client
 
 SEE ALSO
 ========

--- a/vmod/vmod_purge.vcc
+++ b/vmod/vmod_purge.vcc
@@ -94,6 +94,8 @@ Example::
 
 	set req.http.purged = purge.hard();
 
+$Restrict vcl_hit vcl_miss
+
 $Function INT soft(DURATION ttl = 0, DURATION grace = -1, DURATION keep = -1)
 
 Sets the *ttl*, *grace* and *keep*.
@@ -101,9 +103,9 @@ Sets the *ttl*, *grace* and *keep*.
 By default, *ttl* is set to 0 with *grace* and *keep* periods left
 untouched. Setting a negative value for *grace* or *keep* periods
 leaves them untouched. Setting all three parameters to ``0`` is
-equivalent to a hard purge. It can only be called from ``vcl_hit{}``
-or ``vcl_miss{}``. It returns the number of soft-purged objects.
+equivalent to a hard purge. It returns the number of soft-purged objects.
 
+$Restrict vcl_hit vcl_miss
 SEE ALSO
 ========
 

--- a/vmod/vmod_std.c
+++ b/vmod/vmod_std.c
@@ -270,12 +270,7 @@ VCL_VOID v_matchproto_(td_std_late_100_continue)
 vmod_late_100_continue(VRT_CTX, VCL_BOOL late)
 {
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	if (ctx->method != VCL_MET_RECV) {
-		VSLb(ctx->vsl, SLT_VCL_Error,
-		    "std.late_100_continue() only valid in vcl_recv{}");
-		return;
-	}
-
+	AN(ctx->method & VCL_MET_RECV);
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
 	if (ctx->req->want100cont)
 		ctx->req->late100cont = late;

--- a/vmod/vmod_std.vcc
+++ b/vmod/vmod_std.vcc
@@ -521,6 +521,8 @@ Example::
 		...
 	}
 
+$Restrict vcl_recv
+
 $Function VOID late_100_continue(BOOL late)
 
 Controls when varnish reacts to an ``Expect: 100-continue`` client
@@ -555,6 +557,8 @@ Example::
 		...
 	 }
 
+$Restrict vcl_recv
+
 $Function VOID set_ip_tos(INT tos)
 
 Sets the Differentiated Services Codepoint (DSCP) / IPv4 Type of
@@ -572,6 +576,8 @@ Example::
 		std.set_ip_tos(0);
 	}
 
+$Restrict client
+
 $Function VOID rollback(HTTP h)
 
 Restores the *h* HTTP headers to their original state.
@@ -579,6 +585,8 @@ Restores the *h* HTTP headers to their original state.
 Example::
 
 	std.rollback(bereq);
+
+$Restrict backend vcl_recv vcl_pass vcl_hash vcl_purge vcl_miss vcl_hit vcl_deliver vcl_synth
 
 $Function BOOL ban(STRING)
 

--- a/vmod/vmod_unix.c
+++ b/vmod/vmod_unix.c
@@ -49,9 +49,6 @@
 #define VERR(ctx, fmt, ...) \
 	VSLb((ctx)->vsl, SLT_VCL_Error, "vmod unix error: " fmt, __VA_ARGS__)
 
-#define FAILNOINIT(ctx) \
-	FAIL((ctx), "may not be called in vcl_init or vcl_fini")
-
 #define ERRNOTUDS(ctx) \
 	ERR((ctx), "not listening on a Unix domain socket")
 
@@ -93,10 +90,7 @@ vmod_##func(VRT_CTX)					\
 	int ret;					\
 							\
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);		\
-	if ((ctx->method & VCL_MET_TASK_H) != 0) {	\
-		FAILNOINIT(ctx);			\
-		return (-1);				\
-	}						\
+	AZ(ctx->method & VCL_MET_TASK_H);	\
 							\
 	sp = get_sp(ctx);				\
 	if (!sp->listen_sock->uds) {			\

--- a/vmod/vmod_unix.vcc
+++ b/vmod/vmod_unix.vcc
@@ -67,17 +67,25 @@ $Function STRING user()
 
 Return the user name of the peer process owner.
 
+$Restrict client backend
+
 $Function STRING group()
 
 Return the group name of the peer process owner.
+
+$Restrict client backend
 
 $Function INT uid()
 
 Return the numeric user id of the peer process owner.
 
+$Restrict client backend
+
 $Function INT gid()
 
 Return the numeric group id of the peer process owner.
+
+$Restrict client backend
 
 ERRORS
 ======


### PR DESCRIPTION
This PR introduces the $Restrict feature described in [vip4](https://github.com/varnishcache/varnish-cache/wiki/VIP4%3A-Restrict-VMOD-function-call-sites).

It provides the ability to restrict vmod functions and methods scope so that they can only be called
from limited VCL built-in sub routines. The first commit introduces the feature, and the following ones use it on relevant vmods.