### PR TITLE
POC: New beresp.error VCL variable

### DIFF
--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -266,7 +266,13 @@ sub vcl_builtin_backend_error {
   </head>
   <body>
     <h1>Error "} + beresp.status + " " + beresp.reason + {"</h1>
-    <p>"} + beresp.reason + {"</p>
+    <p>"};
+	if (beresp.error) {
+		set beresp.body += beresp.error;
+	} else {
+		set beresp.body += beresp.reason;
+	}
+	set beresp.body += {"</p>
     <h3>Guru Meditation:</h3>
     <p>XID: "} + bereq.xid + {"</p>
     <hr>

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -442,6 +442,7 @@ struct busyobj {
 
 	uint16_t		err_code;
 	const char		*err_reason;
+	const char		*err_resp;
 
 	const char		*client_identity;
 };

--- a/bin/varnishd/cache/cache_backend.h
+++ b/bin/varnishd/cache/cache_backend.h
@@ -82,5 +82,5 @@ void VBP_Insert(struct backend *b, struct vrt_backend_probe const *p,
 void VBP_Remove(struct backend *b);
 void VBP_Control(const struct backend *b, int stop);
 void VBP_Status(struct vsb *, const struct backend *, int details, int json);
-void VBE_Connect_Error(struct VSC_vbe *, int err);
+const char * VBE_Connect_Error(struct VSC_vbe *, int err);
 

--- a/bin/varnishd/cache/cache_vrt_var.c
+++ b/bin/varnishd/cache/cache_vrt_var.c
@@ -623,6 +623,17 @@ VRT_r_beresp_backend(VRT_CTX)
 
 /*--------------------------------------------------------------------*/
 
+VCL_STRING
+VRT_r_beresp_error(VRT_CTX)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+	return (ctx->bo->err_resp);
+}
+
+/*--------------------------------------------------------------------*/
+
 VCL_VOID
 VRT_u_bereq_body(VRT_CTX)
 {

--- a/bin/varnishtest/tests/v00019.vtc
+++ b/bin/varnishtest/tests/v00019.vtc
@@ -69,6 +69,16 @@ varnish v1 -errvcl {Comparison of different types: STRING '==' INT} {
 	}
 }
 
+varnish v1 -vcl {
+	import debug;
+	backend be none;
+	sub vcl_recv {
+		if ("string" == debug.return_strands("string")) {
+			return (fail("should compile"));
+		}
+	}
+}
+
 varnish v1 -errvcl {Symbol not found: 'req.http.req.http.foo'} {
 	backend b { .host = "${localhost}"; }
 	sub vcl_recv {

--- a/bin/varnishtest/tests/v00072.vtc
+++ b/bin/varnishtest/tests/v00072.vtc
@@ -7,7 +7,9 @@ server s1 "" -start -break
 
 varnish v1 -vcl+backend {
 	sub vcl_backend_error {
-		return (fail(error.connection_refused));
+		if (beresp.error != error.connection_refused) {
+			return (abandon);
+		}
 	}
 } -start
 

--- a/bin/varnishtest/tests/v00072.vtc
+++ b/bin/varnishtest/tests/v00072.vtc
@@ -16,4 +16,5 @@ varnish v1 -vcl+backend {
 client c1 {
 	txreq
 	rxresp
+	expect resp.body ~ "<p>Connection refused by the backend</p>"
 } -run

--- a/bin/varnishtest/tests/v00072.vtc
+++ b/bin/varnishtest/tests/v00072.vtc
@@ -1,0 +1,17 @@
+varnishtest "VCL error messages"
+
+# Instead of adding coverage for all errors here, we should probably add
+# error.* coverage to existing test cases.
+
+server s1 "" -start -break
+
+varnish v1 -vcl+backend {
+	sub vcl_backend_error {
+		return (fail(error.connection_refused));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1149,6 +1149,15 @@ beresp.filters
 	``beresp.do_*`` switches is a VCL error.
 
 
+beresp.error
+
+	Type: STRING
+
+	Readable from: vcl_backend_error
+
+	TODO: description (change type to ERROR?)
+
+
 .. _beresp.grace:
 
 beresp.grace

--- a/doc/sphinx/reference/vcl_var.rst
+++ b/doc/sphinx/reference/vcl_var.rst
@@ -1899,3 +1899,16 @@ storage.<name>.used_space
 	Used space in the named stevedore. Only available for the malloc
 	stevedore.
 
+Error messages
+--------------
+
+TODO: general introduction.
+
+error.connection_refused
+
+	Type: ERROR
+
+	Error message: Connection refused by the backend
+
+	TODO: description (maybe mention ECONNREFUSED etc)
+

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -386,6 +386,7 @@ typedef unsigned				VCL_BOOL;
 typedef int64_t					VCL_BYTES;
 typedef vtim_dur				VCL_DURATION;
 typedef const char *				VCL_ENUM;
+typedef const char *				VCL_ERROR;
 typedef const struct gethdr_s *			VCL_HEADER;
 typedef struct http *				VCL_HTTP;
 typedef void					VCL_INSTANCE;

--- a/lib/libvcc/generate.py
+++ b/lib/libvcc/generate.py
@@ -183,7 +183,12 @@ class vardef(object):
             fo.write('\tsym->rname = "HDR_')
             fo.write(self.nam.split(".")[0].upper())
             fo.write('";\n')
-        elif self.rd and self.typ != "HEADER":
+        elif self.typ == "ERROR":
+            emsg = " ".join(self.wr)
+            self.wr = []
+            fo.write('\tsym->rname = "VRT_c_%s()";\n' % cnam)
+            fh.write("#define VRT_c_%s() \"%s\"\n" % (cnam, emsg))
+        elif self.rd and self.typ != "HEADER" and self.typ != "ERROR":
             fo.write('\tsym->rname = "VRT_r_%s(ctx)";\n' % cnam)
             varproto("VCL_" + self.typ + " VRT_r_%s(VRT_CTX)" % cnam)
         fo.write("\tsym->r_methods =\n")
@@ -265,6 +270,11 @@ def parse_var(ln):
         if j[0] == "Unsetable" and j[1] == "from:":
             for i in j[2:]:
                 vu.append(i.strip(",."))
+            continue
+        if j[0] == "Error" and j[1] == "message:":
+            vt = "ERROR"
+            vr = ["all"]
+            vw = j[2:] # stash error message in write permissions
             continue
         if j[0] == "Alias" and j[1] == "of:":
             va = j[2]

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1186,6 +1186,10 @@ cmp_string(struct vcc *tl, struct expr **e, const struct cmps *cp)
 	tk = tl->t;
 	vcc_NextToken(tl);
 	vcc_expr_add(tl, &e2, STRINGS);
+	if (e2->fmt != STRINGS && e2->fmt->stringform) {
+		/* NB: no concatenation processed by vcc_expr_add() */
+		vcc_expr_tostring(tl, &e2);
+	}
 	ERRCHK(tl);
 	if (e2->fmt != STRINGS) {
 		VSB_printf(tl->sb,

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -288,19 +288,18 @@ vcc_expr_tobool(struct vcc *tl, struct expr **e)
  */
 
 static void
-vcc_expr_tostring(struct vcc *tl, struct expr **e, vcc_type_t fmt)
+vcc_expr_tostring(struct vcc *tl, struct expr **e)
 {
 	const char *p;
 	uint8_t	constant = EXPR_VAR;
 
 	CHECK_OBJ_NOTNULL(*e, EXPR_MAGIC);
-	assert(fmt == STRINGS || fmt->stringform);
-	assert(fmt != (*e)->fmt);
+	assert((*e)->fmt != STRINGS);
 
 	p = (*e)->fmt->tostring;
 	if (p != NULL) {
 		AN(*p);
-		*e = vcc_expr_edit(tl, fmt, p, *e, NULL);
+		*e = vcc_expr_edit(tl, STRINGS, p, *e, NULL);
 		(*e)->constant = constant;
 		(*e)->nstr = 1;
 	} else {
@@ -816,7 +815,7 @@ vcc_expr5(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 			ERRCHK(tl);
 			/* Unless asked for a HEADER, fold to string here */
 			if (*e && fmt != HEADER && (*e)->fmt == HEADER) {
-				vcc_expr_tostring(tl, e, STRINGS);
+				vcc_expr_tostring(tl, e);
 				ERRCHK(tl);
 			}
 			return;
@@ -1071,9 +1070,9 @@ vcc_expr_add(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		} else if (tk->tok == '+' &&
 		    ((*e)->fmt == STRINGS || fmt == STRINGS)) {
 			if ((*e)->fmt != STRINGS)
-				vcc_expr_tostring(tl, e, STRINGS);
+				vcc_expr_tostring(tl, e);
 			if (e2->fmt != STRINGS)
-				vcc_expr_tostring(tl, &e2, STRINGS);
+				vcc_expr_tostring(tl, &e2);
 			if (vcc_islit(*e) && vcc_isconst(e2)) {
 				lit = vcc_islit(e2);
 				*e = vcc_expr_edit(tl, STRINGS,
@@ -1420,7 +1419,7 @@ vcc_expr0(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 		return;
 
 	if ((*e)->fmt != STRINGS && fmt->stringform)
-		vcc_expr_tostring(tl, e, STRINGS);
+		vcc_expr_tostring(tl, e);
 
 	if ((*e)->fmt->stringform) {
 		VSB_printf(tl->sb, "Cannot convert type %s(%s) to %s(%s)\n",
@@ -1431,7 +1430,7 @@ vcc_expr0(struct vcc *tl, struct expr **e, vcc_type_t fmt)
 	}
 
 	if (fmt == BODY && !(*e)->fmt->bodyform)
-		vcc_expr_tostring(tl, e, STRINGS);
+		vcc_expr_tostring(tl, e);
 
 	if (fmt == BODY && (*e)->fmt->bodyform) {
 		if ((*e)->fmt == STRINGS)

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -114,6 +114,13 @@ const struct type ENUM[1] = {{
 	.tostring =		"",
 }};
 
+const struct type ERROR[1] = {{
+	.magic =		TYPE_MAGIC,
+	.name =			"ERROR",
+	.stringform =		1,
+	.tostring =		"(\v1)",
+}};
+
 const struct type HEADER[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"HEADER",


### PR DESCRIPTION
Following several VDD discussions, this patch series shows how getting a backend error could look like in VCL, and how it could be articulated in the core code.

This should check the boxes from the last consensus:

- a plain text error message
- a new VCL variable to get the error (`beresp.error`)
- VCL constants for safe comparisons (`error.*`)

The first two commits are unrelated, I found a bug in libvcc while I was working on this. I will submit a pull request once I'm done with that bug (only partly fixed here) so the relevant commits to review are the ones starting with "POC".

If we still have consensus on this approach, I will find someone™ to submit something comprehensive.