### PR TITLE
vav: fix issues and improve tests

### DIFF
--- a/bin/varnishtest/tests/b00008.vtc
+++ b/bin/varnishtest/tests/b00008.vtc
@@ -49,3 +49,5 @@ varnish v1 -cliexpect 60 "param.show first_byte_timeout"
 varnish v1 -cliok "param.set cli_limit 128"
 
 varnish v1 -clierr 201 "param.show"
+
+varnish v1 -cliok "\"help\" \"help\""

--- a/lib/libvarnish/vav.c
+++ b/lib/libvarnish/vav.c
@@ -441,9 +441,6 @@ test_run(const struct test_case *tc, int *ret)
 		return (argv);
 	}
 
-	if (tc->argv[0] != NULL)
-		return (argv);
-
 	for (i = 1; i < argc && tc->argv[i] != NULL && argv[i] != NULL; i++) {
 		if (!strcmp(tc->argv[i], argv[i]))
 			continue;
@@ -455,7 +452,7 @@ test_run(const struct test_case *tc, int *ret)
 		return (argv);
 	}
 
-	if (tc->argv[i] != NULL || argv[i] != NULL) {
+	if (tc->argv[0] == NULL && (tc->argv[i] != NULL || argv[i] != NULL)) {
 		act = i < argc ? "less" : "more";
 		printf(
 		    "ERROR: Parsing string <%s> with flags %x, "

--- a/lib/libvarnish/vav.c
+++ b/lib/libvarnish/vav.c
@@ -192,6 +192,12 @@ VAV_ParseTxt(const char *b, const char *e, int *argc, int flag)
 			b++;
 			continue;
 		}
+		if (sep != NULL && *sep == '"' &&
+		    *b == ',' && (flag & ARGV_COMMA)) {
+			sep = NULL;
+			b++;
+			continue;
+		}
 		if (sep != NULL && *sep == '"' && *b == '"' && (b - sep) < 2) {
 			argv[0] = err_missing_separator;
 			return (argv);
@@ -402,6 +408,7 @@ static const struct test_case *tests[] = {
 	TEST_FAIL(0    , "foo\"bar", invalid_quote),
 	TEST_FAIL(0    , "foo\"bar", invalid_quote),
 	TEST_PASS(0    , "\"foo\" \"bar\"", "foo", "bar"),
+	TEST_PASS(  C  , "\"foo\",\"bar\"", "foo", "bar"),
 	TEST_PASS(    N, "\"foo\"\"bar\"", "\"foo\"\"bar\""),
 	TEST_FAIL(0    , "\"foo\"\"bar\"", missing_separator),
 	NULL

--- a/lib/libvarnish/vav.c
+++ b/lib/libvarnish/vav.c
@@ -192,7 +192,7 @@ VAV_ParseTxt(const char *b, const char *e, int *argc, int flag)
 			b++;
 			continue;
 		}
-		if (sep != NULL && *sep == '"' && *b == '"') {
+		if (sep != NULL && *sep == '"' && *b == '"' && (b - sep) < 2) {
 			argv[0] = err_missing_separator;
 			return (argv);
 		}
@@ -401,6 +401,7 @@ static const struct test_case *tests[] = {
 	TEST_PASS(    N, "foo\"bar", "foo\"bar"),
 	TEST_FAIL(0    , "foo\"bar", invalid_quote),
 	TEST_FAIL(0    , "foo\"bar", invalid_quote),
+	TEST_PASS(0    , "\"foo\" \"bar\"", "foo", "bar"),
 	TEST_PASS(    N, "\"foo\"\"bar\"", "\"foo\"\"bar\""),
 	TEST_FAIL(0    , "\"foo\"\"bar\"", missing_separator),
 	NULL

--- a/lib/libvarnish/vav.c
+++ b/lib/libvarnish/vav.c
@@ -474,18 +474,17 @@ int
 main(int argc, char **argv)
 {
 	const struct test_case **tc;
-	int ret = 0;
+	int ret = 0, fail = 0;
 
 	(void)argc;
 	(void)argv;
 
-	for (tc = tests; ret == 0 && *tc != NULL; tc++) {
+	for (tc = tests; *tc != NULL; ret = 0, tc++) {
 		argv = test_run(*tc, &ret);
 		VAV_Free(argv);
 		if (ret)
-			return (1);
+			fail = 1;
 	}
-
-	return (0);
+	return (fail);
 }
 #endif /* TEST_DRIVER */

--- a/lib/libvarnish/vav.c
+++ b/lib/libvarnish/vav.c
@@ -482,6 +482,8 @@ main(int argc, char **argv)
 	for (tc = tests; ret == 0 && *tc != NULL; tc++) {
 		argv = test_run(*tc, &ret);
 		VAV_Free(argv);
+		if (ret)
+			return (1);
 	}
 
 	return (0);


### PR DESCRIPTION
This PR  improves `vav_test` and fixes two issues in `VAV_ParseTxt`:

- `vav_test` was always returning 0, which makes it always pass make check. Failed tests as expected were not printed in the final report. And the test suite was aborting as soon as a single test would fail.
- `VAV_ParseTxt` was not correctly handling `"foo" "bar"` with no flags, and `"foo", "bar"` with the ARGV_COMMA flag.