### PR TITLE
vfil: Make struct vfil_path usable outside of varnishd

### DIFF
--- a/include/miniobj.h
+++ b/include/miniobj.h
@@ -30,6 +30,16 @@
 			(to)->magic = (type_magic);			\
 	} while (0)
 
+#define ALLOC_OBJ_ARRAY(to, len, fld, type_magic)			\
+	do {								\
+		v_static_assert(					\
+		    sizeof *(to) == offsetof(typeof(*(to)), fld));	\
+		(to) = calloc(1,					\
+		    sizeof *(to) + ((len) * sizeof *((to)->fld)));	\
+		if ((to) != NULL)					\
+			(to)->magic = (type_magic);			\
+	} while (0)
+
 #define FREE_OBJ(to)							\
 	do {								\
 		ZERO_OBJ(&(to)->magic, sizeof (to)->magic);		\

--- a/include/vfil.h
+++ b/include/vfil.h
@@ -41,8 +41,8 @@ int VFIL_writefile(const char *pfx, const char *fn, const char *buf, size_t sz);
 int VFIL_nonblocking(int fd);
 int VFIL_fsinfo(int fd, unsigned *pbs, uintmax_t *size, uintmax_t *space);
 int VFIL_allocate(int fd, uintmax_t size, int insist);
-void VFIL_setpath(struct vfil_path**, const char *path);
+void VFIL_destroypath(struct vfil_path **);
+void VFIL_setpath(struct vfil_path **, const char *path);
 typedef int vfil_path_func_f(void *priv, const char *fn);
 int VFIL_searchpath(const struct vfil_path *, vfil_path_func_f *func,
     void *priv, const char *fni, char **fno);
-


### PR DESCRIPTION
This is a cherry-pick of the uncontroversial parts from #3182 motivated by https://github.com/varnishcache/varnish-cache/issues/3946#issuecomment-1627701080.

If we proceed with exposing libvarnish entirely, I would rather spin a `vpath.h` off `vfil.h` for this purpose.