### PR TITLE
cli: New ban.cancel command

### DIFF
--- a/bin/varnishd/cache/cache_ban.h
+++ b/bin/varnishd/cache/cache_ban.h
@@ -152,6 +152,6 @@ void ban_info_drop(const uint8_t *ban, unsigned len);
 int ban_evaluate(struct worker *wrk, const uint8_t *bs, struct objcore *oc,
     const struct http *reqhttp, unsigned *tests);
 vtim_real ban_time(const uint8_t *banspec);
-int ban_equal(const uint8_t *bs1, const uint8_t *bs2);
+unsigned BAN_Cancel(const struct ban *can, struct ban *ban);
 void BAN_Free(struct ban *b);
 void ban_kick_lurker(void);

--- a/bin/varnishd/cache/cache_ban.h
+++ b/bin/varnishd/cache/cache_ban.h
@@ -152,6 +152,7 @@ void ban_info_drop(const uint8_t *ban, unsigned len);
 int ban_evaluate(struct worker *wrk, const uint8_t *bs, struct objcore *oc,
     const struct http *reqhttp, unsigned *tests);
 vtim_real ban_time(const uint8_t *banspec);
+struct ban * BAN_Alloc(struct ban_proto *bp, ssize_t *lnp);
 unsigned BAN_Cancel(const struct ban *can, struct ban *ban);
 void BAN_Free(struct ban *b);
 void ban_kick_lurker(void);

--- a/bin/varnishd/cache/cache_ban.h
+++ b/bin/varnishd/cache/cache_ban.h
@@ -154,5 +154,6 @@ int ban_evaluate(struct worker *wrk, const uint8_t *bs, struct objcore *oc,
 vtim_real ban_time(const uint8_t *banspec);
 struct ban * BAN_Alloc(struct ban_proto *bp, ssize_t *lnp);
 unsigned BAN_Cancel(const struct ban *can, struct ban *ban);
+const char * BAN_Error(struct ban_proto *bp);
 void BAN_Free(struct ban *b);
 void ban_kick_lurker(void);

--- a/bin/varnishd/cache/cache_ban_build.c
+++ b/bin/varnishd/cache/cache_ban_build.c
@@ -319,7 +319,7 @@ BAN_AddTest(struct ban_proto *bp,
 const char *
 BAN_Commit(struct ban_proto *bp)
 {
-	struct ban  *b, *bi;
+	struct ban *b, *bi;
 	ssize_t ln;
 	vtim_real t0;
 	uint64_t u;
@@ -381,17 +381,8 @@ BAN_Commit(struct ban_proto *bp)
 	if (bi != NULL)
 		ban_info_new(b->spec, ln);	/* Notify stevedores */
 
-	if (cache_param->ban_dups) {
-		/* Hunt down duplicates, and mark them as completed */
-		for (bi = VTAILQ_NEXT(b, list); bi != NULL;
-		    bi = VTAILQ_NEXT(bi, list)) {
-			if (!(bi->flags & BANS_FLAG_COMPLETED) &&
-			    ban_equal(b->spec, bi->spec)) {
-				ban_mark_completed(bi);
-				VSC_C_main->bans_dups++;
-			}
-		}
-	}
+	if (cache_param->ban_dups)
+		VSC_C_main->bans_dups += BAN_Cancel(b, VTAILQ_NEXT(b, list));
 	if (!(b->flags & BANS_FLAG_REQ))
 		ban_kick_lurker();
 	Lck_Unlock(&ban_mtx);

--- a/bin/varnishd/cache/cache_ban_build.c
+++ b/bin/varnishd/cache/cache_ban_build.c
@@ -137,6 +137,14 @@ ban_add_lump(const struct ban_proto *bp, const void *p, uint32_t len)
 /*--------------------------------------------------------------------
  */
 
+const char *
+BAN_Error(struct ban_proto *bp)
+{
+
+	CHECK_OBJ_NOTNULL(bp, BAN_PROTO_MAGIC);
+	return (bp->err);
+}
+
 static const char *
 ban_error(struct ban_proto *bp, const char *fmt, ...)
 {

--- a/bin/varnishtest/tests/c00127.vtc
+++ b/bin/varnishtest/tests/c00127.vtc
@@ -1,0 +1,34 @@
+varnishtest "Cancel bans"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend "" -start
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+varnish v1 -vsl_catchup
+varnish v1 -expect n_object == 1
+
+varnish v1 -clierr 300 "ban.cancel req.http.ban ~ nonexistent"
+
+# create actual bans to cancel
+varnish v1 -cliok "ban req.http.host == ${localhost}"
+varnish v1 -cliok "ban obj.status == 0"
+
+# cancel both bans
+varnish v1 -cliexpect "Bans cancelled: 1" \
+	"ban.cancel req.http.host == ${localhost}"
+varnish v1 -clijson "ban.cancel -j obj.status == 0"
+
+# the object is still accessible
+client c1 -run
+
+varnish v1 -vsl_catchup
+varnish v1 -expect n_object == 1
+varnish v1 -expect cache_hit == 1

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -49,6 +49,18 @@ CLI_CMD(BAN,
 	3, -1
 )
 
+CLI_CMD(BAN_CANCEL,
+	"ban.cancel",
+	"ban.cancel [-j] <field> <operator> <arg> [&& <field> <oper> <arg> ...]",
+	"Mark complete all bans where all the conditions match. If objects"
+	" were invalidated by a ban before the ban was cancelled, the object"
+	" remains invalidated. Bans with only ``obj`` expressions can be"
+	" cancelled before ``ban_lurker_age``, but may still be evaluated"
+	" during cache lookups and invalidate objects.",
+	"See :ref:`vcl(7)_ban` for details",
+	3, -1
+)
+
 CLI_CMD(BAN_LIST,
 	"ban.list",
 	"ban.list [-j]",


### PR DESCRIPTION
```c
CLI_CMD(BAN_CANCEL,
        "ban.cancel",
        "ban.cancel [-j] <field> <operator> <arg> [&& <field> <oper> <arg> ...]",
        "Mark complete all bans where all the conditions match. If objects"
        " were invalidated by a ban before the ban was cancelled, the object"
        " remains invalidated. Bans with only ``obj`` expressions can be"
        " cancelled before ``ban_lurker_age``, but may still be evaluated"
        " during cache lookups and invalidate objects.",
        "See :ref:`vcl(7)_ban` for details",
        3, -1
)
```