### PR TITLE
For BackendClose, also log the short tag as with SessClose

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -240,7 +240,7 @@ vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 	bo->htc->priv = NULL;
 	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0) {
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s close %s", *PFD_Fd(pfd),
-		    VRT_BACKEND_string(d), bo->htc->doclose->desc);
+		    VRT_BACKEND_string(d), bo->htc->doclose->name);
 		VCP_Close(&pfd);
 		AZ(pfd);
 		Lck_Lock(bp->director->mtx);

--- a/include/tbl/vsl_tags.h
+++ b/include/tbl/vsl_tags.h
@@ -154,7 +154,7 @@ SLTM(BackendClose, 0, "Backend connection closed",
 	"The format is::\n\n"
 	"\t%d %s %s [ %s ]\n"
 	"\t|  |  |    |\n"
-	"\t|  |  |    +- Optional reason\n"
+	"\t|  |  |    +- Optional reason, see SessClose for explanation\n"
 	"\t|  |  +------ \"close\" or \"recycle\"\n"
 	"\t|  +--------- Backend display name\n"
 	"\t+------------ Connection file descriptor\n"


### PR DESCRIPTION
this is for consistency, to simplify parsing and to reduce the amount of data logged with VSL.

Filed as a PR because it is a breaking change to the VSL format.

Motivated by #4042