### PR TITLE
-a port ranges

### DIFF
--- a/bin/varnishd/mgt/mgt_acceptor.c
+++ b/bin/varnishd/mgt/mgt_acceptor.c
@@ -371,7 +371,7 @@ MAC_Arg(const char *spec)
 	if (VUS_is(la->endpoint))
 		error = VUS_resolver(av[1], mac_uds, la, &err);
 	else
-		error = VSS_resolver(av[1], "80", mac_tcp, la, &err);
+		error = VSS_resolver_range(av[1], "80", mac_tcp, la, &err);
 
 	if (VTAILQ_EMPTY(&la->socks) || error)
 		ARGV_ERR("Got no socket(s) for %s\n", av[1]);

--- a/bin/varnishd/mgt/mgt_acceptor.c
+++ b/bin/varnishd/mgt/mgt_acceptor.c
@@ -373,7 +373,9 @@ MAC_Arg(const char *spec)
 	else
 		error = VSS_resolver_range(av[1], "80", mac_tcp, la, &err);
 
-	if (VTAILQ_EMPTY(&la->socks) || error)
+	if (error)
+		ARGV_ERR("Got no socket(s) for %s (%s)\n", av[1], err);
+	else if (VTAILQ_EMPTY(&la->socks))
 		ARGV_ERR("Got no socket(s) for %s\n", av[1]);
 	VAV_Free(av);
 }

