### PR TITLE
Add default "Server" and "User-Agent" headers in vtc

### DIFF
--- a/bin/varnishtest/tests/a00024.vtc
+++ b/bin/varnishtest/tests/a00024.vtc
@@ -1,0 +1,52 @@
+varnishtest "test -noserver"
+
+server s1  {
+    rxreq
+    txresp
+    rxreq
+    txresp -hdr "Server: not-s1"
+} -start
+
+server s2  {
+    rxreq
+    txresp
+    rxreq
+    txresp -noserver
+} -start
+
+
+varnish v1 -vcl+backend {
+    sub vcl_recv {
+	    if (req.url == "/home") {
+	        set req.backend_hint = s1;
+	    } else {
+	        set req.backend_hint = s2;
+	    }
+    }
+
+    sub vcl_backend_response {
+        set Beresp.uncacheable = true;
+    }
+} -start
+
+
+client c101 {
+    txreq -url "/home"
+    rxresp
+    # by default, Server header is set to sNAME
+    expect resp.http.Server == "s1"
+    txreq  -url "/home"
+    rxresp
+    # when specified with -hdr, it overrides the default
+    expect resp.http.Server == "not-s1"
+} -run
+
+client c202 {
+	txreq
+	rxresp
+	expect resp.http.Server == "s2"
+    txreq
+	rxresp
+	# default Server header is not included when -noserver is specified
+	expect resp.http.Server == <undef>
+} -run

--- a/bin/varnishtest/tests/a00024.vtc
+++ b/bin/varnishtest/tests/a00024.vtc
@@ -1,16 +1,23 @@
-varnishtest "test -noserver"
+varnishtest "test -nouseragent and -noserver"
 
 server s1  {
     rxreq
+    # by default, User-Agent header is set to cNAME
+    expect req.http.User-Agent == "c101"
     txresp
     rxreq
+    # when specified with -hdr, it overrides the default
+    expect req.http.User-Agent == "not-c101"
     txresp -hdr "Server: not-s1"
 } -start
 
 server s2  {
     rxreq
+    expect req.http.User-Agent == "c202"
     txresp
     rxreq
+    # default User-Agent header is not included when -nouseragent is specified
+    expect req.http.User-Agent == <undef>
     txresp -noserver
 } -start
 
