### PR TITLE
Generalize the VDP API (WIP, early comments welcome)

### DIFF
--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -261,32 +261,40 @@ ved_decode_len(struct vsl_log *vsl, const uint8_t **pp)
  */
 
 static int v_matchproto_(vdp_init_f)
-ved_vdp_esi_init(VRT_CTX, struct vdp_ctx *vdc, void **priv, struct objcore *oc)
+ved_vdp_esi_init(VRT_CTX, struct vdp_ctx *vdc, void **priv,
+    struct objcore *oc, struct req *req,
+    struct http *hd, intmax_t *cl)
 {
 	struct ecx *ecx;
-	struct req *req;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(vdc, VDP_CTX_MAGIC);
+	AN(priv);
 	CHECK_OBJ_ORNULL(oc, OBJCORE_MAGIC);
+	CHECK_OBJ_ORNULL(req, REQ_MAGIC);
+	CHECK_OBJ_NOTNULL(hd, HTTP_MAGIC);
+	AN(cl);
+
+	AZ(*priv);
 	if (oc == NULL || !ObjHasAttr(vdc->wrk, oc, OA_ESIDATA))
 		return (1);
 
-	req = vdc->req;
-	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-	AN(priv);
-	AZ(*priv);
+	if (req == NULL) {
+		VSLb(vdc->vsl, SLT_Error,
+		     "esi can only be used on the client side");
+		return (1);
+	}
 
 	ALLOC_OBJ(ecx, ECX_MAGIC);
 	AN(ecx);
 	assert(sizeof gzip_hdr == 10);
 	ecx->preq = req;
 	*priv = ecx;
-	RFC2616_Weaken_Etag(req->resp);
+	RFC2616_Weaken_Etag(hd);
 
 	req->res_mode |= RES_ESI;
-	if (req->resp_len != 0)
-		req->resp_len = -1;
+	if (*cl != 0)
+		*cl = -1;
 	if (req->esi_level > 0) {
 		assert(req->transport == &VED_transport);
 		CAST_OBJ_NOTNULL(ecx->pecx, req->transport_priv, ECX_MAGIC);
@@ -604,18 +612,22 @@ struct ved_foo {
 };
 
 static int v_matchproto_(vdp_init_f)
-ved_gzgz_init(VRT_CTX, struct vdp_ctx *vdc, void **priv, struct objcore *oc)
+ved_gzgz_init(VRT_CTX, struct vdp_ctx *vdc, void **priv,
+    struct objcore *oc, struct req *req,
+    struct http *hd, intmax_t *cl)
 {
 	ssize_t l;
 	const char *p;
 	struct ved_foo *foo;
-	struct req *req;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(vdc, VDP_CTX_MAGIC);
-	(void)oc;
-	req = vdc->req;
-	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	AN(priv);
+	CHECK_OBJ_ORNULL(oc, OBJCORE_MAGIC);
+	CHECK_OBJ_ORNULL(req, REQ_MAGIC);
+	CHECK_OBJ_NOTNULL(hd, HTTP_MAGIC);
+	AN(cl);
+
 	CAST_OBJ_NOTNULL(foo, *priv, VED_FOO_MAGIC);
 	CHECK_OBJ_NOTNULL(foo->objcore, OBJCORE_MAGIC);
 
@@ -906,14 +918,16 @@ ved_deliver(struct req *req, struct boc *boc, int wantbody)
 		INIT_OBJ(foo, VED_FOO_MAGIC);
 		foo->ecx = ecx;
 		foo->objcore = req->objcore;
-		i = VDP_Push(ctx, req->vdc, req->ws, &ved_gzgz, foo);
-
+		i = VDP_Push(ctx, req->vdc, req->ws, &ved_gzgz, foo,
+		    NULL, req, req->resp, &req->resp_len);
 	} else if (ecx->isgzip && !i) {
 		/* Non-Gzip'ed include in gzip'ed parent */
-		i = VDP_Push(ctx, req->vdc, req->ws, &ved_pretend_gz, ecx);
+		i = VDP_Push(ctx, req->vdc, req->ws, &ved_pretend_gz, ecx,
+		    NULL, req, req->resp, &req->resp_len);
 	} else {
 		/* Anything else goes straight through */
-		i = VDP_Push(ctx, req->vdc, req->ws, &ved_ved, ecx);
+		i = VDP_Push(ctx, req->vdc, req->ws, &ved_ved, ecx,
+		    NULL, req, req->resp, &req->resp_len);
 	}
 
 	if (i == 0) {

--- a/bin/varnishd/cache/cache_filter.h
+++ b/bin/varnishd/cache/cache_filter.h
@@ -104,8 +104,16 @@ enum vdp_action {
 	VDP_END,		/* Last buffer or after, implies VDP_FLUSH */
 };
 
+
+/*
+ * oc: optional, only passed to the first VDP
+ * req: optional, for client-side only VDPs
+ * hd: headers to modify (request or response)
+ * cl: known content-length or -1, settable
+ */
 typedef int vdp_init_f(VRT_CTX, struct vdp_ctx *, void **priv,
-    struct objcore *);
+    struct objcore *oc, struct req *req,
+    struct http *hd, intmax_t *cl);
 /*
  * Return value:
  *	negative:	Error - abandon delivery
@@ -147,7 +155,6 @@ struct vdp_ctx {
 	struct vdp_entry	*nxt;
 	struct worker		*wrk;
 	struct vsl_log		*vsl;
-	struct req		*req;
 };
 
 int VDP_bytes(struct vdp_ctx *, enum vdp_action act, const void *, ssize_t);

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -460,7 +460,7 @@ cnt_transmit(struct worker *wrk, struct req *req)
 		sendbody = 1;
 	}
 
-	VDP_Init(req->vdc, req->wrk, req->vsl, req);
+	VDP_Init(req->vdc, req->wrk, req->vsl);
 	if (req->vdp_filter_list == NULL)
 		req->vdp_filter_list = resp_Get_Filter_List(req);
 	if (req->vdp_filter_list == NULL ||

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -189,12 +189,15 @@ void VDI_Event(const struct director *d, enum vcl_event_e ev);
 void VDI_Init(void);
 
 /* cache_deliver_proc.c */
-void VDP_Init(struct vdp_ctx *vdc, struct worker *wrk, struct vsl_log *vsl,
-    struct req *req);
+void VDP_Init(struct vdp_ctx *vdc, struct worker *wrk, struct vsl_log *vsl);
 uint64_t VDP_Close(struct vdp_ctx *, struct objcore *, struct boc *);
 void VDP_Panic(struct vsb *vsb, const struct vdp_ctx *vdc);
-int VDP_Push(VRT_CTX, struct vdp_ctx *, struct ws *, const struct vdp *,
-    void *priv);
+
+int
+VDP_Push(VRT_CTX, struct vdp_ctx *vdc, struct ws *ws,
+     const struct vdp *vdp, void *priv,
+     struct objcore *oc, struct req *req,
+     struct http *hd, intmax_t *cl);
 int VDP_DeliverObj(struct vdp_ctx *vdc, struct objcore *oc);
 extern const struct vdp VDP_gunzip;
 extern const struct vdp VDP_esi;

--- a/bin/varnishd/cache/cache_vrt_filter.c
+++ b/bin/varnishd/cache/cache_vrt_filter.c
@@ -258,11 +258,14 @@ VCL_StackVDP(struct req *req, const struct vcl *vcl, const char *fl)
 {
 	const struct vfilter *vp;
 	struct vrt_ctx ctx[1];
+	struct objcore *oc;
 
 	AN(fl);
 	VSLbs(req->vsl, SLT_Filters, TOSTRAND(fl));
 	INIT_OBJ(ctx, VRT_CTX_MAGIC);
 	VCL_Req2Ctx(ctx, req);
+
+	oc = req->objcore;
 
 	while (1) {
 		vp = vcl_filter_list_iter(0, &vrt_filters, &vcl->filters, &fl);
@@ -273,7 +276,8 @@ VCL_StackVDP(struct req *req, const struct vcl *vcl, const char *fl)
 			    "Filter '...%s' not found", fl);
 			return (-1);
 		}
-		if (VDP_Push(ctx, req->vdc, req->ws, vp->vdp, NULL))
+		if (VDP_Push(ctx, req->vdc, req->ws, vp->vdp, NULL,
+		    oc, req, req->resp, &req->resp_len))
 			return (-1);
 	}
 }

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -97,7 +97,8 @@ V1D_Deliver(struct req *req, struct boc *boc, int sendbody)
 		}
 		INIT_OBJ(ctx, VRT_CTX_MAGIC);
 		VCL_Req2Ctx(ctx, req);
