### PR TITLE
varnishd: add a feature flag to disable bans in VCL

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -909,6 +909,11 @@ VRT_ban_string(VRT_CTX, VCL_STRING str)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
+	if (!FEATURE(FEATURE_VCL_BAN)) {
+		VRT_fail(ctx, "ban(): Feature flag vcl_ban is off");
+		return (vrt_ban_error(ctx, "Feature flag vcl_ban is off"));;
+	}
+
 	if (str == NULL)
 		return (vrt_ban_error(ctx, "Null argument"));
 

--- a/bin/varnishtest/tests/v00075.vtc
+++ b/bin/varnishtest/tests/v00075.vtc
@@ -1,0 +1,46 @@
+varnishtest "Test vcl_ban"
+
+server s1 {
+	rxreq
+	txresp -status 200 -body "ban"
+} -start
+
+varnish v1 -arg "-p feature=-vcl_ban" -vcl+backend {
+	sub vcl_recv {
+		 ban("obj.status == 0");
+	}
+} -start
+
+logexpect l1 -v v1 {
+	expect * 1001 VCL_Error "ban\\(\\): Feature flag vcl_ban is off"
+} -start
+
+client c1 {
+	txreq -url "/ban"
+	rxresp
+	expect resp.status == 503
+} -run
+
+logexpect l1 -wait
+
+varnish v1 -cliok "param.set feature +vcl_ban"
+
+client c2 {
+	txreq -url "/ban"
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -cliok "param.set feature -vcl_ban"
+
+logexpect l2 -v v1 {
+	expect * * VCL_Error "ban\\(\\): Feature flag vcl_ban is off"
+} -start
+
+client c3 {
+	txreq -url "/ban"
+	rxresp
+	expect resp.status == 503
+} -run
+
+logexpect l2 -wait

--- a/include/tbl/feature_bits.h
+++ b/include/tbl/feature_bits.h
@@ -96,6 +96,11 @@ FEATURE_BIT(VCL_REQ_RESET,			vcl_req_reset,
     "When this happens MAIN.req_reset is incremented."
 )
 
+FEATURE_BIT(VCL_BAN,		vcl_ban,
+    "Allow the use of bans in VCL. "
+    "When this is turned off, bans can only be issued through the CLI."
+)
+
 #undef FEATURE_BIT
 
 /*lint -restore */

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1933,7 +1933,8 @@ PARAM_BITS(
 	/* def */
 	"none,"
 	"+validate_headers,"
-	"+vcl_req_reset",
+	"+vcl_req_reset,"
+	"+vcl_ban",
 	/* descr */
 	"Enable/Disable various minor features.\n"
 	"\tdefault\tSet default value (deprecated: use param.reset)\n"


### PR DESCRIPTION
This is useful on multi-tenant environments to prevent a single user from wiping the whole cache or other user's cache.