### PR TITLE
waiter: report WAITER_REMCLOSE correctly

### DIFF
--- a/bin/varnishd/cache/cache_session.c
+++ b/bin/varnishd/cache/cache_session.c
@@ -712,7 +712,8 @@ SES_NewPool(struct pool *pp, unsigned pool_no)
 	pp->mpl_sess = MPL_New(nb, &cache_param->pool_sess,
 	    &cache_param->workspace_session);
 
-	pp->waiter = Waiter_New();
+	bprintf(nb, "pool%u", pool_no);
+	pp->waiter = Waiter_New(nb);
 }
 
 void

--- a/bin/varnishd/waiter/cache_waiter_kqueue.c
+++ b/bin/varnishd/waiter/cache_waiter_kqueue.c
@@ -120,7 +120,8 @@ vwk_thread(void *priv)
 			AN(Wait_HeapDelete(w, wp));
 			Lck_Unlock(&vwk->mtx);
 			vwk->nwaited--;
-			if (kp->flags & EV_EOF)
+			if (kp->flags & EV_EOF &&
+			    recv(wp->fd, &c, 1, MSG_PEEK) == 0)
 				Wait_Call(w, wp, WAITER_REMCLOSE, now);
 			else
 				Wait_Call(w, wp, WAITER_ACTION, now);

--- a/bin/varnishd/waiter/waiter.h
+++ b/bin/varnishd/waiter/waiter.h
@@ -70,6 +70,6 @@ struct waited {
 
 /* cache_waiter.c */
 int Wait_Enter(const struct waiter *, struct waited *);
-struct waiter *Waiter_New(void);
+struct waiter *Waiter_New(const char *);
 void Waiter_Destroy(struct waiter **);
 const char *Waiter_GetName(void);

--- a/bin/varnishd/waiter/waiter_priv.h
+++ b/bin/varnishd/waiter/waiter_priv.h
@@ -33,6 +33,7 @@
 
 struct waited;
 struct vbh;
+struct VSC_waiter;
 
 struct waiter {
 	unsigned			magic;
@@ -43,6 +44,7 @@ struct waiter {
 
 	void				*priv;
 	struct vbh			*heap;
+	struct VSC_waiter		*vsc;
 };
 
 typedef void waiter_init_f(struct waiter *);

--- a/bin/varnishtest/tests/b00086.vtc
+++ b/bin/varnishtest/tests/b00086.vtc
@@ -1,0 +1,36 @@
+varnishtest "Shutdown"
+
+barrier b1 cond 2
+
+server s1 {
+	rxreq
+	shutdown -read
+	txresp
+} -start
+
+server s2 {
+	rxreq
+	txresp
+	shutdown
+	barrier b1 sync
+} -start
+
+client c1 -connect "${s1_sock}" {
+	txreq
+	shutdown -write
+	rxresp
+	expect resp.status == 200
+} -run
+
+client c2 -connect "${s2_sock}" {
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	txreq
+	non_fatal
+	rxresp
+	fatal
+	expect resp.status == <undef>
+	barrier b1 sync
+} -run

--- a/bin/varnishtest/tests/b00087.vtc
+++ b/bin/varnishtest/tests/b00087.vtc
@@ -1,0 +1,88 @@
+varnishtest "waiter counters"
+
+barrier b1 cond 2
+barrier b2 cond 2
+barrier b3 cond 2
+barrier b4 cond 2
+barrier b5 cond 2
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-p thread_pools=1" -vcl+backend {} -start
+varnish v1 -cliok "param.set timeout_linger 0.5"
+
+varnish v1 -expect WAITER.pool0.conns == 0
+varnish v1 -expect WAITER.pool0.remclose == 0
+varnish v1 -expect WAITER.pool0.timeout == 0
+varnish v1 -expect WAITER.pool0.action == 0
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	# Wait so the client has to take a detour to the waiter
+	barrier b1 sync
+	barrier b2 sync
+
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	# Wait so the client has to take a detour to the waiter
+	barrier b3 sync
+	barrier b4 sync
+} -start
+
+server s1 -wait
+barrier b1 sync
+
+# client c1: conns
+# server s1: remclose
+varnish v1 -expect WAITER.pool0.conns == 1
+varnish v1 -expect WAITER.pool0.remclose == 1
+varnish v1 -expect WAITER.pool0.timeout == 0
+varnish v1 -expect WAITER.pool0.action == 0
+
+barrier b2 sync
+barrier b3 sync
+
+# client c1: conns, action
+# server s1: remclose
+varnish v1 -expect WAITER.pool0.conns == 1
+varnish v1 -expect WAITER.pool0.remclose == 1
+varnish v1 -expect WAITER.pool0.timeout == 0
+varnish v1 -expect WAITER.pool0.action == 1
+
+barrier b4 sync
+client c1 -wait
+
+# client c1: remclose, action
+# server s1: remclose
+varnish v1 -expect WAITER.pool0.conns == 0
+varnish v1 -expect WAITER.pool0.remclose == 2
+varnish v1 -expect WAITER.pool0.timeout == 0
+varnish v1 -expect WAITER.pool0.action == 1
+
+varnish v1 -cliok "param.set timeout_idle 1"
+
+client c2 {
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	barrier b5 sync
+} -start
+
+# client c1: remclose, action
+# client c2: timeout
+# server s1: remclose
+varnish v1 -expect WAITER.pool0.conns == 0
+varnish v1 -expect WAITER.pool0.remclose == 2
+varnish v1 -expect WAITER.pool0.timeout == 1
+varnish v1 -expect WAITER.pool0.action == 1
+
+barrier b5 sync

--- a/bin/varnishtest/tests/b00088.vtc
+++ b/bin/varnishtest/tests/b00088.vtc
@@ -1,0 +1,106 @@
+
+varnishtest "waiter & shutdown"
+
+barrier b1 cond 2
+barrier b2 cond 2
+barrier b3 cond 3
+barrier b4 cond 3
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -arg "-p thread_pools=1" -vcl+backend {} -start
+varnish v1 -cliok "param.set timeout_linger 0.5"
+
+varnish v1 -expect WAITER.pool0.conns == 0
+varnish v1 -expect WAITER.pool0.remclose == 0
+varnish v1 -expect WAITER.pool0.timeout == 0
+varnish v1 -expect WAITER.pool0.action == 0
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	# Wait so the client has to take a detour to the waiter
+	barrier b1 sync
+	barrier b2 sync
+
+	txreq
+	shutdown -write
+	rxresp
+	expect resp.status == 200
+	expect_close
+} -start
+
+server s1 -wait
+barrier b1 sync
+
+# client c1: conns
+# server s1: remclose
+varnish v1 -expect WAITER.pool0.conns == 1
+varnish v1 -expect WAITER.pool0.remclose == 1
+varnish v1 -expect WAITER.pool0.timeout == 0
+varnish v1 -expect WAITER.pool0.action == 0
+
+barrier b2 sync
+client c1 -wait
+
+# client c1: action
+# server s1: remclose
+varnish v1 -expect WAITER.pool0.conns == 0
+varnish v1 -expect WAITER.pool0.remclose == 1
+varnish v1 -expect WAITER.pool0.timeout == 0
+varnish v1 -expect WAITER.pool0.action == 1
+
+client c2 {
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	# Wait so the client has to take a detour to the waiter
+	barrier b3 sync
+	barrier b4 sync
+
+	shutdown -read
+	expect_close
+} -start
+
+client c3 {
+	txreq
+	rxresp
+	expect resp.status == 200
+
+	# Wait so the client has to take a detour to the waiter
+	barrier b3 sync
+	barrier b4 sync
+
+	shutdown
+	expect_close
+} -start
+
+barrier b3 sync
+
+# client c1: action
+# client c2: conns
+# client c3: conns
+# server s1: remclose
+varnish v1 -expect WAITER.pool0.conns == 2
+varnish v1 -expect WAITER.pool0.remclose == 1
+varnish v1 -expect WAITER.pool0.timeout == 0
+varnish v1 -expect WAITER.pool0.action == 1
+
+barrier b4 sync
+client c2 -wait
+client c3 -wait
+
+# client c1: action
+# client c2: remclose
+# client c3: remclose
+# server s1: remclose
+varnish v1 -expect WAITER.pool0.conns == 0
+varnish v1 -expect WAITER.pool0.remclose == 3
+varnish v1 -expect WAITER.pool0.timeout == 0
+varnish v1 -expect WAITER.pool0.action == 1

