### PR TITLE
Ban parser: don't accept object name prefixes

### DIFF
--- a/bin/varnishd/cache/cache_ban_build.c
+++ b/bin/varnishd/cache/cache_ban_build.c
@@ -260,6 +260,9 @@ BAN_AddTest(struct ban_proto *bp,
 
 	VSB_putc(bp->vsb, pv->tag);
 	if (pv->flag & BANS_FLAG_HTTP) {
+		if (strlen(a1 + strlen(pv->name)) < 1)
+			return (ban_error(bp,
+			    "Missing header name: \"%s\"", pv->name));
 		assert(BANS_HAS_ARG1_SPEC(pv->tag));
 		ban_parse_http(bp, a1 + strlen(pv->name));
 	}

--- a/bin/varnishd/cache/cache_ban_build.c
+++ b/bin/varnishd/cache/cache_ban_build.c
@@ -245,9 +245,12 @@ BAN_AddTest(struct ban_proto *bp,
 	if (bp->err != NULL)
 		return (bp->err);
 
-	for (pv = pvars; pv->name != NULL; pv++)
-		if (!strncmp(a1, pv->name, strlen(pv->name)))
+	for (pv = pvars; pv->name != NULL; pv++) {
+		if (!(pv->flag & BANS_FLAG_HTTP) && !strcmp(a1, pv->name))
 			break;
+		if ((pv->flag & BANS_FLAG_HTTP) && !strncmp(a1, pv->name, strlen(pv->name)))
+			break;
+	}
 
 	if (pv->name == NULL)
 		return (ban_error(bp,

--- a/bin/varnishtest/tests/r03962.vtc
+++ b/bin/varnishtest/tests/r03962.vtc
@@ -10,4 +10,5 @@ varnish v1 -cliexpect {Unknown or unsupported field "obj.ageYY"} "ban obj.ageYY 
 varnish v1 -cliexpect {Unknown or unsupported field "req.ur"} "ban req.ur ~ foobarbazzz"
 varnish v1 -cliexpect {Unknown or unsupported field "req.htt"} "ban req.htt ~ foobarbazzz"
 varnish v1 -cliexpect {Unknown or unsupported field "req.htt.XXYY"} "ban req.htt.XXYY ~ foobarbazzz"
+varnish v1 -cliexpect {Missing header name: "obj.http."} "ban obj.http. ~ foobarbazzz"
 varnish v1 -cliok "ban req.http.XXYY ~ foobarbazzz"

--- a/bin/varnishtest/tests/r03962.vtc
+++ b/bin/varnishtest/tests/r03962.vtc
@@ -1,0 +1,13 @@
+varnishtest "ban expression object name prefixes"
+
+server s1 {} -start
+
+varnish v1 -vcl+backend {} -start
+
+
+varnish v1 -cliexpect {Unknown or unsupported field "req.urlXX"} "ban req.urlXX ~ foobarbazzz"
+varnish v1 -cliexpect {Unknown or unsupported field "obj.ageYY"} "ban obj.ageYY < 1d"
+varnish v1 -cliexpect {Unknown or unsupported field "req.ur"} "ban req.ur ~ foobarbazzz"
+varnish v1 -cliexpect {Unknown or unsupported field "req.htt"} "ban req.htt ~ foobarbazzz"
+varnish v1 -cliexpect {Unknown or unsupported field "req.htt.XXYY"} "ban req.htt.XXYY ~ foobarbazzz"
+varnish v1 -cliok "ban req.http.XXYY ~ foobarbazzz"

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -38,6 +38,10 @@ Varnish Cache NEXT (2023-09-15)
 .. PLEASE keep this roughly in commit order as shown by git-log / tig
    (new to old)
 
+* Two bugs in the ban expression parser have been fixed where one of them
+  could lead to a panic if a ban expression with an empty header name was
+  issued (3962_)
+
 * A bug has been fixed where ``unset bereq.body`` had no effect when
   used with a cached body (3914_)
 
@@ -87,6 +91,7 @@ Varnish Cache NEXT (2023-09-15)
 .. _3908: https://github.com/varnishcache/varnish-cache/pull/3908
 .. _3911: https://github.com/varnishcache/varnish-cache/issues/3911
 .. _3914: https://github.com/varnishcache/varnish-cache/pull/3914
+.. _3962: https://github.com/varnishcache/varnish-cache/issues/3962
 
 ================================
 Varnish Cache 7.3.0 (2023-03-15)


### PR DESCRIPTION
Fixes #3962