### PR TITLE
Prepare for 7.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "HEAD"
   pkg-commit:
     type: string
-    default: "master"
+    default: "7.4"
   dist-url:
     type: string
     default: ""

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
 Copyright (c) 2006-2023 Varnish Software
 Copyright 2010-2023 UPLEX - Nils Goroll Systemoptimierung])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [7.4.0], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [7.4.1], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -35,6 +35,14 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
+Varnish Cache 7.4.1 (2023-09-19)
+================================
+
+* Fix the scope of bereq protected headers (3984_).
+
+.. _3984: https://github.com/varnishcache/varnish-cache/issues/3984
+
+================================
 Varnish Cache 7.4.0 (2023-09-15)
 ================================
 


### PR DESCRIPTION
Reviewers must check the following items:

- [ ] Release notes are complete (major release only)
- [ ] Release notes no longer target trunk (major release only)
- [ ] The change log is populated
- [ ] The VRT history in `include/vrt.h` is populated
- [ ] The VRT history refers to the next VRT version
- [ ] The macro `VRT_MAJOR_VERSION` was updated if applicable
- [ ] The macro `VRT_MINOR_VERSION` was updated if applicable
- [ ] The new VRT version follows releases guidelines
- [ ] The new VRT version matches the one from the VRT history
- [ ] Bundled `devicedetect.vcl` was updated (major release only)
- [ ] Running `./autogen.des && make distcheck` succeeds
- [ ] The version in `configure.ac` is correct
- [ ] The copyright notice in `configure.ac` covers the current year
- [ ] The copyright output in `lib/libvarnish/version.c` covers the current year
- [ ] There are no other changes than the ones listed above
