### PR TITLE
WIP: fix connwait signalling vs. VDI/VBE layering

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -679,6 +679,10 @@ vbe_healthy(VRT_CTX, VCL_BACKEND d, VCL_TIME *t)
 	if (t != NULL)
 		*t = bp->changed;
 
+	if (d->vdir->admin_health == VDI_AH_SICK ||
+	    (d->vdir->admin_health == VDI_AH_AUTO && bp->sick))
+		VBE_connwait_signal_all(bp);
+
 	return (!bp->sick);
 }
 

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -488,12 +488,12 @@ do_set_health(struct cli *cli, struct director *d, void *priv)
 	if (d->vdir->admin_health != sh->ah) {
 		d->vdir->health_changed = VTIM_real();
 		d->vdir->admin_health = sh->ah;
+		/*
+		 * notify the director about its health change
+		 * through its healthy callback
+		 */
 		ctx = VCL_Get_CliCtx(0);
-		if (sh->ah == VDI_AH_SICK || (sh->ah == VDI_AH_AUTO &&
-		    d->vdir->methods->healthy != NULL &&
-		    !d->vdir->methods->healthy(ctx, d, NULL))) {
-			VBE_connwait_signal_all(d->priv);
-		    }
+		VRT_Healthy(ctx, d, NULL);
 	}
 	return (0);
 }


### PR DESCRIPTION
the idea here is to use the backend's healthy callback to signal to it a health change from outside.

this fixes the regression from #4183, but makes v74.vtc fail. And also I am not happy about the locking involved and need to spend more time...