### PR TITLE
Remove stretch as its EOL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,6 @@ workflows:
                 - ubuntu:bionic
                 - ubuntu:focal
                 - ubuntu:jammy
-                - debian:stretch
                 - debian:buster
                 - debian:bullseye
                 - debian:bookworm


### PR DESCRIPTION
Remove stretch as it wont build unless we hack the build to replace sources files with archive-urls.