### PR TITLE
Avoid worker startup hang, add startup_timeout

### DIFF
--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -310,6 +310,7 @@ mgt_launch_child(struct cli *cli)
 	int i, cp[2];
 	struct rlimit rl[1];
 	vtim_dur dstart;
+	int bstart;
 	vtim_mono t0;
 
 	if (child_state != CH_STOPPED && child_state != CH_DIED)
@@ -439,10 +440,10 @@ mgt_launch_child(struct cli *cli)
 	AN(child_std_vlu);
 
 	/* Wait for cache/cache_cli.c::CLI_Run() to check in */
-	dstart = vmax(mgt_param.startup_timeout, mgt_param.cli_timeout);
+	bstart = mgt_param.startup_timeout >= mgt_param.cli_timeout;
+	dstart = bstart ? mgt_param.startup_timeout : mgt_param.cli_timeout;
 	t0 = VTIM_mono();
 	if (VCLI_ReadResult(child_cli_in, &u, NULL, dstart)) {
-		int bstart = mgt_param.startup_timeout >= mgt_param.cli_timeout;
 		assert(u == CLIS_COMMS);
 		if (VTIM_mono() - t0 < dstart)
 			mgt_launch_err(cli, u, "Child failed on launch ");

--- a/bin/varnishtest/tests/p00000.vtc
+++ b/bin/varnishtest/tests/p00000.vtc
@@ -9,7 +9,8 @@ process p1 -dump {
 process p1 -expect-text 0 0 {to launch}
 process p1 -write "start\n"
 process p1 -expect-text 0 0 {-spersistent has been deprecated}
-process p1 -wait
+process p1 -write "quit\n"
+process p1 -expect-exit 0x20 -wait
 
 server s1 {
 	rxreq

--- a/bin/varnishtest/tests/r03940.vtc
+++ b/bin/varnishtest/tests/r03940.vtc
@@ -16,8 +16,8 @@ varnish v1 -expectexit 0x40
 process p1 { varnishd \
 	-sdebug=debug,dinit=5s \
 	-pstartup_timeout=3s -pcli_timeout=2s \
-	-n ${tmpdir}/p1 -a :0 -b none 2>&1 } -start
-process p1 -expect-exit 0x2 -wait
+	-n ${tmpdir}/p1 -a :0 -b none 2>&1
+} -expect-exit 0x2 -run
 process p1 -expect-text 0 0 \
 	"Child failed on launch within startup_timeout=3.00s"
 
@@ -36,8 +36,8 @@ varnish v2 -expectexit 0x40
 process p2 { varnishd \
 	-sdebug=debug,dopen=5s \
 	-pstartup_timeout=2s -pcli_timeout=3s \
-	-n ${tmpdir}/p2 -a :0 -b none} -start
-process p2 -expect-exit 0x2 -wait
+	-n ${tmpdir}/p2 -a :0 -b none
+} -expect-exit 0x2 -run
 
 # expect-text does not work here because the panic info pushes the
 # error out of the emulated terminal's view.

--- a/bin/varnishtest/tests/r03940.vtc
+++ b/bin/varnishtest/tests/r03940.vtc
@@ -1,0 +1,45 @@
+varnishtest "test startup_timeout vs. stevedore init / open"
+
+# we test with vtc_varnish and vtc_process because of different code
+# paths in mgr for implicit start vs. cli start
+
+####
+# startup_timeout used, delay in stevedore init
+varnish v1 -arg "-sdebug=debug,dinit=5s -pstartup_timeout=3s -pcli_timeout=2s" \
+	-arg "-p feature=+no_coredump" \
+	-vcl "backend none none;"
+varnish v1 -cliexpect \
+	"Child failed on launch within startup_timeout=3.00s" \
+	"start"
+varnish v1 -expectexit 0x40
+
+process p1 { varnishd \
+	-sdebug=debug,dinit=5s \
+	-pstartup_timeout=3s -pcli_timeout=2s \
+	-n ${tmpdir}/p1 -a :0 -b none 2>&1 } -start
+process p1 -expect-exit 0x2 -wait
+process p1 -expect-text 0 0 \
+	"Child failed on launch within startup_timeout=3.00s"
+
+####
+# cli_timeout used, delay in stevedore open
+
+varnish v2 -arg "-sdebug=debug,dopen=5s -pstartup_timeout=2s -pcli_timeout=3s" \
+	-arg "-p feature=+no_coredump" \
+	-vcl "backend none none;"
+varnish v2 -cliexpect \
+	"launch within cli_timeout=3.00s .tip: set startup_" \
+	"start"
+varnish v2 -cliok "panic.clear"
+varnish v2 -expectexit 0x40
+
+process p2 { varnishd \
+	-sdebug=debug,dopen=5s \
+	-pstartup_timeout=2s -pcli_timeout=3s \
+	-n ${tmpdir}/p2 -a :0 -b none} -start
+process p2 -expect-exit 0x2 -wait
+
+# expect-text does not work here because the panic info pushes the
+# error out of the emulated terminal's view.
+# And I do not want to rely on any x lines to be enough
+shell {grep -q "launch within cli_timeout=3.00s (tip: set startup_" ${p2_err}}

--- a/bin/varnishtest/tests/s00003.vtc
+++ b/bin/varnishtest/tests/s00003.vtc
@@ -47,13 +47,13 @@ varnish v1 -cliok "ban obj.http.date ~ ."
 
 process p1 {
 	varnishd -sTransient=file,${tmpdir}/foo,xxx -blocalhost -a:0 -n ${tmpdir} 2>&1
-} -expect-exit 255 -dump -start -expect-text 0 0 "Invalid number" -wait -screen_dump
+} -expect-exit 0x2 -dump -start -expect-text 0 0 "Invalid number" -wait -screen_dump
 
 process p1 {
 	varnishd -sTransient=file,${tmpdir}/foo,10M,xxx -blocalhost -a:0 -n ${tmpdir} 2>&1
-} -expect-exit 255 -dump -start -expect-text 0 0 "granularity" -wait -screen_dump
+} -expect-exit 0x2 -dump -start -expect-text 0 0 "granularity" -wait -screen_dump
 
 process p1 {
 	varnishd -sTransient=file,${tmpdir}/foo,10m,,foo -blocalhost -a:0 -n ${tmpdir} 2>&1
-} -expect-exit 255 -dump -start -expect-text 0 0 "invalid advice" -wait
+} -expect-exit 0x2 -dump -start -expect-text 0 0 "invalid advice" -wait
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -336,6 +336,18 @@ PARAM_SIMPLE(
 )
 
 PARAM_SIMPLE(
+	/* name */	startup_timeout,
+	/* type */	timeout,
+	/* min */	"0.000",
+	/* max */	NULL,
+	/* def */	"0.000",
+	/* units */	"seconds",
+	/* descr */
+	"Alternative timeout for the initial worker process startup.\n"
+	"If cli_timeout is longer than startup_timeout, it is used instead."
+)
+
+PARAM_SIMPLE(
 	/* name */	clock_skew,
 	/* type */	uint,
 	/* min */	"0",


### PR DESCRIPTION
The first commit is a fix for #3940 by killing the child when it does not come up within the timeout.
The second commit adds a specific `start_timeout` parameter.