### PR TITLE
varnishhist: fix help for -P to mention E

### DIFF
--- a/bin/varnishhist/varnishhist_options.h
+++ b/bin/varnishhist/varnishhist_options.h
@@ -49,7 +49,7 @@
 	)
 
 #define HIS_OPT_P							\
-	VOPT("P:", "[-P <[cb:]tag:[prefix]:field_num[:min:max]>]",	\
+	VOPT("P:", "[-P <[cbE:]tag:[prefix]:field_num[:min:max]>]",	\
 	    "Custom profile definition",				\
 	    "Graph the given custom definition defined as: an optional" \
 	    " (c)lient, (b)ackend or (E)SI filter (defaults to client),"\


### PR DESCRIPTION
#3468 changed the flags to mention `(E)SI` but didn't update the short bits...

I ran across this while working on a spell checking pass for this repository. It seemed worth peeling this out.