### PR TITLE
h2_vsl_frame: Exit early if masked

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -783,6 +783,7 @@ void VSLbs(struct vsl_log *, enum VSL_tag_e tag, const struct strands *s);
 void VSLb_ts(struct vsl_log *, const char *event, vtim_real first,
     vtim_real *pprev, vtim_real now);
 void VSLb_bin(struct vsl_log *, enum VSL_tag_e, ssize_t, const void*);
+int VSL_tag_is_masked(enum VSL_tag_e tag);
 
 static inline void
 VSLb_ts_req(struct req *req, const char *event, vtim_real now)

--- a/bin/varnishd/cache/cache_shmlog.c
+++ b/bin/varnishd/cache/cache_shmlog.c
@@ -130,6 +130,12 @@ vsl_tag_is_masked(enum VSL_tag_e tag)
 	return (*bm & b);
 }
 
+int
+VSL_tag_is_masked(enum VSL_tag_e tag)
+{
+	return (vsl_tag_is_masked(tag));
+}
+
 /*--------------------------------------------------------------------
  * Lay down a header fields, and return pointer to the next record
  */

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -243,6 +243,10 @@ h2_vsl_frame(const struct h2_sess *h2, const void *ptr, size_t len)
 	const char *p;
 	unsigned u;
 
+	if (VSL_tag_is_masked(SLT_H2RxHdr) &&
+	    VSL_tag_is_masked(SLT_H2RxBody))
+		return;
+
 	AN(ptr);
 	assert(len >= 9);
 	b = ptr;


### PR DESCRIPTION
The ``VSB``/``printf`` bits in here come with a very significant performance penalty, also for the case when the log tags are masked (which they are by default).

On my laptop this cuts processing of a 1G POST from 45 seconds down to <1s.