-		if (VDP_Push(ctx, req->vdc, req->ws, VDP_v1l, NULL)) {
+		if (VDP_Push(ctx, req->vdc, req->ws, VDP_v1l, NULL,
+		    NULL, req, req->resp, &req->resp_len)) {
 			v1d_error(req, "Failure to push v1d processor");
 			return;
 		}

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -102,16 +102,23 @@ static const struct vfp xyzzy_vfp_rot13 = {
 #define ROT13_BUFSZ 8
 
 static int v_matchproto_(vdp_init_f)
-xyzzy_vfp_rot13_init(VRT_CTX, struct vdp_ctx *vdc, void **priv, struct objcore *oc)
+xyzzy_vfp_rot13_init(VRT_CTX, struct vdp_ctx *vdc, void **priv,
+    struct objcore *oc, struct req *req,
+    struct http *hd, intmax_t *cl)
 {
-	(void)vdc;
-	(void)oc;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(vdc, VDP_CTX_MAGIC);
 	AN(priv);
+	CHECK_OBJ_ORNULL(oc, OBJCORE_MAGIC);
+	CHECK_OBJ_ORNULL(req, REQ_MAGIC);
+	CHECK_OBJ_NOTNULL(hd, HTTP_MAGIC);
+	AN(cl);
+
 	*priv = malloc(ROT13_BUFSZ);
 	if (*priv == NULL)
 		return (-1);
+
 	return (0);
 }
 
@@ -213,14 +220,20 @@ static const struct vmod_priv_methods priv_pedantic_methods[1] = {{
 
 static int v_matchproto_(vdp_init_f)
 xyzzy_pedantic_init(VRT_CTX, struct vdp_ctx *vdc, void **priv,
-    struct objcore *oc)
+    struct objcore *oc, struct req *req,
+    struct http *hd, intmax_t *cl)
 {
 	struct vdp_state_s *vdps;
 	struct vmod_priv *p;
 
-	(void)oc;
-
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(vdc, VDP_CTX_MAGIC);
+	AN(priv);
+	CHECK_OBJ_ORNULL(oc, OBJCORE_MAGIC);
+	CHECK_OBJ_ORNULL(req, REQ_MAGIC);
+	CHECK_OBJ_NOTNULL(hd, HTTP_MAGIC);
+	AN(cl);
+
 	WS_TASK_ALLOC_OBJ(ctx, vdps, VDP_STATE_MAGIC);
 	if (vdps == NULL)
 		return (-1);
@@ -232,7 +245,6 @@ xyzzy_pedantic_init(VRT_CTX, struct vdp_ctx *vdc, void **priv,
 	p->priv = vdps;
 	p->methods = priv_pedantic_methods;
 
-	AN(priv);
 	*priv = vdps;
 
 	vdps->state = VDPS_INIT;


### PR DESCRIPTION
This commit is to prepare for use of the VDP API also for the backend side to filter `bereq.body` through `bereq.filters`:

The `req` member of `struct vdp_ctx` is removed, because it should only be used for initialization and, consequently, is already nulled in `VDP_DeliverObj()`.

`vdp_init_f()` and its caller `VDP_Push()` gain arguments:

- `req` is only present if the VDP is used on the client side.

- `hd` is a pointer to the outgoing headers corresponding to the body being worked on: `(struct req).resp` on the client side and `(struct busyobj).bereq` on the backend side (tbd).

- `cl` is a pointer to the content-length. -1 indicates 'unknown'.

VDPs should aim for compatibility with both the client and backend use case by using only `hd` and `cl` instead of `req`. If they depend on `req`, they should return an error if `req` is `NULL`.

Note that none of the new arguments would be necessary, they could all (including the existing `oc` argument) be derived from the `VRT_CTX`. The reasons for having these arguments are code clarity and avoidance of code duplication, e.g. for repeatedly figuring out the correct header and length pointer on the client vs. backend side.