### PR TITLE
vev: Log where MGT received its signal from

### DIFF
--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -38,6 +38,7 @@
 
 #include <fcntl.h>
 #include <poll.h>
+#include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -445,9 +445,8 @@ static int v_matchproto_(vev_cb_f)
 mgt_sigint(const struct vev *e, int what)
 {
 
-	(void)e;
 	(void)what;
-	MGT_Complain(C_ERR, "Manager got %s", e->name);
+	MGT_Complain(C_ERR, "Manager got %s from PID %jd", e->name, (intmax_t)e->siginfo->si_pid);
 	(void)fflush(stdout);
 	if (MCH_Running())
 		MCH_Stop_Child();

--- a/bin/varnishd/mgt/mgt_vcl.c
+++ b/bin/varnishd/mgt/mgt_vcl.c
@@ -33,7 +33,10 @@
 
 #include "config.h"
 
+#include <errno.h>
+#include <fcntl.h>
 #include <fnmatch.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/include/vev.h
+++ b/include/vev.h
@@ -53,6 +53,7 @@ struct vev {
 	unsigned		sig_flags;
 	double			timeout;
 	vev_cb_f		*callback;
+	siginfo_t		*siginfo;
 	void			*priv;
 
 	/* priv */

--- a/lib/libvarnish/vev.c
+++ b/lib/libvarnish/vev.c
@@ -175,10 +175,11 @@ vev_get_sig(int sig)
 /*--------------------------------------------------------------------*/
 
 static void
-vev_sighandler(int sig)
+vev_sigaction(int sig, siginfo_t *siginfo, void *ctx)
 {
 	struct vevsig *es;
 
+	(void)ctx;
 	assert(sig < vev_nsig);
 	assert(vev_sigs != NULL);
 	es = &vev_sigs[sig];
@@ -278,8 +279,8 @@ VEV_Start(struct vev_root *evb, struct vev *e)
 		AZ(es->happened);
 		es->vev = e;
 		es->vevb = evb;
-		es->sigact.sa_flags = e->sig_flags;
-		es->sigact.sa_handler = vev_sighandler;
+		es->sigact.sa_flags = e->sig_flags | SA_SIGINFO;
+		es->sigact.sa_sigaction = vev_sigaction;
 	} else {
 		es = NULL;
 	}

--- a/lib/libvarnish/vev.c
+++ b/lib/libvarnish/vev.c
@@ -343,7 +343,7 @@ VEV_Stop(struct vev_root *evb, struct vev *e)
 		assert(es->vev == e);
 		es->vev = NULL;
 		es->vevb = NULL;
-		es->sigact.sa_flags = e->sig_flags;
+		es->sigact.sa_flags = 0;
 		es->sigact.sa_handler = SIG_DFL;
 		AZ(sigaction(e->sig, &es->sigact, NULL));
 		es->happened = 0;


### PR DESCRIPTION
This PR makes MGT log from which PID originates the signal it received.
It does that by adding the SIGINFO flag to sigaction in order to use `sa_sigaction` insead of `sa_handler` and grab the `struct siginfo_t` which contains the origin PID