### PR TITLE
v1p: Fix invalid poll() usage with a new VTIM_poll()

### DIFF
--- a/bin/varnishd/http1/cache_http1_pipe.c
+++ b/bin/varnishd/http1/cache_http1_pipe.c
@@ -149,13 +149,12 @@ V1P_Process(const struct req *req, int fd, struct v1p_acct *v1a,
 		fds[1].revents = 0;
 		tmo = cache_param->pipe_timeout;
 		if (tmo == 0.)
-			tmo = -1.;
+			tmo = NAN;
 		if (deadline > 0.) {
 			tmo_task = deadline - VTIM_real();
-			tmo = (tmo > 0.) ? vmin(tmo, tmo_task) : tmo_task;
-			tmo = vmax(tmo, 0.);
+			tmo = vmin(tmo, tmo_task);
 		}
-		i = poll(fds, 2, (int)(tmo * 1e3));
+		i = poll(fds, 2, VTIM_poll_tmo(tmo));
 		if (i == 0)
 			sc = SC_RX_TIMEOUT;
 		if (i < 1)

--- a/include/vtim.h
+++ b/include/vtim.h
@@ -40,3 +40,4 @@ vtim_real VTIM_real(void);
 void VTIM_sleep(vtim_dur t);
 struct timespec VTIM_timespec(vtim_dur t);
 struct timeval VTIM_timeval(vtim_dur t);
+int VTIM_poll_tmo(vtim_dur);

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -643,10 +643,7 @@ VTCP_read(int fd, void *ptr, size_t len, vtim_dur tmo)
 		pfd[0].fd = fd;
 		pfd[0].events = POLLIN;
 		pfd[0].revents = 0;
-		j = (int)floor(tmo * 1e3);
-		if (j == 0)
-			j++;
-		j = poll(pfd, 1, j);
+		j = poll(pfd, 1, VTIM_poll_tmo(tmo));
 		if (j == 0)
 			return (-2);
 	}

--- a/lib/libvarnish/vtim.c
+++ b/lib/libvarnish/vtim.c
@@ -454,6 +454,15 @@ VTIM_timespec(vtim_dur t)
 	return (tv);
 }
 
+int
+VTIM_poll_tmo(vtim_dur tmo)
+{
+
+	if (isnan(tmo))
+		return (-1);
+	return (vmax_t(int, 0, tmo * 1e3));
+}
+
 #ifdef TEST_DRIVER
 
 #pragma GCC diagnostic ignored "-Wformat-y2k"


### PR DESCRIPTION
The expectations on FreeBSD are stricter than on Linux.