--- a/lib/libvsc/Makefile.am
+++ b/lib/libvsc/Makefile.am
@@ -14,7 +14,8 @@ VSC_SRC = \
 	VSC_sma.vsc \
 	VSC_smf.vsc \
 	VSC_smu.vsc \
-	VSC_vbe.vsc
+	VSC_vbe.vsc \
+	VSC_waiter.vsc
 
 noinst_LTLIBRARIES = libvsc.la
 libvsc_la_SOURCES = $(VSC_SRC)

--- a/lib/libvsc/VSC_waiter.vsc
+++ b/lib/libvsc/VSC_waiter.vsc
@@ -1,0 +1,40 @@
+..
+	This is *NOT* a RST file but the syntax has been chosen so
+	that it may become an RST file at some later date.
+
+.. varnish_vsc_begin::	waiter
+	:oneliner:	Waiter counters
+	:order:		80
+
+.. varnish_vsc:: conns
+	:type:	gauge
+	:level:	debug
+	:oneliner:	Number of idle connections
+
+	Number of idle connections being waited over.
+
+.. varnish_vsc:: remclose
+	:type:	counter
+	:level:	debug
+	:oneliner:	Number of idle connections closed by peer
+
+	Number of idle connections that experienced closure by peer while being
+	waited for.
+
+.. varnish_vsc:: timeout
+	:type:	counter
+	:level:	debug
+	:oneliner:	Number of idle connections timeout
+
+	Number of idle connections that experienced a timeout event while being
+	waited for.
+
+.. varnish_vsc:: action
+	:type:	counter
+	:level:	debug
+	:oneliner:	Number of idle connections read events
+
+	Number of idle connections that experienced a read event while being
+	waited for.
+
+.. varnish_vsc_end::	waiter


### PR DESCRIPTION
There seems to be a discrepancy between the epoll and kqueue
implementation. One implementation is not reporting WAITER_REMCLOSE,
while the other implementation is reporting WAITER_REMCLOSE too soon.

epoll:
We sometimes incorrectly report WAITER_ACTION when it is supposed to be
WAITER_REMCLOSE. We can check EPOLLRDHUP before reading 1 byte with MSG_PEEK to
detect WAITER_REMCLOSE. This saves us from a pontential session detour from the
Waiter to a worker thread.

kqueue:
We incorrectly report WAITER_REMCLOSE when there could be more data to be
read from the socket. Change this so that we perform read of 1 byte with
MSG_PEEK to detect closure when EV_EOF is set.

DESCRIPTION:EVFILT_READ:Sockets:

> It is possible for EOF to be  returned (indicating the connection is gone)
> while there is still data pending in the socket buffer.

- [kqueue (2)](https://man.freebsd.org/cgi/man.cgi?kqueue)
