### PR TITLE
Fix a race between VBP_Remove() and vbp_thread()

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -710,8 +710,12 @@ VBP_Remove(struct backend *be)
 	be->probe = NULL;
 	vt->backend = NULL;
 	if (vt->running) {
+		// task scheduled, it calls vbp_delete()
 		vt->running = -1;
 		vt = NULL;
+	} else if (vt->heap_idx != VBH_NOIDX) {
+		// task done, not yet rescheduled
+		VBH_delete(vbp_heap, vt->heap_idx);
 	}
 	Lck_Unlock(&vbp_mtx);
 	if (vt != NULL) {


### PR DESCRIPTION
Suppose the following happens:

`vbp_task()` finishes with `vt->running = 0` and a heap insert. The `vbp_cond` is signaled under the lock, but now instead of `vbp_thread()` waking up first, `VBP_Remove()` gets the lock and reaches `assert(vt->heap_idx == VBH_NOIDX);` before the racing `vbp_thread()` deleted the heap.

This is unlikely to happen with static backends, because for those, the probe is stopped via the vcl temperature before they get removed.

Fixes https://github.com/nigoroll/libvmod-dynamic/issues/100