### PR TITLE
Minor build fixes

### DIFF
--- a/varnish.m4
+++ b/varnish.m4
@@ -213,9 +213,9 @@ AC_DEFUN([_VARNISH_VMOD], [
 
 	AC_SUBST(m4_toupper(BUILD_VMOD_$1), ["
 
-vmod_$1.lo: vcc_$1_if.c vcc_$1_if.h
+\$(libvmod_$1_la_OBJECTS): vcc_$1_if.c vcc_$1_if.h
 
-vmod_$1.lo: \$(nodist_libvmod_$1_la_SOURCES)
+\$(libvmod_$1_la_OBJECTS): \$(nodist_libvmod_$1_la_SOURCES)
 
 vcc_$1_if.h vmod_$1.rst vmod_$1.man.rst: vcc_$1_if.c
 

--- a/wflags.py
+++ b/wflags.py
@@ -69,7 +69,7 @@ DESIRABLE_WFLAGS = [
 ]
 
 UNDESIRABLE_WFLAGS = [
-    "-Wno-system-headers" # Outside of our control
+    "-Wno-system-headers", # Outside of our control
     "-Wno-thread-safety", # Does not understand our mutexs are wrapped
     "-Wno-old-style-definition", # Does not like vgz
     "-Wno-sign-compare", # Fixable


### PR DESCRIPTION
The first commit I noticed there was a missing comma in wflags.py `UNDESIRABLE_WFLAGS`. The build system didn't seem to care either way but figured it was easy enough to update.

The second commit relates to the auto-generated `BUILD_VMOD_$NAME` helper generated by `VARNISH_VMOD()` in `configure.ac`. When a VMOD adds a CFLAG with `libvmod_$1_la_CFLAGS` the object name is no longer `vmod_$name.lo` but `$library-vmod_name.lo` this changes the build order such that the VCC autogenerated files would not be guaranteed to compile first causing compilation issues. Updating to the `$libvmod_$1_la_OBJECTS` fixes the build order by letting automake/tools figure out the right object name. It might add in more objects than really desired but it's probably better to have the VCC files always built first.

Issue found in the wild: https://github.com/varnish/libvmod-curl/issues/56 