### PR TITLE
Don't go the wrong way with request bodies

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -141,11 +141,10 @@ Bereq_Rollback(VRT_CTX)
 	bo = ctx->bo;
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 
-	if (bo->htc != NULL) {
-		assert(bo->htc->body_status != BS_TAKEN);
-		if (bo->htc->body_status != BS_NONE)
-			bo->htc->doclose = SC_RESP_CLOSE;
-	}
+	if (bo->htc != NULL &&
+	    bo->htc->body_status != BS_NONE &&
+	    bo->htc->body_status != BS_TAKEN)
+		bo->htc->doclose = SC_RESP_CLOSE;
 
 	vbf_cleanup(bo);
 	VCL_TaskLeave(ctx, bo->privs);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -289,13 +289,13 @@ vbf_stp_mkbereq(struct worker *wrk, struct busyobj *bo)
 	bo->ws_bo = WS_Snapshot(bo->ws);
 	HTTP_Clone(bo->bereq, bo->bereq0);
 
-	if (bo->req->req_body_cached) {
+	if (bo->req->req_body_status->avail == 0) {
+		bo->req = NULL;
+		ObjSetState(bo->wrk, oc, BOS_REQ_DONE);
+	} else if (bo->req->req_body_status == BS_CACHED) {
 		AN(bo->req->body_oc);
 		bo->bereq_body = bo->req->body_oc;
 		HSH_Ref(bo->bereq_body);
-		bo->req = NULL;
-		ObjSetState(bo->wrk, oc, BOS_REQ_DONE);
-	} else if (bo->req->req_body_status->avail == 0) {
 		bo->req = NULL;
 		ObjSetState(bo->wrk, oc, BOS_REQ_DONE);
 	}

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -141,8 +141,11 @@ Bereq_Rollback(VRT_CTX)
 	bo = ctx->bo;
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 
-	if (bo->htc != NULL && bo->htc->body_status != BS_NONE)
-		bo->htc->doclose = SC_RESP_CLOSE;
+	if (bo->htc != NULL) {
+		assert(bo->htc->body_status != BS_TAKEN);
+		if (bo->htc->body_status != BS_NONE)
+			bo->htc->doclose = SC_RESP_CLOSE;
+	}
 
 	vbf_cleanup(bo);
 	VCL_TaskLeave(ctx, bo->privs);

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -207,7 +207,7 @@ VRB_Iterate(struct worker *wrk, struct vsl_log *vsl,
 	}
 	if (req->req_body_status == BS_NONE)
 		return (0);
-	if (req->req_body_taken) {
+	if (req->req_body_status == BS_TAKEN) {
 		VSLb(vsl, SLT_VCL_Error,
 		    "Uncached req.body can only be consumed once.");
 		return (-1);
@@ -219,7 +219,7 @@ VRB_Iterate(struct worker *wrk, struct vsl_log *vsl,
 	}
 	Lck_Lock(&req->sp->mtx);
 	if (req->req_body_status->avail > 0) {
-		req->req_body_taken = 1;
+		req->req_body_status = BS_TAKEN;
 		i = 0;
 	} else
 		i = -1;
@@ -277,7 +277,6 @@ VRB_Free(struct req *req)
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 
-	req->req_body_taken = 0;
 	if (req->body_oc == NULL) {
 		AZ(req->req_body_cached);
 		return;

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -66,7 +66,6 @@ vrb_pull(struct req *req, ssize_t maxsize, objiterate_f *func, void *priv)
 	CHECK_OBJ_NOTNULL(req->htc, HTTP_CONN_MAGIC);
 	CHECK_OBJ_NOTNULL(req->vfc, VFP_CTX_MAGIC);
 	vfc = req->vfc;
-	AN(maxsize);
 
 	req->body_oc = HSH_Private(req->wrk);
 	AN(req->body_oc);
@@ -301,11 +300,7 @@ VRB_Cache(struct req *req, ssize_t maxsize)
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 	assert (req->req_step == R_STP_RECV);
-
-	if (maxsize <= 0) {
-		VSLb(req->vsl, SLT_VCL_Error, "Cannot cache an empty req.body");
-		return (-1);
-	}
+	assert(maxsize >= 0);
 
 	/*
 	 * We only allow caching to happen the first time through vcl_recv{}

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -813,7 +813,7 @@ cnt_pipe(struct worker *wrk, struct req *req)
 			bo->req = req;
 			bo->wrk = wrk;
 			/* Unless cached, reqbody is not our job */
-			if (!req->req_body_cached)
+			if (req->req_body_status != BS_CACHED)
 				req->req_body_status = BS_NONE;
 			SES_Close(req->sp, VDI_Http1Pipe(req, bo));
 			nxt = REQ_FSM_DONE;
@@ -900,7 +900,6 @@ cnt_recv_prep(struct req *req, const char *ci)
 		req->client_identity = NULL;
 		req->storage = NULL;
 		req->trace = FEATURE(FEATURE_TRACE);
-		AZ(req->req_body_cached);
 	}
 
 	req->is_hit = 0;

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -119,7 +119,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 			V1L_Chunked(wrk);
 		i = VRB_Iterate(wrk, bo->vsl, bo->req, vbf_iter_req_body, bo);
 
-		if (!bo->req->req_body_cached)
+		if (bo->req->req_body_status != BS_CACHED)
 			bo->no_retry = "req.body not cached";
 
 		if (bo->req->req_body_status == BS_ERROR) {

--- a/bin/varnishtest/tests/c00055.vtc
+++ b/bin/varnishtest/tests/c00055.vtc
@@ -17,8 +17,7 @@ varnish v1 -vcl+backend {
 	import std;
 
 	sub vcl_recv {
-		set req.http.stored = std.cache_req_body(
-			std.bytes(req.http.cache, 1KB));
+		set req.http.stored = std.cache_req_body(1KB);
 		return (pass);
 	}
 
@@ -74,46 +73,4 @@ client c4 {
 client c5 {
 	txreq -req POST -hdr "Content-Length: 1025"
 	expect_close
-} -run
-
-server s1 {
-        rxreq
-        expect req.body == chunked_body
-        txresp
-} -start
-
-client c6 {
-        txreq -req POST -nolen -hdr "Transfer-Encoding: chunked"
-        chunked chunked
-        chunked _
-        chunked body
-        chunkedlen 0
-        rxresp
-        expect resp.http.stored == true
-} -run
-
-server s1 {
-        rxreq
-        expect req.bodylen == 0
-        txresp
-} -start
-
-client c7 {
-        txreq -req POST -nolen -hdr "Transfer-Encoding: chunked"
-        chunkedlen 0
-        rxresp
-        expect resp.http.stored == true
-} -run
-
-server s1 {
-        rxreq
-        expect req.bodylen == 0
-        txresp
-} -start
-
-client c8 {
-        txreq -req POST -nolen -hdr "cache: 0B" -hdr "Transfer-Encoding: chunked"
-        chunkedlen 0
-        rxresp
-        expect resp.http.stored == false
 } -run

--- a/include/tbl/body_status.h
+++ b/include/tbl/body_status.h
@@ -38,6 +38,7 @@ BODYSTATUS(ERROR,	error,		1,	-1,	0)
 BODYSTATUS(CHUNKED,	chunked,	2,	1,	0)
 BODYSTATUS(LENGTH,	length,		3,	1,	1)
 BODYSTATUS(EOF,		eof,		4,	1,	0)
+BODYSTATUS(TAKEN,	taken,		5,	0,	0)
 #undef BODYSTATUS
 
 /*lint -restore */

--- a/include/tbl/body_status.h
+++ b/include/tbl/body_status.h
@@ -39,6 +39,7 @@ BODYSTATUS(CHUNKED,	chunked,	2,	1,	0)
 BODYSTATUS(LENGTH,	length,		3,	1,	1)
 BODYSTATUS(EOF,		eof,		4,	1,	0)
 BODYSTATUS(TAKEN,	taken,		5,	0,	0)
+BODYSTATUS(CACHED,	cached,		6,	2,	1)
 #undef BODYSTATUS
 
 /*lint -restore */

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -41,7 +41,6 @@ REQ_FLAG(waitinglist,		0, 0, "")
 REQ_FLAG(want100cont,		0, 0, "")
 REQ_FLAG(late100cont,		0, 0, "")
 REQ_FLAG(req_reset,		0, 0, "")
-REQ_FLAG(req_body_cached,	0, 0, "")
 #define REQ_BEREQ_FLAG(lower, vcl_r, vcl_w, doc) \
 	REQ_FLAG(lower, vcl_r, vcl_w, doc)
 #include "tbl/req_bereq_flags.h"

--- a/include/tbl/req_flags.h
+++ b/include/tbl/req_flags.h
@@ -42,7 +42,6 @@ REQ_FLAG(want100cont,		0, 0, "")
 REQ_FLAG(late100cont,		0, 0, "")
 REQ_FLAG(req_reset,		0, 0, "")
 REQ_FLAG(req_body_cached,	0, 0, "")
-REQ_FLAG(req_body_taken,	0, 0, "")
 #define REQ_BEREQ_FLAG(lower, vcl_r, vcl_w, doc) \
 	REQ_FLAG(lower, vcl_r, vcl_w, doc)
 #include "tbl/req_bereq_flags.h"


### PR DESCRIPTION
This PR is to revert commits which I think are going in the wrong direction. The issues raised here have become apparent when rebasing #4035 where we actually do things with request bodies and, for the first time, add some more interesting test coverage.

So what is wrong with these changes?

`BS_TAKEN` and `BS_CACHED` are exactly _not_ properties of the request, but of the request body. It can be processed on the client side, or backend side, or both, so the backend side needs to know the status, and going through `bo->req` is a bad idea long term, because we might want to decouple client and backend request more. Needless to say this also adds to complexity, because besides the request body status, also the request flags would need to be checked.

`BS_TAKEN` is important, because a request body can be consumed entirely on the client side, or backend side, and will then not be available for either a retry or a restart.

`BS_CACHED` is important, because it means that, with #4035, the body already has gone through filters.

These changes are partly justified with a new `BS_TRAILERS` to be introduced, for which I see absolutely no reason.

Regarding not caching an empty body, I see no reason why to special case this.