### PR TITLE
Copy timeouts from a via backend if undefined for the destination

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -694,6 +694,18 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 #undef DA
 #undef DN
 
+#define CPTMO(a, b, x) do {				\
+		if ((a)->x < 0.0 || isnan((a)->x))	\
+			(a)->x = (b)->x;		\
+	} while(0)
+
+	if (viabe != NULL) {
+		CPTMO(be, viabe, connect_timeout);
+		CPTMO(be, viabe, first_byte_timeout);
+		CPTMO(be, viabe, between_bytes_timeout);
+	}
+#undef CPTMO
+
 	if (viabe || be->hosthdr == NULL) {
 		if (vrt->endpoint->uds_path != NULL)
 			sa = bogo_ip;

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -41,6 +41,11 @@ Varnish Cache NEXT (2024-09-15)
 .. PLEASE keep this roughly in commit order as shown by git-log / tig
    (new to old)
 
+* for backends using the ``.via`` attribute to connect through a
+  *proxy*, the ``connect_timeout``, ``first_byte_timeout`` and
+  ``between_bytes_timeout`` attributes are now inherited from *proxy*
+  unless explicitly given.
+
 * ``varnishd`` now creates a ``worker_tmpdir`` which can be used by
   VMODs for temporary files. The `VMOD deleveloper documentation`_ has
   details.

--- a/doc/sphinx/reference/vcl-backend.rst
+++ b/doc/sphinx/reference/vcl-backend.rst
@@ -169,6 +169,10 @@ supported.
 The ``.via`` attribute is unrelated to ``.proxy_header``. If both are
 used, a second header is sent as per ``.proxy_header`` specification.
 
+Unless specified for *destination*, the ``connect_timeout``,
+``first_byte_timeout`` and ``between_bytes_timeout`` attributes are
+copied from *proxy* to *destination*.
+
 As of this release, the *proxy* backend used with ``.via`` can not be
 a director, it can not itself use ``.via`` (error: *Can not stack .via
 backends*) and the protocol is fixed to `PROXY2`_.


### PR DESCRIPTION
Inherit the three backend timeouts from a proxy if not defined for the destination.

TODO before merge if otherwise accepted: changes.rst, documentation