### PR TITLE
Run docker without seccomp rules.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,7 @@ jobs:
             docker run \
               --rm \
               -it \
+              --security-opt seccomp=unconfined \
               -e PARAM_DIST=$(echo "<< parameters.platform >>" | cut -d: -f1) \
               -e PARAM_RELEASE=$(echo "<< parameters.platform >>" | cut -d: -f2) \
               -v$(pwd):/varnish-cache \


### PR DESCRIPTION
Ubuntu noble tries to use `fchmodat2` (new syscall) and gets permission denied instead of ENOSYS. 

This is a small security risk but it's running inside of circleci containers anyway so i think its acceptable.