### PR TITLE
Rename VSB_QUOTE_JSON and prepare VSB_quote_*() for returning errors

### DIFF
--- a/bin/varnishd/cache/cache_conn_pool.c
+++ b/bin/varnishd/cache/cache_conn_pool.c
@@ -559,7 +559,7 @@ VCP_Panic(struct vsb *vsb, struct conn_pool *cp)
 	if (PAN_dump_struct(vsb, cp, CONN_POOL_MAGIC, "conn_pool"))
 		return;
 	VSB_cat(vsb, "ident = ");
-	VSB_quote(vsb, cp->ident, VSHA256_DIGEST_LENGTH, VSB_QUOTE_HEX);
+	AZ(VSB_quote(vsb, cp->ident, VSHA256_DIGEST_LENGTH, VSB_QUOTE_HEX));
 	VSB_cat(vsb, ",\n");
 	vcp_panic_endpoint(vsb, cp->endpoint);
 	VSB_indent(vsb, -2);

--- a/bin/varnishd/cache/cache_panic.c
+++ b/bin/varnishd/cache/cache_panic.c
@@ -726,7 +726,7 @@ pan_argv(struct vsb *vsb)
 	VSB_indent(vsb, 2);
 	for (i = 0; i < heritage.argc; i++) {
 		VSB_printf(vsb, "[%d] = ", i);
-		VSB_quote(vsb, heritage.argv[i], -1, VSB_QUOTE_CSTR);
+		AZ(VSB_quote(vsb, heritage.argv[i], -1, VSB_QUOTE_CSTR));
 		VSB_cat(vsb, ",\n");
 	}
 	VSB_indent(vsb, -2);

