### PR TITLE
vte: Provide a CLI-independent API

### DIFF
--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -45,6 +45,7 @@
 #include "cache_director.h"
 #include "cache_vcl.h"
 #include "vcli_serve.h"
+#include "vte.h"
 #include "vtim.h"
 #include "vcc_interface.h"
 
@@ -750,7 +751,7 @@ vcl_cli_list(struct cli *cli, const char * const *av, void *priv)
 {
 	struct vcl *vcl;
 	const char *flg;
-	struct vsb *vsb;
+	struct vte *vte;
 
 	/* NB: Shall generate same output as mcf_vcl_list() */
 
@@ -758,8 +759,8 @@ vcl_cli_list(struct cli *cli, const char * const *av, void *priv)
 	(void)priv;
 	ASSERT_CLI();
 	ASSERT_VCL_ACTIVE();
-	vsb = VSB_new_auto();
-	AN(vsb);
+	vte = VTE_new(7, 80);
+	AN(vte);
 	VTAILQ_FOREACH(vcl, &vcl_head, list) {
 		if (vcl == vcl_active) {
 			flg = "active";
@@ -767,20 +768,22 @@ vcl_cli_list(struct cli *cli, const char * const *av, void *priv)
 			flg = "discarded";
 		} else
 			flg = "available";
-		VSB_printf(vsb, "%s\t%s\t%s\t%6u\t%s", flg, vcl->state,
+		VTE_printf(vte, "%s\t%s\t%s\t%6u\t%s", flg, vcl->state,
 		    vcl->temp->name, vcl->busy, vcl->loaded_name);
 		if (vcl->label != NULL) {
-			VSB_printf(vsb, "\t->\t%s", vcl->label->loaded_name);
+			VTE_printf(vte, "\t->\t%s", vcl->label->loaded_name);
 			if (vcl->nrefs)
-				VSB_printf(vsb, " (%d return(vcl)%s)",
+				VTE_printf(vte, " (%d return(vcl)%s)",
 				    vcl->nrefs, vcl->nrefs > 1 ? "'s" : "");
 		} else if (vcl->nlabels > 0) {
-			VSB_printf(vsb, "\t<-\t(%d label%s)",
+			VTE_printf(vte, "\t<-\t(%d label%s)",
 			    vcl->nlabels, vcl->nlabels > 1 ? "s" : "");
 		}
-		VSB_cat(vsb, "\n");
+		VTE_cat(vte, "\n");
 	}
-	VCLI_VTE(cli, &vsb, 80);
+	AZ(VTE_finish(vte));
+	AZ(VTE_format(vte, VCLI_VTE_format, cli));
+	VTE_destroy(&vte);
 }
 
 static void v_matchproto_(cli_func_t)

--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -46,6 +46,7 @@
 #include "vcli_serve.h"
 #include "vct.h"
 #include "vev.h"
+#include "vte.h"
 #include "vtim.h"
 
 struct vclstate {
@@ -1012,23 +1013,25 @@ mcf_vcl_deps(struct cli *cli, const char * const *av, void *priv)
 {
 	struct vclprog *vp;
 	struct vcldep *vd;
-	struct vsb *vsb;
+	struct vte *vte;
 
 	(void)av;
 	(void)priv;
 
-	vsb = VSB_new_auto();
-	AN(vsb);
+	vte = VTE_new(2, 80);
+	AN(vte);
 
 	VTAILQ_FOREACH(vp, &vclhead, list) {
 		if (VTAILQ_EMPTY(&vp->dfrom)) {
-			VSB_printf(vsb, "%s\n", vp->name);
+			VTE_printf(vte, "%s\n", vp->name);
 			continue;
 		}
 		VTAILQ_FOREACH(vd, &vp->dfrom, lfrom)
-			VSB_printf(vsb, "%s\t%s\n", vp->name, vd->to->name);
+			VTE_printf(vte, "%s\t%s\n", vp->name, vd->to->name);
 	}
-	VCLI_VTE(cli, &vsb, 80);
+	AZ(VTE_finish(vte));
+	AZ(VTE_format(vte, VCLI_VTE_format, cli));
+	VTE_destroy(&vte);
 }
 
 static void v_matchproto_(cli_func_t)

--- a/bin/varnishtest/tests/s00005.vtc
+++ b/bin/varnishtest/tests/s00005.vtc
@@ -132,3 +132,16 @@ varnish v1 -cliexpect \
 	{would create a loop} \
 	{vcl.label lblA vcl5}
 
+# omitting ^vcl1 line to only get aligned fields
+varnish v1 -cliexpect {
+vcl2
+label1           vcl1
+label2           vcl1
+label3           vcl1
+slartibartfast   vcl1
+vcl3
+lblA             vcl3
+vcl4             lblA
+lblB             vcl4
+vcl5             lblB
+} vcl.deps

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -80,6 +80,7 @@ nobase_pkginclude_HEADERS += \
 	vsb.h \
 	vsha256.h \
 	vtcp.h \
+	vte.h \
 	vtim.h \
 	vtree.h \
 	vrnd.h

--- a/include/vcli_serve.h
+++ b/include/vcli_serve.h
@@ -111,6 +111,3 @@ cli_func_t	VCLS_func_ping_json;
 
 /* VTE integration */
 int VCLI_VTE_format(void *priv, const char *fmt, ...) v_printflike_(2, 3);
-
-/* From libvarnish/vte.c */
-void VCLI_VTE(struct cli *cli, struct vsb **src, int width);

--- a/include/vcli_serve.h
+++ b/include/vcli_serve.h
@@ -109,5 +109,8 @@ cli_func_t	VCLS_func_help_json;
 cli_func_t	VCLS_func_ping;
 cli_func_t	VCLS_func_ping_json;
 
+/* VTE integration */
+int VCLI_VTE_format(void *priv, const char *fmt, ...) v_printflike_(2, 3);
+
 /* From libvarnish/vte.c */
 void VCLI_VTE(struct cli *cli, struct vsb **src, int width);

--- a/include/vte.h
+++ b/include/vte.h
@@ -25,6 +25,14 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
+ * Varnish Turbo Encabulator
+ *
+ * Align and print fields in a line-based output. Fields are delimited
+ * with a horizontal tab HT and lines starting with a space SP are kept
+ * verbatim. Lines are delimited with a single new line LF character.
+ *
+ * Using non-ASCII or non-printable ASCII character is undefined behavior.
  */
 
 struct vte;

--- a/include/vte.h
+++ b/include/vte.h
@@ -1,0 +1,33 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2023 Dridi Boukelmoune <dridi.boukelmoune@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+struct vte;
+
+struct vte *VTE_new(int maxfields, int width);
+void VTE_destroy(struct vte **);

--- a/include/vte.h
+++ b/include/vte.h
@@ -30,6 +30,7 @@
 struct vte;
 
 struct vte *VTE_new(int maxfields, int width);
+int VTE_putc(struct vte *, char);
 int VTE_cat(struct vte *, const char *);
 int VTE_printf(struct vte *, const char *, ...) v_printflike_(2, 3);
 void VTE_destroy(struct vte **);

--- a/include/vte.h
+++ b/include/vte.h
@@ -33,4 +33,5 @@ struct vte *VTE_new(int maxfields, int width);
 int VTE_putc(struct vte *, char);
 int VTE_cat(struct vte *, const char *);
 int VTE_printf(struct vte *, const char *, ...) v_printflike_(2, 3);
+int VTE_finish(struct vte *);
 void VTE_destroy(struct vte **);

--- a/include/vte.h
+++ b/include/vte.h
@@ -31,4 +31,5 @@ struct vte;
 
 struct vte *VTE_new(int maxfields, int width);
 int VTE_cat(struct vte *, const char *);
+int VTE_printf(struct vte *, const char *, ...) v_printflike_(2, 3);
 void VTE_destroy(struct vte **);

--- a/include/vte.h
+++ b/include/vte.h
@@ -29,9 +29,12 @@
 
 struct vte;
 
+typedef int VTE_format_f(void *priv, const char *fmt, ...) v_printflike_(2, 3);
+
 struct vte *VTE_new(int maxfields, int width);
 int VTE_putc(struct vte *, char);
 int VTE_cat(struct vte *, const char *);
 int VTE_printf(struct vte *, const char *, ...) v_printflike_(2, 3);
 int VTE_finish(struct vte *);
+int VTE_format(struct vte *, VTE_format_f *func, void *priv);
 void VTE_destroy(struct vte **);

--- a/include/vte.h
+++ b/include/vte.h
@@ -30,4 +30,5 @@
 struct vte;
 
 struct vte *VTE_new(int maxfields, int width);
+int VTE_cat(struct vte *, const char *);
 void VTE_destroy(struct vte **);

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -661,6 +661,22 @@ VCLI_Out(struct cli *cli, const char *fmt, ...)
 	va_end(ap);
 }
 
+int v_matchproto_(VTE_format_f)
+VCLI_VTE_format(void *priv, const char *fmt, ...)
+{
+	struct cli *cli;
+	va_list ap;
+
+	CAST_OBJ_NOTNULL(cli, priv, CLI_MAGIC);
+	AN(fmt);
+
+	va_start(ap, fmt);
+	vcli_outv(cli, fmt, ap);
+	va_end(ap);
+
+	return (0);
+}
+
 /*lint -e{818} cli could be const */
 int
 VCLI_Overflow(struct cli *cli)

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -637,19 +637,27 @@ VCLS_Destroy(struct VCLS **csp)
  * Utility functions for implementing CLI commands
  */
 
+static void
+vcli_outv(struct cli *cli, const char *fmt, va_list ap)
+{
+
+	if (VSB_len(cli->sb) < *cli->limit)
+		(void)VSB_vprintf(cli->sb, fmt, ap);
+	else if (cli->result == CLIS_OK)
+		cli->result = CLIS_TRUNCATED;
+}
+
 /*lint -e{818} cli could be const */
 void
 VCLI_Out(struct cli *cli, const char *fmt, ...)
 {
 	va_list ap;
 
-	AN(cli);
-	va_start(ap, fmt);
 	CHECK_OBJ_NOTNULL(cli, CLI_MAGIC);
-	if (VSB_len(cli->sb) < *cli->limit)
-		(void)VSB_vprintf(cli->sb, fmt, ap);
-	else if (cli->result == CLIS_OK)
-		cli->result = CLIS_TRUNCATED;
+	AN(fmt);
+
+	va_start(ap, fmt);
+	vcli_outv(cli, fmt, ap);
 	va_end(ap);
 }
 

--- a/lib/libvarnish/vte.c
+++ b/lib/libvarnish/vte.c
@@ -146,6 +146,24 @@ vte_update(struct vte *vte)
 }
 
 int
+VTE_putc(struct vte *vte, char c)
+{
+
+	CHECK_OBJ_NOTNULL(vte, VTE_MAGIC);
+	AN(c);
+
+	if (vte->o_sep != 0)
+		return (-1);
+
+	if (VSB_putc(vte->vsb, c) < 0) {
+		vte->o_sep = -1;
+		return (-1);
+	}
+
+	return (vte_update(vte));
+}
+
+int
 VTE_cat(struct vte *vte, const char *s)
 {
 

--- a/lib/libvarnish/vte.c
+++ b/lib/libvarnish/vte.c
@@ -32,6 +32,7 @@
 #include "config.h"
 
 #include <errno.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h> /* for MUSL (ssize_t) */
@@ -155,6 +156,30 @@ VTE_cat(struct vte *vte, const char *s)
 		return (-1);
 
 	if (VSB_cat(vte->vsb, s) < 0) {
+		vte->o_sep = -1;
+		return (-1);
+	}
+
+	return (vte_update(vte));
+}
+
+int
+VTE_printf(struct vte *vte, const char *fmt, ...)
+{
+	va_list ap;
+	int res;
+
+	CHECK_OBJ_NOTNULL(vte, VTE_MAGIC);
+	AN(fmt);
+
+	if (vte->o_sep != 0)
+		return (-1);
+
+	va_start(ap, fmt);
+	res = VSB_vprintf(vte->vsb, fmt, ap);
+	va_end(ap);
+
+	if (res < 0) {
 		vte->o_sep = -1;
 		return (-1);
 	}

--- a/lib/libvarnish/vte.c
+++ b/lib/libvarnish/vte.c
@@ -254,28 +254,24 @@ VTE_format(struct vte *vte, VTE_format_f *func, void *priv)
 	AN(p);
 	q = p;
 
-	for (fno = fsz = 0; *p != '\0'; p++) {
-		if (fsz == 0 && fno == 0 && *p == ' ') {
-			p = strchr(p, '\n');
-			if (p == NULL) {
-				p = q + 1; // trigger final flush
-				break;
-			}
-			continue;
-		}
+	fno = 0;
+	while (*p != 0) {
+		if (fno == 0 && *p == ' ')
+			fsz = strcspn(p, "\n");
+		else
+			fsz = strcspn(p, "\t\n");
+		p += fsz;
 		if (*p == '\t') {
 			assert(vte->f_maxsz[fno] + nsp > fsz);
 			VTE_FORMAT(func, priv, "%.*s%*s",
 			    (int)(p - q), q,
 			    vte->f_maxsz[fno] + nsp - fsz, "");
 			fno++;
-			fsz = 0;
-			q = p + 1;
+			q = ++p;
 		} else if (*p == '\n') {
 			fno = 0;
-			fsz = 0;
-		} else
-			fsz++;
+			p++;
+		}
 	}
 
 	if (q < p)

--- a/lib/libvarnish/vte.c
+++ b/lib/libvarnish/vte.c
@@ -32,6 +32,7 @@
 #include "config.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
@@ -203,6 +204,29 @@ VTE_printf(struct vte *vte, const char *fmt, ...)
 	}
 
 	return (vte_update(vte));
+}
+
+int
+VTE_finish(struct vte *vte)
+{
+
+	CHECK_OBJ_NOTNULL(vte, VTE_MAGIC);
+
+	if (vte->o_sep != 0)
+		return (-1);
+
+	if (VSB_finish(vte->vsb) < 0) {
+		vte->o_sep = -1;
+		return (-1);
+	}
+
+	if (vte->f_cnt == 0) {
+		vte->o_sep = INT_MAX;
+		return (0);
+	}
+
+	vte->o_sep = (vte->o_sz - vte->l_maxsz) / vte->f_cnt;
+	return (0);
 }
 
 void


### PR DESCRIPTION
Some work on the VTE was requested somewhere else, and it so happened to align with #3946 goals, although, this pull request is not moving anything to libvarnishapi.

The new VTE API is inspired by the VSB API and ultimately avoids one printf per character.

One thing I didn't attempt was to adopt the VTE for the `varnishstat -1` output.