### PR TITLE
range: New http_GetContentRange() semantics

### DIFF
--- a/bin/varnishd/cache/cache_range.c
+++ b/bin/varnishd/cache/cache_range.c
@@ -265,14 +265,14 @@ VRG_CheckBo(struct busyobj *bo)
 		return (-1);
 	}
 
-	if (crlo < 0 && crhi < 0 && crlen < 0) {
-		AZ(http_GetHdr(bo->beresp, H_Content_Range, NULL));
-		return (0);
-	}
-
-	if (rlo < 0 && rhi < 0) {
+	if (rlo < 0 && rhi < 0 && crlen != 0) {
 		VSLb(bo->vsl, SLT_Error, "Unexpected content-range header");
 		return (-1);
+	}
+
+	if (crlo < 0 && crhi < 0 && crlen == 0) {
+		AZ(http_GetHdr(bo->beresp, H_Content_Range, NULL));
+		return (0);
 	}
 
 	if (crlo < 0) {		// Content-Range: bytes */123

--- a/bin/varnishtest/tests/c00034.vtc
+++ b/bin/varnishtest/tests/c00034.vtc
@@ -134,7 +134,7 @@ varnish v1 -vsl_catchup
 server s1 {
 	loop 2 {
 		rxreq
-		txresp -nolen -hdr "Content-Length: 100"
+		txresp -hdr "Content-Length: 100"
 		send "0123456789"
 		send "0123456789"
 		send "0123456789"
@@ -210,8 +210,13 @@ varnish v1 -vsl_catchup
 server s1 {
 	rxreq
 	txresp
+
 	rxreq
 	txresp -hdr "Accept-Ranges: foobar"
+
+	rxreq
+	expect req.http.Range == foobar=1-2
+	txresp -status 206 -hdr "Content-Range: foobar 1-2/3"
 } -start
 
 varnish v1 -vcl+backend {
@@ -228,10 +233,16 @@ client c7 {
 	rxresp
 	expect resp.http.foobar == ""
 	expect resp.http.accept-ranges == <undef>
+
 	txreq
 	rxresp
 	expect resp.http.foobar == foobar
 	expect resp.http.accept-ranges == foobar
+
+	txreq -hdr "Range: foobar=1-2"
+	rxresp
+	expect resp.status == 503
+	expect resp.http.content-range == <undef>
 } -run
 
 server s1 {
@@ -265,6 +276,18 @@ server s1 {
 	rxreq
 	expect req.http.range == "bytes=0-0"
 	txresp -hdr "content-range: bytes */*" -bodylen 100
+
+	rxreq
+	expect req.http.range == "bytes=0-0"
+	txresp -hdr "content-range: bytes 0-0/*" -bodylen 100
+
+	# issue 4089
+	rxreq
+	expect req.http.range == "bytes=10-19"
+	txresp -status 206 -hdr "content-range: bytes 10-19/*" \
+		-hdr "transfer-encoding: chunked"
+	chunkedlen 10
+	chunkedlen 0
 } -start
 
 varnish v1 -vcl+backend {
@@ -305,6 +328,15 @@ client c8 {
 	txreq -hdr "range: bytes=0-0" -hdr "return: pass"
 	rxresp
 	expect resp.status == 503
+
+	txreq -hdr "range: bytes=0-0" -hdr "return: pass"
+	rxresp
+	expect resp.status == 503
+
+	# issue 4089
+	txreq -hdr "range: bytes=10-19" -hdr "return: pass"
+	rxresp
+	expect resp.status == 206
 } -run
 
 # range filter without a range header

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -57,6 +57,8 @@
  * Whenever something is deleted or changed in a way which is not
  * binary/load-time compatible, increment MAJOR version
  *
+ * NEXT (2024-09-15)
+ *	[cache.h] http_GetContentRange() changed
  * 19.0 (2024-03-18)
  *	[cache.h] (struct req).filter_list renamed to vdp_filter_list
  *	order of vcl/vmod and director COLD events reversed to directors first


### PR DESCRIPTION
This function returns the content length and puts range indices in lo and hi arguments. A content length of -1 used to be interpreted as something to ignore, but there is a case where the content length may be unknown.

Since we can't represent a zero-length range, because both bounds are inclusive, zero now denotes the lack of content-range header.

Unknown range units are treated as errors as they wouldn't pass the busyobj check for the range header, even for pass transactions. The only way to use "extension" range units is to turn `http_range_support` off.

The calling convention for `http_GetContentRange()` remains otherwise the same, and for good measure `http_GetContentLength()` received a similar description.

Fixes #4089