### PR TITLE
Create a directory owned by the worker process for use as a TMPDIR

### DIFF
--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -319,6 +319,7 @@ mgt_Cflag_atexit(void)
 		VJ_rmdir("vext_cache");
 	}
 	VJ_rmdir("vmod_cache");
+	VJ_rmdir("worker_tmpdir");
 	(void)chdir("/");
 	VJ_rmdir(workdir);
 }
@@ -865,7 +866,7 @@ main(int argc, char * const *argv)
 		    workdir, VAS_errtxt(errno));
 
 	VJ_master(JAIL_MASTER_SYSTEM);
-	AZ(system("rm -rf vmod_cache vext_cache"));
+	AZ(system("rm -rf vmod_cache vext_cache worker_tmpdir"));
 	VJ_master(JAIL_MASTER_LOW);
 
 	if (VJ_make_subdir("vmod_cache", "VMOD cache", NULL)) {
@@ -878,6 +879,13 @@ main(int argc, char * const *argv)
 	    VJ_make_subdir("vext_cache", "VEXT cache", NULL)) {
 		ARGV_ERR(
 		    "Cannot create vmod directory (%s/vext_cache): %s\n",
+		    workdir, VAS_errtxt(errno));
+	}
+
+	if (VJ_make_subdir("worker_tmpdir",
+	    "TMPDIR for the worker process", NULL)) {
+		ARGV_ERR(
+		    "Cannot create vmod directory (%s/worker_tmpdir): %s\n",
 		    workdir, VAS_errtxt(errno));
 	}
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -41,10 +41,16 @@ Varnish Cache NEXT (2024-09-15)
 .. PLEASE keep this roughly in commit order as shown by git-log / tig
    (new to old)
 
+* ``varnishd`` now creates a ``worker_tmpdir`` which can be used by
+  VMODs for temporary files. The `VMOD deleveloper documentation`_ has
+  details.
+
 * The environment variable ``VARNISH_DEFAULT_N`` now provides the
   default "varnish name" / "workdir" as otherwise specified by he
   ``-n`` argument to ``varnishd`` and ``varnish*`` utilities except
   ``varnishtest``.
+
+.. _VMOD deleveloper documentation: doc/sphinx/reference/vmod.rst
 
 ================================
 Varnish Cache 7.5.0 (2024-03-18)


### PR DESCRIPTION
Processes created by the worker might require a `TMPDIR` for temporary files (think: filters). Create a dedicated directory for this purpose, which is otherwise hard to achieve in a universal manner.