### PR TITLE
vcc_action: Accept strings returned by vmods for return(fail())

### DIFF
--- a/bin/varnishtest/tests/v00018.vtc
+++ b/bin/varnishtest/tests/v00018.vtc
@@ -155,3 +155,13 @@ varnish v1 -errvcl {Expected '.' got ';'} {
 		rr;
 	}
 }
+
+varnish v1 -vcl {
+	backend default none;
+
+	import debug;
+
+	sub vcl_recv {
+		return (fail(debug.author()));
+	}
+}

--- a/lib/libvcc/vcc_action.c
+++ b/lib/libvcc/vcc_action.c
@@ -269,7 +269,7 @@ static void
 vcc_act_return_fail(struct vcc *tl)
 {
 	SkipToken(tl, '(');
-	Fb(tl, 1, "VRT_fail(ctx,\n");
+	Fb(tl, 1, "VRT_fail(ctx, \"%%s\",\n");
 	tl->indent += INDENT;
 	vcc_Expr(tl, STRING);
 	tl->indent -= INDENT;


### PR DESCRIPTION
Fixes: #4170