### PR TITLE
varnishtest: Introduce a ${varnishd_args} macro

### DIFF
--- a/bin/varnishtest/vtc.c
+++ b/bin/varnishtest/vtc.c
@@ -216,6 +216,26 @@ macro_undef(struct vtclog *vl, const char *instance, const char *name)
 	AZ(pthread_mutex_unlock(&macro_mtx));
 }
 
+unsigned
+macro_isdef(const char *instance, const char *name)
+{
+	char buf1[256];
+	struct macro *m;
+
+	if (instance != NULL) {
+		bprintf(buf1, "%s_%s", instance, name);
+		name = buf1;
+	}
+
+	AZ(pthread_mutex_lock(&macro_mtx));
+	VTAILQ_FOREACH(m, &macro_list, list)
+		if (!strcmp(name, m->name))
+			break;
+	AZ(pthread_mutex_unlock(&macro_mtx));
+
+	return (m != NULL);
+}
+
 void
 macro_cat(struct vtclog *vl, struct vsb *vsb, const char *b, const char *e)
 {

--- a/bin/varnishtest/vtc.h
+++ b/bin/varnishtest/vtc.h
@@ -132,8 +132,8 @@ int exec_file(const char *fn, const char *script, const char *tmpdir,
 
 void macro_undef(struct vtclog *vl, const char *instance, const char *name);
 void macro_def(struct vtclog *vl, const char *instance, const char *name,
-    const char *fmt, ...)
-    v_printflike_(4, 5);
+    const char *fmt, ...) v_printflike_(4, 5);
+unsigned macro_isdef(const char *instance, const char *name);
 void macro_cat(struct vtclog *, struct vsb *, const char *, const char *);
 struct vsb *macro_expand(struct vtclog *vl, const char *text);
 struct vsb *macro_expandf(struct vtclog *vl, const char *, ...)

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -430,6 +430,10 @@ varnish_launch(struct varnish *v)
 	if (vmod_path != NULL)
 		VSB_printf(vsb, " -p vmod_path=%s", vmod_path);
 	VSB_printf(vsb, " %s", VSB_data(v->args));
+	if (macro_isdef(NULL, "varnishd_args")) {
+		VSB_putc(vsb, ' ');
+		macro_cat(v->vl, vsb, "varnishd_args", NULL);
+	}
 	AZ(VSB_finish(vsb));
 	vtc_log(v->vl, 3, "CMD: %s", VSB_data(vsb));
 	vsb1 = macro_expand(v->vl, VSB_data(vsb));
@@ -1067,6 +1071,12 @@ vsl_catchup(struct varnish *v)
  *
  * \-arg STRING
  *         Pass an argument to varnishd, for example "-h simple_list".
+ *
+ *         If the ${varnishd_args} macro is defined, it is expanded and
+ *         appended to the varnishd command line, before the command line
+ *         itself is expanded. This enables tweaks to the varnishd command
+ *         line without editing test cases. This macro can be defined using
+ *         the ``-D`` option for varnishtest.
  *
  * \-vcl STRING
  *         Specify the VCL to load on this Varnish instance. You'll probably

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -93,8 +93,6 @@ struct varnish {
 
 #define NONSENSE	"%XJEIFLH|)Xspa8P"
 
-#define VARNISHD_ADD_ARGS_ENV_VAR	"VTEST_VARNISHD_ADD_ARGS"
-
 static VTAILQ_HEAD(, varnish)	varnishes =
     VTAILQ_HEAD_INITIALIZER(varnishes);
 
@@ -391,7 +389,7 @@ varnish_launch(struct varnish *v)
 	char abuf[128], pbuf[128];
 	struct pollfd fd[3];
 	enum VCLI_status_e u;
-	const char *err, *env_args;
+	const char *err;
 	char *r = NULL;
 
 	/* Create listener socket */
@@ -431,9 +429,6 @@ varnish_launch(struct varnish *v)
 	VSB_printf(vsb, " -P %s/varnishd.pid", v->workdir);
 	if (vmod_path != NULL)
 		VSB_printf(vsb, " -p vmod_path=%s", vmod_path);
-	env_args = getenv(VARNISHD_ADD_ARGS_ENV_VAR);
-	if (env_args)
-		VSB_printf(vsb, " %s", env_args);
 	VSB_printf(vsb, " %s", VSB_data(v->args));
 	AZ(VSB_finish(vsb));
 	vtc_log(v->vl, 3, "CMD: %s", VSB_data(vsb));
@@ -1072,9 +1067,6 @@ vsl_catchup(struct varnish *v)
  *
  * \-arg STRING
  *         Pass an argument to varnishd, for example "-h simple_list".
- *
- *         The environment variable VTEST_VARNISHD_ADD_ARGS can be used to
- *         inject additional arguments.
  *
  * \-vcl STRING
  *         Specify the VCL to load on this Varnish instance. You'll probably


### PR DESCRIPTION
> If the ${varnishd_args} macro is defined, it is expanded and
> appended to the varnishd command line, before the command line
> itself is expanded. This enables tweaks to the varnishd command
> line without editing test cases. This macro can be defined using
> the ``-D`` option for varnishtest.

Refs #3897