### PR TITLE
stevedore: Log failures to create objects

### DIFF
--- a/bin/varnishd/storage/stevedore.c
+++ b/bin/varnishd/storage/stevedore.c
@@ -88,8 +88,12 @@ STV_NewObject(struct worker *wrk, struct objcore *oc,
 
 	wrk->strangelove = cache_param->nuke_limit;
 	AN(stv->allocobj);
-	if (stv->allocobj(wrk, stv, oc, wsl) == 0)
+	if (stv->allocobj(wrk, stv, oc, wsl) == 0) {
+		VSLb(wrk->vsl, SLT_Error,
+		    "Failed to create object object from %s %s",
+		    stv->name, stv->ident);
 		return (0);
+	}
 	oc->oa_present = 0;
 	wrk->stats->n_object++;
 	VSLb(wrk->vsl, SLT_Storage, "%s %s",

--- a/bin/varnishtest/tests/r03502.vtc
+++ b/bin/varnishtest/tests/r03502.vtc
@@ -41,6 +41,7 @@ logexpect l1 -v v1 -g vxid -q "vxid == 1004" {
 	# Ensure the FetchError is in vbf_beresp2obj()
 	# not later in the VFP. Otherwise we have too much free_space
 	fail add  =	Storage
+	expect 0  =	Error      	{^Failed to create object object from .+ Transient}
 	expect 0  =	FetchError      {^Could not get storage}
 	fail clear
 } -start


### PR DESCRIPTION
We only log a Storage record when we successfully create an object, but there may be no clue regarding which storage backend failed to allocate. We can infer from stevedore VSCs where allocation failures happened, but knowing from a VCL transaction which one failed will give a definitive answer.

This is logged as an Error record, and the existing FetchError record from VFPs ("Could not get storage") is left alone.