### PR TITLE
Consistently abort ESI transactions also for empty includes

### DIFF
--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -879,15 +879,15 @@ ved_deliver(struct req *req, struct boc *boc, int wantbody)
 
 	CAST_OBJ_NOTNULL(ecx, req->transport_priv, ECX_MAGIC);
 
-	if (wantbody == 0) {
-		ved_close(req, boc, 0);
-		return;
-	}
-
 	status = req->resp->status % 1000;
 
 	if (!ecx->incl_cont && status != 200 && status != 204) {
 		ved_close(req, boc, 1);
+		return;
+	}
+
+	if (wantbody == 0) {
+		ved_close(req, boc, 0);
 		return;
 	}
 

--- a/bin/varnishtest/tests/r03865.vtc
+++ b/bin/varnishtest/tests/r03865.vtc
@@ -6,6 +6,11 @@ server s1 {
 	txresp -hdr {surrogate-control: content="ESI/1.0"} \
 	    -body {before <esi:include src="/fail" onerror="abort"/> after}
 
+	rxreq
+	expect req.url == "/abort0"
+	txresp -hdr {surrogate-control: content="ESI/1.0"} \
+	    -body {before <esi:include src="/fail0" onerror="abort"/> after}
+
 } -start
 
 varnish v1 -cliok "param.set feature +esi_disable_xml_check"
@@ -14,6 +19,9 @@ varnish v1 -vcl+backend {
 	sub vcl_backend_fetch {
 		if (bereq.url == "/fail") {
 			return (error(604));
+		}
+		if (bereq.url == "/fail0") {
+			return (error(605));
 		}
 	}
 	sub vcl_backend_response {
@@ -25,11 +33,27 @@ varnish v1 -vcl+backend {
 			set beresp.body = "FOOBAR";
 			return(deliver);
 		}
+		if (beresp.status == 605) {
+			set beresp.body = "";
+			return(deliver);
+		}
 	}
 } -start
 
 client c1 {
 	txreq -url "/abort"
+	non_fatal
+	rxresphdrs
+	expect resp.status == 200
+	rxchunk
+	rxchunk
+	expect_close
+	expect resp.body == "before "
+} -run
+
+client c1 {
+	# #4070
+	txreq -url "/abort0"
 	non_fatal
 	rxresphdrs
 	expect resp.status == 200


### PR DESCRIPTION
When we introduced checking ESI includes for status 200 or 204, we would only (potentially, depending on the `onerror` attribute and `esi_onerror_continue` parameter) abort ESI processing for includes with a non-zero length.

This patch makes behavior consistent to not depend on whether or not an include is empty.

Fixes #4070