### PR TITLE
param: Enable absolute bits parameters

### DIFF
--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -713,7 +713,7 @@ mcf_wash_param(struct cli *cli, struct parspec *pp, enum mcf_which_e which,
 static struct cli_proto cli_params[] = {
 	{ CLICMD_PARAM_SHOW,	"", mcf_param_show, mcf_param_show_json },
 	{ CLICMD_PARAM_SET,	"", mcf_param_set, mcf_param_set_json },
-	{ CLICMD_PARAM_RESET,	"", mcf_param_reset },
+	{ CLICMD_PARAM_RESET,	"", mcf_param_reset, mcf_param_set_json },
 	{ NULL }
 };
 

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -607,6 +607,13 @@ bit(uint8_t *p, unsigned no, enum bit_do act)
 	return (*p & b);
 }
 
+static inline void
+bit_clear(uint8_t *p, unsigned l)
+{
+
+	memset(p, 0, (l + 7) >> 3);
+}
+
 /*--------------------------------------------------------------------
  */
 
@@ -665,14 +672,14 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 
 	if (arg != NULL && !strcmp(arg, "default") &&
 	    strcmp(par->def, "none")) {
-		memset(p, 0, l >> 3);
+		bit_clear(p, l);
 		return (tweak_generic_bits(vsb, par, par->def, p, l, tags,
 		    desc, sign));
 	}
 
 	if (arg != NULL && arg != JSON_FMT) {
 		if (sign == '+' && !strcmp(arg, "none"))
-			memset(p, 0, l >> 3);
+			bit_clear(p, l);
 		else
 			return (bit_tweak(vsb, p, l, arg, tags, desc, sign));
 	} else {

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -675,7 +675,6 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
     uint8_t *p, unsigned l, const char * const *tags, const char *desc,
     char sign)
 {
-	const char *s;
 	unsigned j;
 
 	if (arg != NULL && !strcmp(arg, "default") &&
@@ -690,15 +689,11 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 
 	if (arg == JSON_FMT)
 		VSB_putc(vsb, '"');
-	s = "";
+	VSB_cat(vsb, sign == '+' ? "none" : "all");
 	for (j = 0; j < l; j++) {
-		if (bit(p, j, BTST)) {
-			VSB_printf(vsb, "%s%c%s", s, sign, tags[j]);
-			s = ",";
-		}
+		if (bit(p, j, BTST))
+			VSB_printf(vsb, ",%c%s", sign, tags[j]);
 	}
-	if (*s == '\0')
-		VSB_cat(vsb, sign == '+' ? "none" : "all");
 	if (arg == JSON_FMT)
 		VSB_putc(vsb, '"');
 	return (0);

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -678,6 +678,7 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 	unsigned j;
 
 	if (arg != NULL && !strcmp(arg, "default")) {
+		/* XXX: deprecated in favor of param.reset */
 		return (tweak_generic_bits(vsb, par, par->def, p, l, tags,
 		    desc, sign));
 	}

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -685,23 +685,22 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 		    desc, sign));
 	}
 
