### PR TITLE
Backend: Wakeup clients on waitqueue when BE goes sick

### DIFF
--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -191,6 +191,10 @@ VBP_Update_Backend(struct vbp_target *vt)
 	i = (vt->good < vt->threshold);
 	chg = (i != vt->backend->sick);
 	vt->backend->sick = i;
+	if (i && chg && (vt->backend->director != NULL &&
+	    VBE_is_ah_auto(vt->backend))) {
+		VBE_connwait_signal_all(vt->backend);
+	}
 
 	AN(vt->backend->vcl_name);
 	VSL(SLT_Backend_health, NO_VXID,

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -477,15 +477,23 @@ static int v_matchproto_(vcl_be_func)
 do_set_health(struct cli *cli, struct director *d, void *priv)
 {
 	struct set_health *sh;
+	struct vrt_ctx *ctx;
 
 	(void)cli;
 	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
 	CAST_OBJ_NOTNULL(sh, priv, SET_HEALTH_MAGIC);
+
 	if (d->vdir->admin_health == VDI_AH_DELETED)
 		return (0);
 	if (d->vdir->admin_health != sh->ah) {
 		d->vdir->health_changed = VTIM_real();
 		d->vdir->admin_health = sh->ah;
+		ctx = VCL_Get_CliCtx(0);
+		if (sh->ah == VDI_AH_SICK || (sh->ah == VDI_AH_AUTO &&
+		    d->vdir->methods->healthy != NULL &&
+		    !d->vdir->methods->healthy(ctx, d, NULL))) {
+			VBE_connwait_signal_all(d->priv);
+		    }
 	}
 	return (0);
 }

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -160,8 +160,12 @@ struct vcf {
 void VCA_Init(void);
 void VCA_Shutdown(void);
 
-/* cache_backend_cfg.c */
+/* cache_backend.c */
+struct backend;
+
 void VBE_InitCfg(void);
+void VBE_connwait_signal_all(const struct backend *bp);
+int VBE_is_ah_auto(const struct backend *bp);
 
 /* cache_ban.c */
 

--- a/bin/varnishtest/tests/v00074.vtc
+++ b/bin/varnishtest/tests/v00074.vtc
@@ -1,0 +1,227 @@
+varnishtest "Clients in backend wait queue wakeup when backend goes sick"
+
+################### Backend goes sick from CLI ##########################
+barrier b1 cond 4
+barrier b2 cond 4
+
+server s1 {
+	rxreq
+	barrier b1 sync
+	barrier b2 sync
+	txresp
+} -start
+
+varnish v1 -vcl {
+	backend s1 {
+		.host = "${s1_addr}";
+		.port = "${s1_port}";
+		.max_connections = 1;
+		.wait_timeout = 1h;
+		.wait_limit = 10;
+	}
+
+	sub vcl_recv {
+		return(pass);
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -start
+
+client c2 {
+	barrier b1 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	barrier b2 sync
+} -start
+
+client c3 {
+	barrier b1 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	barrier b2 sync
+} -start
+
+client c4 {
+	barrier b1 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	barrier b2 sync
+} -start
+
+# Going from auto to sick should wakeup reqs in the wait queue
+varnish v1 -cliok "backend.set_health s1 sick"
+
+client c1 -wait
+client c2 -wait
+client c3 -wait
+client c4 -wait
+varnish v1 -expect backend_wait == 3
+varnish v1 -expect backend_wait_fail == 3
+
+#################### Backend goes sick from probe #######################
+
+barrier b3 cond 4
+barrier b4 cond 4
+
+server s2 {
+	# First probe request should succeed
+	rxreq
+	txresp
+	# c5
+	accept
+	rxreq
+	barrier b3 sync
+	barrier b4 sync
+	txresp
+} -start
+
+varnish v1 -stop
+varnish v1 -vcl {
+	backend be {
+		.host = "${s2_addr}";
+		.port = "${s2_port}";
+		.max_connections = 1;
+		.wait_timeout = 1h;
+		.wait_limit = 10;
+	}
+
+	probe default {
+		.interval = 1s;
+		.url = "/probe";
+		.window = 1;
+		.threshold = 1;
+		.initial = 1;
+		.timeout = 0.5s;
+	}
+
+	sub vcl_recv {
+		return(pass);
+	}
+} -start
+varnish v1 -cliok "backend.set_health be auto"
+
+client c5 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -start
+
+client c6 {
+	barrier b3 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	barrier b4 sync
+} -start
+
+client c7 {
+	barrier b3 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	barrier b4 sync
+} -start
+
+client c8 {
+	barrier b3 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	barrier b4 sync
+} -start
+
+
+client c5 -wait
+client c6 -wait
+client c7 -wait
+client c8 -wait
+varnish v1 -expect backend_wait == 3
+varnish v1 -expect backend_wait_fail == 3
+
+########## Admin Healthy -> auto and probe indicates sick ###############
+
+barrier b5 cond 4
+barrier b6 cond 4
+
+server s3 {
+	# First probe request should fail
+	rxreq
+	txresp -status 500
+	accept
+	rxreq
+	barrier b5 sync
+	barrier b6 sync
+	txresp
+} -start
+
+varnish v1 -stop
+varnish v1 -vcl {
+	backend be {
+		.host = "${s3_addr}";
+		.port = "${s3_port}";
+		.max_connections = 1;
+		.wait_timeout = 1h;
+		.wait_limit = 10;
+	}
+
+	probe default {
+		.interval = 10s;
+		.url = "/probe";
+		.window = 1;
+		.threshold = 1;
+		.timeout = 0.5s;
+	}
+
+	sub vcl_recv {
+		return(pass);
+	}
+} -start
+varnish v1 -cliok "backend.set_health be healthy"
+
+client c9 {
+	txreq
+	rxresp
+	expect resp.status == 200
+} -start
+
+client c10 {
+	barrier b5 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	barrier b6 sync
+} -start
+
+client c11 {
+	barrier b5 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	barrier b6 sync
+} -start
+
+client c12 {
+	barrier b5 sync
+	txreq
+	rxresp
+	expect resp.status == 503
+	barrier b6 sync
+} -start
+
+# Going back to probe (auto) that is sick should
+# wake up reqs in the wait queue
+varnish v1 -cliok "backend.set_health be auto"
+
+client c9 -wait
+client c10 -wait
+client c11 -wait
+client c12 -wait
+varnish v1 -expect backend_wait == 3
+varnish v1 -expect backend_wait_fail == 3


### PR DESCRIPTION
This is a followup for #4030, it adds an optimization to purge the backend wait queue when the backend becomes sick.

Three possible transitions trigger this:
- Admin health is set to sick.
- Probe health goes sick when admin health is auto.
- Admin health is set to auto and current probe state is sick.