### PR TITLE
req_fsm: Use status 408 for reset streams

### DIFF
--- a/bin/varnishtest/tests/t02025.vtc
+++ b/bin/varnishtest/tests/t02025.vtc
@@ -46,7 +46,7 @@ varnish v1 -expect req_reset == 1
 # is interpreted as before a second elapsed. Session VXIDs showing up
 # numerous times become increasingly more suspicious. The format can of
 # course be extended to add anything else useful for data mining.
-shell -expect "1000 ${localhost}" {
+shell -expect "1000 ${localhost} 408" {
 	varnishncsa -n ${v1_name} -d \
-		-q 'Timestamp:Reset[2] < 1.0' -F '%{VSL:Begin[2]}x %h'
+		-q 'Timestamp:Reset[2] < 1.0' -F '%{VSL:Begin[2]}x %h %s'
 }

--- a/doc/sphinx/reference/vsl.rst
+++ b/doc/sphinx/reference/vsl.rst
@@ -79,7 +79,8 @@ Restart
 Reset
         The client closed its connection, reset its stream or caused
         a stream error that forced Varnish to reset the stream. Request
-        processing is interrupted and considered failed.
+        processing is interrupted and considered failed, with a 408
+        "Request Timeout" status code.
 
 Pipe handling timestamps
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The 503 synth and 500 minimal response status codes are too misleading in this context, where the failure is attributed to the client. Among existing 4XX status codes, this is the closest if we stretch the timeout definition to "didn't complete rapidly enough before the client went away".