### PR TITLE
Move decision on fetch_chunksize to the storage engine

### DIFF
--- a/bin/varnishd/cache/cache_fetch_proc.c
+++ b/bin/varnishd/cache/cache_fetch_proc.c
@@ -71,19 +71,15 @@ VFP_Error(struct vfp_ctx *vc, const char *fmt, ...)
 enum vfp_status
 VFP_GetStorage(struct vfp_ctx *vc, ssize_t *sz, uint8_t **ptr)
 {
-	ssize_t l;
 
 	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
 	AN(sz);
 	assert(*sz >= 0);
 	AN(ptr);
 
-	l = fetchfrag;
-	if (l == 0)
-		l = *sz;
-	if (l == 0)
-		l = cache_param->fetch_chunksize;
-	*sz = l;
+	if (fetchfrag > 0)
+		*sz = fetchfrag;
+
 	if (!ObjGetSpace(vc->wrk, vc->oc, sz, ptr)) {
 		*sz = 0;
 		*ptr = NULL;

--- a/bin/varnishd/cache/cache_obj.c
+++ b/bin/varnishd/cache/cache_obj.c
@@ -190,6 +190,7 @@ ObjIterate(struct worker *wrk, struct objcore *oc,
  * is no free space, some will be added first.
  *
  * The "sz" argument is an input hint of how much space is desired.
+ * 0 means "unknown", return some default size (maybe fetch_chunksize)
  */
 
 int
@@ -201,7 +202,7 @@ ObjGetSpace(struct worker *wrk, struct objcore *oc, ssize_t *sz, uint8_t **ptr)
 	CHECK_OBJ_NOTNULL(oc->boc, BOC_MAGIC);
 	AN(sz);
 	AN(ptr);
-	assert(*sz > 0);
+	assert(*sz >= 0);
 
 	AN(om->objgetspace);
 	return (om->objgetspace(wrk, oc, sz, ptr));

--- a/bin/varnishd/storage/storage_debug.c
+++ b/bin/varnishd/storage/storage_debug.c
@@ -57,7 +57,7 @@ smd_lsp_getspace(struct worker *wrk, struct objcore *oc, ssize_t *sz,
     uint8_t **ptr)
 {
 	AN(sz);
-	if (*sz > 1)
+	if (*sz > 2)
 		(*sz)--;
 	return (SML_methods.objgetspace(wrk, oc, sz, ptr));
 }

--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -476,6 +476,8 @@ sml_getspace(struct worker *wrk, struct objcore *oc, ssize_t *sz,
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	AN(sz);
 	AN(ptr);
+	if (*sz == 0)
+		*sz = cache_param->fetch_chunksize;
 	assert(*sz > 0);
 
 	o = sml_getobj(wrk, oc);


### PR DESCRIPTION
For chunked encoding, we do not know how big the object is ultimately going to be, so `VFP_GetStorage()` called `ObjGetSpace()` with the `fetch_chunksize` parameter in this case.

Yet which size is best might differ for different storage engines, and having the information that the caller does not know the final size might be relevant. Storage engines could guess that if a request came in for `fetch_chunksize` that this _might_ be the "chunked" case, but that heuristic would be wrong for Objects of just that size advertised via `Content-Length`.

So this patch takes the guesswork out of the game by just passing the magic 0 value down to the storage engine to mean "give me some good chunk of bytes, I do not know how much I am going to need".

---

For context: Over the past two years, this particular aspect has given me a hard time again and again, it was the main driver for an [unnecessarily complicated heuristic](https://gitlab.com/uplex/varnish/slash/-/blob/c57d7879a4ec3509edadd967411757abede9fbf3/src/fellow_cache.c#L5116-5134) and is related to [another issue](https://gitlab.com/uplex/varnish/slash/-/issues/60) which I just fixed.