### PR TITLE
Release 6.0.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_PREREQ(2.59)
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
-Copyright (c) 2006-2022 Varnish Software])
+Copyright (c) 2006-2023 Varnish Software])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [6.0.11], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [6.0.12], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/lib/libvarnish/version.c
+++ b/lib/libvarnish/version.c
@@ -44,5 +44,5 @@ VCS_Message(const char *progname)
 {
 	fprintf(stderr, "%s (%s)\n", progname, VCS_version);
 	fprintf(stderr, "Copyright (c) 2006 Verdens Gang AS\n");
-	fprintf(stderr, "Copyright (c) 2006-2022 Varnish Software\n");
+	fprintf(stderr, "Copyright (c) 2006-2023 Varnish Software\n");
 }

--- a/lib/libvmod_h2/automake_boilerplate.am
+++ b/lib/libvmod_h2/automake_boilerplate.am
@@ -14,11 +14,13 @@ vmodtoolargs = --strict --boilerplate
 
 vmod_LTLIBRARIES = libvmod_h2.la
 
-libvmod_h2_la_CFLAGS =
+libvmod_h2_la_CFLAGS = \
+	@SAN_CFLAGS@
 
 libvmod_h2_la_LDFLAGS = \
 	$(AM_LDFLAGS) \
-	$(VMOD_LDFLAGS)
+	$(VMOD_LDFLAGS) \
+	@SAN_LDFLAGS@
 
 nodist_libvmod_h2_la_SOURCES = vcc_if.c vcc_if.h
 


### PR DESCRIPTION
Reviewers must check the following items:

- [ ] Release notes are complete (major release only)
- [ ] Release notes no longer target trunk (major release only)
- [x] The change log is populated
- [x] The VRT history in `include/vrt.h` is populated
- [x] The VRT history refers to the next VRT version
- [x] The macro `VRT_MAJOR_VERSION` was updated if applicable
- [x] The macro `VRT_MINOR_VERSION` was updated if applicable
- [x] The new VRT version follows releases guidelines
- [x] The new VRT version matches the one from the VRT history
- [ ] Bundled `devicedetect.vcl` was updated (major release only)
- [x] Running `./autogen.des && make distcheck` succeeds
- [x] The version in `configure.ac` is correct
- [x] The copyright notice in `configure.ac` covers the current year
- [x] The copyright output in `lib/libvarnish/version.c` covers the current year
- [ ] There are no other changes than the ones listed above