-	if (arg != NULL && arg != JSON_FMT) {
+	if (arg != NULL && arg != JSON_FMT)
 		return (bit_tweak(vsb, p, l, arg, tags, desc, sign));
-	} else {
-		if (arg == JSON_FMT)
-			VSB_putc(vsb, '"');
-		s = "";
-		for (j = 0; j < l; j++) {
-			if (bit(p, j, BTST)) {
-				VSB_printf(vsb, "%s%c%s", s, sign, tags[j]);
-				s = ",";
-			}
+
+	if (arg == JSON_FMT)
+		VSB_putc(vsb, '"');
+	s = "";
+	for (j = 0; j < l; j++) {
+		if (bit(p, j, BTST)) {
+			VSB_printf(vsb, "%s%c%s", s, sign, tags[j]);
+			s = ",";
 		}
-		if (*s == '\0')
-			VSB_cat(vsb, sign == '+' ? "none" : "all");
-		if (arg == JSON_FMT)
-			VSB_putc(vsb, '"');
 	}
+	if (*s == '\0')
+		VSB_cat(vsb, sign == '+' ? "none" : "all");
+	if (arg == JSON_FMT)
+		VSB_putc(vsb, '"');
 	return (0);
 }
 

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -677,9 +677,7 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 {
 	unsigned j;
 
-	if (arg != NULL && !strcmp(arg, "default") &&
-	    strcmp(par->def, "none")) {
-		bit_clear(p, l);
+	if (arg != NULL && !strcmp(arg, "default")) {
 		return (tweak_generic_bits(vsb, par, par->def, p, l, tags,
 		    desc, sign));
 	}

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -634,6 +634,14 @@ bit_tweak(struct vsb *vsb, uint8_t *p, unsigned l, const char *arg,
 	}
 	for (i = 1; av[i] != NULL; i++) {
 		s = av[i];
+		if (sign == '+' && !strcmp(s, "none")) {
+			bit_clear(p, l);
+			continue;
+		}
+		if (sign == '-' && !strcmp(s, "all")) {
+			bit_clear(p, l);
+			continue;
+		}
 		if (*s != '-' && *s != '+') {
 			VSB_printf(vsb, "Missing '+' or '-' (%s)\n", s);
 			VAV_Free(av);
@@ -678,12 +686,7 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 	}
 
 	if (arg != NULL && arg != JSON_FMT) {
-		if (sign == '+' && !strcmp(arg, "none"))
-			bit_clear(p, l);
-		else if (sign == '-' && !strcmp(arg, "all"))
-			bit_clear(p, l);
-		else
-			return (bit_tweak(vsb, p, l, arg, tags, desc, sign));
+		return (bit_tweak(vsb, p, l, arg, tags, desc, sign));
 	} else {
 		if (arg == JSON_FMT)
 			VSB_putc(vsb, '"');

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -680,6 +680,8 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 	if (arg != NULL && arg != JSON_FMT) {
 		if (sign == '+' && !strcmp(arg, "none"))
 			bit_clear(p, l);
+		else if (sign == '-' && !strcmp(arg, "all"))
+			bit_clear(p, l);
 		else
 			return (bit_tweak(vsb, p, l, arg, tags, desc, sign));
 	} else {
@@ -693,7 +695,7 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 			}
 		}
 		if (*s == '\0')
-			VSB_cat(vsb, sign == '+' ? "none" : "(all enabled)");
+			VSB_cat(vsb, sign == '+' ? "none" : "all");
 		if (arg == JSON_FMT)
 			VSB_putc(vsb, '"');
 	}

--- a/bin/varnishtest/tests/c00054.vtc
+++ b/bin/varnishtest/tests/c00054.vtc
@@ -10,6 +10,7 @@ varnish v1 -cliok "param.show vsl_mask"
 
 varnish v1 -cliexpect {"value": "none"} "param.set -j feature none"
 varnish v1 -cliexpect {"value": "all"} "param.set -j vsl_mask all"
+varnish v1 -cliexpect {"value": "all(,-\w+)+"} "param.reset -j vsl_mask"
 
 varnish v1 -clierr 106 "param.set vsl_mask FooBar"
 varnish v1 -clierr 106 "param.set vsl_mask -FooBar"

--- a/bin/varnishtest/tests/c00054.vtc
+++ b/bin/varnishtest/tests/c00054.vtc
@@ -1,13 +1,5 @@
 varnishtest "bitmap params masking"
 
-
-server s1 {
-	rxreq
-	txresp
-} -start
-
-varnish v1 -vcl+backend {} -start
-
 varnish v1 -cliok "param.show vsl_mask"
 varnish v1 -cliok "param.set vsl_mask -VCL_trace"
 varnish v1 -cliok "param.show vsl_mask"
@@ -15,6 +7,9 @@ varnish v1 -cliok "param.set vsl_mask -WorkThread,-TTL"
 varnish v1 -cliok "param.show vsl_mask"
 varnish v1 -cliok "param.set vsl_mask +WorkThread,+TTL,+Hash"
 varnish v1 -cliok "param.show vsl_mask"
+
+varnish v1 -cliexpect {"value": "none"} "param.set -j feature none"
+
 varnish v1 -clierr 106 "param.set vsl_mask FooBar"
 varnish v1 -clierr 106 "param.set vsl_mask -FooBar"
 varnish v1 -clierr 106 {param.set vsl_mask \"}
@@ -24,9 +19,3 @@ varnish v1 -cliok "param.show debug"
 varnish v1 -cliok "param.show feature"
 varnish v1 -cliok "param.set feature +short_panic"
 varnish v1 -cliok "param.show feature"
-
-
-client c1 {
-	txreq
-	rxresp
-} -run

--- a/bin/varnishtest/tests/c00054.vtc
+++ b/bin/varnishtest/tests/c00054.vtc
@@ -9,6 +9,7 @@ varnish v1 -cliok "param.set vsl_mask +WorkThread,+TTL,+Hash"
 varnish v1 -cliok "param.show vsl_mask"
 
 varnish v1 -cliexpect {"value": "none"} "param.set -j feature none"
+varnish v1 -cliexpect {"value": "all"} "param.set -j vsl_mask all"
 
 varnish v1 -clierr 106 "param.set vsl_mask FooBar"
 varnish v1 -clierr 106 "param.set vsl_mask -FooBar"

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -172,9 +172,11 @@ CLI_CMD(VCL_LABEL,
 
 CLI_CMD(PARAM_RESET,
 	"param.reset",
-	"param.reset <param>",
+	"param.reset [-j] <param>",
 	"Reset parameter to default value.",
-	"",
+	"  The JSON output is the same as ``param.show -j <param>`` and"
+	" contains the updated value as it would be represented by a"
+	" subsequent execution of ``param.show``.\n\n",
 	1,1
 )
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1829,6 +1829,7 @@ PARAM_BITS(
 	/* name */	feature,
 	/* fld */	feature_bits,
 	/* def */
+	"none,"
 	"+validate_headers,"
 	"+vcl_req_reset",
 	/* descr */
@@ -1847,6 +1848,7 @@ PARAM_BITS(
 	/* name */	vcc_feature,
 	/* fld */	vcc_feature_bits,
 	/* def */
+	"none,"
 	"+err_unref,"
 	"+unsafe_path",
 	/* descr */
@@ -1865,6 +1867,7 @@ PARAM_BITS(
 	/* name */	vsl_mask,
 	/* fld */	vsl_mask,
 	/* def */
+	"all,"
 	"-Debug,"
 	"-ExpKill,"
 	"-H2RxBody,"

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1881,6 +1881,7 @@ PARAM_BITS(
 	"-WorkThread",
 	/* descr */
 	"Mask individual VSL messages from being logged.\n"
+	"\tall\tEnable all tags\n"
 	"\tdefault\tSet default value\n"
 	"\nUse +/- prefix in front of VSL tag name to unmask/mask "
 	"individual VSL messages.")

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1834,7 +1834,7 @@ PARAM_BITS(
 	"+vcl_req_reset",
 	/* descr */
 	"Enable/Disable various minor features.\n"
-	"\tdefault\tSet default value\n"
+	"\tdefault\tSet default value (deprecated: use param.reset)\n"
 	"\tnone\tDisable all features.\n\n"
 	"Use +/- prefix to enable/disable individual feature:")
 #ifdef PARAM_ALL
@@ -1853,7 +1853,7 @@ PARAM_BITS(
 	"+unsafe_path",
 	/* descr */
 	"Enable/Disable various VCC behaviors.\n"
-	"\tdefault\tSet default value\n"
+	"\tdefault\tSet default value (deprecated: use param.reset)\n"
 	"\tnone\tDisable all behaviors.\n\n"
 	"Use +/- prefix to enable/disable individual behavior:")
 #ifdef PARAM_ALL
@@ -1885,7 +1885,7 @@ PARAM_BITS(
 	/* descr */
 	"Mask individual VSL messages from being logged.\n"
 	"\tall\tEnable all tags\n"
-	"\tdefault\tSet default value\n"
+	"\tdefault\tSet default value (deprecated: use param.reset)\n"
 	"\nUse +/- prefix in front of VSL tag name to unmask/mask "
 	"individual VSL messages.")
 PARAM_POST


### PR DESCRIPTION
With the introduction of `param.set -j` performing the regular `param.set` operation but outputting `param.show -j` we made it possible for "operators" to atomically set a parameter to a specific value, and know how it would be rendered. This enables safe periodic consistency checks to undo potential manual tweaks.

This change however, left a blind spot for bits parameters, since we either set them to their default value via the "none" or "default" special values, and otherwise with relative values in the form of a series of `-xxx` or `+yyy` tokens.

This patch series adds a new "all" value and allows "all" and "none" to appear in the bits list:

```
param.set foo none,+bar,+baz
```

It also changes the relative default values of some bits parameters to make them all absolute.

The "default" special value is marked as deprecated in favor of `param.reset`.

The `param.reset` command grew a `-j` option to behave like `param.set`, for consistency.

Last but not least, it fixes the handling of "none" and "default" that could spuriously leave up to 7 most significant bits raised.