### PR TITLE
Add a WRONGF() macro for dynamic explanations of wrong situations

### DIFF
--- a/bin/varnishd/cache/cache_ban.c
+++ b/bin/varnishd/cache/cache_ban.c
@@ -547,7 +547,7 @@ ban_evaluate(struct worker *wrk, const uint8_t *bsarg, struct objcore *oc,
 			darg2 = bt.arg2_double;
 			break;
 		default:
-			WRONG("Wrong BAN_ARG code");
+			WRONGF("Wrong BAN_ARG code %d", bt.arg1);
 		}
 
 		switch (bt.oper) {

--- a/include/vas.h
+++ b/include/vas.h
@@ -89,6 +89,14 @@ do {									\
 do {									\
 	VAS_Fail(__func__, __FILE__, __LINE__, expl, VAS_WRONG);	\
 } while (0)
+#define _WRONGF(buf, ...)						\
+do {									\
+	char buf[256];							\
+	snprintf(buf, sizeof buf, __VA_ARGS__);				\
+	WRONG(buf);							\
+} while (0)
+#define WRONGF(...) _WRONGF(VUNIQ_NAME(_wrong), __VA_ARGS__)
+
 
 #define _PTOK(call, var)						\
 do {									\


### PR DESCRIPTION
`F` for format as in `printf()`. The output will be truncated to the fixed size buffer of 255 single byte characters.

The single example use case has been chosen arbitrarily for illustration only.