### PR TITLE
Warn about pitfall: workdir on noexec mountpoint

### DIFF
--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -486,6 +486,7 @@ VCL_Open(const char *fn, struct vsb *msg)
 	if (dlh == NULL) {
 		VSB_cat(msg, "Could not load compiled VCL.\n");
 		VSB_printf(msg, "\tdlopen() = %s\n", dlerror());
+		VSB_cat(msg, "\thint: check for \"noexec\" mount\n");
 		return (NULL);
 	}
 	cnf = dlsym(dlh, "VCL_conf");

--- a/bin/varnishd/mgt/mgt_jail.c
+++ b/bin/varnishd/mgt/mgt_jail.c
@@ -39,6 +39,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 
 #include "mgt/mgt.h"
 #include "common/heritage.h"
@@ -138,6 +139,7 @@ VJ_subproc(enum jail_subproc_e jse)
 int
 VJ_make_workdir(const char *dname)
 {
+	struct statvfs vfs[1];
 	int i;
 
 	AN(dname);
@@ -163,6 +165,17 @@ VJ_make_workdir(const char *dname)
 		ARGV_ERR("Cannot create test-file in %s (%s)\n"
 		    "Check permissions (or delete old directory)\n",
 		    dname, VAS_errtxt(errno));
+
+#ifdef ST_NOEXEC
+	/* deliberately ignore fstatvfs errors */
+	if (! fstatvfs(i, vfs) && vfs->f_flag & ST_NOEXEC) {
+		closefd(&i);
+		AZ(unlink("_.testfile"));
+		ARGV_ERR("Working directory %s (-n argument) "
+		    "can not reside on a file system mounted noexec\n", dname);
+	}
+#endif
+
 	closefd(&i);
 	AZ(unlink("_.testfile"));
 	VJ_master(JAIL_MASTER_LOW);


### PR DESCRIPTION
I also tried `mmap(PROT_READ|PROT_EXEC)`, but, apparently, that needs a proper executable.

Fixes #3943