### PR TITLE
Call VDP_Close() for all cases and revert regression

### DIFF
--- a/bin/varnishd/cache/cache_deliver_proc.c
+++ b/bin/varnishd/cache/cache_deliver_proc.c
@@ -59,7 +59,15 @@ VDP_Panic(struct vsb *vsb, const struct vdp_ctx *vdc)
 	VSB_cat(vsb, "},\n");
 }
 
-
+/*
+ * Ensure that transports have called VDP_Close()
+ * to avoid leaks in VDPs
+ */
+void
+VDP_Fini(struct vdp_ctx *vdc)
+{
+	assert(VTAILQ_EMPTY(&vdc->vdp));
+}
 
 void
 VDP_Init(struct vdp_ctx *vdc, struct worker *wrk, struct vsl_log *vsl,

--- a/bin/varnishd/cache/cache_req.c
+++ b/bin/varnishd/cache/cache_req.c
@@ -313,6 +313,8 @@ Req_Cleanup(struct sess *sp, struct worker *wrk, struct req *req)
 		wrk->stats->ws_client_overflow++;
 
 	wrk->seen_methods = 0;
+
+	VDP_Fini(req->vdc);
 }
 
 /*----------------------------------------------------------------------

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -467,6 +467,8 @@ cnt_transmit(struct worker *wrk, struct req *req)
 	    VCL_StackVDP(req, req->vcl, req->vdp_filter_list)) {
 		VSLb(req->vsl, SLT_Error, "Failure to push processors");
 		req->doclose = SC_OVERLOAD;
+		req->acct.resp_bodybytes +=
+			VDP_Close(req->vdc, req->objcore, boc);
 	} else {
 		if (status < 200 || status == 204) {
 			// rfc7230,l,1691,1695
@@ -503,9 +505,6 @@ cnt_transmit(struct worker *wrk, struct req *req)
 		 * Fail the request. */
 		req->doclose = SC_TX_ERROR;
 	}
-
-	if (req->doclose != SC_NULL)
-		req->acct.resp_bodybytes += VDP_Close(req->vdc, req->objcore, boc);
 
 	if (boc != NULL)
 		HSH_DerefBoc(wrk, req->objcore);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -189,6 +189,7 @@ void VDI_Event(const struct director *d, enum vcl_event_e ev);
 void VDI_Init(void);
 
 /* cache_deliver_proc.c */
+void VDP_Fini(struct vdp_ctx *vdc);
 void VDP_Init(struct vdp_ctx *vdc, struct worker *wrk, struct vsl_log *vsl,
     struct req *req);
 uint64_t VDP_Close(struct vdp_ctx *, struct objcore *, struct boc *);


### PR DESCRIPTION
This PR fixes the issues described in #4067 : 

We add missing `VDP_Close()` calls to the deliver functions of esi and http1, revert a wrong addition of a `VDP_Close()` call, add one at the right place and add a `VDP_Fini()` function with an assertion to ensure all cases are taken care of.