### PR TITLE
Fix order of COLD events for directors vs. VCL (and VMODs, implicitly)

### DIFF
--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -594,9 +594,9 @@ vcl_set_state(struct vcl *vcl, const char *state, struct vsb **msg)
 		if (vcl->busy == 0 && vcl->temp->is_warm) {
 			vcl->temp = VTAILQ_EMPTY(&vcl->ref_list) ?
 			    VCL_TEMP_COLD : VCL_TEMP_COOLING;
+			vcl_BackendEvent(vcl, VCL_EVENT_COLD);
 			AZ(vcl_send_event(vcl, VCL_EVENT_COLD, msg));
 			AZ(*msg);
-			vcl_BackendEvent(vcl, VCL_EVENT_COLD);
 		}
 		else if (vcl->busy)
 			vcl->temp = VCL_TEMP_BUSY;

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -59,6 +59,7 @@
  *
  * NEXT (2024-03-15)
  *	[cache.h] (struct req).filter_list renamed to vdp_filter_list
+ *	order of vcl/vmod and director COLD events reversed to directors first
  * 18.1 (2023-12-05)
  *	vbf_objiterate() implementation changed #4013
  * 18.0 (2023-09-15)


### PR DESCRIPTION
@delthas reported [an interesting issue with vmod_dynamic](https://github.com/nigoroll/libvmod-dynamic/issues/107): When the vmod receives a cold event, it might have some directors left to delete, and when it deletes them, they do not receive a cold event, and a follow up assertion triggers because a warm director is deleted.

I believe the root cause is actually a wrong ordering in Varnish-Cache:

[`vcldir_retire()`](https://github.com/varnishcache/varnish-cache/blob/7aeca4d632827e2db91bf63e67e4c61c9319d038/bin/varnishd/cache/cache_vrt_vcl.c#L257-L258) only sends a `VCL_EVENT_COLD` when the vcl is warm. In other words, it (rightly, IMHO) asserts that a COLD event (if any) has alrady been posted when a director is deleted on a COLD vcl.

Yet, when the director is deleted upon a COLD vmod event, this assertion was wrong, because the COLD events for directors were only posted after vmod events.

Given that vmods do things like deleting directors, it appears (more) correct to post VDI COLD events before VMOD COLD events.
