### PR TITLE
Varnishadm: Add -e argument

### DIFF
--- a/bin/varnishadm/varnishadm.c
+++ b/bin/varnishadm/varnishadm.c
@@ -166,6 +166,24 @@ cli_sock(const char *T_arg, const char *S_arg)
 	return (sock);
 }
 
+static void
+pass_print_answer(int status, char *answer, enum pass_mode_e mode)
+{
+	if (p_arg && answer != NULL) {
+		printf("%-3u %-8zu\n%s", status, strlen(answer), answer);
+	} else if (p_arg) {
+		printf("%-3u %-8u\n", status, 0U);
+	} else {
+		if (mode == pass_interactive)
+			printf("%u\n", status);
+		if (answer != NULL)
+			printf("%s\n", answer);
+		if (status == CLIS_TRUNCATED)
+			printf("[response was truncated]\n");
+	}
+	fflush(stdout);
+}
+
 static unsigned
 pass_answer(int fd, enum pass_mode_e mode)
 {
@@ -183,20 +201,8 @@ pass_answer(int fd, enum pass_mode_e mode)
 		RL_EXIT(1);
 	}
 
-	if (p_arg && answer != NULL) {
-		printf("%-3u %-8zu\n%s", status, strlen(answer), answer);
-	} else if (p_arg) {
-		printf("%-3u %-8u\n", status, 0U);
-	} else {
-		if (mode == pass_interactive)
-			printf("%u\n", status);
-		if (answer != NULL)
-			printf("%s\n", answer);
-		if (status == CLIS_TRUNCATED)
-			printf("[response was truncated]\n");
-	}
+	pass_print_answer(status, answer, mode);
 	free(answer);
-	(void)fflush(stdout);
 	return (status);
 }
 

--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -143,7 +143,7 @@ mcf_askchild(struct cli *cli, const char * const *av, void *priv)
 	}
 	VSB_clear(cli_buf);
 	for (i = 1; av[i] != NULL; i++) {
-		VSB_quote(cli_buf, av[i], strlen(av[i]), 0);
+		VSB_quote(cli_buf, av[i], strlen(av[i]), VSB_QUOTE_CLI);
 		VSB_putc(cli_buf, ' ');
 	}
 	VSB_putc(cli_buf, '\n');

