### PR TITLE
build: Keep an autoconf check for pthread_setname_np()

### DIFF
--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -134,16 +134,14 @@ THR_SetName(const char *name)
 {
 
 	PTOK(pthread_setspecific(name_key, name));
-#if defined(HAVE_PTHREAD_SET_NAME_NP)
-	pthread_set_name_np(pthread_self(), name);
-#elif defined(HAVE_PTHREAD_SETNAME_NP)
-#if defined(__APPLE__)
+#if defined(HAVE_PTHREAD_SETNAME_NP)
+#  if defined(__APPLE__)
 	(void)pthread_setname_np(name);
-#elif defined(__NetBSD__)
+#  elif defined(__NetBSD__)
 	(void)pthread_setname_np(pthread_self(), "%s", (char *)(uintptr_t)name);
-#else
+#  else
 	(void)pthread_setname_np(pthread_self(), name);
-#endif
+#  endif
 #endif
 }
 

--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -134,12 +134,16 @@ THR_SetName(const char *name)
 {
 
 	PTOK(pthread_setspecific(name_key, name));
+#if defined(HAVE_PTHREAD_SET_NAME_NP)
+	pthread_set_name_np(pthread_self(), name);
+#elif defined(HAVE_PTHREAD_SETNAME_NP)
 #if defined(__APPLE__)
 	(void)pthread_setname_np(name);
 #elif defined(__NetBSD__)
 	(void)pthread_setname_np(pthread_self(), "%s", (char *)(uintptr_t)name);
 #else
 	(void)pthread_setname_np(pthread_self(), name);
+#endif
 #endif
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -229,6 +229,8 @@ AC_CHECK_FUNCS([fnmatch], [], [AC_MSG_ERROR([fnmatch(3) is required])])
 
 save_LIBS="${LIBS}"
 LIBS="${PTHREAD_LIBS}"
+AC_CHECK_FUNCS([pthread_set_name_np])
+AC_CHECK_FUNCS([pthread_setname_np])
 AC_CHECK_FUNCS([pthread_mutex_isowned_np])
 AC_CHECK_FUNCS([pthread_getattr_np])
 LIBS="${save_LIBS}"

--- a/configure.ac
+++ b/configure.ac
@@ -229,7 +229,6 @@ AC_CHECK_FUNCS([fnmatch], [], [AC_MSG_ERROR([fnmatch(3) is required])])
 
 save_LIBS="${LIBS}"
 LIBS="${PTHREAD_LIBS}"
-AC_CHECK_FUNCS([pthread_set_name_np])
 AC_CHECK_FUNCS([pthread_setname_np])
 AC_CHECK_FUNCS([pthread_mutex_isowned_np])
 AC_CHECK_FUNCS([pthread_getattr_np])


### PR DESCRIPTION
It is not portable by definition, so we should keep the guards.