### PR TITLE
SAN fixes on Ubuntu 22

### DIFF
--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -173,7 +173,7 @@ Req_New(struct sess *sp)
 	p = (void*)PRNDUP(p + sizeof(*req->vfc));
 
 	req->vdc = (void*)p;
-	memset(req->vdc, 0, sizeof *req->vdc);
+	ZERO_OBJ(req->vdc, sizeof *req->vdc);
 	p = (void*)PRNDUP(p + sizeof(*req->vdc));
 
 	req->htc = (void*)p;

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -567,7 +567,7 @@ mgt_process_f_arg(struct cli *cli, unsigned C_flag, void **fap)
 	return (retval);
 }
 
-static const char *
+static char *
 create_bogo_n_arg(void)
 {
 	struct vsb *vsb;
@@ -842,8 +842,11 @@ main(int argc, char * const *argv)
 
 	assert(d_flag == 0 || F_flag == 0);
 
-	if (C_flag && n_arg == NULL)
-		n_arg = create_bogo_n_arg();
+	p = NULL;
+	if (C_flag && n_arg == NULL) {
+		p = create_bogo_n_arg();
+		n_arg = p;
+	}
 
 	if (S_arg != NULL && !strcmp(S_arg, "none")) {
 		fprintf(stderr,
@@ -860,6 +863,8 @@ main(int argc, char * const *argv)
 
 	workdir = VIN_n_Arg(n_arg);
 	AN(workdir);
+	if (p != NULL)
+		free(p);
 
 	if (i_arg == NULL || *i_arg == '\0')
 		i_arg = mgt_HostName();

--- a/bin/varnishtest/tests/e00029.vtc
+++ b/bin/varnishtest/tests/e00029.vtc
@@ -1,5 +1,7 @@
 varnishtest "ESI max_esi_depth"
 
+feature !sanitizer
+
 # test that the default stack size is sufficient for hitting
 # max_esi_depth
 

--- a/bin/varnishtest/vtc.c
+++ b/bin/varnishtest/vtc.c
@@ -562,6 +562,8 @@ exec_file(const char *fn, const char *script, const char *tmpdir,
 	struct vsb *vsb;
 	const char *p;
 
+	AN(tmpdir);
+
 	(void)signal(SIGPIPE, SIG_IGN);
 
 	PTOK(pthread_mutex_init(&vtc_vrnd_mtx, NULL));


### PR DESCRIPTION
Fix up some issues when configuring varnish with ASAN, UBSAN and workspace emulator on Ubuntu22. I tested locally, with all tests passing, on Bookworm as well since that is what CCI uses for the SAN builds. 

1. 109543e87fbfbda0f9dc1fb5397327f6000de277- Initialize the VDP CTX in `Req_new()`. I think just using INIT_OBJ is okay here and aligns with the rest of the structs initialized in this section.
2. 6ea6c934ae1c69ef2b5bf867e4709b66bacd540f- Increase `thread_pool_stack` in  e29.vtc. Without the increase the test would segfault on Ubuntu 22.
3. 569c68a8630f38431b6394be1e738ba4391bea1b - Free value created from `create_bogo_n_arg()`. Let me know if there is a more desired way to structure the temporary value to free. 


Ubsan error from `Req_new()`:
```
In function ‘memset’,
    inlined from ‘Req_New’ at cache/cache_req.c:176:2:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:59:10: error: ‘__builtin_memset’ offset [0, 63] is out of the bounds [0, 0] [-Werror=array-bounds]
   59 |   return __builtin___memset_chk (__dest, __ch, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   60 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Ubsan error from exec_file:
```
vtc.c: In function ‘exec_file’:
vtc.c:602:9: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  602 |         macro_def(vltop, NULL, "tmpdir", "%s", tmpdir);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[4]: *** [Makefile:851: varnishtest-vtc.o] Error 1
```