### PR TITLE
doc: Use a raw string for regular expressions

### DIFF
--- a/doc/sphinx/vtc-syntax.py
+++ b/doc/sphinx/vtc-syntax.py
@@ -38,7 +38,7 @@ import re
 def parse_file(fn, cl, tl, sl):
     p = False
     section = ""
-    resec = re.compile("\s*/?\* SECTION: ")
+    resec = re.compile(r"\s*/?\* SECTION: ")
 
     try:
         # Python3


### PR DESCRIPTION
Since Python 3.12 unknown escape sequences trigger a warning.

---

Not expecting a review, I will merge this as soon as CI completes, unless there are failures.