### PR TITLE
vsm: Drastically refine status checks

### DIFF
--- a/bin/varnishtest/Makefile.am
+++ b/bin/varnishtest/Makefile.am
@@ -49,7 +49,8 @@ varnishtest_SOURCES = \
 		vtc_subr.c \
 		vtc_syslog.c \
 		vtc_tunnel.c \
-		vtc_varnish.c
+		vtc_varnish.c \
+		vtc_vsm.c
 
 varnishtest_LDADD = \
 		$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
@@ -60,6 +61,7 @@ varnishtest_LDADD = \
 varnishtest_CFLAGS = \
 		-DVTEST_WITH_VTC_LOGEXPECT \
 		-DVTEST_WITH_VTC_VARNISH \
+		-DVTEST_WITH_VTC_VSM \
 		-DTOP_BUILDDIR='"${top_builddir}"'
 
 EXTRA_DIST = $(top_srcdir)/bin/varnishtest/tests/*.vtc \

--- a/bin/varnishtest/cmds.h
+++ b/bin/varnishtest/cmds.h
@@ -59,6 +59,9 @@ CMD_TOP(tunnel)
 CMD_TOP(varnish)
 #endif
 CMD_TOP(varnishtest)
+#ifdef VTEST_WITH_VTC_VSM
+CMD_TOP(vsm)
+#endif
 CMD_TOP(vtest)
 #undef CMD_TOP
 

--- a/bin/varnishtest/tests/a00025.vtc
+++ b/bin/varnishtest/tests/a00025.vtc
@@ -2,29 +2,25 @@ varnishtest "Basic VSM status check"
 
 # just launch varnishd
 varnish v1 -cliok ping
-# POLA? vsm m1 -expect-status mgt-running
-vsm m1 -expect-status mgt-running,wrk-restarted
+vsm m1 -expect-status mgt-running
 
 varnish v1 -vcl "backend be none;"
-# POLA? vsm m1 -expect-status mgt-running
-vsm m1 -expect-status mgt-running,wrk-restarted
-
-varnish v1 -start
-# POLA? vsm m1 -expect-status mgt-running,mgt-changed,wrk-running
-vsm m1 -expect-status mgt-running,mgt-changed,mgt-restarted,wrk-running
-
-varnish v1 -vcl "backend be none;"
-# POLA? vsm m1 -expect-status mgt-running,wrk-running,wrk-changed
-vsm m1 -expect-status mgt-running,wrk-running
-
-# The order of status flags does not matter, the next one is equivalent.
-varnish v1 -vcl "backend be none;"
-vsm m1 -expect-status wrk-running,mgt-running
-
-varnish v1 -stop
-# POLA? vsm m1 -expect-status mgt-running,mgt-changed
 vsm m1 -expect-status mgt-running
 
 varnish v1 -start
-# POLA? vsm m1 -expect-status mgt-running,mgt-changed,wrk-running,wrk-restarted
-vsm m1 -expect-status mgt-running,mgt-changed,mgt-restarted,wrk-running
+vsm m1 -expect-status \
+	mgt-running,mgt-changed,wrk-running,wrk-changed,wrk-restarted
+
+varnish v1 -vcl "backend be none;"
+vsm m1 -expect-status mgt-running,wrk-running,wrk-changed
+
+# The order of status flags does not matter, the next one is equivalent.
+varnish v1 -vcl "backend be none;"
+vsm m1 -expect-status wrk-changed,wrk-running,mgt-running
+
+varnish v1 -stop
+vsm m1 -expect-status mgt-running,mgt-changed
+
+varnish v1 -start
+vsm m1 -expect-status \
+	mgt-running,mgt-changed,wrk-running,wrk-changed,wrk-restarted

--- a/bin/varnishtest/tests/a00025.vtc
+++ b/bin/varnishtest/tests/a00025.vtc
@@ -1,0 +1,30 @@
+varnishtest "Basic VSM status check"
+
+# just launch varnishd
+varnish v1 -cliok ping
+# POLA? vsm m1 -expect-status mgt-running
+vsm m1 -expect-status mgt-running,wrk-restarted
+
+varnish v1 -vcl "backend be none;"
+# POLA? vsm m1 -expect-status mgt-running
+vsm m1 -expect-status mgt-running,wrk-restarted
+
+varnish v1 -start
+# POLA? vsm m1 -expect-status mgt-running,mgt-changed,wrk-running
+vsm m1 -expect-status mgt-running,mgt-changed,mgt-restarted,wrk-running
+
+varnish v1 -vcl "backend be none;"
+# POLA? vsm m1 -expect-status mgt-running,wrk-running,wrk-changed
+vsm m1 -expect-status mgt-running,wrk-running
+
+# The order of status flags does not matter, the next one is equivalent.
+varnish v1 -vcl "backend be none;"
+vsm m1 -expect-status wrk-running,mgt-running
+
+varnish v1 -stop
+# POLA? vsm m1 -expect-status mgt-running,mgt-changed
+vsm m1 -expect-status mgt-running
+
+varnish v1 -start
+# POLA? vsm m1 -expect-status mgt-running,mgt-changed,wrk-running,wrk-restarted
+vsm m1 -expect-status mgt-running,mgt-changed,mgt-restarted,wrk-running

--- a/bin/varnishtest/tests/c00123.vtc
+++ b/bin/varnishtest/tests/c00123.vtc
@@ -31,10 +31,11 @@ client c1 {
 
 # in practice a little over fetch_chunksize is allocated
 varnish v1 -expect SM?.s0.c_bytes < 20000
+varnish v1 -vsl_catchup
 
 # reset s0 counters
-varnish v1 -cliok stop
-varnish v1 -cliok start
+varnish v1 -stop
+varnish v1 -start
 varnish v1 -expect SM?.s0.c_bytes == 0
 
 # content-length req.body streaming also needs one chunk
@@ -45,10 +46,11 @@ client c2 {
 } -run
 
 varnish v1 -expect SM?.s0.c_bytes < 20000
+varnish v1 -vsl_catchup
 
 # reset s0 counters
-varnish v1 -cliok stop
-varnish v1 -cliok start
+varnish v1 -stop
+varnish v1 -start
 
 # chunked req.body caching allocates storage for the entire body
 client c3 {
@@ -60,10 +62,11 @@ client c3 {
 } -run
 
 varnish v1 -expect SM?.s0.c_bytes > 100000
+varnish v1 -vsl_catchup
 
 # reset s0 counters
-varnish v1 -cliok stop
-varnish v1 -cliok start
+varnish v1 -stop
+varnish v1 -start
 
 # content-length req.body caching allocates storage for the entire body
 client c4 {
@@ -73,3 +76,4 @@ client c4 {
 } -run
 
 varnish v1 -expect SM?.s0.c_bytes > 100000
+varnish v1 -vsl_catchup

--- a/bin/varnishtest/tests/u00008.vtc
+++ b/bin/varnishtest/tests/u00008.vtc
@@ -39,6 +39,10 @@ process p1 -expect-text 0 0 "VBE.vcl1.s1.req"
 process p1 -expect-text 0 0 "DIAG"
 process p1 -screen_dump
 
+varnish v1 -stop
+process p1 -expect-text 2 1 "Uptime child:   Not Running"
+process p1 -screen_dump
+
 process p1 -write {dek}
 process p1 -expect-text 0 1 "Concurrent connections used:"
 process p1 -screen_dump

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -204,7 +204,7 @@ varnishlog_thread(void *priv)
 	struct VSL_cursor *c;
 	enum VSL_tag_e tag;
 	uint64_t vxid;
-	unsigned len;
+	unsigned len, vs;
 	const char *tagname, *data;
 	int type, i, opt;
 	struct vsb *vsb = NULL;
@@ -271,7 +271,8 @@ varnishlog_thread(void *priv)
 		if (i == 0) {
 			/* Nothing to do but wait */
 			v->vsl_idle++;
