### PR TITLE
Consistent locking when logging to H2 session vsl

### DIFF
--- a/bin/varnishd/http2/cache_http2.h
+++ b/bin/varnishd/http2/cache_http2.h
@@ -274,3 +274,7 @@ task_func_t h2_do_req;
 #ifdef TRANSPORT_MAGIC
 vtr_req_fail_f h2_req_fail;
 #endif
+
+/* cache_http2_session.c */
+void
+H2S_Lock_VSLb(const struct h2_sess *, enum VSL_tag_e, const char *, ...);

--- a/bin/varnishd/http2/cache_http2_hpack.c
+++ b/bin/varnishd/http2/cache_http2_hpack.c
@@ -325,7 +325,7 @@ h2h_decode_hdr_fini(const struct h2_sess *h2)
 		    "HPACK compression error/fini (%s)", VHD_Error(d->vhd_ret));
 		ret = H2CE_COMPRESSION_ERROR;
 	} else if (d->error == NULL && !d->has_scheme) {
-		VSLb(h2->vsl, SLT_Debug, "Missing :scheme");
+		H2S_Lock_VSLb(h2, SLT_Debug, "Missing :scheme");
 		ret = H2SE_MISSING_SCHEME; //rfc7540,l,3087,3090
 	} else
 		ret = d->error;
@@ -377,7 +377,7 @@ h2h_decode_bytes(struct h2_sess *h2, const uint8_t *in, size_t in_l)
 		    d->out, d->out_l, &d->out_u);
 
 		if (d->vhd_ret < 0) {
-			VSLb(hp->vsl, SLT_BogoHeader,
+			H2S_Lock_VSLb(h2, SLT_BogoHeader,
 			    "HPACK compression error (%s)",
 			    VHD_Error(d->vhd_ret));
 			d->error = H2CE_COMPRESSION_ERROR;
@@ -449,7 +449,7 @@ h2h_decode_bytes(struct h2_sess *h2, const uint8_t *in, size_t in_l)
 	if (d->limit < 0) {
 		/* Fatal error, the client exceeded both http_req_size
 		 * and h2_max_header_list_size. */
-		VSLb(h2->vsl, SLT_SessError, "Header list too large");
+		H2S_Lock_VSLb(h2, SLT_SessError, "Header list too large");
 		return (H2CE_ENHANCE_YOUR_CALM);
 	}
 

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -232,11 +232,12 @@ h2_kill_req(struct worker *wrk, struct h2_sess *h2,
 		if (r2->cond != NULL)
 			PTOK(pthread_cond_signal(r2->cond));
 		r2 = NULL;
+		Lck_Unlock(&h2->sess->mtx);
 	} else {
+		Lck_Unlock(&h2->sess->mtx);
 		if (r2->state == H2_S_OPEN && h2->new_req == r2->req)
 			(void)h2h_decode_hdr_fini(h2);
 	}
-	Lck_Unlock(&h2->sess->mtx);
 	if (r2 != NULL)
 		h2_del_req(wrk, r2);
 }

--- a/bin/varnishd/http2/cache_http2_send.c
+++ b/bin/varnishd/http2/cache_http2_send.c
@@ -209,7 +209,7 @@ H2_Send_Frame(struct worker *wrk, struct h2_sess *h2,
 	s = writev(h2->sess->fd, iov, len == 0 ? 1 : 2);
 	if (s != sizeof hdr + len) {
 		if (errno == EWOULDBLOCK) {
-			VSLb(h2->vsl, SLT_Debug,
+			H2S_Lock_VSLb(h2, SLT_Debug,
 			     "H2: stream %u: Hit idle_send_timeout", stream);
 		}
 		/*
@@ -414,9 +414,7 @@ H2_Send_RST(struct worker *wrk, struct h2_sess *h2, const struct h2_req *r2,
 	AN(H2_SEND_HELD(h2, r2));
 	AN(h2e);
 
-	Lck_Lock(&h2->sess->mtx);
-	VSLb(h2->vsl, SLT_Debug, "H2: stream %u: %s", stream, h2e->txt);
-	Lck_Unlock(&h2->sess->mtx);
+	H2S_Lock_VSLb(h2, SLT_Debug, "H2: stream %u: %s", stream, h2e->txt);
 	vbe32enc(b, h2e->val);
 
 	H2_Send_Frame(wrk, h2, H2_F_RST_STREAM, 0, sizeof b, stream, b);

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -429,7 +429,7 @@ h2_new_session(struct worker *wrk, void *arg)
 	while (h2_rxframe(wrk, h2)) {
 		HTC_RxInit(h2->htc, h2->ws);
 		if (WS_Overflowed(h2->ws)) {
-			VSLb(h2->vsl, SLT_Debug, "H2: Empty Rx Workspace");
+			H2S_Lock_VSLb(h2, SLT_SessError, "H2: Empty Rx Workspace");
 			h2->error = H2CE_INTERNAL_ERROR;
 			break;
 		}
@@ -439,8 +439,8 @@ h2_new_session(struct worker *wrk, void *arg)
 	AN(h2->error);
 
 	/* Delete all idle streams */
-	VSLb(h2->vsl, SLT_Debug, "H2 CLEANUP %s", h2->error->name);
 	Lck_Lock(&h2->sess->mtx);
+	VSLb(h2->vsl, SLT_Debug, "H2 CLEANUP %s", h2->error->name);
 	VTAILQ_FOREACH(r2, &h2->streams, list) {
 		if (r2->error == 0)
 			r2->error = h2->error;


### PR DESCRIPTION
Currently, some of the logging to the H2 session vsl is done withouth holding the session lock, even when multiple streams are active. This PR is an attempt to make things more consistent in that regard.