### PR TITLE
Avoid stale PRIV_{TASK,TOP} pointers by calling VRT_priv_{task,top} for each such argument

### DIFF
--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -156,8 +156,6 @@ vcc_NewProc(struct vcc *tl, struct symbol *sym)
 	AN(p);
 	VTAILQ_INIT(&p->calls);
 	VTAILQ_INIT(&p->uses);
-	VTAILQ_INIT(&p->priv_tasks);
-	VTAILQ_INIT(&p->priv_tops);
 	VTAILQ_INSERT_TAIL(&tl->procs, p, list);
 	p->prologue = VSB_new_auto();
 	AN(p->prologue);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -207,7 +207,6 @@ struct symbol {
 };
 
 VTAILQ_HEAD(tokenhead, token);
-VTAILQ_HEAD(procprivhead, procpriv);
 
 struct proc {
 	unsigned		magic;
@@ -215,8 +214,6 @@ struct proc {
 	const struct method	*method;
 	VTAILQ_HEAD(,proccall)	calls;
 	VTAILQ_HEAD(,procuse)	uses;
-	struct procprivhead	priv_tasks;
-	struct procprivhead	priv_tops;
 	VTAILQ_ENTRY(proc)	list;
 	struct token		*name;
 	unsigned		ret_bitmap;
@@ -483,8 +480,6 @@ extern const struct xrefuse XREF_ACTION[1];
 void vcc_AddUses(struct vcc *, const struct token *, const struct token *,
     const struct symbol *sym, const struct xrefuse *use);
 int vcc_CheckUses(struct vcc *tl);
-const char *vcc_MarkPriv(struct vcc *, struct procprivhead *,
-    const char *);
 
 #define ERRCHK(tl)      do { if ((tl)->err) return; } while (0)
 #define ErrInternal(tl) vcc__ErrInternal(tl, __func__, __LINE__)

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -401,7 +401,6 @@ vcc_priv_arg(struct vcc *tl, const char *p, struct symbol *sym)
 	char buf[64];
 	struct inifin *ifp;
 	const char *f = NULL;
-	struct procprivhead *marklist = NULL;
 
 	AN(sym);
 	AN(sym->vmod_name);
@@ -417,31 +416,18 @@ vcc_priv_arg(struct vcc *tl, const char *p, struct symbol *sym)
 		return (vcc_mk_expr(VOID, "&%s", buf));
 	}
 
-	if (!strcmp(p, "PRIV_TASK")) {
+	if (!strcmp(p, "PRIV_TASK"))
 		f = "task";
-		marklist = &tl->curproc->priv_tasks;
-	} else if (!strcmp(p, "PRIV_TOP")) {
+	else if (!strcmp(p, "PRIV_TOP")) {
 		f = "top";
 		sym->r_methods &= VCL_MET_TASK_C;
-		marklist = &tl->curproc->priv_tops;
 	} else {
 		WRONG("Wrong PRIV_ type");
 	}
 	AN(f);
-	AN(marklist);
-	bprintf(buf, "ARG_priv_%s_%s", f, sym->vmod_name);
 
-	if (vcc_MarkPriv(tl, marklist, sym->vmod_name) == NULL)
-		VSB_printf(tl->curproc->prologue,
-			   "  struct vmod_priv *%s = "
-			   "VRT_priv_%s(ctx, &VGC_vmod_%s);\n"
-			   "  if (%s == NULL) {\n"
-			   "    VRT_fail(ctx, \"failed to get %s priv "
-			   "for vmod %s\");\n"
-			   "    return;\n"
-			   "  }\n",
-			   buf, f, sym->vmod_name, buf, f, sym->vmod_name);
-	return (vcc_mk_expr(VOID, "%s", buf));
+	return (vcc_mk_expr(VOID, "VRT_priv_%s(ctx, &VGC_vmod_%s)",
+	    f, sym->vmod_name));
 }
 
 struct func_arg {

--- a/lib/libvcc/vcc_xref.c
+++ b/lib/libvcc/vcc_xref.c
@@ -63,11 +63,6 @@ struct procuse {
 	struct proc		*fm;
 };
 
-struct procpriv {
-	VTAILQ_ENTRY(procpriv)	list;
-	const char		*vmod;
-};
-
 /*--------------------------------------------------------------------*/
 
 static void
@@ -466,29 +461,4 @@ VCC_XrefTable(struct vcc *tl)
 	VCC_WalkSymbols(tl, vcc_xreftable, SYM_##U, SYM_NONE);		\
 	Fc(tl, 0, "*/\n\n");
 #include "vcc_namespace.h"
-}
-
-/*---------------------------------------------------------------------
- * mark vmod as referenced, return NULL if not yet marked, vmod if marked
- */
-
-const char *
-vcc_MarkPriv(struct vcc *tl, struct procprivhead *head,
-    const char *vmod)
-{
-	struct procpriv *pp;
-
-	AN(vmod);
-
-	VTAILQ_FOREACH(pp, head, list) {
-		if (pp->vmod == vmod)
-			return (vmod);
-		AN(strcmp(pp->vmod, vmod));
-	}
-
-	pp = TlAlloc(tl, sizeof *pp);
-	assert(pp != NULL);
-	pp->vmod = vmod;
-	VTAILQ_INSERT_TAIL(head, pp, list);
-	return (NULL);
 }


### PR DESCRIPTION
Description mostly identical to that of the second commit:

Before this change, we would call `VRT_priv_*` only once per subroutine, which can be *) a nice performance optimization, but leaves us with stale pointers after a rollback.

Rather than adding complications for the rollback case just to keep the option of the "per subroutine pointer cache", just retrieve a fresh priv pointer every time.

The other use of the per subroutine initialization was error handling, which needs additional code outside the function arguments, simply because a `return` statement is not possible within function arguments. We remove the requirement for error handling by making sure that `VRT_priv_{task,top}` always return a valid pointer: They now fall back to a heap allocation if the workspace is full, which is unlikely and should not impact the happy path. In other words, the fallback only exists to avoid the need for error handling.

Fixes https://github.com/varnish/varnish-modules/issues/222

Alternative implementation to #4060

----

*) It is not an optimization in all cases, for example the priv pointers were intialized unconditionally, even if code using them was not reached - but then again, this is something C compilers might optimize...