### PR TITLE
[cci] add ubuntu:noble, fix arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
         description: the Linux distribution (debian|ubuntu)
         type: string
       release:
-        description: the release name (buster|bullseye|bionic|focal|jammy)
+        description: the release name (buster|bullseye|bookworm|focal|jammy|noble)
         type: string
       make_target:
         description: the make target to execute during the build
@@ -419,11 +419,6 @@ workflows:
           name: build_debian_bookworm
           dist: debian
           release: bookworm
-      # latest ubuntu uses sanitizers
-      - build:
-          name: build_ubuntu_bionic
-          dist: ubuntu
-          release: bionic
       - build:
           name: build_ubuntu_focal
           dist: ubuntu
@@ -459,7 +454,6 @@ workflows:
           matrix:
             parameters:
               platform:
-                - ubuntu:bionic
                 - ubuntu:focal
                 - ubuntu:jammy
                 - ubuntu:noble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,8 +223,7 @@ jobs:
       - image: centos:7
     working_directory: /workspace
     steps:
-      - setup_remote_docker:
-          version: 20.10.11
+      - setup_remote_docker
       - run:
           name: Install docker
           command: yum install -y docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,11 +405,12 @@ workflows:
           dist: fedora
           release: latest
           make_target: witness.dot
-      # latest debian uses sanitizers
+      # oldest debian goes 32bit
       - build:
           name: build_debian_buster
           dist: debian
           release: buster
+          prefix: i386/
       - build:
           name: build_debian_bullseye
           dist: debian
@@ -418,11 +419,9 @@ workflows:
           name: build_debian_bookworm
           dist: debian
           release: bookworm
-          extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator
-      # oldest ubuntu goes 32bit
+      # latest ubuntu uses sanitizers
       - build:
           name: build_ubuntu_bionic
-          prefix: i386/
           dist: ubuntu
           release: bionic
       - build:
@@ -437,6 +436,7 @@ workflows:
           name: build_ubuntu_noble
           dist: ubuntu
           release: noble
+          extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator
       - build:
           name: build_alpine
           dist: alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,6 +434,10 @@ workflows:
           dist: ubuntu
           release: jammy
       - build:
+          name: build_ubuntu_noble
+          dist: ubuntu
+          release: noble
+      - build:
           name: build_alpine
           dist: alpine
           release: "latest"
@@ -458,6 +462,7 @@ workflows:
                 - ubuntu:bionic
                 - ubuntu:focal
                 - ubuntu:jammy
+                - ubuntu:noble
                 - debian:buster
                 - debian:bullseye
                 - debian:bookworm


### PR DESCRIPTION
looks like the remote docker image we were using was ancient, that seems to have broken more recent builds, like `noble` and `arch`