-			if (!(VSM_Status(vsm) & VSM_WRK_RUNNING)) {
+			vs = VSM_Status(vsm) & VSM_WRK_MASK;
+			if ((vs & ~VSM_WRK_CHANGED) != VSM_WRK_RUNNING) {
 				/* Abandoned - try reconnect */
 				VSL_DeleteCursor(c);
 				c = NULL;

--- a/bin/varnishtest/vtc_vsm.c
+++ b/bin/varnishtest/vtc_vsm.c
@@ -1,0 +1,296 @@
+/*-
+ * Copyright (c) 2023 Varnish Software AS
+ * All rights reserved.
+ *
+ * Author: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifdef VTEST_WITH_VTC_VSM
+
+#include "config.h"
+
+#include <sys/types.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "vapi/vsm.h"
+
+#include "vtc.h"
+#include "vav.h"
+
+struct vtc_vsm {
+	unsigned			magic;
+#define VTC_VSM_MAGIC			0x5ca77a36
+	VTAILQ_ENTRY(vtc_vsm)		list;
+
+	char				*name;
+	char				*n_arg;
+	struct vtclog			*vl;
+	struct vsm			*vsm;
+};
+
+static VTAILQ_HEAD(, vtc_vsm) vsms = VTAILQ_HEAD_INITIALIZER(vsms);
+
+static struct vtc_vsm *
+vsm_new(const char *name)
+{
+	struct vtc_vsm *m;
+
+	ALLOC_OBJ(m, VTC_VSM_MAGIC);
+	AN(m);
+	REPLACE(m->name, name);
+	REPLACE(m->n_arg, "${v1_name}");
+	m->vl = vtc_logopen("%s", name);
+
+	VTAILQ_INSERT_TAIL(&vsms, m, list);
+	return (m);
+}
+
+static void
+vsm_detach(struct vtc_vsm *m)
+{
+
+	CHECK_OBJ_NOTNULL(m, VTC_VSM_MAGIC);
+	if (m->vsm == NULL)
+		vtc_fatal(m->vl, "Cannot detach unattached VSM");
+	vtc_log(m->vl, 3, "Detaching from VSM");
+	VSM_Destroy(&m->vsm);
+	AZ(m->vsm);
+}
+
+static void
+vsm_attach(struct vtc_vsm *m)
+{
+	struct vsb *n_arg;
+
+	CHECK_OBJ_NOTNULL(m, VTC_VSM_MAGIC);
+	if (m->vsm != NULL)
+		vsm_detach(m);
+
+	n_arg = macro_expandf(m->vl, "%s", m->n_arg);
+	if (n_arg == NULL)
+		vtc_fatal(m->vl, "Could not expand -n argument");
+	vtc_log(m->vl, 3, "Attaching to VSM: %s", VSB_data(n_arg));
+
+	m->vsm = VSM_New();
+	AN(m->vsm);
+
+	if (VSM_Arg(m->vsm, 'n', VSB_data(n_arg)) <= 0)
+		vtc_fatal(m->vl, "-n argument error: %s", VSM_Error(m->vsm));
+	if (VSM_Attach(m->vsm, -1))
+		vtc_fatal(m->vl, "VSM_Attach: %s", VSM_Error(m->vsm));
+
+	VSB_destroy(&n_arg);
+}
+
+static void
+vsm_delete(struct vtc_vsm *m)
+{
+
+	CHECK_OBJ_NOTNULL(m, VTC_VSM_MAGIC);
+	if (m->vsm != NULL)
+		vsm_detach(m);
+	REPLACE(m->name, NULL);
+	REPLACE(m->n_arg, NULL);
+	vtc_logclose(m->vl);
+	FREE_OBJ(m);
+}
+
+#define STATUS_BITS()					\
+	STATUS_BIT(VSM_MGT_RUNNING,	mgt-running);	\
+	STATUS_BIT(VSM_MGT_CHANGED,	mgt-changed);	\
+	STATUS_BIT(VSM_MGT_RESTARTED,	mgt-restarted);	\
+	STATUS_BIT(VSM_WRK_RUNNING,	wrk-running);	\
+	STATUS_BIT(VSM_WRK_CHANGED,	wrk-changed);	\
+	STATUS_BIT(VSM_WRK_RESTARTED,	wrk-restarted);
+
+static void
+vsm_expect_status(struct vtc_vsm *m, const char *exp)
+{
+	struct vsb *stat;
+	const char *sep;
+	char **av;
+	unsigned bstat, bexp, bfound;
+	int argc, i;
+
+	CHECK_OBJ_NOTNULL(m, VTC_VSM_MAGIC);
+	if (exp == NULL)
+		vtc_fatal(m->vl, "Missing expected status");
+
+	if (m->vsm == NULL)
+		vsm_attach(m);
+
+	av = VAV_Parse(exp, &argc, ARGV_COMMA|ARGV_NOESC);
+	AN(av);
+
+	bexp = 0;
+	for (i = 1; i < argc; i++) {
+#define STATUS_BIT(b, s)				\
+		if (!strcasecmp(#s, av[i])) {		\
+			bexp |= b;			\
+			continue;			\
+		}
+		STATUS_BITS()
+#undef STATUS_BIT
+		vtc_fatal(m->vl, "Unknown status bit: %s", av[i]);
+	}
+	VAV_Free(av);
+
+	bfound = 0;
+	bstat = VSM_Status(m->vsm);
+	stat = VSB_new_auto();
+	AN(stat);
+	sep = "";
+#define STATUS_BIT(b, s)				\
+	if (bstat & b) {				\
+		VSB_cat(stat, sep);			\
+		VSB_cat(stat, #s);			\
+		bfound |= b;				\
+		sep = ",";				\
+	}
+	STATUS_BITS();
+#undef STATUS_BIT
+
+	if (bstat != bfound) {
+		vtc_fatal(m->vl, "VSM status bits not handled: %x",
+		    bstat & ~bfound);
+	}
+
+	if (bstat != bexp) {
+		AZ(VSB_finish(stat));
+		vtc_fatal(m->vl, "Expected VSM status '%s' got '%s'",
+		    exp, VSB_data(stat));
+	}
+
+	VSB_destroy(&stat);
+	vtc_log(m->vl, 4, "Found expected VSM status");
+}
+
+/* SECTION: vsm vsm
+ *
+ * Interact with the shared memory of a varnish instance.
+ *
+ * To define a VSM consumer, use this syntax::
+ *
+ *     vsm mNAME [-n STRING]
+ *
+ * Arguments:
+ *
+ * mNAME
+ *         Identify the VSM consumer, it must starts with 'm'.
+ *
+ * \-n STRING
+ *         Choose the working directory of the varnish instance. By default
+ *         a VSM consumer connects to ``${v1_name}``.
+ *
+ * \-attach
+ *         Attach to a new varnish instance. Implicitly detach from the
+ *         current varnish instance if applicable.
+ *
+ * \-detach
+ *         Detach from the current varnish instance.
+ *
+ * \-expect-status STRING
+ *         Check that the status of VSM matches the list of status flags from
+ *         STRING. The expected status is represented as a comma-separated
+ *         list of flags. The list of flags in STRING is not sensitive to the
+ *         order of flags.
+ *
+ *         The available flags are:
+ *
+ *         - ``mgt-running``
+ *         - ``mgt-changed``
+ *         - ``mgt-restarted``
+ *         - ``wrk-running``
+ *         - ``wrk-changed``
+ *         - ``wrk-restarted``
+ *
+ *         Expecting a status automatically attaches to the varnish instance
+ *         if that was not already the case.
+ */
+
+void
+cmd_vsm(CMD_ARGS)
+{
+	struct vtc_vsm *m, *m2;
+
+	(void)priv;
+
+	if (av == NULL) {
+		/* Reset and free */
+		VTAILQ_FOREACH_SAFE(m, &vsms, list, m2) {
+			CHECK_OBJ_NOTNULL(m, VTC_VSM_MAGIC);
+			VTAILQ_REMOVE(&vsms, m, list);
+			vsm_delete(m);
+		}
+		return;
+	}
+
+	AZ(strcmp(av[0], "vsm"));
+	av++;
+
+	VTC_CHECK_NAME(vl, av[0], "VSM", 'm');
+	VTAILQ_FOREACH(m, &vsms, list) {
+		if (!strcmp(m->name, av[0]))
+			break;
+	}
+
+	if (m == NULL) {
+		m = vsm_new(*av);
+		AN(m);
+	}
+	av++;
+
+	for (; *av != NULL; av++) {
+		if (vtc_error)
+			break;
+		if (!strcmp(*av, "-attach")) {
+			vsm_attach(m);
+			continue;
+		}
+		if (!strcmp(*av, "-detach")) {
+			vsm_detach(m);
+			continue;
+		}
+		if (!strcmp(*av, "-expect-status")) {
+			vsm_expect_status(m, av[1]);
+			av++;
+			continue;
+		}
+		if (!strcmp(*av, "-n")) {
+			if (av[1] == NULL)
+				vtc_fatal(m->vl, "Missing -n argument");
+			REPLACE(m->n_arg, av[1]);
+			av++;
+			continue;
+		}
+		vtc_fatal(vl, "Unknown VSM argument: %s", *av);
+	}
+}
+
+#endif /* VTEST_WITH_VTC_VSM */

--- a/doc/sphinx/Makefile.am
+++ b/doc/sphinx/Makefile.am
@@ -159,7 +159,8 @@ VTCSYN_SRC = \
 	$(top_srcdir)/bin/varnishtest/vtc_process.c \
 	$(top_srcdir)/bin/varnishtest/vtc_syslog.c \
 	$(top_srcdir)/bin/varnishtest/vtc_tunnel.c \
-	$(top_srcdir)/bin/varnishtest/vtc_varnish.c
+	$(top_srcdir)/bin/varnishtest/vtc_varnish.c \
+	$(top_srcdir)/bin/varnishtest/vtc_vsm.c
 include/vtc-syntax.rst: $(srcdir)/vtc-syntax.py $(VTCSYN_SRC)
 	$(AM_V_GEN) $(PYTHON) $(srcdir)/vtc-syntax.py $(VTCSYN_SRC) > ${@}_
 	@mv -f ${@}_ ${@}

--- a/doc/sphinx/reference/vsm.rst
+++ b/doc/sphinx/reference/vsm.rst
@@ -106,18 +106,18 @@ VSM files.
 VSM and Containers
 ------------------
 
-The varnish way works great with single purpose containers. By sharing
-the varnish working directory read-only, vsm readers can be run in
-containers separate from those running varnishd instances on the same
-host.
+The Varnish Shared Memory model works well in single-purpose containers.
+By sharing the Varnish working directory read-only, VSM readers can run
+in individual containers separate from those running varnishd instances on
+the same host.
 
-When running varnishd and vsm readers in the same process namespace,
-pid information can be used by vsm readers to determine if varnishd
-processes are alive.
+On Linux, if varnishd and VSM readers run in the same process namespace, the
+VSM readers can rely on the PID advertised by varnishd to determine whether
+the manager and cache processes are alive.
 
-But, when running varnishd and vsm readers in different containers,
-the pid information has no relevance and may even be ambiguous across
-name spaces.
+However, if they live in different containers, exposing the Varnish working
+directory as a volume to containers running VSM readers, the PIDs exposed by
+varnishd are no longer relevant across namespaces.
 
-Thus, with such setups, the environment variable VSM_NOPID needs to be
-set for vsm readers to disable use of pid information.
+To disable liveness checks based on PIDs, the variable ``VSM_NOPID`` needs to
+be present in the environment of VSM readers.

--- a/doc/sphinx/reference/vsm.rst
+++ b/doc/sphinx/reference/vsm.rst
@@ -102,3 +102,22 @@ a chance to discover the deallocation.
 
 The include file <vapi/vsm.h> provides the supported API for accessing
 VSM files.
+
+VSM and Containers
+------------------
+
+The varnish way works great with single purpose containers. By sharing
+the varnish working directory read-only, vsm readers can be run in
+containers separate from those running varnishd instances on the same
+host.
+
+When running varnishd and vsm readers in the same process namespace,
+pid information can be used by vsm readers to determine if varnishd
+processes are alive.
+
+But, when running varnishd and vsm readers in different containers,
+the pid information has no relevance and may even be ambiguous across
+name spaces.
+
+Thus, with such setups, the environment variable VSM_NOPID needs to be
+set for vsm readers to disable use of pid information.

--- a/include/vapi/vsm.h
+++ b/include/vapi/vsm.h
@@ -130,6 +130,9 @@ int VSM_Attach(struct vsm *, int progress);
 #define VSM_WRK_CHANGED		(1U<<10)
 #define VSM_WRK_RESTARTED	(1U<<11)
 
+#define VSM_MGT_MASK 0x00ff
+#define VSM_WRK_MASK 0xff00
+
 unsigned VSM_Status(struct vsm *);
 	/*
 	 * Returns a bitmap of the current status and changes in it

--- a/lib/libvarnishapi/vsm.c
+++ b/lib/libvarnishapi/vsm.c
@@ -151,6 +151,8 @@ struct vsm {
 
 	int			attached;
 	double			patience;
+
+	int			couldkill;
 };
 
 /*--------------------------------------------------------------------*/
@@ -362,6 +364,8 @@ VSM_New(void)
 	vd->child->vsm = vd;
 	vd->wdfd = -1;
 	vd->patience = 5;
+	if (getenv("VSM_NOPID") != NULL)
+		vd->couldkill = -1;
 	return (vd);
 }
 
@@ -488,10 +492,14 @@ vsm_vlu_hash(struct vsm *vd, struct vsm_set *vs, const char *line)
 	int i;
 	uintmax_t id1, id2;
 
-	(void)vd;
-
 	i = sscanf(line, "# %ju %ju", &id1, &id2);
 	if (i != 2) {
+		vs->retval |= VSM_MGT_RESTARTED | VSM_MGT_CHANGED;
+		return (0);
+	}
+	if (vd->couldkill >= 0 && !kill(id1, 0)) {
+		vd->couldkill = 1;
+	} else if (vd->couldkill > 0 && errno == ESRCH) {
 		vs->retval |= VSM_MGT_RESTARTED | VSM_MGT_CHANGED;
 		return (0);
 	}
@@ -693,7 +701,8 @@ vsm_refresh_set(struct vsm *vd, struct vsm_set *vs)
 
 	vs->fst.st_size = lseek(vs->fd, 0L, SEEK_CUR);
 
-	vs->retval |= vs->flag_running;
+	if (vd->couldkill < 1 || !kill(vs->id1, 0))
+		vs->retval |= vs->flag_running;
 	return (vs->retval);
 }
 

