### PR TITLE
h2: Ensure highest_stream is consistent also on Upgrade: h2c

### DIFF
--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -287,6 +287,8 @@ h2_ou_session(struct worker *wrk, struct h2_sess *h2,
 
 	/* Start req thread */
 	r2 = h2_new_req(h2, 1, req);
+	AZ(h2->highest_stream);
+	h2->highest_stream = r2->stream;
 	req->transport = &HTTP2_transport;
 	assert(req->req_step == R_STP_TRANSPORT);
 	req->task->func = h2_do_req;

--- a/bin/varnishtest/tests/t02001.vtc
+++ b/bin/varnishtest/tests/t02001.vtc
@@ -1,6 +1,6 @@
 varnishtest	"H1->H2 Upgrade"
 
-barrier b1 cond 2
+barrier b1 cond 2 -cyclic
 
 server s1 {
 	rxreq
@@ -37,6 +37,11 @@ server s1 {
 	expect req.http.host == foo.bar
 	barrier b1 sync
 	txresp -status 402 -bodylen 11
+
+	rxreq
+	expect req.url == /upgrade3
+	barrier b1 sync
+	txresp -status 200
 } -start
 
 varnish v1 -vsl_catchup
@@ -148,6 +153,40 @@ client c1 {
 	send "Upgrade: h2c\r\n"
 	send "\r\n"
 	expect_close
+} -run
+
+varnish v1 -vsl_catchup
+
+varnish v1 -expect MEMPOOL.req0.live == 0
+varnish v1 -expect MEMPOOL.req1.live == 0
+varnish v1 -expect MEMPOOL.sess0.live == 0
+varnish v1 -expect MEMPOOL.sess1.live == 0
+
+# Upgrade: h2c followed by activity on the newly opened stream
+client c1 {
+	send "GET /upgrade3 HTTP/1.1\r\n"
+	send "Host: foo.bar\r\n"
+	send "Upgrade: h2c\r\n"
+	send "HTTP2-Settings: AAMAAABkAAQAAP__\r\n"
+	send "\r\n"
+	rxresp
+	expect resp.status == 101
+	expect resp.http.upgrade == h2c
+	expect resp.http.connection == Upgrade
+	txpri
+	stream 0 {
+		rxsettings
+		txsettings
+		txsettings -ack
+		rxsettings
+		expect settings.ack == true
+	} -run
+	barrier b1 sync
+	stream 1 {
+		txwinup -size 256
+		rxresp
+		expect resp.status == 200
+	} -run
 } -run
 
 varnish v1 -vsl_catchup


### PR DESCRIPTION
`highest_stream` gets used both in transmitting goaway frames, and also for internal protocol consistency checks.

For the `Upgrade: h2c` handling we fail to bump this when kicking off the stream for the request that got the upgrade, so any subsequent frame transmitted on that stream will be treated with an inconsistent view on `highest_stream`. In particular, this leads to an erroneous `PROTOCOL_ERROR` on reception of a `WINDOW_UPDATE`.