### PR TITLE
Add counter for premature Iovec flushes

### DIFF
--- a/bin/varnishd/http1/cache_http1_line.c
+++ b/bin/varnishd/http1/cache_http1_line.c
@@ -278,8 +278,10 @@ V1L_Write(const struct worker *wrk, const void *ptr, ssize_t len)
 	v1l->liov += len;
 	v1l->niov++;
 	v1l->cliov += len;
-	if (v1l->niov >= v1l->siov)
+	if (v1l->niov >= v1l->siov) {
 		(void)V1L_Flush(wrk);
+		VSC_C_main->http1_iovs_flush++;
+	}
 	return (len);
 }
 
@@ -298,8 +300,10 @@ V1L_Chunked(const struct worker *wrk)
 	 * If there is no space for chunked header, a chunk of data and
 	 * a chunk tail, we might as well flush right away.
 	 */
-	if (v1l->niov + 3 >= v1l->siov)
+	if (v1l->niov + 3 >= v1l->siov) {
 		(void)V1L_Flush(wrk);
+		VSC_C_main->http1_iovs_flush++;
+	}
 	v1l->siov--;
 	v1l->ciov = v1l->niov++;
 	v1l->cliov = 0;

--- a/bin/varnishtest/tests/b00081.vtc
+++ b/bin/varnishtest/tests/b00081.vtc
@@ -1,17 +1,196 @@
 varnishtest "test iovec flush counter"
 
-server s1 {
+server s0 {
 	rxreq
 	txresp
-} -start
+} -dispatch
 
-varnish v1 -arg "-p http1_iovs=5" -vcl+backend {} -start
+# http1_iovs
+# Simple request/response
 
-varnish v1 -expect MAIN.http1_iovs_flush == 0
+varnish v1 -vcl+backend {} -start
+
+varnish v1 -cliok "param.set http1_iovs 30"
 
 client c1 {
 	txreq
 	rxresp
 } -run
 
