### PR TITLE
obj: List transient flags in a single place

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -326,6 +326,8 @@ enum oc_flags {
 #include "tbl/oc_flags.h"
 };
 
+#define OC_F_TRANSIENT (OC_F_PRIVATE | OC_F_HFM | OC_F_HFP)
+
 enum oc_exp_flags {
 #define OC_EXP_FLAG(U, l, v)	OC_EF_##U = v,
 #include "tbl/oc_exp_flags.h"

--- a/bin/varnishd/cache/cache_deliver_proc.c
+++ b/bin/varnishd/cache/cache_deliver_proc.c
@@ -277,7 +277,7 @@ VDP_DeliverObj(struct vdp_ctx *vdc, struct objcore *oc)
 	AZ(vdc->oc);
 	vdc->hp = NULL;
 	vdc->clen = NULL;
-	final = oc->flags & (OC_F_PRIVATE | OC_F_HFM | OC_F_HFP) ? 1 : 0;
+	final = oc->flags & OC_F_TRANSIENT ? 1 : 0;
 	r = ObjIterate(vdc->wrk, oc, vdc, vdp_objiterate, final);
 	if (r < 0)
 		return (r);

--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -831,7 +831,7 @@ HSH_Cancel(struct worker *wrk, struct objcore *oc, struct boc *boc)
 
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
-	if ((oc->flags & (OC_F_PRIVATE | OC_F_HFM | OC_F_HFP)) == 0)
+	if ((oc->flags & OC_F_TRANSIENT) == 0)
 		return;
 
 	/*

--- a/bin/varnishd/cache/cache_obj.c
+++ b/bin/varnishd/cache/cache_obj.c
@@ -225,7 +225,7 @@ obj_extend_condwait(const struct objcore *oc)
 	if (oc->boc->transit_buffer == 0)
 		return;
 
-	assert(oc->flags & (OC_F_PRIVATE | OC_F_HFM | OC_F_HFP));
+	assert(oc->flags & OC_F_TRANSIENT);
 	/* NB: strictly signaling progress both ways would be prone to
 	 * deadlocks, so instead we wait for signals from the client side
 	 * when delivered_so_far so far is updated, but in case the fetch
@@ -279,7 +279,7 @@ ObjWaitExtend(const struct worker *wrk, const struct objcore *oc, uint64_t l,
 		rv = oc->boc->fetched_so_far;
 		assert(l <= rv || oc->boc->state == BOS_FAILED);
 		if (oc->boc->transit_buffer > 0) {
-			assert(oc->flags & (OC_F_PRIVATE | OC_F_HFM | OC_F_HFP));
+			assert(oc->flags & OC_F_TRANSIENT);
 			/* Signal the new client position */
 			oc->boc->delivered_so_far = l;
 			PTOK(pthread_cond_signal(&oc->boc->cond));


### PR DESCRIPTION
To avoid repetition and mistakes, and in order to clarify the meaning of certain conditions, a new OC_F_TRANSIENT pseudo-flag is introduced. This was prompted by an incoming change to transit buffer where identifying transient delivery requires again to check the same set of flags.