### PR TITLE
Release 7.3.1

### DIFF
--- a/bin/varnishtest/vtc_varnish.c
+++ b/bin/varnishtest/vtc_varnish.c
@@ -417,7 +417,7 @@ varnish_launch(struct varnish *v)
 	VSB_cat(vsb, " -p syslog_cli_traffic=off");
 	VSB_cat(vsb, " -p thread_pool_min=10");
 	VSB_cat(vsb, " -p debug=+vtc_mode");
-	VSB_cat(vsb, " -p vsl_mask=+Debug");
+	VSB_cat(vsb, " -p vsl_mask=+Debug,+H2RxHdr,+H2RxBody");
 	VSB_cat(vsb, " -p h2_initial_window_size=1m");
 	VSB_cat(vsb, " -p h2_rx_window_low_water=64k");
 	if (!v->has_a_arg) {

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.69)
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
 Copyright (c) 2006-2023 Varnish Software])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [7.3.0], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [7.3.1], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -102,10 +102,10 @@ Varnish Cache 7.3.1 (2023-11-13)
   In particular, this feature is used to reduce resource consumption
   of HTTP/2 "rapid reset" attacks (see below).
 
-  Note, in particular, that *req_reset* events may lead to client
-  tasks for which no VCL is called ever. Presumably, this is thus the
-  first time that valid `vcl(7)` client transactions may not contain
-  any ``VCL_call`` records.
+  Note that *req_reset* events may lead to client tasks for which no
+  VCL is called ever. Presumably, this is thus the first time that
+  valid `vcl(7)` client transactions may not contain any ``VCL_call``
+  records.
 
 * The ``cli_limit`` parameter default has been increased from 48KB to
   64KB.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -30,6 +30,10 @@ directory, also available in HTML format at
 http://varnish-cache.org/docs/trunk/whats-new/index.html and via
 individual releases. These documents are updated as part of the
 release process.
+================================
+Varnish Cache 7.3.1 (2023-11-13)
+================================
+
 
 ================================
 Varnish Cache 7.3.0 (2023-03-15)


### PR DESCRIPTION
Reviewers must check the following items:

- [ ] Release notes are complete (major release only)
- [ ] Release notes no longer target trunk (major release only)
- [x] The change log is populated
- [x] The VRT history in `include/vrt.h` is populated
- [x] The VRT history refers to the next VRT version
- [x] The macro `VRT_MAJOR_VERSION` was updated if applicable
- [x] The macro `VRT_MINOR_VERSION` was updated if applicable
- [x] The new VRT version follows releases guidelines
- [x] The new VRT version matches the one from the VRT history
- [ ] Bundled `devicedetect.vcl` was updated (major release only)
- [x] Running `./autogen.des && make distcheck` succeeds
- [x] The version in `configure.ac` is correct
- [x] The copyright notice in `configure.ac` covers the current year
- [x] The copyright output in `lib/libvarnish/version.c` covers the current year
- [ ] There are no other changes than the ones listed above