### PR TITLE
Leave `HSH_Cancel()` to the transport

### DIFF
--- a/bin/varnishd/cache/cache_objhead.h
+++ b/bin/varnishd/cache/cache_objhead.h
@@ -75,4 +75,3 @@ void HSH_AddString(struct req *, void *ctx, const char *str);
 unsigned HSH_Purge(struct worker *, struct objhead *, vtim_real ttl_now,
     vtim_dur ttl, vtim_dur grace, vtim_dur keep);
 struct objcore *HSH_Private(const struct worker *wrk);
-void HSH_Cancel(struct worker *, struct objcore *, struct boc *);

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -488,13 +488,13 @@ cnt_transmit(struct worker *wrk, struct req *req)
 
 	VSLb_ts_req(req, "Resp", W_TIM_real(wrk));
 
-	HSH_Cancel(wrk, req->objcore, boc);
-
 	if (req->doclose == SC_NULL && (req->objcore->flags & OC_F_FAILED)) {
 		/* The object we delivered failed due to a streaming error.
 		 * Fail the request. */
 		req->doclose = SC_TX_ERROR;
 	}
+	if (req->doclose != SC_NULL)
+		HSH_Cancel(wrk, req->objcore, NULL);
 
 	if (boc != NULL)
 		HSH_DerefBoc(wrk, req->objcore);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -251,6 +251,7 @@ void BAN_Shutdown(void);
 void BAN_NewObjCore(struct objcore *oc);
 void BAN_DestroyObj(struct objcore *oc);
 int BAN_CheckObject(struct worker *, struct objcore *, struct req *);
+void HSH_Cancel(struct worker *, struct objcore *, struct boc *);
 
 /* cache_busyobj.c */
 void VBO_Init(void);

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -169,4 +169,6 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 		sc = SC_REM_CLOSE;
 	if (sc != SC_NULL)
 		Req_Fail(req, sc);
+
+	HSH_Cancel(req->wrk, req->objcore, boc);
 }

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -352,4 +352,6 @@ h2_deliver(struct req *req, struct boc *boc, int sendbody)
 
 	AZ(req->wrk->v1l);
 	req->acct.resp_bodybytes += VDP_Close(req->vdc);
+
+	HSH_Cancel(req->wrk, req->objcore, boc);
 }


### PR DESCRIPTION
This patch enables transports to keep references also to _final_ (`OC_F_PRIVATE | OC_F_HFM | OC_F_HFP`) objects until after the transport's delivery callback returns, effectively making them responsible for deciding when/if they do not need a _final_ object's body any more.

The net effect of the patch should be zero: where `HSH_Cancel()` was called from `cnt_transmit()`, it is now called before happy path returns from transports' deliver callbacks. For error returns, a call remains in `cnt_transmit()`.

The use case is [libvdp-pesi](https://gitlab.com/uplex/varnish/libvdp-pesi): In this VMOD, we currently need to copy _final_ objects because of that single `HSH_Cancel()` call *1). With this patch, it becomes possible to only keep a reference and avoid the copy for one out of two cases *2).
The resulting simplification can be seen here: https://gitlab.com/uplex/varnish/libvdp-pesi/-/merge_requests/2/diffs

----

*1) I had also explored an alternative (`T_FINAL`) node type to block the ESI subrequest until time comes to execute, but that is prone to deadlocks, so I never activated that code to run by default.

*2) The other case is less relevant and could be addressed later by adding, for VDPs, the option veto the `final` argument to `ObjIterate()`.