### PR TITLE
vcl_vrt: Skip VCL execution if the client is gone

### DIFF
--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -44,6 +44,7 @@ typedef void vtr_sess_panic_f (struct vsb *, const struct sess *);
 typedef void vtr_req_panic_f (struct vsb *, const struct req *);
 typedef void vtr_req_fail_f (struct req *, stream_close_t);
 typedef void vtr_reembark_f (struct worker *, struct req *);
+typedef int vtr_poll_f (struct req *);
 typedef int vtr_minimal_response_f (struct req *, uint16_t status);
 
 struct transport {
@@ -64,6 +65,7 @@ struct transport {
 	vtr_sess_panic_f		*sess_panic;
 	vtr_req_panic_f			*req_panic;
 	vtr_reembark_f			*reembark;
+	vtr_poll_f			*poll;
 	vtr_minimal_response_f		*minimal_response;
 
 	VTAILQ_ENTRY(transport)		list;

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -438,6 +438,16 @@ h2_new_session(struct worker *wrk, void *arg)
 	wrk->vsl = NULL;
 }
 
+static int v_matchproto_(vtr_poll_f)
+h2_poll(struct req *req)
+{
+	struct h2_req *r2;
+
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	CAST_OBJ_NOTNULL(r2, req->transport_priv, H2_REQ_MAGIC);
+	return (r2->error ? -1 : 1);
+}
+
 struct transport HTTP2_transport = {
 	.name =			"HTTP/2",
 	.magic =		TRANSPORT_MAGIC,
@@ -447,4 +457,5 @@ struct transport HTTP2_transport = {
 	.req_body =		h2_req_body,
 	.req_fail =		h2_req_fail,
 	.sess_panic =		h2_sess_panic,
+	.poll =			h2_poll,
 };

--- a/bin/varnishtest/tests/t02014.vtc
+++ b/bin/varnishtest/tests/t02014.vtc
@@ -5,6 +5,9 @@ barrier b2 sock 3
 barrier b3 sock 3
 barrier b4 sock 3
 
+barrier b2_err cond 2
+barrier b3_err cond 2
+
 server s1 {
 	rxreq
 	txresp -bodylen 66300
@@ -64,6 +67,13 @@ client c1 {
 	stream 0 -wait
 } -run
 
+varnish v1 -vsl_catchup
+
+logexpect l2 -v v1 -g raw {
+	expect * * ReqMethod GET
+	expect * = VCL_call DELIVER
+} -start
+
 client c2 {
 	stream 0 {
 		barrier b2 sync
@@ -71,6 +81,7 @@ client c2 {
 
 	stream 1 {
 		txreq -hdr barrier ${b2_sock}
+		barrier b2_err sync
 		txdata -data "fail"
 		rxrst
 		expect rst.err == STREAM_CLOSED
@@ -78,7 +89,17 @@ client c2 {
 	} -run
 
 	stream 0 -wait
-} -run
+} -start
+
+logexpect l2 -wait
+barrier b2_err sync
+
+client c2 -wait
+
+logexpect l3 -v v1 -g raw {
+	expect * * ReqMethod POST
+	expect * = VCL_call DELIVER
+} -start
 
 client c3 {
 	stream 0 {
@@ -96,6 +117,7 @@ client c3 {
 	stream 1 {
 		txreq -req "POST" -hdr barrier ${b3_sock} -nostrend
 		txdata -data "ok"
+		barrier b3_err sync
 		txdata -data "fail"
 		rxrst
 		expect rst.err == STREAM_CLOSED
@@ -117,4 +139,9 @@ client c3 {
 	} -run
 
 	stream 0 -wait
-} -run
+} -start
+
+logexpect l3 -wait
+barrier b3_err sync
+
+client c3 -wait

--- a/bin/varnishtest/tests/t02014.vtc
+++ b/bin/varnishtest/tests/t02014.vtc
@@ -1,6 +1,9 @@
 varnishtest "Exercise h/2 sender flow control code"
 
-barrier b1 sock 3 -cyclic
+barrier b1 sock 3
+barrier b2 sock 3
+barrier b3 sock 3
+barrier b4 sock 3
 
 server s1 {
 	rxreq
@@ -23,7 +26,9 @@ varnish v1 -vcl+backend {
 	}
 
 	sub vcl_deliver {
-		vtc.barrier_sync("${b1_sock}");
+		if (req.http.barrier) {
+			vtc.barrier_sync(req.http.barrier);
+		}
 	}
 } -start
 
@@ -43,7 +48,7 @@ client c1 {
 	} -start
 
 	stream 1 {
-		txreq
+		txreq -hdr barrier ${b1_sock}
 		barrier b1 sync
 		delay .5
 		txwinup -size 256
@@ -61,15 +66,15 @@ client c1 {
 
 client c2 {
 	stream 0 {
-		barrier b1 sync
+		barrier b2 sync
 	} -start
 
 	stream 1 {
-		txreq
+		txreq -hdr barrier ${b2_sock}
 		txdata -data "fail"
 		rxrst
 		expect rst.err == STREAM_CLOSED
-		barrier b1 sync
+		barrier b2 sync
 	} -run
 
 	stream 0 -wait
@@ -77,8 +82,8 @@ client c2 {
 
 client c3 {
 	stream 0 {
-		barrier b1 sync
-		barrier b1 sync
+		barrier b3 sync
+		barrier b4 sync
 		delay .5
 		txwinup -size 256
 		delay .5
@@ -89,17 +94,17 @@ client c3 {
 	} -start
 
 	stream 1 {
-		txreq -req "POST" -nostrend
+		txreq -req "POST" -hdr barrier ${b3_sock} -nostrend
 		txdata -data "ok"
 		txdata -data "fail"
 		rxrst
 		expect rst.err == STREAM_CLOSED
-		barrier b1 sync
+		barrier b3 sync
 	} -run
 
 	stream 3 {
-		txreq
-		barrier b1 sync
+		txreq -hdr barrier ${b4_sock}
+		barrier b4 sync
 		delay .5
 		txwinup -size 256
 		delay .5

--- a/bin/varnishtest/tests/t02025.vtc
+++ b/bin/varnishtest/tests/t02025.vtc
@@ -1,0 +1,49 @@
+varnishtest "h2 reset interrupt"
+
+barrier b1 sock 2
+barrier b2 sock 2
+
+varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.set debug +syncvsl"
+varnish v1 -vcl {
+	import vtc;
+
+	backend be none;
+
+	sub vcl_recv {
+		vtc.barrier_sync("${b1_sock}");
+		vtc.barrier_sync("${b2_sock}");
+	}
+
+	sub vcl_miss {
+		vtc.panic("unreachable");
+	}
+} -start
+
+logexpect l1 -v v1 -g raw -i Debug {
+	expect * * Debug "^H2RXF RST_STREAM"
+} -start
+
+client c1 {
+	stream 1 {
+		txreq
+		barrier b1 sync
+		txrst
+	} -run
+} -start
+
+logexpect l1 -wait
+barrier b2 sync
+
+varnish v1 -vsl_catchup
+varnish v1 -expect req_reset == 1
+
+# NB: The varnishncsa command below shows a minimal pattern to collect
+# "rapid reset" suspects per session, with the IP address. Here rapid
+# is interpreted as before a second elapsed. Session VXIDs showing up
+# numerous times become increasingly more suspicious. The format can of
+# course be extended to add anything else useful for data mining.
+shell -expect "1000 ${localhost}" {
+	varnishncsa -n ${v1_name} -d \
+		-q 'Timestamp:Reset[2] < 1.0' -F '%{VSL:Begin[2]}x %h'
+}

--- a/doc/sphinx/reference/vsl.rst
+++ b/doc/sphinx/reference/vsl.rst
@@ -76,6 +76,10 @@ Resp
 Restart
 	Client request is being restarted.
 
+Reset
+        The client closed its connection or reset its stream. Request
+        processing is interrupted and considered failed.
+
 Pipe handling timestamps
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/sphinx/reference/vsl.rst
+++ b/doc/sphinx/reference/vsl.rst
@@ -77,7 +77,8 @@ Restart
 	Client request is being restarted.
 
 Reset
-        The client closed its connection or reset its stream. Request
+        The client closed its connection, reset its stream or caused
+        a stream error that forced Varnish to reset the stream. Request
         processing is interrupted and considered failed.
 
 Pipe handling timestamps

--- a/include/tbl/feature_bits.h
+++ b/include/tbl/feature_bits.h
@@ -91,6 +91,11 @@ FEATURE_BIT(TRACE,			trace,
     "Required for tracing vcl_init / vcl_fini"
 )
 
+FEATURE_BIT(VCL_REQ_RESET,			vcl_req_reset,
+    "Stop processing client VCL once the client is gone. "
+    "When this happens MAIN.req_reset is incremented."
+)
+
 #undef FEATURE_BIT
 
 /*lint -restore */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1782,7 +1782,9 @@ PARAM_PRE
 PARAM_BITS(
 	/* name */	feature,
 	/* fld */	feature_bits,
-	/* def */	"+validate_headers",
+	/* def */
+	"+validate_headers,"
+	"+vcl_req_reset",
 	/* descr */
 	"Enable/Disable various minor features.\n"
 	"\tdefault\tSet default value\n"

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -40,6 +40,7 @@ REQ_FLAG(is_hit,		0, 0, "")
 REQ_FLAG(waitinglist,		0, 0, "")
 REQ_FLAG(want100cont,		0, 0, "")
 REQ_FLAG(late100cont,		0, 0, "")
+REQ_FLAG(req_reset,		0, 0, "")
 #define REQ_BEREQ_FLAG(lower, vcl_r, vcl_w, doc) \
 	REQ_FLAG(lower, vcl_r, vcl_w, doc)
 #include "tbl/req_bereq_flags.h"

--- a/lib/libvsc/VSC_main.vsc
+++ b/lib/libvsc/VSC_main.vsc
@@ -350,7 +350,9 @@
 	:oneliner:	Requests reset
 
 	Number of times a client left before the VCL processing of its
-	requests completed.
+	requests completed. For HTTP/2 sessions, either the stream was
+	reset by an RST_STREAM frame from the client, or a stream or
+	connection error occurred.
 
 .. varnish_vsc:: n_object
 	:type:	gauge

--- a/lib/libvsc/VSC_main.vsc
+++ b/lib/libvsc/VSC_main.vsc
@@ -345,6 +345,13 @@
 	Number of times an HTTP/2 stream was refused because the queue was
 	too long already. See also parameter thread_queue_limit.
 
+.. varnish_vsc:: req_reset
+	:group: wrk
+	:oneliner:	Requests reset
+
+	Number of times a client left before the VCL processing of its
+	requests completed.
+
 .. varnish_vsc:: n_object
 	:type:	gauge
 	:group: wrk


### PR DESCRIPTION
This is the main commit message:

> Once a client is reportedly gone, processing its VCL task(s) is just a
> waste of resources. The execution of client-facing VCL is intercepted
> and an artificial return(fail) is returned in that scenario.
> 
> Thanks to the introduction of the universal return(fail) proper error
> handling and resource tear down is already in place, which makes this
> change safe modulus unknown bugs. This adds a circuit breaker anywhere
> in the client state machine where there is VCL execution.
> 
> A new Reset time stamp is logged to convey when a task does not complete
> because the client is gone. This is a good complement to the walk away
> feature and its original circuit breaker for the waiting list, but this
> has not been integrated yet.
> 
> While the request is technically failed, it won't increase the vcl_fail
> counter, and a new req_reset counter is incremented.
> 
> Refs #3835
> Refs 61a15cbffe1141c13b87e30d48ce1402f84433bf
> Refs e5efc2c8dc0d003e5f0fa1a30b598f5949112897
> Refs ba54dc919076b1ddb85434d886ce82a6553d926b
> Refs 6f50a00f80c7f74b2a8b18bb80593f58b74816fd
> Refs b8816994cfab58261d8000ea8e6941cb5de640fa

This change is limited to h2 reset in a broader sense than just receiving an `RST_STREAM` frame, and it is conceivable to achieve a similar attack for HTTP/1 sessions with a rapid TCP reset, but this would also be less effective. It should also be easier to detect and mitigate with firewall rules.

However implementing client polling for HTTP/1 clients is not as straightforward as h2, so an HTTP/1 client can effectively trigger a workload and not stick around, yet the VCL will be processed until completion. We could probably use the waiter facility, but this needs some research.