### PR TITLE
All sensible platforms have <sys/statvfs.h> these days.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,10 +214,7 @@ CFLAGS="${save_CFLAGS}"
 # Checks for header files.
 AC_CHECK_HEADERS([sys/endian.h])
 AC_CHECK_HEADERS([sys/filio.h])
-AC_CHECK_HEADERS([sys/mount.h], [], [], [#include <sys/param.h>])
 AC_CHECK_HEADERS([sys/personality.h])
-AC_CHECK_HEADERS([sys/statvfs.h])
-AC_CHECK_HEADERS([sys/vfs.h])
 AC_CHECK_HEADERS([endian.h])
 AC_CHECK_HEADERS([pthread_np.h], [], [], [#include <pthread.h>])
 AC_CHECK_HEADERS([priv.h])

--- a/lib/libvarnish/vfil.c
+++ b/lib/libvarnish/vfil.c
@@ -41,16 +41,7 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <string.h>
-#ifdef HAVE_SYS_MOUNT_H
-#  include <sys/param.h>
-#  include <sys/mount.h>
-#endif
-#ifdef HAVE_SYS_STATVFS_H
-#  include <sys/statvfs.h>
-#endif
-#ifdef HAVE_SYS_VFS_H
-#  include <sys/vfs.h>
-#endif
+#include <sys/statvfs.h>
 #ifdef HAVE_FALLOCATE
 #  include <linux/magic.h>
 #endif
@@ -188,7 +179,6 @@ VFIL_fsinfo(int fd, unsigned *pbs, uintmax_t *psize, uintmax_t *pspace)
 {
 	unsigned bs;
 	uintmax_t size, space;
-#if defined(HAVE_SYS_STATVFS_H)
 	struct statvfs fsst;
 
 	if (fstatvfs(fd, &fsst))
@@ -196,17 +186,6 @@ VFIL_fsinfo(int fd, unsigned *pbs, uintmax_t *psize, uintmax_t *pspace)
 	bs = fsst.f_frsize;
 	size = fsst.f_blocks * fsst.f_frsize;
 	space = fsst.f_bavail * fsst.f_frsize;
-#elif defined(HAVE_SYS_MOUNT_H) || defined(HAVE_SYS_VFS_H)
-	struct statfs fsst;
-
-	if (fstatfs(fd, &fsst))
-		return (-1);
-	bs = fsst.f_bsize;
-	size = fsst.f_blocks * fsst.f_bsize;
-	space = fsst.f_bavail * fsst.f_bsize;
-#else
-#error no struct statfs / struct statvfs
-#endif
 
 	if (pbs)
 		*pbs = bs;

--- a/lib/libvarnish/vfil.c
+++ b/lib/libvarnish/vfil.c
@@ -42,8 +42,9 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/statvfs.h>
-#ifdef HAVE_FALLOCATE
+#if defined(__linux__) && defined(HAVE_FALLOCATE)
 #  include <linux/magic.h>
+#  include <sys/vfs.h>
 #endif
 
 #include "vdef.h"


### PR DESCRIPTION
Eliminate autocrap checks and unused fall-back code paths.