--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -146,7 +146,7 @@ vpi_ref_panic(struct vsb *vsb, unsigned n, const struct vcl *vcl)
 	VSB_printf(vsb, "pos = %u,\n", ref->pos);
 	if (src != NULL) {
 		VSB_cat(vsb, "src = ");
-		VSB_quote(vsb, src, w, VSB_QUOTE_CSTR);
+		AZ(VSB_quote(vsb, src, w, VSB_QUOTE_CSTR));
 		VSB_putc(vsb, '\n');
 	} else {
 		VSB_printf(vsb, "token = \"%s\"\n", ref->token);

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -256,16 +256,16 @@ h2_vsl_frame(const struct h2_sess *h2, const void *ptr, size_t len)
 	if (p != NULL)
 		VSB_cat(vsb, p);
 	else
-		VSB_quote(vsb, b + 3, 1, VSB_QUOTE_HEX);
+		AZ(VSB_quote(vsb, b + 3, 1, VSB_QUOTE_HEX));
 
 	u = vbe32dec(b) >> 8;
 	VSB_printf(vsb, "[%u] ", u);
-	VSB_quote(vsb, b + 4, 1, VSB_QUOTE_HEX);
+	AZ(VSB_quote(vsb, b + 4, 1, VSB_QUOTE_HEX));
 	VSB_putc(vsb, ' ');
-	VSB_quote(vsb, b + 5, 4, VSB_QUOTE_HEX);
+	AZ(VSB_quote(vsb, b + 5, 4, VSB_QUOTE_HEX));
 	if (u > 0) {
 		VSB_putc(vsb, ' ');
-		VSB_quote(vsb, b + 9, len - 9, VSB_QUOTE_HEX);
+		AZ(VSB_quote(vsb, b + 9, len - 9, VSB_QUOTE_HEX));
 	}
 	AZ(VSB_finish(vsb));
 	Lck_Lock(&h2->sess->mtx);

--- a/bin/varnishd/mgt/mgt_child.c
+++ b/bin/varnishd/mgt/mgt_child.c
@@ -106,9 +106,7 @@ mgt_panic_record(pid_t r)
 	AN(child_panic);
 	VTIM_format(VTIM_real(), time_str);
 	VSB_printf(child_panic, "Panic at: %s\n", time_str);
-	VSB_quote(child_panic, heritage.panic_str,
-	    strnlen(heritage.panic_str, heritage.panic_str_len),
-	    VSB_QUOTE_NONL);
+	AZ(VSB_quote(child_panic, heritage.panic_str, strnlen(heritage.panic_str, heritage.panic_str_len), VSB_QUOTE_NONL));
 	AZ(VSB_finish(child_panic));
 	MGT_Complain(C_ERR, "Child (%jd) %s",
 	    (intmax_t)r, VSB_data(child_panic));

--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -143,7 +143,7 @@ mcf_askchild(struct cli *cli, const char * const *av, void *priv)
 	}
 	VSB_clear(cli_buf);
 	for (i = 1; av[i] != NULL; i++) {
-		VSB_quote(cli_buf, av[i], strlen(av[i]), 0);
+		AZ(VSB_quote(cli_buf, av[i], strlen(av[i]), 0));
 		VSB_putc(cli_buf, ' ');
 	}
 	VSB_putc(cli_buf, '\n');

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -420,7 +420,7 @@ tweak_string(struct vsb *vsb, const struct parspec *par, const char *arg)
 		VSB_quote(vsb, *p, -1, 0);
 	} else if (arg == JSON_FMT) {
 		VSB_putc(vsb, '"');
-		VSB_quote(vsb, *p, -1, VSB_QUOTE_JSON);
+		VSB_quote(vsb, *p, -1, VSB_QUOTE_VJSON);
 		VSB_putc(vsb, '"');
 	} else {
 		REPLACE(*p, arg);

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -417,10 +417,10 @@ tweak_string(struct vsb *vsb, const struct parspec *par, const char *arg)
 
 	AN(p);
 	if (arg == NULL) {
-		VSB_quote(vsb, *p, -1, 0);
+		AZ(VSB_quote(vsb, *p, -1, 0));
 	} else if (arg == JSON_FMT) {
 		VSB_putc(vsb, '"');
-		VSB_quote(vsb, *p, -1, VSB_QUOTE_VJSON);
+		AZ(VSB_quote(vsb, *p, -1, VSB_QUOTE_VJSON));
 		VSB_putc(vsb, '"');
 	} else {
 		REPLACE(*p, arg);

--- a/bin/varnishd/proxy/cache_proxy_proto.c
+++ b/bin/varnishd/proxy/cache_proxy_proto.c
@@ -762,8 +762,7 @@ VPX_Send_Proxy(int fd, int version, const struct sess *sp)
 
 	vsb2 = VSB_new_auto();
 	AN(vsb2);
-	VSB_quote(vsb2, VSB_data(vsb), VSB_len(vsb),
-	    version == 2 ? VSB_QUOTE_HEX : 0);
+	AZ(VSB_quote(vsb2, VSB_data(vsb), VSB_len(vsb), version == 2 ? VSB_QUOTE_HEX : 0));
 	AZ(VSB_finish(vsb2));
 	VSL(SLT_Debug, NO_VXID, "PROXY_HDR %s", VSB_data(vsb2));
 	VSB_destroy(&vsb2);

--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -205,9 +205,9 @@ vsb_fcat(struct vsb *vsb, const struct fragment *f, const char *dflt)
 {
 	if (f->gen == CTX.gen) {
 		assert(f->b <= f->e);
-		VSB_quote(vsb, f->b, f->e - f->b, CTX.quote_how);
+		AZ(VSB_quote(vsb, f->b, f->e - f->b, CTX.quote_how));
 	} else if (dflt)
-		VSB_quote(vsb, dflt, -1, CTX.quote_how);
+		AZ(VSB_quote(vsb, dflt, -1, CTX.quote_how));
 	else
 		return (-1);
 	return (0);
@@ -253,7 +253,7 @@ format_fragment(const struct format *format)
 	if (format->frag->gen != CTX.gen) {
 		if (format->string == NULL)
 			return (-1);
-		VSB_quote(CTX.vsb, format->string, -1, CTX.quote_how);
+		AZ(VSB_quote(CTX.vsb, format->string, -1, CTX.quote_how));
 		return (0);
 	}
 	AZ(vsb_fcat(CTX.vsb, format->frag, NULL));
@@ -370,14 +370,14 @@ format_auth(const struct format *format)
 		VSB_destroy(&vsb);
 		if (format->string == NULL)
 			return (-1);
-		VSB_quote(CTX.vsb, format->string, -1, CTX.quote_how);
+		AZ(VSB_quote(CTX.vsb, format->string, -1, CTX.quote_how));
 		return (0);
 	}
 	AZ(VSB_finish(vsb));
 	q = strchr(VSB_data(vsb), ':');
 	if (q != NULL)
 		*q = '\0';
-	VSB_quote(CTX.vsb, VSB_data(vsb), -1, CTX.quote_how);
+	AZ(VSB_quote(CTX.vsb, VSB_data(vsb), -1, CTX.quote_how));
 	VSB_destroy(&vsb);
 	return (1);
 }

--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -578,7 +578,7 @@ addf_vsl(enum VSL_tag_e tag, long i, const char *prefix)
 
 	ALLOC_OBJ(w, VSL_WATCH_MAGIC);
 	AN(w);
-	if (VSL_tagflags[tag] && CTX.quote_how != VSB_QUOTE_JSON)
+	if (VSL_tagflags[tag] && CTX.quote_how != VSB_QUOTE_VJSON)
 		VUT_Error(vut, 1, "Tag %s can contain control characters",
 		    VSL_tags[tag]);
 	w->tag = tag;
@@ -972,7 +972,7 @@ dispatch_f(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 		while (skip == 0 && 1 == VSL_Next(t->c)) {
 			tag = VSL_TAG(t->c->rec.ptr);
 			if (VSL_tagflags[tag] &&
-			    CTX.quote_how != VSB_QUOTE_JSON)
+			    CTX.quote_how != VSB_QUOTE_VJSON)
 				continue;
 
 			b = VSL_CDATA(t->c->rec.ptr);
@@ -1200,7 +1200,7 @@ main(int argc, char * const *argv)
 		case 'j':
 			REPLACE(CTX.missing_string, "");
 			REPLACE(CTX.missing_int, "0");
-			CTX.quote_how = VSB_QUOTE_JSON;
+			CTX.quote_how = VSB_QUOTE_VJSON;
 			break;
 		case 'w':
 			/* Write to file */

--- a/bin/varnishstat/varnishstat_help_gen.c
+++ b/bin/varnishstat/varnishstat_help_gen.c
@@ -71,7 +71,7 @@ main(void)
 		n = strchr(p, '\n');
 		if (n != NULL && n > p) {
 			VSB_putc(vsb, '\t');
-			VSB_quote(vsb, p, (int)(n - p), VSB_QUOTE_CSTR);
+			AZ(VSB_quote(vsb, p, (int)(n - p), VSB_QUOTE_CSTR));
 			VSB_cat(vsb, ",\n");
 			u++;
 		}

--- a/bin/varnishtest/vtc_log.c
+++ b/bin/varnishtest/vtc_log.c
@@ -237,8 +237,7 @@ vtc_dump(struct vtclog *vl, int lvl, const char *pfx, const char *str, int len)
 			len = strlen(str);
 		else if (str[0] == 0x1f && (uint8_t)str[1] == 0x8b)
 			quote = VSB_QUOTE_HEX; // Dump gzip data in HEX
-		VSB_quote_pfx(vl->vsb, buf, str,
-		    len > MAX_DUMP ? MAX_DUMP : len, quote);
+		AZ(VSB_quote_pfx(vl->vsb, buf, str, len > MAX_DUMP ? MAX_DUMP : len, quote, NULL));
 		if (quote == VSB_QUOTE_HEX)
 			VSB_putc(vl->vsb, '\n');
 		if (len > MAX_DUMP)

--- a/bin/varnishtest/vtc_logexp.c
+++ b/bin/varnishtest/vtc_logexp.c
@@ -693,7 +693,7 @@ cmd_logexp_common(struct logexp *le, struct vtclog *vl,
 	AN(test->str);
 	AZ(VSB_printf(test->str, "%s %s %s %s ", av[0], av[1], av[2], av[3]));
 	if (av[4])
-		VSB_quote(test->str, av[4], -1, 0);
+		AZ(VSB_quote(test->str, av[4], -1, 0));
 	AZ(VSB_finish(test->str));
 	test->skip_max = skip_max;
 	test->vxid = vxid;

--- a/bin/varnishtest/vtc_main.c
+++ b/bin/varnishtest/vtc_main.c
@@ -328,8 +328,7 @@ tst_cb(const struct vev *ve, int what)
 		p = strchr(jp->bp->buf, '\0');
 		if (p > jp->bp->buf && p[-1] != '\n')
 			VSB_putc(cbvsb, '\n');
-		VSB_quote_pfx(cbvsb, "*    diag  0.0 ",
-		    VSB_data(jp->bp->diag), -1, VSB_QUOTE_NONL);
+		AZ(VSB_quote_pfx(cbvsb, "*    diag  0.0 ", VSB_data(jp->bp->diag), -1, VSB_QUOTE_NONL, NULL));
 		AZ(VSB_finish(cbvsb));
 		rel_buf(&jp->bp);
 
@@ -900,7 +899,7 @@ main(int argc, char * const *argv)
 			break;
 		case 'p':
 			VSB_cat(params_vsb, " -p ");
-			VSB_quote(params_vsb, optarg, -1, 0);
+			AZ(VSB_quote(params_vsb, optarg, -1, 0));
 			break;
 		case 'q':
 			if (vtc_verbosity > 0)

--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -256,7 +256,7 @@ varnishlog_thread(void *priv)
 				if (vsb == NULL)
 					vsb = VSB_new_auto();
 				VSB_clear(vsb);
-				VSB_quote(vsb, data, len, VSB_QUOTE_HEX);
+				AZ(VSB_quote(vsb, data, len, VSB_QUOTE_HEX));
 				AZ(VSB_finish(vsb));
 				/* +2 to skip "0x" */
 				vtc_log(v->vl, 4, "vsl| %10ju %-15s %c [%s]",

--- a/include/vsb.h
+++ b/include/vsb.h
@@ -87,7 +87,7 @@ void		 VSB_destroy(struct vsb **);
 	 * Basic "show me the string" mode
 	 * All output is a single line
 	 */
-#define VSB_QUOTE_JSON		2
+#define VSB_QUOTE_VJSON		2
 	/*
 	 * JSON-like output suitable for inclusion between "..."
 	 * Quotes <0x20 as \u%04x
@@ -120,7 +120,7 @@ void		 VSB_destroy(struct vsb **);
 #define VSB_QUOTE_ESCHEX	32
 	/*
 	 * Use \x%02x instead of \%03o
-	 * Not valid with VSB_QUOTE_JSON and VSB_QUOTE_HEX
+	 * Not valid with VSB_QUOTE_VJSON and VSB_QUOTE_HEX
 	 */
 
 void		 VSB_quote_pfx(struct vsb *, const char*, const void *,

--- a/include/vsb.h
+++ b/include/vsb.h
@@ -80,28 +80,34 @@ void		 VSB_destroy(struct vsb **);
 
 /*
  * VSB_quote[_pfx] has four major modes, and two modifiers
+ *
+ * Return != 0 for error, _pfx also sets err to the first error byte
  */
 
 #define VSB_QUOTE_PLAIN		0
 	/*
 	 * Basic "show me the string" mode
 	 * All output is a single line
+	 * Never fails
 	 */
 #define VSB_QUOTE_VJSON		2
 	/*
 	 * JSON-like output suitable for inclusion between "..."
 	 * Quotes <0x20 as \u%04x
 	 * Keeps >0x7e unquoted
+	 * Never fails
 	 */
 #define VSB_QUOTE_HEX		4
 	/*
 	 * Hex dump, single line.
 	 * All zero data is compressed to "0x0...0"
+	 * Never fails
 	 */
 #define VSB_QUOTE_CSTR		8
 	/*
 	 * C lanuage source code literal string(s)
 	 * Breaks strings at \n (expecting string concatenation)
+	 * Never fails
 	 */
 #define VSB_QUOTE_UNSAFE	16
 	/*
@@ -109,23 +115,26 @@ void		 VSB_destroy(struct vsb **);
 	 * " and \ are not quoted
 	 * Splits output to new line at '\n'
 	 * Implies VSB_QUOTE_NONL
+	 * Never fails
 	 */
 
 #define VSB_QUOTE_NONL		1
 	/*
 	 * If the output does not end in \n, append \n
 	 * Can be combined with all other modes.
+	 * Never fails
 	 */
 
 #define VSB_QUOTE_ESCHEX	32
 	/*
 	 * Use \x%02x instead of \%03o
 	 * Not valid with VSB_QUOTE_VJSON and VSB_QUOTE_HEX
+	 * Never fails
 	 */
 
-void		 VSB_quote_pfx(struct vsb *, const char*, const void *,
-		     int len, int how);
-void		 VSB_quote(struct vsb *, const void *, int len, int how);
+int		 VSB_quote_pfx(struct vsb *, const char*, const void *,
+		    int len, int how, const void **);
+int		 VSB_quote(struct vsb *, const void *, int len, int how);
 void		 VSB_indent(struct vsb *, int);
 int		 VSB_tofile(const struct vsb *, int fd);
 #ifdef __cplusplus

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -695,7 +695,7 @@ VCLI_JSON_str(struct cli *cli, const char *s)
 
 	CHECK_OBJ_NOTNULL(cli, CLI_MAGIC);
 	VSB_putc(cli->sb, '"');
-	VSB_quote(cli->sb, s, -1, VSB_QUOTE_JSON);
+	VSB_quote(cli->sb, s, -1, VSB_QUOTE_VJSON);
 	VSB_putc(cli->sb, '"');
 }
 

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -695,7 +695,7 @@ VCLI_JSON_str(struct cli *cli, const char *s)
 
 	CHECK_OBJ_NOTNULL(cli, CLI_MAGIC);
 	VSB_putc(cli->sb, '"');
-	VSB_quote(cli->sb, s, -1, VSB_QUOTE_VJSON);
+	AZ(VSB_quote(cli->sb, s, -1, VSB_QUOTE_VJSON));
 	VSB_putc(cli->sb, '"');
 }
 
@@ -730,7 +730,7 @@ VCLI_Quote(struct cli *cli, const char *s)
 {
 
 	CHECK_OBJ_NOTNULL(cli, CLI_MAGIC);
-	VSB_quote(cli->sb, s, -1, 0);
+	AZ(VSB_quote(cli->sb, s, -1, 0));
 }
 
 void

--- a/lib/libvarnish/vsb.c
+++ b/lib/libvarnish/vsb.c
@@ -533,11 +533,11 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 	int nl;
 
 	nl = how &
-	    (VSB_QUOTE_JSON|VSB_QUOTE_HEX|VSB_QUOTE_CSTR|VSB_QUOTE_UNSAFE);
+	    (VSB_QUOTE_VJSON|VSB_QUOTE_HEX|VSB_QUOTE_CSTR|VSB_QUOTE_UNSAFE);
 	AZ(nl & (nl - 1)); // Only one bit can be set
 
 	if (how & VSB_QUOTE_ESCHEX)
-		AZ(how & (VSB_QUOTE_JSON|VSB_QUOTE_HEX));
+		AZ(how & (VSB_QUOTE_VJSON|VSB_QUOTE_HEX));
 
 	if (how & VSB_QUOTE_UNSAFE)
 		how |= VSB_QUOTE_NONL;
@@ -573,7 +573,7 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 		    *q == '"' ||
 		    *q == '\\' ||
 		    (*q == '?' && (how & VSB_QUOTE_CSTR)) ||
-		    (*q > 0x7e && !(how & VSB_QUOTE_JSON))
+		    (*q > 0x7e && !(how & VSB_QUOTE_VJSON))
 		) {
 			quote++;
 			break;
@@ -598,7 +598,7 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 		switch (*q) {
 		case '?':
 			/* Avoid C Trigraph insanity */
-			if (how & VSB_QUOTE_CSTR && !(how & VSB_QUOTE_JSON))
+			if (how & VSB_QUOTE_CSTR && !(how & VSB_QUOTE_VJSON))
 				(void)VSB_putc(s, '\\');
 			(void)VSB_putc(s, *q);
 			break;
@@ -611,7 +611,7 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 		case '\n':
 			if (how & VSB_QUOTE_CSTR) {
 				VSB_printf(s, "\\n\"\n%s\"", pfx);
-			} else if (how & VSB_QUOTE_JSON) {
+			} else if (how & VSB_QUOTE_VJSON) {
 				VSB_cat(s, "\\n");
 			} else if (how & VSB_QUOTE_NONL) {
 				VSB_putc(s, *q);
@@ -632,9 +632,9 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 		default:
 			if (0x20 <= *q && *q <= 0x7e)
 				VSB_putc(s, *q);
-			else if (*q > 0x7e && (how & VSB_QUOTE_JSON))
+			else if (*q > 0x7e && (how & VSB_QUOTE_VJSON))
 				VSB_putc(s, *q);
-			else if (how & VSB_QUOTE_JSON)
+			else if (how & VSB_QUOTE_VJSON)
 				VSB_printf(s, "\\u%04x", *q);
 			else if (how & VSB_QUOTE_ESCHEX)
 				VSB_printf(s, "\\x%02x", *q);

--- a/lib/libvarnish/vsb.c
+++ b/lib/libvarnish/vsb.c
@@ -524,13 +524,16 @@ vsb_quote_hex(struct vsb *s, const uint8_t *u, size_t len)
 	}
 }
 
-void
-VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
+int
+VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how,
+    const void **err)
 {
 	const uint8_t *p = v;
 	const uint8_t *q;
 	int quote = 0;
 	int nl;
+
+	(void)err;	// TODO
 
 	nl = how &
 	    (VSB_QUOTE_VJSON|VSB_QUOTE_HEX|VSB_QUOTE_CSTR|VSB_QUOTE_UNSAFE);
@@ -553,7 +556,7 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 	}
 
 	if (len == 0)
-		return;
+		return (0);
 
 	VSB_cat(s, pfx);
 
@@ -561,7 +564,7 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 		vsb_quote_hex(s, v, len);
 		if (how & VSB_QUOTE_NONL)
 			VSB_putc(s, '\n');
-		return;
+		return (0);
 	}
 
 	if (how & VSB_QUOTE_CSTR)
@@ -587,7 +590,7 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 			(void)VSB_putc(s, '\n');
 		if (how & VSB_QUOTE_CSTR)
 			VSB_putc(s, '"');
-		return;
+		return (0);
 	}
 
 	nl = 0;
