### PR TITLE
varnishd: introduce a new paramter 'reuseport'

### DIFF
--- a/bin/varnishd/cache/cache_acceptor.c
+++ b/bin/varnishd/cache/cache_acceptor.c
@@ -599,12 +599,18 @@ vca_accept_task(struct worker *wrk, void *arg)
  */
 
 void
-VCA_NewPool(struct pool *pp)
+VCA_NewPool(struct pool *pp, unsigned pool_no)
 {
 	struct listen_sock *ls;
 	struct poolsock *ps;
 
 	VTAILQ_FOREACH(ls, &heritage.socks, list) {
+		CHECK_OBJ_NOTNULL(ls, LISTEN_SOCK_MAGIC);
+
+		if (cache_param->reuseport && !ls->uds &&
+		    ls->pool_no != pool_no)
+			continue;
+
 		ALLOC_OBJ(ps, POOLSOCK_MAGIC);
 		AN(ps);
 		ps->lsock = ls;

--- a/bin/varnishd/cache/cache_pool.c
+++ b/bin/varnishd/cache/cache_pool.c
@@ -169,7 +169,7 @@ pool_mkpool(unsigned pool_no)
 		(void)usleep(10000);
 
 	SES_NewPool(pp, pool_no);
-	VCA_NewPool(pp);
+	VCA_NewPool(pp, pool_no);
 
 	return (pp);
 }

--- a/bin/varnishd/cache/cache_pool.h
+++ b/bin/varnishd/cache/cache_pool.h
@@ -64,5 +64,5 @@ struct pool {
 void *pool_herder(void*);
 task_func_t pool_stat_summ;
 extern struct lock			pool_mtx;
-void VCA_NewPool(struct pool *);
+void VCA_NewPool(struct pool *, unsigned);
 void VCA_DestroyPool(struct pool *);

--- a/bin/varnishd/common/heritage.h
+++ b/bin/varnishd/common/heritage.h
@@ -46,6 +46,7 @@ struct listen_sock {
 	VTAILQ_ENTRY(listen_sock)	arglist;
 	int				sock;
 	int				uds;
+	unsigned			pool_no;
 	char				*endpoint;
 	const char			*name;
 	const struct suckaddr		*addr;

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -761,9 +761,6 @@ main(int argc, char * const *argv)
 	/* Process delayed arguments */
 	VTAILQ_FOREACH(alp, &arglist, list) {
 		switch(alp->arg[0]) {
-		case 'a':
-			MAC_Arg(alp->val);
-			break;
 		case 'f':
 			if (*alp->val != '\0')
 				alp->priv = mgt_f_read(alp->val);
@@ -796,6 +793,19 @@ main(int argc, char * const *argv)
 			break;
 		case 's':
 			STV_Config(alp->val);
+			break;
+		default:
+			break;
+		}
+		cli_check(cli);
+	}
+
+	MCF_ParamProtect(cli, "reuseport");
+
+	VTAILQ_FOREACH(alp, &arglist, list) {
+		switch(alp->arg[0]) {
+		case 'a':
+			MAC_Arg(alp->val);
 			break;
 		default:
 			break;

--- a/configure.ac
+++ b/configure.ac
@@ -517,6 +517,20 @@ AC_CHECK_DECL([SO_ACCEPTFILTER],
         #include <sys/socket.h>
     ])
 
+AC_CHECK_DECL([SO_REUSEPORT],
+    AC_DEFINE(HAVE_REUSEPORT,1,[Define to 1 if you have reuseport]),
+    [], [
+        #include <sys/types.h>
+        #include <sys/socket.h>
+    ])
+
+AC_CHECK_DECL([SO_REUSEPORT_LB],
+    AC_DEFINE(HAVE_REUSEPORT_LB,1,[Define to 1 if you have reuseport lb]),
+    [], [
+        #include <sys/types.h>
+        #include <sys/socket.h>
+    ])
+
 AC_CHECK_DECL([SO_RCVTIMEO],
     [],
     AC_MSG_ERROR([SO_RCVTIMEO is needed to build Varnish.]), [

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -80,6 +80,29 @@ PARAM_SIMPLE(
 )
 #undef PLATFORM_FLAGS
 
+#if defined(HAVE_REUSEPORT) || defined(HAVE_REUSEPORT_LB)
+#  define PLATFORM_FLAGS MUST_RESTART
+#else
+#  define PLATFORM_FLAGS NOT_IMPLEMENTED
+#endif
+PARAM_SIMPLE(
+	/* name */	reuseport,
+	/* type */	boolean,
+	/* min */	NULL,
+	/* max */	NULL,
+	/* def */	"off",
+	/* units */	"bool",
+	/* descr */
+	"Accept clients on multiple sockets with the same address. "
+	"Using a listen group helps load balance incoming clients between "
+	"the pools more efficient. This require SO_REUSEPORT or "
+	"SO_REUSEPORT_LB support from the kernel. If both are available "
+	"SO_REUSEPORT_LB is used to create the listen group.\n\n"
+	"NB: MUST BE SET ON THE COMMAND LINE.",
+	/* flags */	PLATFORM_DEPENDENT | PLATFORM_FLAGS,
+)
+#undef PLATFORM_FLAGS
+
 PARAM_SIMPLE(
 	/* name */	acceptor_sleep_decay,
 	/* type */	double,

--- a/include/vtcp.h
+++ b/include/vtcp.h
@@ -61,6 +61,7 @@ int VTCP_open(const char *addr, const char *def_port, vtim_dur timeout,
     const char **err);
 void VTCP_close(int *s);
 int VTCP_bind(const struct suckaddr *addr, const char **errp);
+int VTCP_bind_reuseport(const struct suckaddr *addr, const char **errp);
 int VTCP_listen(const struct suckaddr *addr, int depth, const char **errp);
 int VTCP_listen_on(const char *addr, const char *def_port, int depth,
     const char **errp);


### PR DESCRIPTION
The reuseport paramter controls whether or not we will create a listen group in the kernel using SO_REUSEPORT (or SO_REUSEPORT_LB for some platforms). This leads to a more efficient load distribution across the thread pools.

For backward compability reasons, leave this off by default.