+varnish v1 -expect MAIN.http1_iovs_flush == 0
+
+# Decreasing http1_iovs causes premature flushes
+varnish v1 -cliok "param.set http1_iovs 5"
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+varnish v1 -expect MAIN.http1_iovs_flush > 0
+
+##################################################
+# Increase number of headers on fetch side
+
+varnish v1 -cliok "param.set http1_iovs 30"
+
+varnish v1 -stop
+varnish v1 -vcl+backend {
+	sub vcl_backend_fetch {
+		set bereq.http.hdr1 = "hdr";
+		set bereq.http.hdr2 = "hdr";
+		set bereq.http.hdr3 = "hdr";
+		set bereq.http.hdr4 = "hdr";
+		set bereq.http.hdr5 = "hdr";
+		set bereq.http.hdr6 = "hdr";
+		set bereq.http.hdr7 = "hdr";
+		set bereq.http.hdr8 = "hdr";
+		set bereq.http.hdr9 = "hdr";
+		set bereq.http.hdr10 = "hdr";
+		set bereq.http.hdr11 = "hdr";
+		set bereq.http.hdr12 = "hdr";
+		set bereq.http.hdr13 = "hdr";
+		set bereq.http.hdr14 = "hdr";
+		set bereq.http.hdr15 = "hdr";
+		set bereq.http.hdr16 = "hdr";
+		set bereq.http.hdr17 = "hdr";
+		set bereq.http.hdr18 = "hdr";
+		set bereq.http.hdr19 = "hdr";
+		set bereq.http.hdr20 = "hdr";
+	}
+} -start
+
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+# http1_iovs parameter does not affect fetch
+varnish v1 -expect MAIN.http1_iovs_flush == 0
+
+#####################################################
+# Increase number of headers on deliver side
+
+varnish v1 -stop
+varnish v1 -vcl+backend {
+	sub vcl_deliver {
+		set resp.http.hdr1 = "hdr";
+		set resp.http.hdr2 = "hdr";
+		set resp.http.hdr3 = "hdr";
+		set resp.http.hdr4 = "hdr";
+		set resp.http.hdr5 = "hdr";
+		set resp.http.hdr6 = "hdr";
+		set resp.http.hdr7 = "hdr";
+		set resp.http.hdr8 = "hdr";
+		set resp.http.hdr9 = "hdr";
+		set resp.http.hdr10 = "hdr";
+		set resp.http.hdr11 = "hdr";
+		set resp.http.hdr12 = "hdr";
+		set resp.http.hdr13 = "hdr";
+		set resp.http.hdr14 = "hdr";
+		set resp.http.hdr15 = "hdr";
+		set resp.http.hdr16 = "hdr";
+		set resp.http.hdr17 = "hdr";
+		set resp.http.hdr18 = "hdr";
+		set resp.http.hdr19 = "hdr";
+		set resp.http.hdr20 = "hdr";
+	}
+} -start
+
+varnish v1 -cliok "param.set http1_iovs 30"
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+# http1_iovs parameter affects deliver
+varnish v1 -expect MAIN.http1_iovs_flush > 0
+
+##################################################
+# Compare with workspace_thread
+# 0.5k is enough for simplest request/response
+
+varnish v1 -cliok "param.reset http1_iovs"
+varnish v1 -stop
+
+varnish v1 -cliok "param.set workspace_thread 0.5k"
+varnish v1 -vcl+backend {} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+varnish v1 -expect MAIN.http1_iovs_flush == 0
+
+# Increase number of headers on fetch side
+varnish v1 -stop
+varnish v1 -vcl+backend {
+	sub vcl_backend_fetch {
+		set bereq.http.hdr1 = "hdr";
+		set bereq.http.hdr2 = "hdr";
+		set bereq.http.hdr3 = "hdr";
+		set bereq.http.hdr4 = "hdr";
+		set bereq.http.hdr5 = "hdr";
+		set bereq.http.hdr6 = "hdr";
+		set bereq.http.hdr7 = "hdr";
+		set bereq.http.hdr8 = "hdr";
+		set bereq.http.hdr9 = "hdr";
+		set bereq.http.hdr10 = "hdr";
+		set bereq.http.hdr11 = "hdr";
+		set bereq.http.hdr12 = "hdr";
+		set bereq.http.hdr13 = "hdr";
+		set bereq.http.hdr14 = "hdr";
+		set bereq.http.hdr15 = "hdr";
+		set bereq.http.hdr16 = "hdr";
+		set bereq.http.hdr17 = "hdr";
+		set bereq.http.hdr18 = "hdr";
+		set bereq.http.hdr19 = "hdr";
+		set bereq.http.hdr20 = "hdr";
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+# workspace_thread parameter affects fetch
+varnish v1 -expect MAIN.http1_iovs_flush > 0
+
+# Increase number of headers on deliver side
+varnish v1 -stop
+varnish v1 -vcl+backend {
+	sub vcl_deliver {
+		set resp.http.hdr1 = "hdr";
+		set resp.http.hdr2 = "hdr";
+		set resp.http.hdr3 = "hdr";
+		set resp.http.hdr4 = "hdr";
+		set resp.http.hdr5 = "hdr";
+		set resp.http.hdr6 = "hdr";
+		set resp.http.hdr7 = "hdr";
+		set resp.http.hdr8 = "hdr";
+		set resp.http.hdr9 = "hdr";
+		set resp.http.hdr10 = "hdr";
+		set resp.http.hdr11 = "hdr";
+		set resp.http.hdr12 = "hdr";
+		set resp.http.hdr13 = "hdr";
+		set resp.http.hdr14 = "hdr";
+		set resp.http.hdr15 = "hdr";
+		set resp.http.hdr16 = "hdr";
+		set resp.http.hdr17 = "hdr";
+		set resp.http.hdr18 = "hdr";
+		set resp.http.hdr19 = "hdr";
+		set resp.http.hdr20 = "hdr";
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+# workspace_thread parameter affects deliver
 varnish v1 -expect MAIN.http1_iovs_flush > 0

--- a/bin/varnishtest/tests/b00081.vtc
+++ b/bin/varnishtest/tests/b00081.vtc
@@ -1,0 +1,17 @@
+varnishtest "test iovec flush counter"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-p http1_iovs=5" -vcl+backend {} -start
+
+varnish v1 -expect MAIN.http1_iovs_flush == 0
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+varnish v1 -expect MAIN.http1_iovs_flush > 0

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -448,7 +448,10 @@ PARAM_SIMPLE(
 	/* descr */
 	"Number of io vectors to allocate for HTTP1 protocol transmission."
 	"  A HTTP1 header needs 7 + 2 per HTTP header field."
-	"  Allocated from workspace_thread.",
+	"  Allocated from workspace_thread."
+	"  This parameter affects only io vectors used for client delivery."
+	"  For backend fetches, the maximum number of io vectors (up to IOV_MAX)"
+	"  is allocated from available workspace_thread memory.",
 	/* flags */	WIZARD
 )
 

--- a/lib/libvsc/VSC_main.vsc
+++ b/lib/libvsc/VSC_main.vsc
@@ -942,4 +942,8 @@
 	from a backend. They are done to verify the gzip stream while it's
 	inserted in storage.
 
+
+.. varnish_vsc:: http1_iovs_flush
+	:oneliner:	Premature iovec flushes
+
 .. varnish_vsc_end::	main


### PR DESCRIPTION
This PR adds a counter for premature iovec flushes (V1L_Flush).  This  can be useful to detect when we run out of iovecs during a transaction (due to small workspace_thread or http1_iovs values for example).
The second commit improves the doc of http1_iovs parameter and adds some test coverage.