### PR TITLE
Introduce a Linux jail

### DIFF
--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -84,6 +84,7 @@ varnishd_SOURCES = \
 	mgt/mgt_jail_solaris.c \
 	mgt/mgt_jail_solaris_tbl.h \
 	mgt/mgt_jail_unix.c \
+	mgt/mgt_jail_linux.c \
 	mgt/mgt_main.c \
 	mgt/mgt_param.c \
 	mgt/mgt_param_tcp.c \

--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -163,6 +163,7 @@ void VJ_rmdir(const char *);
 
 extern const struct jail_tech jail_tech_unix;
 extern const struct jail_tech jail_tech_solaris;
+extern const struct jail_tech jail_tech_linux;
 
 /* mgt_main.c */
 extern struct vsb *vident;

--- a/bin/varnishd/mgt/mgt_jail.c
+++ b/bin/varnishd/mgt/mgt_jail.c
@@ -86,6 +86,9 @@ static const struct choice vj_choice[] = {
 #ifdef HAVE_SETPPRIV
 	{ "solaris",	&jail_tech_solaris },
 #endif
+#ifdef __linux__
+	{ "linux",	&jail_tech_linux },
+#endif
 	{ "unix",	&jail_tech_unix },
 	{ "none",	&jail_tech_none },
 	{ NULL,		NULL },

--- a/bin/varnishd/mgt/mgt_jail_linux.c
+++ b/bin/varnishd/mgt/mgt_jail_linux.c
@@ -1,0 +1,83 @@
+/*-
+ * Copyright (c) 2024 Varnish Software AS
+ * All rights reserved.
+ *
+ * Author: Thibaut Artis <thibaut.artis@varnish-software.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "config.h"
+
+#ifdef __linux__
+
+#include <fcntl.h>
+#include <grp.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "mgt/mgt.h"
+#include "common/heritage.h"
+
+static int vjl_init(char **args) {
+	return jail_tech_unix.init(args);
+}
+
+static void vjl_master(enum jail_master_e jme) {
+	jail_tech_unix.master(jme);
+}
+
+static void vjl_subproc(enum jail_subproc_e jse) {
+	jail_tech_unix.subproc(jse);
+}
+
+static int vjl_make_subdir(const char *dname, const char *what, struct vsb *vsb) {
+	return jail_tech_unix.make_subdir(dname, what, vsb);
+}
+
+static int vjl_make_workdir(const char *dname, const char *what, struct vsb *vsb) {
+	return jail_tech_unix.make_workdir(dname, what, vsb);
+}
+
+static void vjl_fixfd(int fd, enum jail_fixfd_e what) {
+	return jail_tech_unix.fixfd(fd, what);
+}
+
+const struct jail_tech jail_tech_linux = {
+	.magic =	JAIL_TECH_MAGIC,
+	.name =		"linux",
+	.init =		vjl_init,
+	.master =	vjl_master,
+	.make_subdir =	vjl_make_subdir,
+	.make_workdir =	vjl_make_workdir,
+	.fixfd =	vjl_fixfd,
+	.subproc =	vjl_subproc,
+};
+
+#endif /* __linux__ */

--- a/bin/varnishd/mgt/mgt_jail_linux.c
+++ b/bin/varnishd/mgt/mgt_jail_linux.c
@@ -40,6 +40,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/prctl.h>
 #include <sys/stat.h>
 
 #include "mgt/mgt.h"
@@ -55,6 +56,14 @@ static void vjl_master(enum jail_master_e jme) {
 
 static void vjl_subproc(enum jail_subproc_e jse) {
 	jail_tech_unix.subproc(jse);
+	/*
+	 * On linux mucking about with uid/gid disables core-dumps,
+	 * reenable them again.
+	 */
+	if (prctl(PR_SET_DUMPABLE, 1) != 0) {
+		MGT_Complain(C_INFO,
+		    "Could not set dumpable bit.  Core dumps turned off");
+	}
 }
 
 static int vjl_make_subdir(const char *dname, const char *what, struct vsb *vsb) {

--- a/bin/varnishd/mgt/mgt_jail_unix.c
+++ b/bin/varnishd/mgt/mgt_jail_unix.c
@@ -44,10 +44,6 @@
 #include "mgt/mgt.h"
 #include "common/heritage.h"
 
-#ifdef __linux__
-#include <sys/prctl.h>
-#endif
-
 static gid_t vju_mgt_gid;
 static uid_t vju_uid;
 static gid_t vju_gid;
@@ -229,17 +225,6 @@ vju_subproc(enum jail_subproc_e jse)
 	} else {
 		AZ(setuid(vju_uid));
 	}
-
-#ifdef __linux__
-	/*
-	 * On linux mucking about with uid/gid disables core-dumps,
-	 * reenable them again.
-	 */
-	if (prctl(PR_SET_DUMPABLE, 1) != 0) {
-		MGT_Complain(C_INFO,
-		    "Could not set dumpable bit.  Core dumps turned off");
-	}
-#endif
 }
 
 static int v_matchproto_(jail_make_dir_f)

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -177,6 +177,9 @@ usage(void)
 #ifdef HAVE_SETPPRIV
 	printf(FMT, "", "  -j solaris");
 #endif
+#ifdef __linux__
+	printf(FMT, "", "  -j linux");
+#endif
 	printf(FMT, "", "  -j unix");
 	printf(FMT, "", "  -j none");
 

--- a/doc/sphinx/reference/varnishd.rst
+++ b/doc/sphinx/reference/varnishd.rst
@@ -445,6 +445,11 @@ specific options. Available jails are:
 
     -j solaris,worker=basic
 
+-j <linux[,user=`user`][,ccgroup=`group`][,workuser=`user`]>
+
+  Default on Linux platforms, it overloads the UNIX jail with
+  Linux-specific mechanisms.
+
 -j <unix[,user=`user`][,ccgroup=`group`][,workuser=`user`]>
 
   Default on all other platforms when `varnishd` is started with an


### PR DESCRIPTION
The idea for this PR originates [here](https://github.com/varnishcache/varnish-cache/pull/4123)
It introduces a Linux jail which overloads the UNIX one
It currently only re enables core dumps after playing with uid/gid and outputs some logs when the working directory is not on a tmpfs partition