@@ -647,12 +650,13 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 		VSB_putc(s, '"');
 	if ((how & VSB_QUOTE_NONL) && !nl)
 		VSB_putc(s, '\n');
+	return (0);
 }
 
-void
+int
 VSB_quote(struct vsb *s, const void *v, int len, int how)
 {
-	VSB_quote_pfx(s, "", v, len, how);
+	return (VSB_quote_pfx(s, "", v, len, how, NULL));
 }
 
 /*

--- a/lib/libvarnish/vsb_test.c
+++ b/lib/libvarnish/vsb_test.c
@@ -84,30 +84,30 @@ static struct tc tcs[] = {
 		"PFX\"\\x00\\n\"\nPFX\"~\\x7f\\xff\"",
 	},
 	/*
-	 * VSB_QUOTE_JSON puts >0x7e literally
+	 * VSB_QUOTE_VJSON puts >0x7e literally
 	 */
 	{
-		VSB_QUOTE_JSON,
+		VSB_QUOTE_VJSON,
 		4, "\xf0\x9f\x90\xb0",
 		"PFX\xf0\x9f\x90\xb0",
 	},
 	/*
-	 * VSB_QUOTE_JSON encodes <0x20 as \u00XX, which looks like
+	 * VSB_QUOTE_VJSON encodes <0x20 as \u00XX, which looks like
 	 * unicode codepoints in the JSON standard, but are just
 	 * individual bytes
 	 */
 	{
-		VSB_QUOTE_JSON,
+		VSB_QUOTE_VJSON,
 		5, "\"\x01\x02\x03\x04",
 		"PFX\\\"\\u0001\\u0002\\u0003\\u0004",
 	},
 	{
-		VSB_QUOTE_JSON,
+		VSB_QUOTE_VJSON,
 		5, "\x00\n\x7e\x7f\xff",
 		"PFX\\u0000\\n~\x7f\xff",
 	},
 	{
-		VSB_QUOTE_JSON | VSB_QUOTE_NONL,
+		VSB_QUOTE_VJSON | VSB_QUOTE_NONL,
 		5, "\x00\n\x7e\x7f\xff",
 		"PFX\\u0000\\n~\x7f\xff\n",
 	},
