### PR TITLE
Fix and optimize 304 object copying

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -769,7 +769,8 @@ vbf_objiterate(void *priv, unsigned flush, const void *ptr, ssize_t len)
 	uint8_t *pd;
 
 	CAST_OBJ_NOTNULL(bo, priv, BUSYOBJ_MAGIC);
-	(void)flush;
+
+	flush &= OBJ_ITER_END;
 
 	while (len > 0) {
 		l = len;
@@ -777,7 +778,7 @@ vbf_objiterate(void *priv, unsigned flush, const void *ptr, ssize_t len)
 			return (1);
 		l = vmin(l, len);
 		memcpy(pd, ps, l);
-		VFP_Extend(bo->vfc, l, l == len ? VFP_END : VFP_OK);
+		VFP_Extend(bo->vfc, l, flush && l == len ? VFP_END : VFP_OK);
 		ps += l;
 		len -= l;
 	}

--- a/bin/varnishtest/tests/b00062.vtc
+++ b/bin/varnishtest/tests/b00062.vtc
@@ -2,7 +2,11 @@ varnishtest "Test that we properly wait for certain 304 cases"
 
 server s1 {
 	rxreq
-	txresp -hdr "Last-Modified: Wed, 11 Sep 2013 13:36:55 GMT" -body "Geoff Still Rules"
+	txresp -hdr "Last-Modified: Wed, 11 Sep 2013 13:36:55 GMT" \
+	       -hdr "Geoff: Still Rules" \
+	       -bodylen 130560
+
+	       # 2*64k-512 ^^^ see sml_trimstore() st->space - st->len < 512
 
 	# The IMS request we will spend some time to process for the sake of
 	# this test.
@@ -17,7 +21,7 @@ server s1 {
 	txresp -body "x"
 } -start
 
-varnish v1 -vcl+backend {
+varnish v1 -arg "-p fetch_maxchunksize=64k" -vcl+backend {
 	sub vcl_backend_response {
 		set beresp.ttl = 1s;
 		set beresp.grace = 1s;
@@ -30,7 +34,8 @@ client c1 {
 	txreq
 	rxresp
 	expect resp.status == 200
-	expect resp.body == "Geoff Still Rules"
+	expect resp.http.Geoff == "Still Rules"
+	expect resp.bodylen == 130560
 } -run
 
 # let the object's ttl and grace expire
@@ -42,7 +47,8 @@ client c2 {
 	rxresp
 	# we did not disable grace in the request, so we should get the graced object here
 	expect resp.status == 200
-	expect resp.body == "Geoff Still Rules"
+	expect resp.http.Geoff == "Still Rules"
+	expect resp.bodylen == 130560
 } -start
 
 delay .1
@@ -52,7 +58,8 @@ client c3 {
 	txreq
 	rxresp
 	expect resp.status == 200
-	expect resp.body == "Geoff Still Rules"
+	expect resp.http.Geoff == "Still Rules"
+	expect resp.bodylen == 130560
 } -start
 
 client c2 -wait


### PR DESCRIPTION
(edit: Added a second commit which depends on the first)

TL;DR: Fix trimstore use in 304 and copy objects efficiently ("defragmented")

### Commit 1: Call trimstore only once when copying the body after a 304

It is my understanding that the objtrimstore stevedore API function is only to be called once when the object is complete, which I believe is also in line with the comment on `ObjExtend()` that _The final flag must be set on the last call_.

If this understanding of the API is correct, we did not adhere to it in the fetch code when we made a copy of an existing stale object after a 304 response: There, we iterated over the stale object and did not set the final flag just once when the object was complete, but rather after each storage segment was copied.

This commit fixes this, adds some pedentry to the simple storage and extends b00062.vtc to test this behavior specifically. On top, g6.vtc also triggered without the fix but the duplicate trim detection in place.

This issue has originally surfaced in the SLASH/fellow storage where the trimstore function implicitly asserted to only be called once.

Ref 115742b07c8bad6d465f1c981ee264f934a4492b
Ref https://gitlab.com/uplex/varnish/slash/-/issues/33

### Commit 2: Optimize 304 template object copying

When copying a stale object after a 304 revalidation, we iterated over it and allocated new storage for each storage segment.
    
So, at best, we kept the fragmentation of the existing object, or made it even worse. This is particularly relevant when the existing object was created from a chunked response, in which case the original segments might have been particularly small and, consequently, many in number.
    
Because we wait for the stale object to complete, we know the total length (`OA_LEN`) upfront, and can ask the storage serving the copy for exactly the right length. This is much more efficient, as fragmentation is lowered and the storage engine might make a much better allocation decision when it knows the full length rather than getting piecemeal requests.
    
We implement the improved allocation scheme through additional state kept for the duration of the template object copy: `struct vbf_objiter_priv` holds the pointer to the newly created busy object, the total yet unallocated length (initialized to `OA_LEN` of the existing object) and pointer/length to the unused portion of the currently open segment, if any.