### PR TITLE
chore(m4): spelling: reentrant

### DIFF
--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -244,7 +244,7 @@ AS_IF([test "x$ax_pthread_clang" = "xyes"],
       [ax_pthread_flags="-pthread,-lpthread -pthread"])
 
 
-# The presence of a feature test macro requesting re-entrant function
+# The presence of a feature test macro requesting reentrant function
 # definitions is, on some systems, a strong hint that pthreads support is
 # correctly enabled
 


### PR DESCRIPTION
Split from https://github.com/varnishcache/varnish-cache/pull/4153/commits/a0a9a044b3de44fc54301a5064fe145d5af0e2c2