### PR TITLE
pthread_cond_{timed,}wait shall not return an error code of [EINTR].

### DIFF
--- a/bin/varnishd/cache/cache_conn_pool.c
+++ b/bin/varnishd/cache/cache_conn_pool.c
@@ -497,8 +497,6 @@ VCP_Wait(struct worker *wrk, struct pfd *pfd, vtim_real when)
 	while (pfd->state == PFD_STATE_STOLEN) {
 		r = Lck_CondWaitUntil(&wrk->cond, &cp->mtx, when);
 		if (r != 0) {
-			if (r == EINTR)
-				continue;
 			assert(r == ETIMEDOUT);
 			Lck_Unlock(&cp->mtx);
 			return (1);


### PR DESCRIPTION
Nitpick noticed during review of #4030

https://pubs.opengroup.org/onlinepubs/009604599/functions/pthread_cond_timedwait.html

Piling as a PR because of the freeze

FYI this goes back to eecd409d13f145765de3aeee4984179e0ae008b5