### PR TITLE
circleci: Retire EOL platforms

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,8 +1,7 @@
-FROM centos:7
+FROM fedora-latest
 
-RUN set -e;\
-	yum install -y epel-release; \
-	yum install -y \
+RUN set -e; \
+	dnf -y install \
 	    automake \
 	    git \
 	    jemalloc-devel \
@@ -12,4 +11,4 @@ RUN set -e;\
 	    make \
 	    pcre2-devel \
 	    python3 \
-	    python-sphinx
+	    python3-sphinx

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
                   if grep 'AC_INIT.*trunk.*' ./configure.ac; then
                       sed -i -e "s/AC_INIT(\[\(.*\)\],\s*\[\(.*\)\],\s*\[\(.*\)\])/AC_INIT([\1],[$(date +%Y%m%d)],[\3])/" ./configure.ac
                   else
-                      sed -i -e "s/AC_INIT(\[\(.*\)\],\s*\[\(.*\)\],\s*\[\(.*\)\])/AC_INIT([\1],[\2-$(date +%Y%m%d)],[\3])/" ./configure.ac
+                      sed -i -e "s/AC_INIT(\[\(.*\)\],\s*\[\(.*\)\],\s*\[\(.*\)\])/AC_INIT([\1],[\2.$(date +%Y%m%d)],[\3])/" ./configure.ac
                   fi
                   ./autogen.des
                   make dist -j 16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,7 @@ workflows:
       - build:
           name: build_alpine
           dist: alpine
-          release: "latest"
+          release: latest
           extra_conf: --without-contrib
           make_target: check
       - build:
@@ -450,7 +450,7 @@ workflows:
                 - almalinux:8
                 - almalinux:9
                 - fedora:latest
-                - alpine:3
+                - alpine:latest
               rclass:
                 - arm.medium
                 - medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
   package:
     parameters:
       platform:
-        description: the Linux distribution, with release, e.g. debian:buster, fedora:latest
+        description: the Linux distribution, with release, e.g. debian:bookworm, fedora:latest
         type: string
       rclass:
         description: the resource class to use, usually arm.medium or medium
@@ -204,7 +204,7 @@ jobs:
         description: the Linux distribution (debian|ubuntu)
         type: string
       release:
-        description: the release name (buster|bullseye|bookworm|focal|jammy|noble)
+        description: the release name (bullseye|bookworm|focal|jammy|noble)
         type: string
       make_target:
         description: the make target to execute during the build
@@ -395,14 +395,10 @@ workflows:
           make_target: witness.dot
       # oldest debian goes 32bit
       - build:
-          name: build_debian_buster
-          dist: debian
-          release: buster
-          prefix: i386/
-      - build:
           name: build_debian_bullseye
           dist: debian
           release: bullseye
+          prefix: i386/
       - build:
           name: build_debian_bookworm
           dist: debian
@@ -449,7 +445,6 @@ workflows:
                 - ubuntu:focal
                 - ubuntu:jammy
                 - ubuntu:noble
-                - debian:buster
                 - debian:bullseye
                 - debian:bookworm
                 - almalinux:8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
   package:
     parameters:
       platform:
-        description: the Linux distribution, with release, e.g. debian:buster, centos:7
+        description: the Linux distribution, with release, e.g. debian:buster, fedora:latest
         type: string
       rclass:
         description: the resource class to use, usually arm.medium or medium
@@ -164,18 +164,12 @@ jobs:
           command: |
             mkdir -p packages
             case "<< parameters.platform >>" in
-                debian:*|ubuntu:*)  EXT=deb ;;
-                centos:*|fedora:*)  EXT=rpm ;;
-                almalinux:*)        EXT=rpm ;;
-                alpine:*)           EXT=apk ;;
+                debian:*|ubuntu:*)    EXT=deb ;;
+                almalinux:*|fedora:*) EXT=rpm ;;
+                alpine:*)             EXT=apk ;;
                 *)
                     echo "unrecognized platform: << parameters.platform >>"
                     exit 1
-            esac
-
-            case "<< parameters.platform >>" in
-                centos:stream9)     REPO=quay.io/centos/ ;;
-                *)                  REPO= ;;
             esac
 
             case "<< parameters.rclass >>" in
