### PR TITLE
h2: Add support for busy_stats_rate

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -200,6 +200,8 @@ h2_del_req(struct worker *wrk, struct h2_req *r2)
 	}
 
 	Req_Cleanup(sp, wrk, r2->req);
+	if (FEATURE(FEATURE_BUSY_STATS_RATE))
+		WRK_AddStat(wrk);
 	Req_Release(r2->req);
 }
 


### PR DESCRIPTION
When discussing #4055 during last bugwash, we realized that `busy_stats_rate` was only used in h1, which could potentially explain why enabling it did not fix the issue. This PR introduces the feature flag support in h2.

Refs #4055