### PR TITLE
Add VCL_Shutdown to wait for VCL references to vanish

### DIFF
--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -560,6 +560,7 @@ child_main(int sigmagic, size_t altstksz)
 	VCA_Shutdown();
 	BAN_Shutdown();
 	EXP_Shutdown();
+	STV_warn();
 	VCL_Shutdown();
 	STV_close();
 

--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -388,6 +388,20 @@ cli_quit(int sig)
 }
 
 /*=====================================================================
+ * XXX Generalize?
+ */
+
+static void
+bit_set(volatile uint8_t *p, unsigned no)
+{
+	uint8_t b;
+
+	p += (no >> 3);
+	b = (0x80 >> (no & 7));
+	*p |= b;
+}
+
+/*=====================================================================
  * Run the child process
  */
 
@@ -538,12 +552,15 @@ child_main(int sigmagic, size_t altstksz)
 
 	CLI_Run();
 
+	bit_set(cache_param->debug_bits, DBG_VCLREL);
+
 	if (shutdown_delay > 0)
 		VTIM_sleep(shutdown_delay);
 
 	VCA_Shutdown();
 	BAN_Shutdown();
 	EXP_Shutdown();
+	VCL_Shutdown();
 	STV_close();
 
 	printf("Child dies\n");

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -502,6 +502,7 @@ struct vsb *VCL_Rel_CliCtx(struct vrt_ctx **);
 void VCL_Panic(struct vsb *, const char *nm, const struct vcl *);
 void VCL_Poll(void);
 void VCL_Init(void);
+void VCL_Shutdown(void);
 
 #define VCL_MET_MAC(l,u,t,b) \
     void VCL_##l##_method(struct vcl *, struct worker *, struct req *, \

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -582,6 +582,7 @@ void V2D_Init(void);
 
 /* stevedore.c */
 void STV_open(void);
+void STV_warn(void);
 void STV_close(void);
 const struct stevedore *STV_next(void);
 int STV_BanInfoDrop(const uint8_t *ban, unsigned len);

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -1270,3 +1270,26 @@ VCL_Init(void)
 	Lck_New(&vcl_mtx, lck_vcl);
 	VSL_Setup(&vsl_cli, NULL, 0);
 }
+
+void
+VCL_Shutdown(void)
+{
+	struct vcl *vcl;
+	unsigned c = 0;
+
+	while (1) {
+		Lck_Lock(&vcl_mtx);
+		VTAILQ_FOREACH(vcl, &vcl_head, list)
+			if (vcl->busy)
+				break;
+		Lck_Unlock(&vcl_mtx);
+		if (vcl == NULL)
+			return;
+		if (++c % 10 == 0) {
+			fprintf(stderr, "shutdown waiting for %u reference%s "
+			    "on %s\n", vcl->busy, vcl->busy > 1 ? "s" : "",
+			    vcl->loaded_name);
+		}
+		usleep(100 * 1000);
+	}
+}

--- a/bin/varnishd/storage/stevedore.c
+++ b/bin/varnishd/storage/stevedore.c
@@ -199,18 +199,25 @@ STV_open(void)
 }
 
 void
+STV_warn(void)
+{
+	struct stevedore *stv;
+
+	ASSERT_CLI();
+	STV_Foreach(stv)
+		if (stv->close != NULL)
+			stv->close(stv, 1);
+}
+
+void
 STV_close(void)
 {
 	struct stevedore *stv;
-	int i;
 
 	ASSERT_CLI();
-	for (i = 1; i >= 0; i--) {
-		/* First send close warning */
-		STV_Foreach(stv)
-			if (stv->close != NULL)
-				stv->close(stv, i);
-	}
+	STV_Foreach(stv)
+		if (stv->close != NULL)
+			stv->close(stv, 0);
 }
 
 /*-------------------------------------------------------------------

--- a/bin/varnishtest/tests/r01506.vtc
+++ b/bin/varnishtest/tests/r01506.vtc
@@ -68,4 +68,5 @@ client c1 {
 } -run
 
 varnish v1 -expect sc_range_short == 0
+varnish v1 -stop
 server s1 -wait


### PR DESCRIPTION
[A panic with SLASH/fellow](https://gitlab.com/uplex/varnish/slash/-/issues/61) exposed a problem in Varnish-Cache: We shut down stevedores unconditionally, no matter if still used or not. While an argument could be made that stevedores should wait for all object references to be returned before actually shutting down (which SLASH/fellow does, but limited to a fixed number of retries), this would not have helped in this particular case, because a `.free_space` variable was queried which, by definition, requires no reference on stevedore objects whatsoever.

So this PR adds `VCL_Shutdown()` to wait for all VCL references to vanish before closing stevedores.