@@ -191,7 +185,7 @@ jobs:
               -e PARAM_RELEASE=$(echo "<< parameters.platform >>" | cut -d: -f2) \
               -v$(pwd):/varnish-cache \
               --platform linux/$ARCH \
-              ${REPO}<< parameters.platform >> \
+              << parameters.platform >> \
               /varnish-cache/.circleci/make-$EXT-packages.sh
       - run:
           name: List created packages
@@ -241,26 +235,23 @@ jobs:
             docker cp /workspace workspace:/
             docker run --volumes-from workspace -w /workspace << parameters.prefix >><< parameters.dist >>:<< parameters.release >> sh -c '
             case "<< parameters.dist >>" in
-            centos|almalinux|fedora)
-                yum groupinstall -y "Development Tools"
+            almalinux|fedora)
+                dnf -y groupinstall "Development Tools"
                 case "<< parameters.dist >>:<< parameters.release >>" in
-                    centos:stream9|almalinux:9)
-                        dnf install -y "dnf-command(config-manager)"
-                        yum config-manager --set-enabled crb
-                        yum install -y diffutils
-                        yum install -y epel-release
+                    almalinux:9)
+                        dnf -y install "dnf-command(config-manager)"
+                        dnf config-manager --set-enabled crb
+                        dnf -y install diffutils
+                        dnf -y install epel-release
                         ;;
                     almalinux:8)
-                        dnf install -y "dnf-command(config-manager)"
-                        yum config-manager --set-enabled powertools
-                        yum install -y diffutils
-                        yum install -y epel-release
-                        ;;
-                    centos:7)
-                        yum install -y epel-release
+                        dnf -y install "dnf-command(config-manager)"
+                        dnf config-manager --set-enabled powertools
+                        dnf -y install diffutils
+                        dnf -y install epel-release
                         ;;
                 esac
-                yum install -y \
+                dnf -y install \
                     cpio \
                     automake \
                     git \
@@ -336,7 +327,7 @@ jobs:
             archlinux)
                 useradd varnish
                 ;;
-            centos|almalinux|fedora)
+            almalinux|fedora)
                 adduser varnish
                 ;;
             *)
@@ -388,15 +379,6 @@ workflows:
         - << pipeline.parameters.build-pkgs >>
         - << pipeline.parameters.dist-url >>
     jobs:
-      - build:
-          name: build_centos_7
-          dist: centos
-          release: "7"
-      - build:
-          name: build_centos_stream_9
-          prefix: quay.io/centos/
-          dist: centos
-          release: stream9
       - build:
           name: build_almalinux_8
           dist: almalinux
@@ -470,8 +452,6 @@ workflows:
                 - debian:buster
                 - debian:bullseye
                 - debian:bookworm
-                - centos:7
-                - centos:stream9
                 - almalinux:8
                 - almalinux:9
                 - fedora:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,12 @@ jobs:
   dist:
     description: Build or download varnish-x.y.z.tar.gz that is used later for the packaging jobs
     docker:
-      - image: centos:7
+      - image: fedora:latest
     steps:
       - run:
           name: Install deps
           command: |
-            yum install -y epel-release
-            yum install -y \
+            dnf -y install \
                 automake \
                 jemalloc-devel \
                 git \
@@ -46,7 +45,7 @@ jobs:
                 make \
                 pcre2-devel \
                 python3 \
-                python-sphinx
+                python3-sphinx
       - checkout
       - when:
           condition: << pipeline.parameters.dist-url >>
@@ -98,7 +97,7 @@ jobs:
   tar_pkg_tools:
     description: Builds archives with the packaging tools from https://github.com/varnishcache/pkg-varnish-cache
     docker:
-      - image: centos:7
+      - image: fedora:latest
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -106,7 +105,7 @@ jobs:
       - run:
           name: Grab the pkg repo
           command: |
-            yum install -y git
+            dnf -y install git
             mkdir -p ~/.ssh
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
             echo ${CIRCLE_REPOSITORY_URL}
@@ -219,21 +218,14 @@ jobs:
         default: medium
         type: string
     docker:
-      - image: centos:7
+      - image: << parameters.prefix >><< parameters.dist >>:<< parameters.release >>
     resource_class: << parameters.rclass >>
     working_directory: /workspace
     steps:
