### PR TITLE
build: Run test cases after refreshing the test suite

### DIFF
--- a/vtc.am
+++ b/vtc.am
@@ -11,7 +11,7 @@
 VTC_LOG_COMPILER = $(top_builddir)/bin/varnishtest/varnishtest -v -i
 TEST_EXTENSIONS = .vtc
 
-check-local: vtc-check-tests
+check: vtc-check-tests
 
 vtc-check-tests:
 	@mkdir -p tests ; \


### PR DESCRIPTION
This was fixed after several attempts in the past [1] and I convinced myself that I was doing it wrong when I implemented generic VSC rules similarly to how VTC rules were centralized [2] but some lessons will never be learned.

The reason why I was so easily convinced is that the '-local' suffix is clearly documented, but the '-am' one is not, which leads me to believe that it is an implementation detail we shouldn't rely on. The documentation clearly states the lack of '-local' ordering, one more reason not to rely on 'check-local'.

If we can use neither 'check-local' nor 'check-am' reliably for the test suite refresh vs execution ordering, maybe there's a simpler solution?

Fixes #3942

[1] 85e3d442c7895e96b4a59a697921a8491f820461
[2] dcaf616c66d93de69735237967cc091fa490bb93