### PR TITLE
vsc: Revamp vsc.c and VSC_Iter()

### DIFF
--- a/lib/libvarnishapi/vsc.c
+++ b/lib/libvarnishapi/vsc.c
@@ -405,7 +405,7 @@ vsc_map_seg(const struct vsc *vsc, struct vsm *vsm, struct vsc_seg *sp)
 		usleep(10000);
 
 	if (head->ready == 0) {
-		VSM_Unmap(vsm, sp->fantom);
+		AZ(VSM_Unmap(vsm, sp->fantom));
 		return (-1);
 	}
 

--- a/lib/libvarnishapi/vsc.c
+++ b/lib/libvarnishapi/vsc.c
@@ -48,7 +48,6 @@
 #include "vjsn.h"
 #include "vsb.h"
 #include "vsc_priv.h"
-#include "vmb.h"
 
 #include "vapi/vsc.h"
 #include "vapi/vsm.h"


### PR DESCRIPTION
This is a change implemented mostly by @mbgrydeland in the first commit:

> This patch polishes and fixes up the VSC parts of libvarnishapi. Main
> points are:
> 
> 1) The merging of the VSM list and the VSC segment list is done in a
> separate loop from where the callbacks are executed. This prevents a
> VSM_Status() being executed in a callback from interfering with the update
> of the VSC segment list to match the VSM list.
> 
> 2) Failures to map counters does not remove the counter from the VSC seg
> list. Previously we would remove VSC seg list elements on map failures,
> but doing so would then cause issues when attempting to consolidate the
> VSM list and the VSC seg list on the next call to VSC_Iter(). With this
> patch, map failures are recorded as a state without removing the VSC seg
> list, and map failures will be retried on subsequenct VSC_Iter() calls.
> 
> 3) Handle failures to map the corresponding DOC seg during mapping of a
> counter seg gracefully. Previously this would cause an assert. Now it will
> cause a map failure of the counter seg.

It is a followup to ba7bf7ff6dba835e2cba9ad0a07131819272fb8e that was fixing one of two symptoms of failed mappings, at "unmap" time. The other symptom was failing to find the VSC_DOC segment of a VSC segment, and we eventually identified a scenario that could lead to this inconsistency, and this scenario could also trigger the first symptom.

The problem with the single VSC iteration loop (coordinating a loop over two same-ordered lists of VSM segments and their VSC counterparts) is that we could fail to map a doc segment (on Linux `vm.max_map_count` is our suspect in the `sysctl` department), go on to the next iteration, clean up stale segments (reducing the number of maps) and successfully mapping a VSC segment lacking documentation.

The changes are strictly internal and otherwise maintain the current observable behavior.