@@ -170,8 +170,8 @@ main(int argc, char *argv[])
 				VSB_cat(vsbo, "\n\t0");
 			if (tc->how & VSB_QUOTE_NONL)
 				VSB_cat(vsbo, "\n\tVSB_QUOTE_NONL");
-			if (tc->how & VSB_QUOTE_JSON)
-				VSB_cat(vsbo, "\n\tVSB_QUOTE_JSON");
+			if (tc->how & VSB_QUOTE_VJSON)
+				VSB_cat(vsbo, "\n\tVSB_QUOTE_VJSON");
 			if (tc->how & VSB_QUOTE_HEX)
 				VSB_cat(vsbo, "\n\tVSB_QUOTE_HEX");
 			if (tc->how & VSB_QUOTE_CSTR)

--- a/lib/libvarnish/vsb_test.c
+++ b/lib/libvarnish/vsb_test.c
@@ -147,24 +147,24 @@ main(int argc, char *argv[])
 	AN(vsbo);
 
 	for (tc = tcs; tc->in; tc++) {
-		VSB_quote_pfx(vsb, "PFX", tc->in, tc->inlen, tc->how);
+		AZ(VSB_quote_pfx(vsb, "PFX", tc->in, tc->inlen, tc->how, NULL));
 		assert(VSB_finish(vsb) == 0);
 
 		VSB_clear(vsbo);
 		VSB_printf(vsbo, "0x%02x: ", tc->how);
-		VSB_quote(vsbo, tc->in, tc->inlen, VSB_QUOTE_HEX);
+		AZ(VSB_quote(vsbo, tc->in, tc->inlen, VSB_QUOTE_HEX));
 		VSB_cat(vsbo, " -> ");
-		VSB_quote(vsbo, VSB_data(vsb), -1, VSB_QUOTE_HEX);
+		AZ(VSB_quote(vsbo, VSB_data(vsb), -1, VSB_QUOTE_HEX));
 		VSB_cat(vsbo, " (");
-		VSB_quote(vsbo, tc->out, -1, VSB_QUOTE_ESCHEX);
+		AZ(VSB_quote(vsbo, tc->out, -1, VSB_QUOTE_ESCHEX));
 		VSB_cat(vsbo, ")");
 		if (strcmp(VSB_data(vsb), tc->out)) {
 			VSB_cat(vsbo, "\nShould have been:\n\t");
-			VSB_quote(vsbo, tc->out, -1, VSB_QUOTE_HEX);
+			AZ(VSB_quote(vsbo, tc->out, -1, VSB_QUOTE_HEX));
 			VSB_cat(vsbo, "\nThat's:\n\t");
-			VSB_quote(vsbo, VSB_data(vsb), -1, VSB_QUOTE_ESCHEX);
+			AZ(VSB_quote(vsbo, VSB_data(vsb), -1, VSB_QUOTE_ESCHEX));
 			VSB_cat(vsbo, "\nvs:\n\t");
-			VSB_quote(vsbo, tc->out, -1, VSB_QUOTE_ESCHEX);
+			AZ(VSB_quote(vsbo, tc->out, -1, VSB_QUOTE_ESCHEX));
 			VSB_printf(vsbo, "\nFlags 0x%02x = ", tc->how);
 			if (!tc->how)
 				VSB_cat(vsbo, "\n\t0");

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -340,7 +340,7 @@ EncToken(struct vsb *sb, const struct token *t)
 {
 
 	assert(t->tok == CSTR);
-	VSB_quote(sb, t->dec, -1, VSB_QUOTE_CSTR);
+	AZ(VSB_quote(sb, t->dec, -1, VSB_QUOTE_CSTR));
 }
 
 /*--------------------------------------------------------------------
@@ -363,7 +363,7 @@ EmitCoordinates(const struct vcc *tl, struct vsb *vsb)
 	VSB_cat(vsb, "\nstatic const char *srcname[VGC_NSRCS] = {\n");
 	VTAILQ_FOREACH(sp, &tl->sources, list) {
 		VSB_cat(vsb, "\t");
-		VSB_quote(vsb, sp->name, -1, VSB_QUOTE_CSTR);
+		AZ(VSB_quote(vsb, sp->name, -1, VSB_QUOTE_CSTR));
 		VSB_cat(vsb, ",\n");
 	}
 	VSB_cat(vsb, "};\n");
@@ -371,9 +371,9 @@ EmitCoordinates(const struct vcc *tl, struct vsb *vsb)
 	VSB_printf(vsb, "\nstatic const char *srcbody[%u] = {\n", tl->nsources);
 	VTAILQ_FOREACH(sp, &tl->sources, list) {
 		VSB_cat(vsb, "    /* ");
-		VSB_quote(vsb, sp->name, -1, VSB_QUOTE_CSTR);
+		AZ(VSB_quote(vsb, sp->name, -1, VSB_QUOTE_CSTR));
 		VSB_cat(vsb, " */\n");
-		VSB_quote_pfx(vsb, "\t", sp->b, sp->e - sp->b, VSB_QUOTE_CSTR);
+		AZ(VSB_quote_pfx(vsb, "\t", sp->b, sp->e - sp->b, VSB_QUOTE_CSTR, NULL));
 		VSB_cat(vsb, ",\n");
 	}
 	VSB_cat(vsb, "};\n\n");

--- a/lib/libvcc/vcc_utils.c
+++ b/lib/libvcc/vcc_utils.c
@@ -102,7 +102,7 @@ vcc_regexp(struct vcc *tl, struct vsb *vgc_name)
 	Fh(tl, 0, "static struct vre *%s;\n", buf);
 	ifp = New_IniFin(tl);
 	VSB_printf(ifp->ini, "\tVPI_re_init(&%s, ",buf);
-	VSB_quote(ifp->ini, VSB_data(pattern), -1, VSB_QUOTE_CSTR);
+	AZ(VSB_quote(ifp->ini, VSB_data(pattern), -1, VSB_QUOTE_CSTR));
 	VSB_cat(ifp->ini, ");");
 	VSB_printf(ifp->fin, "\t\tVPI_re_fini(%s);", buf);
 	VSB_destroy(&pattern);

--- a/lib/libvcc/vcc_var.c
+++ b/lib/libvcc/vcc_var.c
@@ -82,7 +82,7 @@ vcc_Var_Wildcard(struct vcc *tl, struct symbol *parent, struct symbol *sym)
 	for (p = sym->name; *p != '\0'; p++) {
 		if (!vct_istchar(*p)) {
 			VSB_cat(tl->sb, "Invalid character '");
-			VSB_quote(tl->sb, p, 1, VSB_QUOTE_PLAIN);
+			AZ(VSB_quote(tl->sb, p, 1, VSB_QUOTE_PLAIN));
 			VSB_cat(tl->sb, "' in header name.\n");
 			tl->err = 1;
 			return;

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -343,13 +343,13 @@ vcc_emit_setup(struct vcc *tl, const struct vmod_import *vim)
 	VSB_printf(ifp->ini, "\t    sizeof(%s),\n", vim->func_name);
 	VSB_printf(ifp->ini, "\t    \"%.*s\",\n", PF(mod));
 	VSB_cat(ifp->ini, "\t    ");
-	VSB_quote(ifp->ini, vim->path, -1, VSB_QUOTE_CSTR);
+	AZ(VSB_quote(ifp->ini, vim->path, -1, VSB_QUOTE_CSTR));
 	VSB_cat(ifp->ini, ",\n");
 	AN(vim->file_id);
 	VSB_printf(ifp->ini, "\t    \"%s\",\n", vim->file_id);
 	if (vim->from_vext) {
 		VSB_cat(ifp->ini, "\t    ");
-		VSB_quote(ifp->ini, vim->path, -1, VSB_QUOTE_CSTR);
+		AZ(VSB_quote(ifp->ini, vim->path, -1, VSB_QUOTE_CSTR));
 		VSB_cat(ifp->ini, "\n");
 	} else {
 		VSB_printf(ifp->ini, "\t    \"./vmod_cache/_vmod_%.*s.%s\"\n",

--- a/tools/coccinelle/archive/vsb_quote.cocci
+++ b/tools/coccinelle/archive/vsb_quote.cocci
@@ -1,0 +1,21 @@
+/*
+ * This patch applies the update of the VSB_quote[_pfx] signature
+ *
+ * note: declaring the parameters just as expression is simplistic,
+ * but does the job for this one-off patch
+ */
+
+@@
+expression vsb, pfx, ptr, len, how;
+@@
+
+- VSB_quote_pfx(vsb, pfx, ptr, len, how)
++ AZ(VSB_quote_pfx(vsb, pfx, ptr, len, how, NULL))
+
+@@
+expression vsb, ptr, len, how;
+@@
+
+- VSB_quote(vsb, ptr, len, how)
++ AZ(VSB_quote(vsb, ptr, len, how))
+


### PR DESCRIPTION
We rename our existing JSON quoting to make clear that it is not quite JSON.

For standard JSON quoting, we are going to need to signal failures, so prepare VSB_quote*() for that.