### PR TITLE
vbp: Rework probe state management

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -499,7 +499,7 @@ vbp_task(struct worker *wrk, void *priv)
  */
 
 static void * v_matchproto_(bgthread_t)
-vbp_thread(struct worker *wrk, void *priv)
+vbp_scheduler(struct worker *wrk, void *priv)
 {
 	vtim_real now, nxt;
 	struct vbp_target *vt;
@@ -808,5 +808,5 @@ VBP_Init(void)
 	vbp_heap = VBH_new(NULL, vbp_cmp, vbp_update);
 	AN(vbp_heap);
 	PTOK(pthread_cond_init(&vbp_cond, NULL));
-	WRK_BgThread(&thr, "backend-poller", vbp_thread, NULL);
+	WRK_BgThread(&thr, "backend-probe-scheduler", vbp_scheduler, NULL);
 }

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -116,6 +116,8 @@ vbp_delete(struct vbp_target *vt)
 {
 	CHECK_OBJ_NOTNULL(vt, VBP_TARGET_MAGIC);
 
+	assert(vt->heap_idx == VBH_NOIDX);
+
 #define DN(x)	/**/
 	VRT_BACKEND_PROBE_HANDLE();
 #undef DN
@@ -462,7 +464,6 @@ vbp_task(struct worker *wrk, void *priv)
 	Lck_Lock(&vbp_mtx);
 	if (vt->running < 0) {
 		assert(vt->state == vbp_state_deleted);
-		assert(vt->heap_idx == VBH_NOIDX);
 		vbp_delete(vt);
 	} else {
 		assert(vt->state == vbp_state_running);
@@ -752,10 +753,8 @@ VBP_Remove(struct backend *be)
 	} else
 		assert(vt->state == vbp_state_cold);
 	Lck_Unlock(&vbp_mtx);
-	if (vt != NULL) {
-		assert(vt->heap_idx == VBH_NOIDX);
+	if (vt != NULL)
 		vbp_delete(vt);
-	}
 }
 
 /*-------------------------------------------------------------------*/

--- a/doc/graphviz/cache_backend_probe.dot
+++ b/doc/graphviz/cache_backend_probe.dot
@@ -5,31 +5,33 @@ digraph cache_backend_probe {
 	scheduled
 	running
 	cold
-	deleted
+	cooling	# going cold while task runs
+	deleted # from cooling, removed while task runs
 	FREE
 
 	edge [fontname=Courier]
 
-	edge [label="vbp_task()"]
-	deleted -> FREE
+	# via vbp_task() or vbp_thread() scheduling error
+	edge [label="vbp_task_complete()"]
 	running -> scheduled
+	cooling -> cold
+	deleted -> FREE
 
 	edge [label="vbp_thread()"]
 	scheduled -> running
 
-	edge [label="vbp_thread() error"]
-	scheduled -> scheduled
-
-	edge [label="VBP_Control()"]
+	edge [label="VBP_Control(enable)"]
+	cooling -> running
 	cold -> scheduled
+
+	edge [label="VBP_Control(disable)"]
+	running -> cooling
 	scheduled -> cold
-	running -> cold
 
 	edge [label="VBP_Insert()"]
 	ALLOC -> cold
 
 	edge [label="VBP_Remove()"]
-	running -> deleted # should not happen. we should go through some cool first
-	scheduled -> FREE # This should not happen. VBP_Control should have set cold
+	cooling -> deleted
 	cold -> FREE
 }

--- a/doc/graphviz/cache_backend_probe.dot
+++ b/doc/graphviz/cache_backend_probe.dot
@@ -1,0 +1,35 @@
+# cache_backend_probe struct vbp_state
+
+digraph cache_backend_probe {
+	ALLOC
+	scheduled
+	running
+	cold
+	deleted
+	FREE
+
+	edge [fontname=Courier]
+
+	edge [label="vbp_task()"]
+	deleted -> FREE
+	running -> scheduled
+
+	edge [label="vbp_thread()"]
+	scheduled -> running
+
+	edge [label="vbp_thread() error"]
+	scheduled -> scheduled
+
+	edge [label="VBP_Control()"]
+	cold -> scheduled
+	scheduled -> cold
+	running -> cold
+
+	edge [label="VBP_Insert()"]
+	ALLOC -> cold
+
+	edge [label="VBP_Remove()"]
+	running -> deleted # should not happen. we should go through some cool first
+	scheduled -> FREE # This should not happen. VBP_Control should have set cold
+	cold -> FREE
+}


### PR DESCRIPTION
I will be away until July, but I would appreciate reviews and collection of feedback in the meantime. Also, for the unlikely event that everyone is absolutely happy about it, I would also not oppose a merge.

----

Every time I looked at the probe code in the past, my mind ended up twisted and confused. A probe could change the "enabled" state (tracking the temperature) or be removed at any time (unless the `mtx` is held), yet the code did not seem to reflect this.

We un-twist my mind by implementing probe states:

* `cold`: reflects cold backend temperature
* `scheduled`: probe is on binheap, waiting for its time to come
* `running`: a task has been started to run the probe
* `cooling`: running probe disabled
* `deleted`: running probe removed (while `cooling` only)
    
With this new scheme, we can now have (I think) a clean state diagram (see [dot file](https://github.com/varnishcache/varnish-cache/pull/4115/files#diff-ec9bb69f6f070e85d0ba0b62a2300d7c603120d04b8efea17a1fb123ea31d3f2)):

![cache_backend_probe](https://github.com/varnishcache/varnish-cache/assets/1528104/097d9954-5341-40cd-97cc-3b99363d79b2)

* a probe begins in the `cold` state
* from `cold`, it can either get removed or scheduled via `VBP_Control(..., 1)`
* from `scheduled`, it can go back to `cold` (via `VBP_Control(..., 0)`) or be picked up by `vbp_thread()` to change to `running` (aka task started)
* once the task finishes, it normally goes back to `scheduled`, but in the meantime it could have changed to `cooling` or further on to `deleted`, so `vbp_task_comple()` handles these cases and either transitions to `cold` or deletes the probe
* if the task can not be scheduled, the same handling happens
   
We now also remove running probes from the binheap to remove complexity. I am not entirely sure if there could have been a good reason for keeping running probes on the binheap, so if this is the case, we might want to reconsider this change. But it is not obvious to me how deleting and reinserting just to delete and reinsert later should be better than deleting and reinserting later.

Written to fix #4108 for good