### PR TITLE
vtc: Stabilize r02310.vtc

### DIFF
--- a/bin/varnishtest/tests/r02310.vtc
+++ b/bin/varnishtest/tests/r02310.vtc
@@ -11,6 +11,7 @@ server s1 {
 varnish v1 -vcl+backend {} -start
 
 varnish v1 -cliok "param.set feature +http2"
+varnish v1 -cliok "param.set feature -vcl_req_reset"
 
 client c1 {
 	send "GET / HTTP/1.1\r\n"


### PR DESCRIPTION
> The test is racy, since #3998 we no longer perform the backend fetch if the client disconnects before it is started. Thus, the test will be stuck at [this](https://github.com/varnishcache/varnish-cache/blob/5e98181a6180a50df0836539b2bc12b2264fb8fe/bin/varnishtest/tests/r02310.vtc#L37) line until it times out since the [other](https://github.com/varnishcache/varnish-cache/blob/5e98181a6180a50df0836539b2bc12b2264fb8fe/bin/varnishtest/tests/r02310.vtc#L7C2-L7C9) `barrier b1 sync` will never be reached.

Fixes: #4098