### PR TITLE
Release 7.4.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
 Copyright (c) 2006-2023 Varnish Software
 Copyright 2010-2023 UPLEX - Nils Goroll Systemoptimierung])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [7.4.1], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [7.4.2], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -35,12 +35,8 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
-Varnish Cache 7.4.1 (2023-09-19)
+Varnish Cache 7.4.2 (2023-11-13)
 ================================
-
-* Fix the scope of bereq protected headers (3984_).
-
-.. _3984: https://github.com/varnishcache/varnish-cache/issues/3984
 
 * The ``vcl_req_reset`` feature (controllable through the ``feature``
   parameter, see `varnishd(1)`) has been added and enabled by default
@@ -109,6 +105,14 @@ Varnish Cache 7.4.1 (2023-09-19)
 .. _3997: https://github.com/varnishcache/varnish-cache/pull/3997
 .. _3998: https://github.com/varnishcache/varnish-cache/pull/3998
 .. _3999: https://github.com/varnishcache/varnish-cache/pull/3999
+
+================================
+Varnish Cache 7.4.1 (2023-09-19)
+================================
+
+* Fix the scope of bereq protected headers (3984_).
+
+.. _3984: https://github.com/varnishcache/varnish-cache/issues/3984
 
 ================================
 Varnish Cache 7.4.0 (2023-09-15)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -50,10 +50,10 @@ Varnish Cache 7.4.2 (2023-11-13)
   In particular, this feature is used to reduce resource consumption
   of HTTP/2 "rapid reset" attacks (see below).
 
-  Note, in particular, that *req_reset* events may lead to client
-  tasks for which no VCL is called ever. Presumably, this is thus the
-  first time that valid `vcl(7)` client transactions may not contain
-  any ``VCL_call`` records.
+  Note that *req_reset* events may lead to client tasks for which no
+  VCL is called ever. Presumably, this is thus the first time that
+  valid `vcl(7)` client transactions may not contain any ``VCL_call``
+  records.
 
 * Added mitigation options and visibility for HTTP/2 "rapid reset"
   attacks (CVE-2023-44487_, 3996_, 3997_, 3998_, 3999_).

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -42,6 +42,74 @@ Varnish Cache 7.4.1 (2023-09-19)
 
 .. _3984: https://github.com/varnishcache/varnish-cache/issues/3984
 
+* The ``vcl_req_reset`` feature (controllable through the ``feature``
+  parameter, see `varnishd(1)`) has been added and enabled by default
+  to terminate client side VCL processing early when the client is
+  gone.
+
+  *req_reset* events trigger a VCL failure and are reported to
+  `vsl(7)` as ``Timestamp: Reset`` and accounted to ``main.req_reset``
+  in `vsc` as visible through ``varnishstat(1)``.
+
+  In particular, this feature is used to reduce resource consumption
+  of HTTP/2 "rapid reset" attacks (see below).
+
+  Note, in particular, that *req_reset* events may lead to client
+  tasks for which no VCL is called ever. Presumably, this is thus the
+  first time that valid `vcl(7)` client transactions may not contain
+  any ``VCL_call`` records.
+
+* Added mitigation options and visibility for HTTP/2 "rapid reset"
+  attacks (CVE-2023-44487_, 3996_, 3997_, 3998_, 3999_).
+
+  Global rate limit controls have been added as parameters, which can
+  be overridden per HTTP/2 session from VCL using the new vmod ``h2``:
+
+  * The ``h2_rapid_reset`` parameter and ``h2.rapid_reset()`` function
+    define a threshold duration for an ``RST_STREAM`` to be classified
+    as "rapid": If an ``RST_STREAM`` frame is parsed sooner than this
+    duration after a ``HEADERS`` frame, it is accounted against the
+    rate limit described below.
+
+    The default is one second.
+
+  * The ``h2_rapid_reset_limit`` parameter and
+    ``h2.rapid_reset_limit()`` function define how many "rapid" resets
+    may be received during the time span defined by the
+    ``h2_rapid_reset_period`` parameter / ``h2.rapid_reset_period()``
+    function before the HTTP/2 connection is forcibly closed with a
+    ``GOAWAY`` and all ongoing VCL client tasks of the connection are
+    aborted.
+
+    The defaults are 100 and 60 seconds, corresponding to an allowance
+    of 100 "rapid" resets per minute.
+
+  * The ``h2.rapid_reset_budget()`` function can be used to query the
+    number of currently allowed "rapid" resets.
+
+  * Sessions closed due to rapid reset rate limiting are reported as
+    ``SessClose RAPID_RESET`` in `vsl(7)` and accounted to
+    ``main.sc_rapid_reset`` in `vsc` as visible through
+    ``varnishstat(1)``.
+
+* The ``cli_limit`` parameter default has been increased from 48KB to
+  64KB.
+
+* ``VSUB_closefrom()`` now falls back to the base implementation not
+  only if ``close_range()`` was determined to be unusable at compile
+  time, but also at run time. That is to say, even if
+  ``close_range()`` is compiled in, the fallback to the naive
+  implementation remains.
+
+* Improved HPACK header validation.
+
+.. _CVE-2023-44487: https://nvd.nist.gov/vuln/detail/CVE-2023-44487
+
+.. _3996: https://github.com/varnishcache/varnish-cache/issues/3996
+.. _3997: https://github.com/varnishcache/varnish-cache/pull/3997
+.. _3998: https://github.com/varnishcache/varnish-cache/pull/3998
+.. _3999: https://github.com/varnishcache/varnish-cache/pull/3999
+
 ================================
 Varnish Cache 7.4.0 (2023-09-15)
 ================================


### PR DESCRIPTION
Reviewers must check the following items:

- [ ] Release notes are complete (major release only)
- [ ] Release notes no longer target trunk (major release only)
- [x] The change log is populated
- [x] The VRT history in `include/vrt.h` is populated
- [x] The VRT history refers to the next VRT version
- [x] The macro `VRT_MAJOR_VERSION` was updated if applicable
- [x] The macro `VRT_MINOR_VERSION` was updated if applicable
- [x] The new VRT version follows releases guidelines
- [x] The new VRT version matches the one from the VRT history
- [ ] Bundled `devicedetect.vcl` was updated (major release only)
- [x] Running `./autogen.des && make distcheck` succeeds
- [x] The version in `configure.ac` is correct
- [x] The copyright notice in `configure.ac` covers the current year
- [x] The copyright output in `lib/libvarnish/version.c` covers the current year
- [x] There are no other changes than the ones listed above