-      - setup_remote_docker
-      - run:
-          name: Install docker
-          command: yum install -y docker
       - checkout
       - run:
           name: Extract and build
           command: |
-            docker create --name workspace -v /workspace << parameters.prefix >><< parameters.dist >>:<< parameters.release >> /bin/true
-            docker cp /workspace workspace:/
-            docker run --volumes-from workspace -w /workspace << parameters.prefix >><< parameters.dist >>:<< parameters.release >> sh -c '
             case "<< parameters.dist >>" in
             almalinux|fedora)
                 dnf -y groupinstall "Development Tools"
@@ -337,27 +329,23 @@ jobs:
 
             chown -R varnish:varnish .
 
-            export ASAN_OPTIONS=abort_on_error=1,detect_odr_violation=1,detect_leaks=1,detect_stack_use_after_return=1,detect_invalid_pointer_pairs=1,handle_segv=0,handle_sigbus=0,use_sigaltstack=0,disable_coredump=0
-            export LSAN_OPTIONS=abort_on_error=1,use_sigaltstack=0,suppressions=$(pwd)/tools/lsan.suppr
-            export TSAN_OPTIONS=abort_on_error=1,halt_on_error=1,use_sigaltstack=0,suppressions=$(pwd)/tools/tsan.suppr
-            export UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1,use_sigaltstack=0,suppressions=$(pwd)/tools/ubsan.suppr
-
-            sudo -u varnish \
+            sudo -u varnish sh -c '
+                export ASAN_OPTIONS=abort_on_error=1,detect_odr_violation=1,detect_leaks=1,detect_stack_use_after_return=1,detect_invalid_pointer_pairs=1,handle_segv=0,handle_sigbus=0,use_sigaltstack=0,disable_coredump=0
+                export LSAN_OPTIONS=abort_on_error=1,use_sigaltstack=0,suppressions=$(pwd)/tools/lsan.suppr
+                export TSAN_OPTIONS=abort_on_error=1,halt_on_error=1,use_sigaltstack=0,suppressions=$(pwd)/tools/tsan.suppr
+                export UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1,use_sigaltstack=0,suppressions=$(pwd)/tools/ubsan.suppr
                 autoreconf -i -v
-            sudo -u varnish \
                 ./configure \
-                << pipeline.parameters.configure_args >> \
-                << parameters.extra_conf >>
-            sudo -u varnish \
-                --preserve-env=ASAN_OPTIONS,LSAN_OPTIONS,TSAN_OPTIONS,UBSAN_OPTIONS \
+                    << pipeline.parameters.configure_args >> \
+                    << parameters.extra_conf >>
                 make -j 4 -k << parameters.make_target >> VERBOSE=1 \
-                DISTCHECK_CONFIGURE_FLAGS="<< pipeline.parameters.configure_args >> \
+                    DISTCHECK_CONFIGURE_FLAGS="<< pipeline.parameters.configure_args >> \
                 << parameters.extra_conf >>"
             '
 
   collect_packages:
     docker:
-      - image: centos:7
+      - image: fedora:latest
     steps:
       - attach_workspace:
           at: ~/project

--- a/.circleci/make-rpm-packages.sh
+++ b/.circleci/make-rpm-packages.sh
@@ -6,30 +6,27 @@ echo "PARAM_RELEASE: $PARAM_RELEASE"
 echo "PARAM_DIST: $PARAM_DIST"
 
 if [ -z "$PARAM_RELEASE" ]; then
-    echo "Env variable PARAM_RELEASE is not set! For example PARAM_RELEASE=stream, for CentOS stream"
+    echo "Env variable PARAM_RELEASE is not set! For example PARAM_RELEASE=9, for almalinux"
     exit 1
 elif [ -z "$PARAM_DIST" ]; then
-    echo "Env variable PARAM_DIST is not set! For example PARAM_DIST=centos"
+    echo "Env variable PARAM_DIST is not set! For example PARAM_DIST=fedora"
     exit 1
 fi
 
 case "$PARAM_DIST:$PARAM_RELEASE" in
     almalinux:9)
