### PR TITLE
esi: Restore the original onerror behavior

### DIFF
--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -881,8 +881,9 @@ ved_deliver(struct req *req, struct boc *boc, int wantbody)
 
 	status = req->resp->status % 1000;
 
-	if (ecx->abrt && status != 200 && status != 204) {
-		ved_close(req, boc, 1);
+	if (FEATURE(FEATURE_ESI_INCLUDE_ONERROR) &&
+	    status != 200 && status != 204) {
+		ved_close(req, boc, ecx->abrt);
 		return;
 	}
 

--- a/bin/varnishtest/tests/e00035.vtc
+++ b/bin/varnishtest/tests/e00035.vtc
@@ -8,7 +8,7 @@ server s1 {
 
 	rxreq
 	expect req.url == "/fail"
-	txresp -hdr "content-length: 100" -nolen
+	txresp -hdr "content-length: 100"
 	delay 0.1
 } -start
 
@@ -17,6 +17,7 @@ varnish v1 -cliok "param.set feature +esi_include_onerror"
 varnish v1 -vcl+backend {
 	sub vcl_backend_response {
 		set beresp.do_esi = beresp.http.surrogate-control ~ "ESI/1.0";
+		set beresp.do_stream = beresp.http.stream != "false";
 		unset beresp.http.surrogate-control;
 	}
 } -start
@@ -38,13 +39,34 @@ server s1 {
 
 	rxreq
 	expect req.url == "/fail"
-	txresp -hdr "content-length: 100" -nolen
+	txresp -hdr "content-length: 100"
 	delay 0.1
 } -start
 
 client c1 {
 	fatal
 	txreq -url "/continue"
+	rxresp
+	expect resp.body == "before  after"
+} -run
+
+server s1 -wait
+
+server s1 {
+	rxreq
+	expect req.url == "/continue-no-stream"
+	txresp -hdr {surrogate-control: content="ESI/1.0"} \
+	    -body {before <esi:include src="/err" onerror="continue"/> after}
+
+	rxreq
+	expect req.url == "/err"
+	txresp -hdr "content-encoding chunked" -hdr "stream: false"
+	chunked "incomplete"
+} -start
+
+client c1 {
+	fatal
+	txreq -url "/continue-no-stream"
 	rxresp
 	expect resp.body == "before  after"
 } -run

--- a/bin/varnishtest/tests/r03241.vtc
+++ b/bin/varnishtest/tests/r03241.vtc
@@ -1,24 +1,16 @@
 varnishtest "ESI include out of workspace"
 
-
 server s1 {
 	rxreq
 	expect req.http.esi0 == "foo"
-	txresp -body {
-		<html>
-		Before include
-		<esi:include src="/body" sr="foo"/>
-		After include
-		</html>
-	}
+	txresp -body {before <esi:include src="/body" sr="foo"/> after}
 	rxreq
 	expect req.url == "/body1"
 	expect req.http.esi0 != "foo"
-	txresp -body {
-		Included file
-	}
+	txresp -body "include"
 } -start
 
+varnish v1 -cliok "param.set feature +esi_disable_xml_check"
 varnish v1 -vcl+backend {
 	import vtc;
 
@@ -48,9 +40,8 @@ logexpect l1 -v v1 -g raw {
 client c1 {
 	txreq -hdr "Host: foo"
 	rxresp
-	# XXX this is actually wrong (missed include)
-	expect resp.bodylen == 57
 	expect resp.status == 200
+	expect resp.body == "before  after"
 }  -run
 
 logexpect l1 -wait

--- a/bin/varnishtest/tests/r03241.vtc
+++ b/bin/varnishtest/tests/r03241.vtc
@@ -4,8 +4,12 @@ varnishtest "ESI include out of workspace"
 server s1 {
 	rxreq
 	expect req.http.esi0 == "foo"
-	txresp -body {<html>Before include<esi:include
-		src="/body" sr="foo"/>After include</html>
+	txresp -body {
+		<html>
+		Before include
+		<esi:include src="/body" sr="foo"/>
+		After include
+		</html>
 	}
 	rxreq
 	expect req.url == "/body1"
@@ -43,11 +47,10 @@ logexpect l1 -v v1 -g raw {
 
 client c1 {
 	txreq -hdr "Host: foo"
-	rxresphdrs
+	rxresp
+	# XXX this is actually wrong (missed include)
+	expect resp.bodylen == 57
 	expect resp.status == 200
-	rxchunk
-	expect_close
-	expect resp.body == {<html>Before include}
 }  -run
 
 logexpect l1 -wait

--- a/bin/varnishtest/tests/r03865.vtc
+++ b/bin/varnishtest/tests/r03865.vtc
@@ -93,7 +93,7 @@ client c1 {
 	fatal
 	txreq -url "/continue"
 	rxresp
-	expect resp.body == "before FOOBAR after"
+	expect resp.body == "before  after"
 } -run
 
 varnish v1 -cliok "param.set max_esi_depth 0"

--- a/bin/varnishtest/tests/r04053.vtc
+++ b/bin/varnishtest/tests/r04053.vtc
@@ -1,0 +1,37 @@
+varnishtest "Override ESI status check for onerror=abort"
+
+server s1 {
+        rxreq
+        expect req.http.esi-level == 0
+        txresp -body {before <esi:include src="/fail"/> after}
+
+        rxreq
+        expect req.http.esi-level == 1
+        txresp -status 500 -hdr "transfer-encoding: chunked"
+        delay 0.1
+        chunked 500
+	chunkedlen 0
+} -start
+
+varnish v1 -cliok "param.set feature +esi_disable_xml_check"
+varnish v1 -cliok "param.set feature +esi_include_onerror"
+
+varnish v1 -vcl+backend {
+        sub vcl_recv {
+                set req.http.esi-level = req.esi_level;
+        }
+        sub vcl_backend_response {
+                set beresp.do_esi = bereq.http.esi-level == "0";
+        }
+        sub vcl_deliver {
+                if (req.esi_level > 0 && resp.status != 200) {
+			set resp.status = 200;
+                }
+        }
+} -start
+
+client c1 {
+        txreq
+        rxresp
+        expect resp.body == "before 500 after"
+} -run

--- a/doc/sphinx/users-guide/esi.rst
+++ b/doc/sphinx/users-guide/esi.rst
@@ -128,7 +128,10 @@ continue in case of failures, by setting::
     param.set feature +esi_include_onerror
 
 Once this feature flag is enabled, a delivery failure can only continue
-if an ``onerror`` attribute said so.
+if an ``onerror`` attribute said so. The ESI specification states that
+in that case the failing fragment is not delivered, which is honored based
+on the status code, or based on the response body only when streaming is
+disabled (see ``beresp.do_stream``).
 
 Can an ESI fragment also use ESI-includes ?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is a partial revert of 582ded6a2d6ae1a4467b1eb500f2725b42888016 to restore the assumed onerror=continue behavior for ESI includes, unless the feature flag esi_include_onerror is raised.

The part of the change that considers all status codes besides 200 and 204 to be errors for ESI includes remains. A test case covers VCL's ability to "bless" error responses by overriding resp.status, allowing ESI delivery to continue on this criterion.

Fixes #4053