### PR TITLE
Move implementation of transit_buffer to the storage engine

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -597,8 +597,6 @@ vbf_stp_fetchbody(struct worker *wrk, struct busyobj *bo)
 		}
 		AZ(vfc->failed);
 		l = est;
-		if (oc->boc->transit_buffer > 0)
-			l = vmin_t(ssize_t, l, oc->boc->transit_buffer);
 		assert(l >= 0);
 		if (VFP_GetStorage(vfc, &l, &ptr) != VFP_OK) {
 			bo->htc->doclose = SC_RX_BODY;

--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -473,11 +473,15 @@ sml_getspace(struct worker *wrk, struct objcore *oc, ssize_t *sz,
 	struct storage *st;
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
+	CHECK_OBJ_NOTNULL(oc->boc, BOC_MAGIC);
 	AN(sz);
 	AN(ptr);
 	if (*sz == 0)
 		*sz = cache_param->fetch_chunksize;
 	assert(*sz > 0);
+	if (oc->boc->transit_buffer > 0)
+		*sz = vmin_t(ssize_t, *sz, oc->boc->transit_buffer);
 
 	o = sml_getobj(wrk, oc);
 	CHECK_OBJ_NOTNULL(o, OBJECT_MAGIC);


### PR DESCRIPTION
By the same argument as #4056, storage engines might be able to make a better decision on the layout of object bodies if they know the expected length upfront, thus the transit buffer limit should be implemented at the storage layer.
This is also in line with the "other end" of the transit buffer, the "free behind" from the client side, being implemented in the object iterator.