--- a/bin/varnishtest/tests/m00000.vtc
+++ b/bin/varnishtest/tests/m00000.vtc
@@ -186,7 +186,7 @@ shell {
 
 varnish v1 -clierr 300 "vcl.load f1 ${tmpdir}/f1"
 
-shell -exit 1 -expect {failing as requested} {
+shell -exit 3 -expect {failing as requested} {
 	varnishadm -t 10 -n ${tmpdir}/v1 vcl.load f1 ${tmpdir}/f1
 }
 

--- a/bin/varnishtest/tests/u00000.vtc
+++ b/bin/varnishtest/tests/u00000.vtc
@@ -116,7 +116,7 @@ shell {varnishadm -n ${tmpdir}/v1 start}
 
 shell {varnishadm -n ${tmpdir}/v1 debug.listen_address}
 
-shell -exit 1 -expect "Command failed with error code 500" {
+shell -exit 5 -expect "Command failed with error code 500" {
 	varnishadm -n ${tmpdir}/v1 quit
 }
 

--- a/bin/varnishtest/tests/u00001.vtc
+++ b/bin/varnishtest/tests/u00001.vtc
@@ -60,3 +60,57 @@ shell -err {
 	varnishadm -n ${v1_name} -p |
 	python3 -c 'import sys, json; print(json.load(sys.stdin))'
 }
+
+shell {
+	cat > cli_file.txt <<-EOF
+	status
+	foo
+	vcl.list
+	EOF
+}
+
+shell {
+	cat > expected_success.txt <<-EOF
+	Child in state running
+	Unknown request.
+	Type 'help' for more info.
+
+	active   auto    warm      0   vcl1
+
+	EOF
+}
+
+shell {
+	cat > expected_abort.txt <<-EOF
+	Child in state running
+	Unknown request.
+	Type 'help' for more info.
+
+	EOF
+}
+
+shell { varnishadm -n ${v1_name} < cli_file.txt }
+shell { varnishadm -n ${v1_name} < cli_file.txt | diff -u expected_success.txt - }
+
+shell -exit 1 { varnishadm -e -n ${v1_name} < cli_file.txt }
+shell { varnishadm -e -n ${v1_name} < cli_file.txt | diff -u expected_abort.txt - }
+
+shell { cat cli_file.txt | varnishadm -n ${v1_name} }
+shell { cat cli_file.txt | varnishadm -n ${v1_name} | diff -u expected_success.txt - }
+
+shell -exit 1 { cat cli_file.txt | varnishadm -e -n ${v1_name} }
+shell { cat cli_file.txt | varnishadm -e -n ${v1_name} | diff -u expected_abort.txt - }
+
+shell {
+	cat > cli_file.txt <<-EOF
+	status
+	-foo
+	vcl.list
+	EOF
+}
+
+shell { varnishadm -e -n ${v1_name} < cli_file.txt }
+shell { varnishadm -e -n ${v1_name} < cli_file.txt | diff -u expected_success.txt - }
+
+shell { cat cli_file.txt | varnishadm -e -n ${v1_name} }
+shell { cat cli_file.txt | varnishadm -e -n ${v1_name} | diff -u expected_success.txt - }

--- a/bin/varnishtest/tests/u00001.vtc
+++ b/bin/varnishtest/tests/u00001.vtc
@@ -114,3 +114,17 @@ shell { varnishadm -e -n ${v1_name} < cli_file.txt | diff -u expected_success.tx
 
 shell { cat cli_file.txt | varnishadm -e -n ${v1_name} }
 shell { cat cli_file.txt | varnishadm -e -n ${v1_name} | diff -u expected_success.txt - }
+
+shell {
+	cat > cli_heredoc.txt <<-EOF1
+	vcl.inline bar << EOF2
+	vcl 4.1;
+
+	backend default none;
+	EOF2
+	EOF1
+}
+
+shell { varnishadm -e -p -n ${v1_name} < cli_heredoc.txt }
+shell { varnishadm -n ${v1_name} vcl.discard bar }
+shell { cat cli_heredoc.txt | varnishadm -e -p -n ${v1_name} }

--- a/bin/varnishtest/tests/u00001.vtc
+++ b/bin/varnishtest/tests/u00001.vtc
@@ -34,7 +34,6 @@ shell {
 # same command via stdin
 shell {
 	echo status | varnishadm -n ${v1_name} -p | tr ' ' _ >actual.txt
-	printf '\n' >>actual.txt
 	diff -u expected.txt actual.txt
 }
 

--- a/bin/varnishtest/tests/u00012.vtc
+++ b/bin/varnishtest/tests/u00012.vtc
@@ -32,7 +32,7 @@ process p1 -screen_dump -write "\x04" -wait
 process p1 -log {varnishadm -t foobar 2>&1} -expect-exit 2 -run
 process p1 -expect-text 0 0 "-t: Invalid argument:"
 
-process p1 -log {varnishadm -Q 2>&1} -expect-exit 1 -run
+process p1 -log {varnishadm -Q 2>&1} -expect-exit 2 -run
 process p1 -expect-text 0 0 "Usage: varnishadm"
 
 process p2 -log {varnishadm -h 2>&1} -expect-exit 0 -run

--- a/doc/sphinx/reference/varnishadm.rst
+++ b/doc/sphinx/reference/varnishadm.rst
@@ -41,11 +41,12 @@ OPTIONS
 =======
 
 -e
-    Exit immediately if a command fails in `pass` mode and return the CLI
-    status code of the failing command divided by 100. This has no effect
-    on `interactive` mode (except when `-p` is used). Similarly to `CLI
-    Command File` (see :ref:`varnishd(1)`), if a command is prefixed with
-    '-', its failure will be ignored and will not cause varnishadm to exit.
+    Exit immediately if a command fails in `pass` mode with an exit 
+    status indicating the nature of the error (See EXIT STATUS for details).
+    This has no effect on `interactive` mode (except when `-p` is used).
+    Similarly to `CLI Command File` (see :ref:`varnishd(1)`), if a command
+    is prefixed with '-', its failure will be ignored and will not cause
+    varnishadm to exit.
 
 -h
     Print program usage and exit.
@@ -82,7 +83,13 @@ EXIT STATUS
 ===========
 
 If a command is given, the exit status of the `varnishadm` utility is
-zero if the command succeeded, and non-zero otherwise.
+zero if the command succeeded, and one of the following otherwise:
+
+1: could not execute the command
+2: bad usage
+3: the command failed
+4: the connection was lost
+5: the CLI session was terminated
 
 EXAMPLES
 ========

--- a/doc/sphinx/reference/varnishadm.rst
+++ b/doc/sphinx/reference/varnishadm.rst
@@ -19,7 +19,7 @@ Control a running Varnish instance
 SYNOPSIS
 ========
 
-varnishadm [-h] [-n ident] [-p] [-S secretfile] [-T [address]:port] [-t timeout] [command [...]]
+varnishadm [-e] [-h] [-n ident] [-p] [-S secretfile] [-T [address]:port] [-t timeout] [command [...]]
 
 
 DESCRIPTION
@@ -39,6 +39,13 @@ replies between the CLI socket and stdin/stdout.
 
 OPTIONS
 =======
+
+-e
+    Exit immediately if a command fails in `pass` mode and return the CLI
+    status code of the failing command divided by 100. This has no effect
+    on `interactive` mode (except when `-p` is used). Similarly to `CLI
+    Command File` (see :ref:`varnishd(1)`), if a command is prefixed with
+    '-', its failure will be ignored and will not cause varnishadm to exit.
 
 -h
     Print program usage and exit.

--- a/include/vcli.h
+++ b/include/vcli.h
@@ -56,12 +56,19 @@ enum VCLI_status_e {
 	CLIS_CLOSE	= 500
 };
 
+typedef enum {
+	PROTO_FULL = 0,
+	PROTO_STATUS,
+	PROTO_HEADLESS
+} vcls_proto_e;
+
 /* Length of first line of response */
 #define CLI_LINE0_LEN	13
 #define CLI_AUTH_RESPONSE_LEN		64	/* 64 hex + NUL */
 
 #if !defined(VCLI_PROTOCOL_ONLY)
 /* Convenience functions exported in libvarnishapi */
+int VCLI_Write(int fd, vcls_proto_e proto, unsigned status, const char *result);
 int VCLI_WriteResult(int fd, unsigned status, const char *result);
 int VCLI_ReadResult(int fd, unsigned *status, char **ptr, double tmo);
 void VCLI_AuthResponse(int S_fd, const char *challenge,

--- a/include/vcli_serve.h
+++ b/include/vcli_serve.h
@@ -81,6 +81,7 @@ struct cli {
 	char			*ident;
 	struct VCLS		*cls;
 	volatile unsigned	*limit;
+	char			*hdoc;
 };
 
 /* The implementation must provide these functions */

--- a/include/vcli_serve.h
+++ b/include/vcli_serve.h
@@ -37,6 +37,7 @@
 
 struct cli;	/* NB: struct cli is opaque at this level.  */
 struct VCLS;
+struct VCLP;
 
 typedef void cli_func_t(struct cli*, const char * const *av, void *priv);
 
@@ -91,6 +92,7 @@ void VCLI_JSON_begin(struct cli *cli, unsigned ver, const char * const * av);
 void VCLI_JSON_end(struct cli *cli);
 void VCLI_SetResult(struct cli *cli, unsigned r);
 
+/* CLI server */
 typedef int cls_cb_f(void *priv);
 typedef void cls_cbc_f(const struct cli*);
 struct VCLS *VCLS_New(struct VCLS *);
@@ -101,6 +103,12 @@ struct cli *VCLS_AddFd(struct VCLS *cs, int fdi, int fdo, cls_cb_f *closefunc,
 void VCLS_AddFunc(struct VCLS *cs, unsigned auth, struct cli_proto *clp);
 int VCLS_Poll(struct VCLS *cs, const struct cli*, int timeout);
 void VCLS_Destroy(struct VCLS **);
+
+/* CLI proxy */
+struct VCLP *VCLP_New(int fdi, int fdo, int sock, vcls_proto_e proto, double timeout);
+int VCLP_Poll(struct VCLP *cp, int timeout);
+void VCLP_Destroy(struct VCLP **);
+void VCLP_SetHooks(struct VCLP *, cls_cbc_f *, cls_cbc_f *);
 
 /* From libvarnish/cli.c */
 cli_func_t	VCLS_func_close;

--- a/include/vsb.h
+++ b/include/vsb.h
@@ -123,6 +123,11 @@ void		 VSB_destroy(struct vsb **);
 	 * Not valid with VSB_QUOTE_JSON and VSB_QUOTE_HEX
 	 */
 
+#define VSB_QUOTE_CLI		64
+	/*
+	 * Add quotes ".." around arguments when needed
+	 */
+
 void		 VSB_quote_pfx(struct vsb *, const char*, const void *,
 		     int len, int how);
 void		 VSB_quote(struct vsb *, const void *, int len, int how);

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -627,15 +627,11 @@ VCLS_Poll(struct VCLS *cs, const struct cli *cli, int timeout)
 	j = poll(pfd, 1, timeout);
 	if (j <= 0)
 		return (j);
-	if (pfd[0].revents & POLLHUP)
+	i = read(cfd->fdi, buf, sizeof buf);
+	if (i <= 0)
 		k = 1;
-	else {
-		i = read(cfd->fdi, buf, sizeof buf);
-		if (i <= 0)
-			k = 1;
-		else
-			k = cls_feed(cfd, buf, buf + i);
-	}
+	else
+		k = cls_feed(cfd, buf, buf + i);
 	if (k) {
 		i = cls_close_fd(cs, cfd);
 		if (i < 0)

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -677,7 +677,7 @@ vclp_forward(struct cli *cli, const char * const *av, void *priv)
 	AN(cli_buf);
 	VSB_clear(cli_buf);
 	for (i = 1; av[i] != NULL; i++) {
-		VSB_quote(cli_buf, av[i], strlen(av[i]), 0);
+		VSB_quote(cli_buf, av[i], strlen(av[i]), VSB_QUOTE_CLI);
 		VSB_putc(cli_buf, ' ');
 	}
 	VSB_putc(cli_buf, '\n');

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -73,6 +73,7 @@ struct VCLS {
 #define VCLS_MAGIC			0x60f044a3
 	VTAILQ_HEAD(,VCLS_fd)		fds;
 	unsigned			nfd;
+	vcls_proto_e			proto;
 	VTAILQ_HEAD(,cli_proto)		funcs;
 	cls_cbc_f			*before, *after;
 	volatile unsigned		*limit;
@@ -343,7 +344,7 @@ cls_exec(struct VCLS_fd *cfd, char * const *av)
 		s[lim - 1] = '\0';
 		assert(strlen(s) <= lim);
 	}
-	if (VCLI_WriteResult(cfd->fdo, cli->result, s) ||
+	if (VCLI_Write(cfd->fdo, cs->proto, cli->result, s) ||
 	    cli->result == CLIS_CLOSE)
 		retval = 1;
 

--- a/lib/libvarnish/vcli_serve.c
+++ b/lib/libvarnish/vcli_serve.c
@@ -425,6 +425,7 @@ cls_feed(struct VCLS_fd *cfd, const char *p, const char *e)
 				cfd->argv = av;
 				cfd->argc = ac;
 				cfd->match = av[ac - 1];
+				cli->hdoc = strdup(av[ac - 1]);
 				cfd->last_arg = VSB_new_auto();
 				AN(cfd->last_arg);
 			} else {
@@ -450,6 +451,7 @@ cls_feed(struct VCLS_fd *cfd, const char *p, const char *e)
 				cfd->argv[cfd->argc - 2] =
 				    VSB_data(cfd->last_arg);
 				i = cls_exec(cfd, cfd->argv);
+				REPLACE(cli->hdoc, NULL);
 				cfd->argv[cfd->argc - 2] = NULL;
 				VAV_Free(cfd->argv);
 				cfd->argv = NULL;
@@ -676,7 +678,13 @@ vclp_forward(struct cli *cli, const char * const *av, void *priv)
 	cli_buf = VSB_new_auto();
 	AN(cli_buf);
 	VSB_clear(cli_buf);
-	for (i = 1; av[i] != NULL; i++) {
+	for (i = 1; av[i] != NULL && av[i+1] != NULL; i++) {
+		VSB_quote(cli_buf, av[i], strlen(av[i]), VSB_QUOTE_CLI);
+		VSB_putc(cli_buf, ' ');
+	}
+	if (av[i] != NULL && cli->hdoc != NULL) {
+		VSB_printf(cli_buf, "<< %s\n%s\n%s", cli->hdoc, av[i], cli->hdoc);
+	} else if (av[i] != NULL) {
 		VSB_quote(cli_buf, av[i], strlen(av[i]), VSB_QUOTE_CLI);
 		VSB_putc(cli_buf, ' ');
 	}


### PR DESCRIPTION
> -e
    Exit immediately if a command fails in `pass` mode and return the CLI
    status code of the failing command. This has no effect on `interactive`
    mode (except when `-p` is used). Similarly to `CLI Command File` (see
    :ref:`varnishd(1)`), if a command is prefixed with '-', its failure will
    be ignored and will not cause varnishadm to exit.

Fixes: #4012