--- a/bin/varnishtest/tests/b00085.vtc
+++ b/bin/varnishtest/tests/b00085.vtc
@@ -18,65 +18,109 @@ client c1 {
 
 	# Bad ranges
 
-	txreq -hdr "resolve: localhost:-"
+	txreq -hdr "resolve: :-"
 	rxresp
-	expect resp.reason == "Range start missing"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:foo-"
+	txreq -hdr "resolve: :foo-"
 	rxresp
-	expect resp.reason == "Range start invalid"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:foo80-"
+	txreq -hdr "resolve: :foo80-"
 	rxresp
-	expect resp.reason == "Range start invalid"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:80foo-"
+	txreq -hdr "resolve: :80foo-"
 	rxresp
-	expect resp.reason == "Range start invalid"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:80-"
+	txreq -hdr "resolve: :80-"
 	rxresp
-	expect resp.reason == "Range end missing"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:80-foo"
+	txreq -hdr "resolve: :-foo"
 	rxresp
-	expect resp.reason == "Range end invalid"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:80-foo81"
+	txreq -hdr "resolve: :-80"
 	rxresp
-	expect resp.reason == "Range end invalid"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:80-81foo"
+	txreq -hdr "resolve: :80-foo"
 	rxresp
-	expect resp.reason == "Range end invalid"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:65535-65536"
+	txreq -hdr "resolve: :80-foo81"
 	rxresp
-	expect resp.reason == "Range end invalid"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:80--81"
+	txreq -hdr "resolve: :80-81foo"
 	rxresp
-	expect resp.reason == "Only one hyphen allowed"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:80-81-"
+	txreq -hdr "resolve: :80--81"
 	rxresp
-	expect resp.reason == "Only one hyphen allowed"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:81-80"
+	txreq -hdr "resolve: :80- -81"
 	rxresp
-	expect resp.reason == "Range start higher than range end"
+	expect resp.reason ~ "Failed"
 
-	txreq -hdr "resolve: localhost:0-1"
+	txreq -hdr "resolve: :80 -81"
 	rxresp
-	expect resp.reason == "Range start cannot be 0"
+	expect resp.reason ~ "Failed"
 
-	# No addr
+	txreq -hdr "resolve: :80- 81"
+	rxresp
+	expect resp.reason ~ "Failed"
+
+	txreq -hdr "resolve: :-80-81"
+	rxresp
+	expect resp.reason ~ "Failed"
+
+	txreq -hdr "resolve: : -80-81"
+	rxresp
+	expect resp.reason ~ "Failed"
+
+	txreq -hdr "resolve: :- 80-81"
+	rxresp
+	expect resp.reason ~ "Failed"
+
+	txreq -hdr "resolve: :80-81-"
+	rxresp
+	expect resp.reason ~ "Failed"
+
+	txreq -hdr "resolve: :80-81 -"
+	rxresp
+	expect resp.reason ~ "Failed"
+
+	txreq -hdr "resolve: :65535-65536"
+	rxresp
+	expect resp.reason == "Failed: Range end higher than 65535"
+
+	txreq -hdr "resolve: :81-80"
+	rxresp
+	expect resp.reason == "Failed: Range start higher than range end"
+
+	txreq -hdr "resolve: :0-1"
+	rxresp
+	expect resp.reason == "Failed: Range start cannot be 0"
+
+	# No address
 
 	txreq -hdr "resolve: :80"
 	rxresp
 	expect resp.reason == "0.0.0.0:80, :::80"
 
+	txreq -hdr "resolve: :http"
+	rxresp
+	expect resp.reason == "0.0.0.0:80, :::80"
+
 	txreq -hdr "resolve: :80-81"
+	rxresp
+	expect resp.reason == "0.0.0.0:80, :::80, 0.0.0.0:81, :::81"
+
+	txreq -hdr "resolve: :80-81" -hdr "def-port: 8001"
 	rxresp
 	expect resp.reason == "0.0.0.0:80, :::80, 0.0.0.0:81, :::81"
 
@@ -154,13 +198,21 @@ client c1 {
 
 	txreq -hdr "resolve: 127.0.0.1" -hdr "def-port: 80" -hdr "fail-port: 80"
 	rxresp
-	expect resp.reason == "vmod-debug: fail_port"
+	expect resp.reason == "Failed: bad port"
 
 	txreq -hdr "resolve: 127.0.0.1:80-81" -hdr "fail-port: 80"
 	rxresp
-	expect resp.reason == "vmod-debug: fail_port"
+	expect resp.reason == "Failed: bad port"
 
 	txreq -hdr "resolve: 127.0.0.1:80-82" -hdr "fail-port: 81"
 	rxresp
-	expect resp.reason == "127.0.0.1:80, vmod-debug: fail_port"
+	expect resp.reason == "127.0.0.1:80, bad port"
+
+	txreq -hdr "resolve: 127.0.0.1:80-82" -hdr "fail-port: 82"
+	rxresp
+	expect resp.reason == "127.0.0.1:80, 127.0.0.1:81, bad port"
+
+	txreq -hdr "resolve: :80-82" -hdr "fail-port: 81"
+	rxresp
+	expect resp.reason == "0.0.0.0:80, :::80, bad port"
 } -run

--- a/bin/varnishtest/tests/b00085.vtc
+++ b/bin/varnishtest/tests/b00085.vtc
@@ -70,6 +70,16 @@ client c1 {
 	rxresp
 	expect resp.reason == "Range start cannot be 0"
 
+	# No addr
+
+	txreq -hdr "resolve: :80"
+	rxresp
+	expect resp.reason == "0.0.0.0:80, :::80"
+
+	txreq -hdr "resolve: :80-81"
+	rxresp
+	expect resp.reason == "0.0.0.0:80, :::80, 0.0.0.0:81, :::81"
+
 	# No port
 
 	txreq -hdr "resolve: 127.0.0.1"

--- a/bin/varnishtest/tests/b00085.vtc
+++ b/bin/varnishtest/tests/b00085.vtc
@@ -1,0 +1,156 @@
+varnishtest "Test VSS_resolver_range"
+
+varnish v1 -vcl {
+	backend default none;
+
+	import debug;
+
+	sub vcl_recv {
+		return (synth(200, debug.resolve_range(req.http.resolve,
+		    req.http.def-port, req.http.fail-port)));
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.reason == "vmod-debug: s was NULL"
+
+	# Bad ranges
+
+	txreq -hdr "resolve: localhost:-"
+	rxresp
+	expect resp.reason == "Range start missing"
+
+	txreq -hdr "resolve: localhost:foo-"
+	rxresp
+	expect resp.reason == "Range start invalid"
+
+	txreq -hdr "resolve: localhost:foo80-"
+	rxresp
+	expect resp.reason == "Range start invalid"
+
+	txreq -hdr "resolve: localhost:80foo-"
+	rxresp
+	expect resp.reason == "Range start invalid"
+
+	txreq -hdr "resolve: localhost:80-"
+	rxresp
+	expect resp.reason == "Range end missing"
+
+	txreq -hdr "resolve: localhost:80-foo"
+	rxresp
+	expect resp.reason == "Range end invalid"
+
+	txreq -hdr "resolve: localhost:80-foo81"
+	rxresp
+	expect resp.reason == "Range end invalid"
+
+	txreq -hdr "resolve: localhost:80-81foo"
+	rxresp
+	expect resp.reason == "Range end invalid"
+
+	txreq -hdr "resolve: localhost:65535-65536"
+	rxresp
+	expect resp.reason == "Range end invalid"
+
+	txreq -hdr "resolve: localhost:80--81"
+	rxresp
+	expect resp.reason == "Only one hyphen allowed"
+
+	txreq -hdr "resolve: localhost:80-81-"
+	rxresp
+	expect resp.reason == "Only one hyphen allowed"
+
+	txreq -hdr "resolve: localhost:81-80"
+	rxresp
+	expect resp.reason == "Range start higher than range end"
+
+	txreq -hdr "resolve: localhost:0-1"
+	rxresp
+	expect resp.reason == "Range start cannot be 0"
+
+	# No port
+
+	txreq -hdr "resolve: 127.0.0.1"
+	rxresp
+	expect resp.reason == "127.0.0.1:0"
+
+	txreq -hdr "resolve: 127.0.0.1" -hdr "def-port: 8000"
+	rxresp
+	expect resp.reason == "127.0.0.1:8000"
+
+	txreq -hdr "resolve: [::1]" -hdr "def-port: 8000"
+	rxresp
+	expect resp.reason == "::1:8000"
+
+	txreq -hdr "resolve: ::1" -hdr "def-port: 8000"
+	rxresp
+	expect resp.reason == "::1:8000"
+
+	# No range
+
+	txreq -hdr "resolve: 127.0.0.1:0"
+	rxresp
+	expect resp.reason == "127.0.0.1:0"
+
+	txreq -hdr "resolve: 127.0.0.1:http"
+	rxresp
+	expect resp.reason == "127.0.0.1:80"
+
+	txreq -hdr "resolve: 127.0.0.1:8000"
+	rxresp
+	expect resp.reason == "127.0.0.1:8000"
+
+	txreq -hdr "resolve: 127.0.0.1:8000" -hdr "def-port: 8001"
+	rxresp
+	expect resp.reason == "127.0.0.1:8000"
+
+	# Different address formats
+
+	txreq -hdr "resolve: 127.0.0.1:80-81"
+	rxresp
+	expect resp.reason == "127.0.0.1:80, 127.0.0.1:81"
+
+	txreq -hdr "resolve: 127.0.0.1 80-81"
+	rxresp
+	expect resp.reason == "127.0.0.1:80, 127.0.0.1:81"
+
+	txreq -hdr "resolve: [::1]:80-81"
+	rxresp
+	expect resp.reason == "::1:80, ::1:81"
+
+	txreq -hdr "resolve: [::1] 80-81"
+	rxresp
+	expect resp.reason == "::1:80, ::1:81"
+
+	txreq -hdr "resolve: [::]:80-81"
+	rxresp
+	expect resp.reason == ":::80, :::81"
+
+	txreq -hdr "resolve: [::] 80-81"
+	rxresp
+	expect resp.reason == ":::80, :::81"
+
+	txreq -hdr "resolve: [::1]:80-81"
+	rxresp
+	expect resp.reason == "::1:80, ::1:81"
+
+	txreq -hdr "resolve: ::1 80-81"
+	rxresp
+	expect resp.reason == "::1:80, ::1:81"
+
+	# Fail ports
+
+	txreq -hdr "resolve: 127.0.0.1" -hdr "def-port: 80" -hdr "fail-port: 80"
+	rxresp
+	expect resp.reason == "vmod-debug: fail_port"
+
+	txreq -hdr "resolve: 127.0.0.1:80-81" -hdr "fail-port: 80"
+	rxresp
+	expect resp.reason == "vmod-debug: fail_port"
+
+	txreq -hdr "resolve: 127.0.0.1:80-82" -hdr "fail-port: 81"
+	rxresp
+	expect resp.reason == "127.0.0.1:80, vmod-debug: fail_port"
+} -run

--- a/bin/varnishtest/tests/c00121.vtc
+++ b/bin/varnishtest/tests/c00121.vtc
@@ -87,5 +87,5 @@ varnish v1 -errvcl {Backend path: The empty abstract socket name is not supporte
 	}
 }
 
-shell -err -expect "Error: Got no socket(s) for @" \
+shell -err -expect "Error: Got no socket(s) for @ (The empty abstract socket name is not supported)" \
 	"varnishd -n ${tmpdir}/v0 -a @ -b None"

--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -84,7 +84,9 @@ Basic options
   ("127.0.0.1") or an IPv6 address enclosed in square brackets
   ("[::1]")
 
-  If port is not specified, port 80 (http) is used.
+  The port can be a port number (80), a service name (http), or a port
+  range (80-81). Port ranges are inclusive and cannot overlap. If port
+  is not specified, port 80 (http) is used.
 
   At least one of ip_address or port is required.
 

--- a/include/vss.h
+++ b/include/vss.h
@@ -36,6 +36,8 @@ int VSS_resolver(const char *addr, const char *def_port, vss_resolved_f *func,
    void *priv, const char **err);
 int VSS_resolver_socktype(const char *addr, const char *def_port,
     vss_resolved_f *func, void *priv, const char **err, int socktype);
+int VSS_resolver_range(const char *addr, const char *def_port,
+    vss_resolved_f *func, void *priv, const char **errp);
 const struct suckaddr *VSS_ResolveOne(void *dst,
     const char *addr, const char *port,
     int family, int socktype, int flags);

--- a/lib/libvarnish/vss.c
+++ b/lib/libvarnish/vss.c
@@ -106,34 +106,31 @@ vss_parse_range(char *str, char **addr, char **port, unsigned long *lo,
     unsigned long *hi)
 {
 	const char *errp;
-	char *hyphen, *end;
+	char *end;
 	unsigned long l, h;
 
 	errp = vss_parse(str, addr, port);
-	if (*port == NULL)
+	if (errp != NULL)
 		return (errp);
-
-	hyphen = strchr(*port, '-');
-	if (hyphen == NULL)
+	if (*port == NULL || **port == '-')
 		return (NULL);
-	if (**port == '-')
-		return ("Range start missing");
 
 	l = strtoul(*port, &end, 10);
-	if (end != hyphen)
-		return ("Range start invalid");
-	if (strchr(hyphen + 1, '-') != NULL)
-		return ("Only one hyphen allowed");
+	if (end[0] != '-' || end[1] == '\0')
+		return (NULL);
+	if (strchr(end + 1, '-') != NULL)
+		return (NULL);
+	h = strtoul(end + 1, &end, 10);
+	if (end[0] != '\0')
+		return (NULL);
+
+	/* Port range of the form 80-81 */
 	if (l == 0)
 		return ("Range start cannot be 0");
-	if (hyphen[1] == '\0')
-		return ("Range end missing");
-
-	h = strtoul(hyphen + 1, &end, 10);
-	if (*end != '\0' || h > 65535)
-		return ("Range end invalid");
 	if (h < l)
 		return ("Range start higher than range end");
+	if (h > 65535)
+		return ("Range end higher than 65535");
 
 	*lo = l;
 	*hi = h;

--- a/lib/libvarnish/vss.c
+++ b/lib/libvarnish/vss.c
@@ -37,6 +37,7 @@
 #include <netdb.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "vdef.h"
 
@@ -97,6 +98,45 @@ vss_parse(char *str, char **addr, char **port)
 	}
 	*p++ = '\0';
 	*port = p;
+	return (NULL);
+}
+
+static const char *
+vss_parse_range(char *str, char **addr, char **port, unsigned long *lo,
+    unsigned long *hi)
+{
+	const char *errp;
+	char *hyphen, *end;
+	unsigned long l, h;
+
+	errp = vss_parse(str, addr, port);
+	if (*port == NULL)
+		return (errp);
+
+	hyphen = strchr(*port, '-');
+	if (hyphen == NULL)
+		return (NULL);
+	if (**port == '-')
+		return ("Range start missing");
+
+	l = strtoul(*port, &end, 10);
+	if (end != hyphen)
+		return ("Range start invalid");
+	if (strchr(hyphen + 1, '-') != NULL)
+		return ("Only one hyphen allowed");
+	if (l == 0)
+		return ("Range start cannot be 0");
+	if (hyphen[1] == '\0')
+		return ("Range end missing");
+
+	h = strtoul(hyphen + 1, &end, 10);
+	if (*end != '\0' || h > 65535)
+		return ("Range end invalid");
+	if (h < l)
+		return ("Range start higher than range end");
+
+	*lo = l;
+	*hi = h;
 	return (NULL);
 }
 
@@ -193,6 +233,44 @@ VSS_resolver(const char *addr, const char *def_port, vss_resolved_f *func,
 {
 	return (VSS_resolver_socktype(
 	    addr, def_port, func, priv, errp, SOCK_STREAM));
+}
+
+int
+VSS_resolver_range(const char *addr, const char *def_port, vss_resolved_f *func,
+    void *priv, const char **errp)
+{
+	char *p, *hp, *pp;
+	unsigned long lo = 0, hi = 0, i;
+	int error = 0;
+
+	AN(addr);
+	AN(func);
+	AN(errp);
+
+	p = strdup(addr);
+	AN(p);
+	*errp = vss_parse_range(p, &hp, &pp, &lo, &hi);
+	if (*errp != NULL) {
+		free(p);
+		return (-1);
+	}
+
+	if (lo == 0) {
+		/* No port range (0 not allowed in range) */
+		free(p);
+		return (VSS_resolver(addr, def_port, func, priv, errp));
+	}
+
+	for (i = lo; i <= hi && !error; i++) {
+		/* pp points to the first character of the range definition.
+		 * The range definition includes the biggest port number, so the
+		 * buffer must be big enough to fit each number individually.
+		 */
+		sprintf(pp, "%lu", i);
+		error = VSS_resolver(hp, pp, func, priv, errp);
+	}
+	free(p);
+	return (error);
 }
 
 const struct suckaddr *

--- a/lib/libvarnish/vss.c
+++ b/lib/libvarnish/vss.c
@@ -261,13 +261,16 @@ VSS_resolver_range(const char *addr, const char *def_port, vss_resolved_f *func,
 		return (VSS_resolver(addr, def_port, func, priv, errp));
 	}
 
+	/* Undo vss_parse() string modifications */
+	memcpy(p, addr, pp - p);
+
 	for (i = lo; i <= hi && !error; i++) {
 		/* pp points to the first character of the range definition.
 		 * The range definition includes the biggest port number, so the
 		 * buffer must be big enough to fit each number individually.
 		 */
 		sprintf(pp, "%lu", i);
-		error = VSS_resolver(hp, pp, func, priv, errp);
+		error = VSS_resolver(p, def_port, func, priv, errp);
 	}
 	free(p);
 	return (error);

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -40,6 +40,8 @@
 #include "cache/cache_filter.h"
 
 #include "vsa.h"
+#include "vss.h"
+#include "vtcp.h"
 #include "vtim.h"
 #include "vcc_debug_if.h"
 #include "VSC_debug.h"
@@ -1440,4 +1442,49 @@ xyzzy_caller_xsub(VRT_CTX, struct VPFX(debug_caller) *caller)
 	AN(caller->sub);
 
 	return (caller->sub);
+}
+
+struct resolve_priv {
+	struct vsb vsb[1];
+	const char *fail_port;
+	const char *errp[1];
+};
+
+static int v_matchproto_(vus_resolved_f)
+resolve_cb(void *priv, const struct suckaddr *sa)
+{
+	struct resolve_priv *p;
+	char abuf[VTCP_ADDRBUFSIZE], pbuf[VTCP_PORTBUFSIZE];
+
+	p = (struct resolve_priv *)priv;
+	CHECK_OBJ_NOTNULL(p->vsb, VSB_MAGIC);
+	AN(sa);
+	VTCP_name(sa, abuf, sizeof abuf, pbuf, sizeof pbuf);
+	if (p->fail_port != NULL && !strcmp(p->fail_port, pbuf)) {
+		*(p->errp) = "vmod-debug: fail_port";
+		return (-1);
+	}
+	VSB_printf(p->vsb, "%s%s:%s", VSB_len(p->vsb) ? ", " : "", abuf, pbuf);
+	return (0);
+}
+
+VCL_STRING
+xyzzy_resolve_range(VRT_CTX, struct VARGS(resolve_range) *args)
+{
+	struct resolve_priv p;
+	const char *def_port;
+	int ret;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	if (args->addr == NULL)
+		return ("vmod-debug: s was NULL");
+	memset(&p, 0, sizeof p);
+	WS_VSB_new(p.vsb, ctx->ws);
+	p.fail_port = args->valid_fail_port ? args->fail_port : NULL;
+	def_port = args->valid_def_port ? args->def_port : NULL;
+	ret = VSS_resolver_range(args->addr, def_port, resolve_cb, &p, p.errp);
+	if (ret)
+		VSB_printf(p.vsb, "%s%s", VSB_len(p.vsb) ? ", " : "",
+		    *(p.errp));
+	return (WS_VSB_finish(p.vsb, ctx->ws, NULL));
 }

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -1461,7 +1461,7 @@ resolve_cb(void *priv, const struct suckaddr *sa)
 	AN(sa);
 	VTCP_name(sa, abuf, sizeof abuf, pbuf, sizeof pbuf);
 	if (p->fail_port != NULL && !strcmp(p->fail_port, pbuf)) {
-		*(p->errp) = "vmod-debug: fail_port";
+		*(p->errp) = "bad port";
 		return (-1);
 	}
 	VSB_printf(p->vsb, "%s%s:%s", VSB_len(p->vsb) ? ", " : "", abuf, pbuf);
@@ -1484,7 +1484,7 @@ xyzzy_resolve_range(VRT_CTX, struct VARGS(resolve_range) *args)
 	def_port = args->valid_def_port ? args->def_port : NULL;
 	ret = VSS_resolver_range(args->addr, def_port, resolve_cb, &p, p.errp);
 	if (ret)
-		VSB_printf(p.vsb, "%s%s", VSB_len(p.vsb) ? ", " : "",
+		VSB_printf(p.vsb, "%s%s", VSB_len(p.vsb) ? ", " : "Failed: ",
 		    *(p.errp));
 	return (WS_VSB_finish(p.vsb, ctx->ws, NULL));
 }

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -399,6 +399,13 @@ $Method VOID .call()
 
 $Method SUB .xsub()
 
+$Function STRING resolve_range(STRING addr, [STRING def_port], [STRING fail_port])
+
+Resolve addr and return the result. If addr has a port range, all successfully
+resolved sockets are retuned in a comma delimited string. If fail_port is
+specified, the resolution callback will fail for that port, and the reason will
+be appended to the return value.
+
 DEPRECATED
 ==========
 


### PR DESCRIPTION
This PR extends the syntax of the varnishd `-a` argument to support port ranges. The range is inclusive, and failing to bind to any port in the range will terminate startup. This change should not affect any existing setup.