### PR TITLE
Add VMOD version information to Panic output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ cscope.*out
 /vmod/vcc_*_if.c
 /vmod/vcc_*_if.h
 /vmod/vmod_*.rst
+/vmod/vmod_vcs_version.txt
 
 # Man-files and binaries
 /man/*.1

--- a/bin/varnishd/cache/cache_vrt_vmod.c
+++ b/bin/varnishd/cache/cache_vrt_vmod.c
@@ -65,6 +65,8 @@ struct vmod {
 	const char		*abi;
 	unsigned		vrt_major;
 	unsigned		vrt_minor;
+	const char		*vcs;
+	const char		*version;
 };
 
 static VTAILQ_HEAD(,vmod)	vmods = VTAILQ_HEAD_INITIALIZER(vmods);
@@ -147,6 +149,8 @@ VPI_Vmod_Init(VRT_CTX, struct vmod **hdl, unsigned nbr, void *ptr, int len,
 		v->abi = d->abi;
 		v->vrt_major = d->vrt_major;
 		v->vrt_minor = d->vrt_minor;
+		v->vcs = d->vcs;
+		v->version = d->version;
 
 		REPLACE(v->nm, nm);
 		REPLACE(v->path, path);
@@ -201,9 +205,19 @@ VMOD_Panic(struct vsb *vsb)
 
 	VSB_cat(vsb, "vmods = {\n");
 	VSB_indent(vsb, 2);
-	VTAILQ_FOREACH(v, &vmods, list)
-		VSB_printf(vsb, "%s = {%p, %s, %u.%u},\n",
-		    v->nm, v, v->abi, v->vrt_major, v->vrt_minor);
+	VTAILQ_FOREACH(v, &vmods, list) {
+		VSB_printf(vsb, "%s = {", v->nm);
+		VSB_indent(vsb, 2);
+		VSB_printf(vsb, "p=%p, abi=\"%s\", vrt=%u.%u,\n",
+			   v, v->abi, v->vrt_major, v->vrt_minor);
+		VSB_bcat(vsb, "vcs=", 4);
+		VSB_quote(vsb, v->vcs, -1, VSB_QUOTE_CSTR);
+		VSB_bcat(vsb, ", version=", 10);
+		VSB_quote(vsb, v->version, -1, VSB_QUOTE_CSTR);
+		VSB_indent(vsb, -2);
+		VSB_bcat(vsb, "},\n", 3);
+	}
+
 	VSB_indent(vsb, -2);
 	VSB_cat(vsb, "},\n");
 }
@@ -218,8 +232,11 @@ ccf_debug_vmod(struct cli *cli, const char * const *av, void *priv)
 	(void)av;
 	(void)priv;
 	ASSERT_CLI();
-	VTAILQ_FOREACH(v, &vmods, list)
-		VCLI_Out(cli, "%5d %s (%s)\n", v->ref, v->nm, v->path);
+	VTAILQ_FOREACH(v, &vmods, list) {
+		VCLI_Out(cli, "%5d %s (path=\"%s\", version=\"%s\","
+		    " vcs=\"%s\")\n", v->ref, v->nm, v->path, v->version,
+		    v->vcs);
+	}
 }
 
 static struct cli_proto vcl_cmds[] = {

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -41,6 +41,42 @@ Varnish Cache NEXT (2025-03-15)
 .. PLEASE keep this roughly in commit order as shown by git-log / tig
    (new to old)
 
+* Two fields have been added to the VMOD data registered with varnish-cache:
+
+  - ``vcs`` for Version Control System is intended as an identifier from the
+    source code management system, e.g. the git revision, to identify the exact
+    source code which was used to build a VMOD binary.
+
+  - ``version`` is intended as a more user friendly identifier as to which
+    version of a vmod a binary represents.
+
+  Panics and the ``debug.vmod`` CLI command output now contain these
+  identifiers.
+
+  Where supported by the compiler and linker, the ``vcs`` identifier is also
+  reachable via the ``.vmod_vcs`` section of the vmod shared object ELF file and
+  can be extracted, for example, using ``readelf -p.vmod_vcs <file>``
+
+* ``vmodtool.py`` now creates a file ``vmod_vcs_version.txt`` in the current
+  working directory when called from a git tree. This file is intended to
+  transport version control system information to builds from distribution
+  bundles.
+
+  vmod authors should add it to the distribution and otherwise ignore it for
+  SCM.
+
+  Where git and automake are used, this can be accomplished by adding
+  ``vmod_vcs_version.txt`` to the ``.gitignore`` file and to the ``EXTRA_DIST``
+  and ``DISTCLEANFILES`` variables in ``Makefile.am``.
+
+  If neither git is used nor ``vmod_vcs_version.txt`` present, ``vmodtool.py``
+  will add ``NOGIT`` to the vmod as the vcs identifier.
+
+* ``vmodtool.py`` now accepts a ``$Version`` stanza in vmod vcc files to set the
+  vmod version as registered with Varnish-Cache. If ``$Version`` is not present,
+  an attempt is made to extract ``PACKAGE_STRING`` from an automake
+  ``Makefile``, otherwise ``NOVERSION`` is used as the version identifier.
+
 * The scope of VCL variables ``req.is_hitmiss`` and ``req.is_hitpass`` is now
   restricted to ``vcl_miss, vcl_deliver, vcl_pass, vcl_synth`` and ``vcl_pass,
   vcl_deliver, vcl_synth`` respectively.

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -56,6 +56,7 @@ data structures that do all the hard work.
 The std VMODs vmod.vcc file looks somewhat like this::
 
 	$ABI strict
+	$Version my.version
 	$Module std 3 "Varnish Standard Module"
 	$Event event_function
 	$Function STRING toupper(STRANDS s)
@@ -72,6 +73,11 @@ RunTime), in which case it needs to be built for the exact Varnish
 version, use ``strict``.  If it complies to the VRT and only needs
 to be rebuilt when breaking changes are introduced to the VRT API,
 use ``vrt``.
+
+The ``$Version`` line is also optional. It specifies the version identifier
+compiled into the VMOD binary for later identification. If omitted,
+``PACKAGE_STRING`` from an automake ``Makefile`` will be used, or ``NOVERSION``
+otherwise.
 
 The ``$Module`` line gives the name of the module, the manual section
 where the documentation will reside, and the description.

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -493,6 +493,8 @@ struct vmod_data {
 	const char			*proto;
 	const char			*json;
 	const char			*abi;
+	const char			*vcs;
+	const char			*version;
 };
 
 /***********************************************************************

--- a/vmod/Makefile.am
+++ b/vmod/Makefile.am
@@ -5,7 +5,9 @@ TESTS = @VMOD_TESTS@
 include $(top_srcdir)/vsc.am
 include $(top_srcdir)/vtc.am
 
-EXTRA_DIST = $(TESTS)
+EXTRA_DIST = $(TESTS) vmod_vcs_version.txt
+
+DISTCLEANFILES = vmod_vcs_version.txt
 
 AM_LDFLAGS  = $(AM_LT_LDFLAGS)
 


### PR DESCRIPTION
This commit adds a facility which I had wanted for a very long time, and should have added much earlier: Analyzing bug reports with VMODs involved used to be complicated by the fact that they typically did not contain reliable version information.

We add to vmodtool.py the generic code to create version information from generate.py with minor modifications. It adds the version set for autotools and, if possible, the git revision to the vmodtool-generated interface code. We copy that to struct vrt and output it for panics.

Being at it, we polish the panic output slightly for readability.

As an example, the output from a panic now might look like this:

```perl
vmods = {
  curl = {p=0x7ff9e064a230, abi="Varnish trunk 403a4743751bb6ae81abfb185abae13419ee0fb7", vrt=18.1,
    version="libvmod-curl 1.0.4 / 8cf03452ee59ded56fde5fb3175ffec755a6c78b"},
  directors = {p=0x7ff9e064a2a0, abi="Varnish trunk 403a4743751bb6ae81abfb185abae13419ee0fb7", vrt=0.0,
    version="Varnish trunk 403a4743751bb6ae81abfb185abae13419ee0fb7"},
},
```