### PR TITLE
Add ObjWaitExtend2() to provide a consistent boc state

### DIFF
--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -335,7 +335,7 @@ void ObjDestroy(const struct worker *, struct objcore **);
 int ObjGetSpace(struct worker *, struct objcore *, ssize_t *sz, uint8_t **ptr);
 void ObjExtend(struct worker *, struct objcore *, ssize_t l, int final);
 uint64_t ObjWaitExtend(const struct worker *, const struct objcore *,
-    uint64_t l);
+    uint64_t l, enum boc_state_e *statep);
 void ObjSetState(struct worker *, const struct objcore *,
     enum boc_state_e next);
 void ObjWaitState(const struct objcore *, enum boc_state_e want);

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -41,6 +41,11 @@ Varnish Cache NEXT (2024-09-15)
 .. PLEASE keep this roughly in commit order as shown by git-log / tig
    (new to old)
 
+* The ObjWaitExtend() Object API function gained a ``statep`` argument
+  to optionally return the busy object state consistent with the
+  current extension. A ``NULL`` value may be passed if the caller does
+  not require it.
+
 * for backends using the ``.via`` attribute to connect through a
   *proxy*, the ``connect_timeout``, ``first_byte_timeout`` and
   ``between_bytes_timeout`` attributes are now inherited from *proxy*

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -48,7 +48,7 @@
 
 #define VRT_MAJOR_VERSION	19U
 
-#define VRT_MINOR_VERSION	0U
+#define VRT_MINOR_VERSION	1U
 
 /***********************************************************************
  * Major and minor VRT API versions.
@@ -58,6 +58,8 @@
  * binary/load-time compatible, increment MAJOR version
  *
  * NEXT (2024-09-15)
+ * 19.1 (2024-05-27)
+ *	[cache_varnishd.h] ObjWaitExtend() gained statep argument
  * 19.0 (2024-03-18)
  *	[cache.h] (struct req).filter_list renamed to vdp_filter_list
  *	order of vcl/vmod and director COLD events reversed to directors first


### PR DESCRIPTION
For context see [SLASH/fellow issue #44](https://gitlab.com/uplex/varnish/slash/-/issues/44).

Clients to the Object API need to know not only the current extension (new length) of streaming objects, but also the streaming state - in particular `BOS_FINISHED` and `BOS_FAILED`. The latter for obvious reasons, and the former to call the delivery function with `OBJ_ITER_END`, which then likely results in `VDP_END` sent down the delivery pipeline.

Background:

It is important for efficient delivery to not receive an additional `VDP_END` with a null buffer, but rather combined with the last chunk of data, so, consequently, it is important to reliably send `OBJ_INTER_END` also with the last chunk of data.

Consequent to all of this, `ObjWaitExtend()` callers need to know when `BOS_FINISHED` has been reached for some extension.

The current API, however, does not provide a consistent view of the streaming state, which is only available from within the critical region of `ObjWaitExtend()`.

Thus, we add the streaming state as an optional return value.

With this commit, we also remove a superfluous line to set `rv` again: Because `boc->fetched_so_far` must only be updated while holding the `boc` mutex, reading the value again provides no benefit.