### PR TITLE
h2: the :scheme pseudo header is not optional

### DIFF
--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -211,11 +211,14 @@ vtr_deliver_f h2_deliver;
 vtr_minimal_response_f h2_minimal_response;
 #endif /* TRANSPORT_MAGIC */
 
+#define H2H_DECODE_FLAG_SCHEME_SEEN	0x1
+
 /* http2/cache_http2_hpack.c */
 struct h2h_decode {
 	unsigned			magic;
 #define H2H_DECODE_MAGIC		0xd092bde4
 
+	int				flags;
 	h2_error			error;
 	enum vhd_ret_e			vhd_ret;
 	char				*out;

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -601,11 +601,13 @@ static h2_error
 h2_end_headers(struct worker *wrk, struct h2_sess *h2,
     struct req *req, struct h2_req *r2)
 {
+	int scheme_seen;
 	h2_error h2e;
 	ssize_t cl;
 
 	ASSERT_RXTHR(h2);
 	assert(r2->state == H2_S_OPEN);
+	scheme_seen = h2->decode->flags & H2H_DECODE_FLAG_SCHEME_SEEN;
 	h2e = h2h_decode_fini(h2);
 	h2->new_req = NULL;
 	if (h2e != NULL) {
@@ -656,10 +658,17 @@ h2_end_headers(struct worker *wrk, struct h2_sess *h2,
 		VSLb(h2->vsl, SLT_Debug, "Missing :method");
 		return (H2SE_PROTOCOL_ERROR); //rfc7540,l,3087,3090
 	}
+
 	if (req->http->hd[HTTP_HDR_URL].b == NULL) {
 		VSLb(h2->vsl, SLT_Debug, "Missing :path");
 		return (H2SE_PROTOCOL_ERROR); //rfc7540,l,3087,3090
 	}
+
+	if (!(scheme_seen)) {
+		VSLb(h2->vsl, SLT_Debug, "Missing :scheme");
+		return (H2SE_PROTOCOL_ERROR); //rfc7540,l,3087,3090
+	}
+
 	AN(req->http->hd[HTTP_HDR_PROTO].b);
 
 	if (*req->http->hd[HTTP_HDR_URL].b == '*' &&

--- a/bin/varnishtest/tests/t02026.vtc
+++ b/bin/varnishtest/tests/t02026.vtc
@@ -1,0 +1,48 @@
+varnishtest "Dublicate pseudo-headers"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-p feature=+http2" -vcl+backend {
+} -start
+
+#client c1 {
+#	txreq -url "/some/path" -url "/some/other/path"
+#	rxresp
+#	expect resp.status == 400
+#} -run
+
+#client c1 {
+#	txreq -req "GET" -req "POST"
+#	rxresp
+#	expect resp.status == 400
+#} -run
+
+#client c1 {
+#	txreq -proto "HTTP/1.1" -proto "HTTP/2.0"
+#	rxresp
+#	expect resp.status == 400
+#} -run
+
+client c1 {
+	stream 1 {
+		txreq -url "/some/path" -url "/some/other/path"
+		rxrst
+	} -run
+} -run
+
+client c1 {
+	stream 1 {
+		txreq -scheme "http" -scheme "https"
+		rxrst
+	} -run
+} -run
+
+client c1 {
+	stream 1 {
+		txreq -req "GET" -req "POST"
+		rxrst
+	} -run
+} -run


### PR DESCRIPTION
The :scheme pseudo header is not optional in H/2 except when doing CONNECT. There is also a strict requirement for it appear only once.

Signed-off-by: Asad Sajjad Ahmed <asadsa@varnish-software.com>

Conflicts:
	bin/varnishtest/tests/t02025.vtc

---

This was submitted to the 6.0 branch instead of trunk first. I noticed it thanks to the test case collision while porting #3998 to the 6.0 branch.