-        dnf install -y 'dnf-command(config-manager)'
-        yum config-manager --set-enabled crb
-        yum install -y epel-release
+        dnf -y install 'dnf-command(config-manager)'
+        dnf config-manager --set-enabled crb
+        dnf -y install epel-release
         ;;
-    centos:stream|almalinux:8)
-        dnf install -y 'dnf-command(config-manager)'
-        yum config-manager --set-enabled powertools
-        yum install -y epel-release
-        ;;
-    centos:7)
-        yum install -y epel-release
+    almalinux:8)
+        dnf -y install 'dnf-command(config-manager)'
+        dnf config-manager --set-enabled powertools
+        dnf -y install epel-release
         ;;
 esac
 
-yum install -y rpm-build yum-utils
+dnf -y install rpm-build dnf-utils
 
 export DIST_DIR=build
 
@@ -73,7 +70,7 @@ rpmbuild() {
         "$@"
 }
 
-yum-builddep -y "$DIST_DIR"/redhat/varnish.spec
+dnf builddep -y "$DIST_DIR"/redhat/varnish.spec
 rpmbuild -bs "$DIST_DIR"/redhat/varnish.spec
 rpmbuild --rebuild "$RESULT_DIR"/varnish-*.src.rpm
 

--- a/bin/varnishtest/tests/b00058.vtc
+++ b/bin/varnishtest/tests/b00058.vtc
@@ -5,8 +5,8 @@ feature cmd {getent hosts localhost && getent services http}
 varnish v1 -arg "-p vcc_feature=-err_unref" -vcl {
 	backend b1 {.host = "127.0.0.1";}
 	backend b2 {.host = "[::1]:8080";}
-	backend b3 {.host = "localhost:8081";}
-	backend b4 {.host = "localhost:http";}
+	backend b3 {.host = "${localhost}:8081";}
+	backend b4 {.host = "${localhost}:http";}
 	backend b5 {.host = "127.0.0.1";.port = "8081";}
 	backend b6 {.host = "127.0.0.1";.port = "http";}
 }

--- a/bin/varnishtest/tests/p00000.vtc
+++ b/bin/varnishtest/tests/p00000.vtc
@@ -3,7 +3,7 @@ varnishtest "Test Basic persistence"
 feature persistent_storage
 
 process p1 -dump {
-	varnishd -spersistent -b localhost -n ${tmpdir} -a :0 -d 2>&1
+	varnishd -spersistent -b ${localhost} -n ${tmpdir} -a :0 -d 2>&1
 } -start -expect-exit 1
 
 process p1 -expect-text 0 0 {to launch}

--- a/bin/varnishtest/tests/s00003.vtc
+++ b/bin/varnishtest/tests/s00003.vtc
@@ -46,14 +46,14 @@ varnish v1 -vsl_catchup
 varnish v1 -cliok "ban obj.http.date ~ ."
 
 process p1 {
-	varnishd -sTransient=file,${tmpdir}/foo,xxx -blocalhost -a:0 -n ${tmpdir} 2>&1
+	varnishd -sTransient=file,${tmpdir}/foo,xxx -b${localhost} -a:0 -n ${tmpdir} 2>&1
 } -expect-exit 0x2 -dump -start -expect-text 0 0 "Invalid number" -wait -screen_dump
 
 process p1 {
-	varnishd -sTransient=file,${tmpdir}/foo,10M,xxx -blocalhost -a:0 -n ${tmpdir} 2>&1
+	varnishd -sTransient=file,${tmpdir}/foo,10M,xxx -b${localhost} -a:0 -n ${tmpdir} 2>&1
 } -expect-exit 0x2 -dump -start -expect-text 0 0 "granularity" -wait -screen_dump
 
 process p1 {
-	varnishd -sTransient=file,${tmpdir}/foo,10m,,foo -blocalhost -a:0 -n ${tmpdir} 2>&1
+	varnishd -sTransient=file,${tmpdir}/foo,10m,,foo -b${localhost} -a:0 -n ${tmpdir} 2>&1
 } -expect-exit 0x2 -dump -start -expect-text 0 0 "invalid advice" -wait
 


### PR DESCRIPTION
We retire:

- centos:7
- debian:buster (10)

This is not trivial because centos:7 is the base image of many jobs.