@@ -35,7 +42,7 @@ client c101 {
     rxresp
     # by default, Server header is set to sNAME
     expect resp.http.Server == "s1"
-    txreq  -url "/home"
+    txreq  -url "/home" -hdr "User-Agent: not-c101"
     rxresp
     # when specified with -hdr, it overrides the default
     expect resp.http.Server == "not-s1"
@@ -45,7 +52,7 @@ client c202 {
 	txreq
 	rxresp
 	expect resp.http.Server == "s2"
-    txreq
+    txreq -nouseragent
 	rxresp
 	# default Server header is not included when -noserver is specified
 	expect resp.http.Server == <undef>

--- a/bin/varnishtest/tests/b00000.vtc
+++ b/bin/varnishtest/tests/b00000.vtc
@@ -52,8 +52,7 @@ varnish v1 -expect client_req == 1
 varnish v1 -expect cache_miss == 1
 varnish v1 -expect s_sess == 1
 varnish v1 -expect s_resp_bodybytes == 7
-varnish v1 -expect s_resp_hdrbytes == 146
-
+varnish v1 -expect s_resp_hdrbytes == 158
 client c1 {
 	txreq -url "/2"
 	rxresp
@@ -67,4 +66,4 @@ varnish v1 -expect client_req == 2
 varnish v1 -expect cache_miss == 2
 varnish v1 -expect s_sess == 2
 varnish v1 -expect s_resp_bodybytes == 14
-varnish v1 -expect s_resp_hdrbytes == 292
+varnish v1 -expect s_resp_hdrbytes == 316

--- a/bin/varnishtest/tests/b00053.vtc
+++ b/bin/varnishtest/tests/b00053.vtc
@@ -35,7 +35,7 @@ varnish v1 -expect client_req == 1
 varnish v1 -expect cache_miss == 1
 varnish v1 -expect s_sess == 1
 varnish v1 -expect s_resp_bodybytes == 7
-varnish v1 -expect s_resp_hdrbytes == 146
+varnish v1 -expect s_resp_hdrbytes == 158
 
 # varnishtest "vtc v_* macros when the listen address is UDS" (a00019)
 

--- a/bin/varnishtest/tests/c00036.vtc
+++ b/bin/varnishtest/tests/c00036.vtc
@@ -2,13 +2,13 @@ varnishtest "Backend close retry"
 
 server s1 -repeat 1 {
 	rxreq
-	txresp -nodate -bodylen 5
+	txresp -noserver -nodate -bodylen 5
 
 	rxreq
 	accept
 
 	rxreq
-	txresp -nodate -bodylen 6
+	txresp -noserver -nodate -bodylen 6
 
 } -start
 

--- a/bin/varnishtest/tests/e00003.vtc
+++ b/bin/varnishtest/tests/e00003.vtc
@@ -50,7 +50,7 @@ varnish v1 -vcl+backend {
 
 logexpect l1 -v v1 -g request {
 	expect 0 1001   Begin   "^req .* rxreq"
-	expect * =	ReqAcct	"^29 0 29 182 75 257$"
+	expect * =	ReqAcct	"^45 0 45 182 75 257$"
 	expect 0 =      End
 } -start
 
@@ -73,7 +73,7 @@ logexpect l4 -v v1 -g request {
 logexpect l5 -v v1 -g request {
 	expect * 1006   Begin   "^req .* rxreq"
 	# Header bytes is 5 larger than in l1 due to two item X-Varnish hdr
-	expect * =	ReqAcct	"^29 0 29 187 75 262$"
+	expect * =	ReqAcct	"^45 0 45 187 75 262$"
 	expect 0 =      End
 } -start
 

--- a/bin/varnishtest/tests/e00003.vtc
+++ b/bin/varnishtest/tests/e00003.vtc
@@ -50,7 +50,7 @@ varnish v1 -vcl+backend {
 
 logexpect l1 -v v1 -g request {
 	expect 0 1001   Begin   "^req .* rxreq"
-	expect * =	ReqAcct	"^29 0 29 170 75 245$"
+	expect * =	ReqAcct	"^29 0 29 182 75 257$"
 	expect 0 =      End
 } -start
 
@@ -73,7 +73,7 @@ logexpect l4 -v v1 -g request {
 logexpect l5 -v v1 -g request {
 	expect * 1006   Begin   "^req .* rxreq"
 	# Header bytes is 5 larger than in l1 due to two item X-Varnish hdr
-	expect * =	ReqAcct	"^29 0 29 175 75 250$"
+	expect * =	ReqAcct	"^29 0 29 187 75 262$"
 	expect 0 =      End
 } -start
 

--- a/bin/varnishtest/tests/l00002.vtc
+++ b/bin/varnishtest/tests/l00002.vtc
@@ -26,8 +26,9 @@ varnish v1 -vcl+backend {
 # POST /1 HTTP/1.1\r\n		 18 bytes
 # Host: foo\r\n			 11 bytes
 # Content-Length: 4\r\n		 19 bytes
+# User-Agent: c1\r\n		 16 bytes
 # \r\n				  2 bytes
-# Total:			 50 bytes
+# Total:			 66 bytes
 # Response:
 # HTTP/1.1 200 OK\r\n		 17 bytes
 # Content-Length: 1000\r\n	 22 bytes
@@ -75,7 +76,7 @@ varnish v1 -vcl+backend {
 # Total:			 28 bytes
 logexpect l1 -v v1 -g session {
 	expect * 1001	Begin	"^req .* rxreq"
-	expect * =	ReqAcct	"^50 4 54 99 1000 1099$"
+	expect * =	ReqAcct	"^66 4 70 99 1000 1099$"
 	expect 0 =	End
 	expect * 1003	Begin	"^req .* rxreq"
 	expect * =	ReqAcct "^30 0 30 99 2000 2099$"
@@ -111,7 +112,7 @@ client c1 {
 
 logexpect l1 -wait
 
-varnish v1 -expect s_req_hdrbytes == 117
+varnish v1 -expect s_req_hdrbytes == 133
 varnish v1 -expect s_req_bodybytes == 4
 varnish v1 -expect s_resp_hdrbytes == 325
 varnish v1 -expect s_resp_bodybytes == 5000

--- a/bin/varnishtest/tests/l00002.vtc
+++ b/bin/varnishtest/tests/l00002.vtc
@@ -33,8 +33,9 @@ varnish v1 -vcl+backend {
 # Content-Length: 1000\r\n	 22 bytes
 # Connection: keep-alive\r\n	 24 bytes
 # Accept-Ranges: bytes\r\n	 22 bytes
+# Server: s1\r\n		 12 bytes
 # \r\n				  2 bytes
-# Total:			 87 bytes
+# Total:			 99 bytes
 
 # Request (1003):
 # GET /2 HTTP/1.1\r\n		 17 bytes
@@ -46,8 +47,9 @@ varnish v1 -vcl+backend {
 # Content-Length: 2000\r\n	 22 bytes
 # Connection: keep-alive\r\n	 24 bytes
 # Accept-Ranges: bytes\r\n	 22 bytes
+# Server: s1\r\n		 12 bytes
 # \r\n				  2 bytes
-# Total:			 87 bytes
+# Total:			 99 bytes
 
 # Request (1005):
 # GET /2 HTTP/1.1\r\n		 17 bytes
@@ -59,8 +61,9 @@ varnish v1 -vcl+backend {
 # Content-Length: 2000\r\n	 22 bytes
 # Connection: keep-alive\r\n	 24 bytes
 # Accept-Ranges: bytes\r\n	 22 bytes
+# Server: s1\r\n		 12 bytes
 # \r\n				  2 bytes
-# Total:			 87 bytes
+# Total:			 99 bytes
 
 # Request (1006):
 # GET\r\n			  5 bytes
@@ -72,13 +75,13 @@ varnish v1 -vcl+backend {
 # Total:			 28 bytes
 logexpect l1 -v v1 -g session {
 	expect * 1001	Begin	"^req .* rxreq"
-	expect * =	ReqAcct	"^50 4 54 87 1000 1087$"
+	expect * =	ReqAcct	"^50 4 54 99 1000 1099$"
 	expect 0 =	End
 	expect * 1003	Begin	"^req .* rxreq"
-	expect * =	ReqAcct "^30 0 30 87 2000 2087$"
+	expect * =	ReqAcct "^30 0 30 99 2000 2099$"
 	expect 0 =	End
 	expect * 1005	Begin	"^req .* rxreq"
-	expect * =	ReqAcct "^30 0 30 87 2000 2087$"
+	expect * =	ReqAcct "^30 0 30 99 2000 2099$"
 	expect 0 =	End
 	expect * 1006	Begin	"^req .* rxreq"
 	expect * =	ReqAcct	"^7 0 7 28 0 28$"
@@ -110,5 +113,5 @@ logexpect l1 -wait
 
 varnish v1 -expect s_req_hdrbytes == 117
 varnish v1 -expect s_req_bodybytes == 4
-varnish v1 -expect s_resp_hdrbytes == 289
+varnish v1 -expect s_resp_hdrbytes == 325
 varnish v1 -expect s_resp_bodybytes == 5000

--- a/bin/varnishtest/tests/l00003.vtc
+++ b/bin/varnishtest/tests/l00003.vtc
@@ -31,8 +31,9 @@ varnish v1 -vcl+backend {
 # Request (1001):
 # GET / HTTP/1.1\r\n			16 bytes
 # Host: foo\r\n				11 bytes
+# User-Agent: c1\r\n			16 bytes
 # \r\n					 2 bytes
-# Total:				29 bytes
+# Total:				45 bytes
 
 # Reponse:
 # HTTP/1.1 200 OK\r\n			17 bytes
@@ -64,7 +65,7 @@ varnish v1 -vcl+backend {
 
 logexpect l1 -v v1 -g request {
 	expect 0 1001	Begin	"^req .* rxreq"
-	expect * =	ReqAcct		"^29 0 29 105 15 120$"
+	expect * =	ReqAcct		"^45 0 45 105 15 120$"
 	expect 0 =	End
 	expect * 1003	Begin		"^req .* esi"
 	expect * =	ReqAcct		"^0 0 0 0 12 12$"
@@ -86,7 +87,7 @@ client c1 {
 
 logexpect l1 -wait
 
-varnish v1 -expect s_req_hdrbytes == 29
+varnish v1 -expect s_req_hdrbytes == 45
 varnish v1 -expect s_req_bodybytes == 0
 varnish v1 -expect s_resp_hdrbytes == 105
 varnish v1 -expect s_resp_bodybytes == 15

--- a/bin/varnishtest/tests/l00003.vtc
+++ b/bin/varnishtest/tests/l00003.vtc
@@ -39,8 +39,9 @@ varnish v1 -vcl+backend {
 # Accept-Ranges: bytes\r\n		22 bytes
 # Transfer-Encoding: chunked\r\n	28 bytes
 # Connection: keep-alive\r\n		24 bytes
+# Server: s1\r\n		 	12 bytes
 # \r\n					 2 bytes
-# Total:				93 bytes
+# Total:				105 bytes
 
 # Response body:
 # Chunk len				 - bytes
@@ -63,7 +64,7 @@ varnish v1 -vcl+backend {
 
 logexpect l1 -v v1 -g request {
 	expect 0 1001	Begin	"^req .* rxreq"
-	expect * =	ReqAcct		"^29 0 29 93 15 108$"
+	expect * =	ReqAcct		"^29 0 29 105 15 120$"
 	expect 0 =	End
 	expect * 1003	Begin		"^req .* esi"
 	expect * =	ReqAcct		"^0 0 0 0 12 12$"
@@ -87,5 +88,5 @@ logexpect l1 -wait
 
 varnish v1 -expect s_req_hdrbytes == 29
 varnish v1 -expect s_req_bodybytes == 0
-varnish v1 -expect s_resp_hdrbytes == 93
+varnish v1 -expect s_resp_hdrbytes == 105
 varnish v1 -expect s_resp_bodybytes == 15

--- a/bin/varnishtest/tests/l00004.vtc
+++ b/bin/varnishtest/tests/l00004.vtc
@@ -26,15 +26,18 @@ varnish v1 -vcl+backend {
 # POST / HTTP/1.1\r\n			17 bytes
 # Host: foo\r\n				11 bytes
 # Content-Length: 4\r\n			19 bytes
+# User-Agent: c1\r\n			16 bytes
 # \r\n					 2 bytes
-# Total:				49 bytes
+# Total:				65 bytes
 
 # bereq:
 # POST / HTTP/1.1\r\n			17 bytes
 # Content-Length: 4\r\n			19 bytes
+# Host: foo\r\n				11 bytes
+# User-Agent: c1\r\n			16 bytes
 # test: yes\r\n				11 bytes
 # \r\n					 2 bytes
-# Total:				49 bytes
+# Total:				76 bytes
 
 # reqbody
 # asdf					 4 bytes
@@ -49,7 +52,7 @@ varnish v1 -vcl+backend {
 
 logexpect l1 -v v1 -g request {
 	expect 0 1001	Begin		"^req .* rxreq"
-	expect * =	PipeAcct	"^49 60 4 54$"
+	expect * =	PipeAcct	"^65 76 4 54$"
 	expect 0 =	End
 } -start
 
@@ -62,6 +65,6 @@ client c1 {
 
 logexpect l1 -wait
 
-varnish v1 -expect s_pipe_hdrbytes == 49
+varnish v1 -expect s_pipe_hdrbytes == 65
 varnish v1 -expect s_pipe_in == 4
 varnish v1 -expect s_pipe_out == 54

--- a/bin/varnishtest/tests/l00004.vtc
+++ b/bin/varnishtest/tests/l00004.vtc
@@ -42,13 +42,14 @@ varnish v1 -vcl+backend {
 # resp:
 # HTTP/1.1 200 OK\r\n			17 bytes
 # Content-Length: 4\r\n			19 bytes
+# Server: s1\r\n		 	12 bytes
 # \r\n					 2 bytes
 # fdsa					 4 bytes
-# Total:				42 bytes
+# Total:				54 bytes
 
 logexpect l1 -v v1 -g request {
 	expect 0 1001	Begin		"^req .* rxreq"
-	expect * =	PipeAcct	"^49 60 4 42$"
+	expect * =	PipeAcct	"^49 60 4 54$"
 	expect 0 =	End
 } -start
 
@@ -63,4 +64,4 @@ logexpect l1 -wait
 
 varnish v1 -expect s_pipe_hdrbytes == 49
 varnish v1 -expect s_pipe_in == 4
-varnish v1 -expect s_pipe_out == 42
+varnish v1 -expect s_pipe_out == 54

--- a/bin/varnishtest/tests/l00005.vtc
+++ b/bin/varnishtest/tests/l00005.vtc
@@ -28,9 +28,10 @@ varnish v1 -vcl+backend {
 # Request (1002):
 # POST /1 HTTP/1.1\r\n		 18 bytes
 # Content-Length: 4\r\n		 19 bytes
+# User-Agent: c1\r\n		 16 bytes
 # Host: foo.bar\r\n		 15 bytes
 # \r\n				  2 bytes
-# Total:			 54 bytes
+# Total:			 70 bytes
 # Response:
 # HTTP/1.1 200 OK\r\n		 17 bytes
 # Content-Length: 1000\r\n	 22 bytes
@@ -41,9 +42,10 @@ varnish v1 -vcl+backend {
 # Request (1004):
 # POST /2 HTTP/1.1\r\n		 18 bytes
 # Content-Length: 4\r\n		 19 bytes
+# User-Agent: c1\r\n		 16 bytes
 # Host: foo.bar\r\n		 15 bytes
 # \r\n				  2 bytes
-# Total:			 54 bytes
+# Total:			 70 bytes
 # Reponse:
 # HTTP/1.1\r\n			 10 bytes
 # \r\n				  2 bytes
@@ -55,10 +57,10 @@ logexpect l1 -v v1 -g session {
 	expect 0 1003	Begin		"^req .* rxreq"
 	expect * =	End
 	expect 0 1002   Begin		"^bereq "
-	expect * =      BereqAcct       "^54 4 58 53 1000 1053$"
+	expect * =      BereqAcct       "^70 4 74 53 1000 1053$"
 	expect 0 =      End
 	expect 0 1004	Begin		"^bereq"
-	expect * =	BereqAcct	"^54 4 58 12 0 12$"
+	expect * =	BereqAcct	"^70 4 74 12 0 12$"
 	expect * =	End
 
 } -start

--- a/bin/varnishtest/tests/l00005.vtc
+++ b/bin/varnishtest/tests/l00005.vtc
@@ -34,8 +34,9 @@ varnish v1 -vcl+backend {
 # Response:
 # HTTP/1.1 200 OK\r\n		 17 bytes
 # Content-Length: 1000\r\n	 22 bytes
+# Server: s1\r\n		 12 bytes
 # \r\n				  2 bytes
-# Total:			 41 bytes
+# Total:			 53 bytes
 
 # Request (1004):
 # POST /2 HTTP/1.1\r\n		 18 bytes
@@ -54,7 +55,7 @@ logexpect l1 -v v1 -g session {
 	expect 0 1003	Begin		"^req .* rxreq"
 	expect * =	End
 	expect 0 1002   Begin		"^bereq "
-	expect * =      BereqAcct       "^54 4 58 41 1000 1041$"
+	expect * =      BereqAcct       "^54 4 58 53 1000 1053$"
 	expect 0 =      End
 	expect 0 1004	Begin		"^bereq"
 	expect * =	BereqAcct	"^54 4 58 12 0 12$"

--- a/bin/varnishtest/tests/r00498.vtc
+++ b/bin/varnishtest/tests/r00498.vtc
@@ -3,7 +3,7 @@ varnishtest "very very very long return header"
 server s1 {
 	rxreq
 	expect req.url == "/"
-	txresp -hdr "Location: ${string,repeat,8136,1}" -nodate -body {foo}
+	txresp -noserver -hdr "Location: ${string,repeat,8136,1}" -nodate -body {foo}
 } -start
 
 varnish v1 -vcl+backend {

--- a/bin/varnishtest/tests/r01140.vtc
+++ b/bin/varnishtest/tests/r01140.vtc
@@ -4,18 +4,18 @@ server s1 {
 	# This response should almost completely fill the storage
 	rxreq
 	expect req.url == /url1
-	txresp -bodylen 1048400
+	txresp -noserver -bodylen 1048400
 
 	# The next one should not fit in the storage, ending up in transient
 	# with zero ttl (=shortlived)
 	rxreq
 	expect req.url == /url2
-	txresp -bodylen 1024
+	txresp -noserver -bodylen 1024
 
 	# And therefore this one should be fetched next
 	rxreq
 	expect req.url == /url2
-	txresp -bodylen 1025
+	txresp -noserver -bodylen 1025
 } -start
 
 varnish v1 -arg "-p nuke_limit=0 -p shortlived=0" \

--- a/bin/varnishtest/tests/r01637.vtc
+++ b/bin/varnishtest/tests/r01637.vtc
@@ -25,7 +25,7 @@ varnish v1  -arg "-sdefault,1M" -arg "-p nuke_limit=0 -p gzip_level=0" \
 } -start
 
 logexpect l1 -v v1 -g vxid -q "vxid == 1004" {
-	expect 25 1004	VCL_call        {^BACKEND_RESPONSE}
+	expect 26 1004	VCL_call        {^BACKEND_RESPONSE}
 	expect 0  =	BerespHeader    {^free:}
 	expect 0  =	VCL_return      {^deliver}
 	expect 0  =	Timestamp       {^Process}

--- a/bin/varnishtest/tests/r02831.vtc
+++ b/bin/varnishtest/tests/r02831.vtc
@@ -3,7 +3,7 @@ varnishtest "#2831: Out of storage in cache_req_body"
 server s1 {
 	rxreq
 	expect req.url == "/obj1"
-	txresp -bodylen 1048400
+	txresp -noserver -bodylen 1048400
 } -start
 
 varnish v1 \

--- a/bin/varnishtest/tests/t02005.vtc
+++ b/bin/varnishtest/tests/t02005.vtc
@@ -7,10 +7,10 @@ server s1 {
 	rxreq
 	expect req.http.content-length == 7
 	expect req.http.transfer-encoding == <undef>
-	txresp -hdr "Accept-ranges: bytes" -hdr "Content-Type: text/plain" -body response
+	txresp -noserver -hdr "Accept-ranges: bytes" -hdr "Content-Type: text/plain" -body response
 
 	rxreq
-	txresp -hdr "Accept-ranges: bytes"
+	txresp -noserver -hdr "Accept-ranges: bytes"
 } -start
 
 varnish v1 -vcl+backend {

--- a/bin/varnishtest/tests/t02015.vtc
+++ b/bin/varnishtest/tests/t02015.vtc
@@ -2,7 +2,7 @@ varnishtest "h2 ReqAcct"
 
 server s1 {
 	rxreq
-	txresp -bodylen 12345
+	txresp -noserver -bodylen 12345
 } -start
 
 varnish v1 -cliok "param.set feature +http2"

--- a/bin/varnishtest/tests/u00003.vtc
+++ b/bin/varnishtest/tests/u00003.vtc
@@ -34,9 +34,9 @@ process p1 -winsz 25 200 {varnishncsa -n ${v1_name}} -start
 delay 1
 
 client c1 {
-	txreq -url /1?foo=bar -hdr "authorization: basic dXNlcjpwYXNz"
+	txreq -nouseragent -url /1?foo=bar -hdr "authorization: basic dXNlcjpwYXNz"
 	rxresp
-	txreq -url /1?foo=bar -hdr "baz: qux"
+	txreq -nouseragent -url /1?foo=bar -hdr "baz: qux"
 	rxresp
 } -run
 
@@ -46,7 +46,7 @@ shell "mv ${tmpdir}/ncsa.log ${tmpdir}/ncsa.old.log"
 shell "kill -HUP `cat ${tmpdir}/ncsa.pid`"
 
 client c2 {
-	txreq -url /2
+	txreq -nouseragent -url /2
 	rxresp
 } -run
 

--- a/bin/varnishtest/tests/u00010.vtc
+++ b/bin/varnishtest/tests/u00010.vtc
@@ -22,7 +22,7 @@ client c1 {
 
 varnish v1 -vsl_catchup
 
-process p1 -expect-text 1 1 {list length 6}
+process p1 -expect-text 1 1 {list length 7}
 
 process p1 -writehex 0c
 

--- a/bin/varnishtest/tests/v00051.vtc
+++ b/bin/varnishtest/tests/v00051.vtc
@@ -188,6 +188,7 @@ logexpect l1012 -v v1 -g vxid -q "vxid == 1012" {
 	expect 0 =	BereqProtocol	{^HTTP/1.1}
 	expect 0 =	BereqHeader	{^foo: pipe}
 	expect 0 =	BereqHeader	{^Host: }
+	expect 0 =	BereqHeader	{^User-Agent: c1}
 	expect 0 =	BereqHeader	{^X-Forwarded-For: }
 	expect 0 =	BereqHeader	{^Via: }
 	expect 0 =	BereqHeader	{^X-Varnish: 1011}
@@ -207,6 +208,7 @@ logexpect l1011 -v v1 -g vxid -q "vxid == 1011" {
 	expect 0 =	ReqProtocol     {^HTTP/1.1}
 	expect 0 =	ReqHeader       {^foo: pipe}
 	expect 0 =	ReqHeader       {^Host: }
+	expect 0 =	reqHeader	{^User-Agent: c1}
 	expect 0 =	ReqHeader       {^X-Forwarded-For: }
 	expect 0 =	ReqHeader	{^Via: }
 	expect 0 =	VCL_call        {^RECV}

--- a/bin/varnishtest/tests/v00064.vtc
+++ b/bin/varnishtest/tests/v00064.vtc
@@ -3,16 +3,16 @@ varnishtest "vbf_stp_condfetch could not get storage #3273"
 server s1 {
     rxreq
     expect req.url == "/transient"
-    txresp -bodylen 1048400
+    txresp -noserver -bodylen 1048400
 
     rxreq
     expect req.url == "/malloc"
-    txresp -hdr "Cache-Control: max-age=2" -hdr "Last-Modified: Fri, 03 Apr 2020 13:00:01 GMT" -bodylen 1048292
+    txresp -noserver -hdr "Cache-Control: max-age=2" -hdr "Last-Modified: Fri, 03 Apr 2020 13:00:01 GMT" -bodylen 1048292
 
     rxreq
     expect req.http.If-Modified-Since == "Fri, 03 Apr 2020 13:00:01 GMT"
     expect req.url == "/malloc"
-    txresp -status 304
+    txresp -noserver -status 304
 } -start
 
 varnish v1 \

--- a/bin/varnishtest/vtc_http.c
+++ b/bin/varnishtest/vtc_http.c
@@ -769,7 +769,7 @@ cmd_http_gunzip(CMD_ARGS)
 
 static char* const *
 http_tx_parse_args(char * const *av, struct vtclog *vl, struct http *hp,
-    char *body, unsigned nohost, unsigned nodate)
+    char *body, unsigned nohost, unsigned nodate, unsigned noserver)
 {
 	long bodylen = 0;
 	char *b, *c;
@@ -795,6 +795,8 @@ http_tx_parse_args(char * const *av, struct vtclog *vl, struct http *hp,
 				nohost = 1;
 			if (!strncasecmp(av[1], "Date:", 5))
 				nodate = 1;
+			if (!strncasecmp(av[1], "Server:", 7))
+				noserver = 1;
 			VSB_printf(hp->vsb, "%s%s", av[1], nl);
 			av++;
 		} else if (!strcmp(*av, "-hdrlen")) {
@@ -859,6 +861,8 @@ http_tx_parse_args(char * const *av, struct vtclog *vl, struct http *hp,
 		macro_cat(vl, hp->vsb, "date", NULL);
 		VSB_cat(hp->vsb, nl);
 	}
+	if (!noserver)
+		VSB_printf(hp->vsb, "Server: %s%s", hp->sess->name, nl);
 	if (body != NULL && !nolen)
 		VSB_printf(hp->vsb, "Content-Length: %ld%s", bodylen, nl);
 	VSB_cat(hp->vsb, nl);
@@ -898,6 +902,9 @@ http_tx_parse_args(char * const *av, struct vtclog *vl, struct http *hp,
  *
  *         \-reason STRING (txresp only)
  *                 What message to put in the status line (default: "OK").
+ *
+ *         \-noserver (txresp only)
+ *                 Don't include a Server header with the id of the server.
  *
  *         These three switches can appear in any order but must come before the
  *         following ones.
@@ -960,6 +967,7 @@ cmd_http_txresp(CMD_ARGS)
 	const char *status = "200";
 	const char *reason = "OK";
 	char* body = NULL;
+	unsigned noserver = 0;
 
 	(void)vl;
 	CAST_OBJ_NOTNULL(hp, priv, HTTP_MAGIC);
@@ -980,6 +988,9 @@ cmd_http_txresp(CMD_ARGS)
 			reason = av[1];
 			av++;
 			continue;
+		} else if (!strcmp(*av, "-noserver")) {
+			noserver = 1;
+			continue;
 		} else
 			break;
 	}
@@ -989,7 +1000,7 @@ cmd_http_txresp(CMD_ARGS)
 	/* send a "Content-Length: 0" header unless something else happens */
 	REPLACE(body, "");
 
-	av = http_tx_parse_args(av, vl, hp, body, 1, 0);
+	av = http_tx_parse_args(av, vl, hp, body, 1, 0, noserver);
 	if (*av != NULL)
 		vtc_fatal(hp->vl, "Unknown http txresp spec: %s\n", *av);
 
@@ -1221,7 +1232,7 @@ cmd_http_txreq(CMD_ARGS)
 				"HTTP2-Settings: %s%s", nl, nl, up, nl);
 
 	nohost = strcmp(proto, "HTTP/1.1") != 0;
-	av = http_tx_parse_args(av, vl, hp, NULL, nohost, 1);
+	av = http_tx_parse_args(av, vl, hp, NULL, nohost, 1, 1);
 	if (*av != NULL)
 		vtc_fatal(hp->vl, "Unknown http txreq spec: %s\n", *av);
 	http_write(hp, 4, "txreq");


### PR DESCRIPTION
As discussed on varnish-dev ML: https://varnish-cache.org/lists/pipermail/varnish-dev/2023-July/009755.html

This adds default "Server: sNAME" and "User-Agent: cNAME" headers to server `txresp` and client `txreq` respectively in vtc, with the ability to disable them with `-noserver` and `-nouseragent`. Also, both can be overridden with `-hdr`