### PR TITLE
Make ctx->vsl not NULL in vcl_init

### DIFF
--- a/bin/varnishd/cache/cache_shmlog.c
+++ b/bin/varnishd/cache/cache_shmlog.c
@@ -114,6 +114,13 @@ vsl_sanity(const struct vsl_log *vsl)
 	assert(vsl->wlp <= vsl->wle);
 }
 
+static inline void
+vsl_flush(struct vsl_log *vsl)
+{
+	if (IS_NO_VXID(vsl->wid) || DO_DEBUG(DBG_SYNCVSL))
+			VSL_Flush(vsl, 0);
+}
+
 /*--------------------------------------------------------------------
  * Check if the VSL_tag is masked by parameter bitmap
  */
@@ -403,8 +410,7 @@ vslb_simple(struct vsl_log *vsl, enum VSL_tag_e tag,
 	memcpy(p, str, length - 1);
 	p[length - 1] = '\0';
 
-	if (DO_DEBUG(DBG_SYNCVSL))
-		VSL_Flush(vsl, 0);
+	vsl_flush(vsl);
 }
 
 /*--------------------------------------------------------------------
@@ -439,8 +445,7 @@ VSLbs(struct vsl_log *vsl, enum VSL_tag_e tag, const struct strands *s)
 
 	(void)strands_cat(p, l, s);
 
-	if (DO_DEBUG(DBG_SYNCVSL))
-		VSL_Flush(vsl, 0);
+	vsl_flush(vsl);
 }
 
 /*--------------------------------------------------------------------
@@ -498,8 +503,7 @@ VSLbv(struct vsl_log *vsl, enum VSL_tag_e tag, const char *fmt, va_list ap)
 		mlen = n + 1;
 	(void)vslb_get(vsl, tag, &mlen);
 
-	if (DO_DEBUG(DBG_SYNCVSL))
-		VSL_Flush(vsl, 0);
+	vsl_flush(vsl);
 }
 
 void
@@ -563,8 +567,7 @@ VSLb_bin(struct vsl_log *vsl, enum VSL_tag_e tag, ssize_t len, const void *ptr)
 	assert(vsl->wlp <= vsl->wle);
 	vsl->wlr++;
 
-	if (DO_DEBUG(DBG_SYNCVSL))
-		VSL_Flush(vsl, 0);
+	vsl_flush(vsl);
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -136,9 +136,8 @@ VCL_Get_CliCtx(int msg)
 	if (msg) {
 		ctx_cli.msg = VSB_new_auto();
 		AN(ctx_cli.msg);
-	} else {
-		ctx_cli.vsl = &vsl_cli;
 	}
+	ctx_cli.vsl = &vsl_cli;
 	ctx_cli.ws = &ws_cli;
 	WS_Assert(ctx_cli.ws);
 	return (&ctx_cli);

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -683,12 +683,12 @@ VRT_fail(VRT_CTX, const char *fmt, ...)
 	AN(fmt);
 	AZ(strchr(fmt, '\n'));
 	va_start(ap, fmt);
-	if (ctx->vsl != NULL) {
-		VSLbv(ctx->vsl, SLT_VCL_Error, fmt, ap);
-	} else {
-		AN(ctx->msg);
+	if (ctx->msg != NULL) {
 		VSB_vprintf(ctx->msg, fmt, ap);
 		VSB_putc(ctx->msg, '\n');
+	} else {
+		AN(ctx->vsl);
+		VSLbv(ctx->vsl, SLT_VCL_Error, fmt, ap);
 	}
 	va_end(ap);
 	ctx->vpi->handling = VCL_RET_FAIL;


### PR DESCRIPTION
This is a common source of panic when vmods functions/methods that log to vsl get called from housekeeping vcl subroutines.
We currently already have `ctx->vsl` set in `vcl_fini`, this will set it in `vcl_init` too.