--- a/lib/libvarnishapi/vsm.c
+++ b/lib/libvarnishapi/vsm.c
@@ -732,7 +732,7 @@ VSM_Status(struct vsm *vd)
 	/* Open workdir */
 	if (vd->wdfd < 0) {
 		retval |= VSM_MGT_RESTARTED | VSM_MGT_CHANGED;
-		retval |= VSM_WRK_RESTARTED | VSM_MGT_CHANGED;
+		retval |= VSM_WRK_RESTARTED | VSM_WRK_CHANGED;
 		vd->wdfd = open(vd->wdname, O_RDONLY);
 		if (vd->wdfd < 0)
 			(void)vsm_diag(vd,


### PR DESCRIPTION
From the main patch of the series:

> Roughly:
> 
> - index hash change means restarted
> - index new plus or minus means changed
> - reopening the index means restarted
> 
> This aligns with my POLA expectations, except for one we can do nothing about after the removal of SIGNULL liveness checks.
> 
> Refs b845c2789cae4f165e30a3d0f3af1bfbbeca98ee

I wasted a fair amount of time trying to get transaction logs from a VTC involving a restart of the cache process. Ever since we stopped sending `SIGNULL` the cache process became virtually always running once started for the first time. Especially since `vtc_varnish` would only check the `VSM_WRK_RUNNING` flag.

Between a probable copy-pasta mistake and alleged logic errors, the `VSM_WRK_CHANGED` flag was effectively dead.

It turned out to be really hard to test, so I started a minimal `vtc_vsm` facility, and it became obscenely easy.

I picked a test case to test the result, and it wasn't even restarting the child process correctly...

This is very much incomplete, except for the overall structure of the patch series (I cut some corners) and this code has not seen anything remotely close to production.

And for now, I can go back to my troubleshooting in peace.