### PR TITLE
tests get larger thread pool, necessary for ppc32

### DIFF
--- a/bin/varnishtest/tests/e00016.vtc
+++ b/bin/varnishtest/tests/e00016.vtc
@@ -27,7 +27,7 @@ server s1 {
 } -start
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 varnish v1 -cliok "param.set feature +esi_disable_xml_check"
 
 varnish v1 -syntax 4.0 -vcl+backend {

--- a/bin/varnishtest/tests/e00029.vtc
+++ b/bin/varnishtest/tests/e00029.vtc
@@ -16,7 +16,7 @@ server s1 {
 	chunkedlen 0
 } -start
 
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 varnish v1 -cliok "param.set feature +esi_include_onerror"
 varnish v1 -vcl+backend {
 	sub vcl_backend_response {

--- a/bin/varnishtest/tests/e00030.vtc
+++ b/bin/varnishtest/tests/e00030.vtc
@@ -52,7 +52,7 @@ server s1 {
 } -start
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 varnish v1 -cliok "param.set feature +esi_disable_xml_check"
 
 varnish v1 -vcl+backend {

--- a/bin/varnishtest/tests/e00034.vtc
+++ b/bin/varnishtest/tests/e00034.vtc
@@ -73,7 +73,7 @@ server s1 {
 } -start
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 
 varnish v1 -syntax 4.1 -vcl+backend {
 	import debug;

--- a/bin/varnishtest/tests/l00003.vtc
+++ b/bin/varnishtest/tests/l00003.vtc
@@ -15,7 +15,7 @@ server s1 {
 } -start
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 
 varnish v1 -vcl+backend {
 	sub vcl_backend_response {

--- a/bin/varnishtest/tests/r01737.vtc
+++ b/bin/varnishtest/tests/r01737.vtc
@@ -24,7 +24,7 @@ server s1 {
 } -start
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 varnish v1 -cliok "param.set feature +esi_disable_xml_check"
 
 varnish v1 -vcl+backend {

--- a/bin/varnishtest/tests/r01781.vtc
+++ b/bin/varnishtest/tests/r01781.vtc
@@ -14,7 +14,7 @@ server s1 {
 } -start
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 varnish v1 -cliok "param.set feature +esi_disable_xml_check"
 
 varnish v1 -vcl+backend {

--- a/bin/varnishtest/tests/r01878.vtc
+++ b/bin/varnishtest/tests/r01878.vtc
@@ -15,7 +15,7 @@ server s1 {
 } -start
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 
 varnish v1 -vcl+backend {
 	sub vcl_backend_response {

--- a/bin/varnishtest/tests/r02849.vtc
+++ b/bin/varnishtest/tests/r02849.vtc
@@ -23,7 +23,7 @@ server s1 {
 } -start
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 
 varnish v1 -vcl+backend {
 	sub vcl_recv {

--- a/bin/varnishtest/tests/v00042.vtc
+++ b/bin/varnishtest/tests/v00042.vtc
@@ -34,7 +34,7 @@ server s1 {
 } -start
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 
 varnish v1 -vcl+backend {
 	import debug;

--- a/bin/varnishtest/tests/v00043.vtc
+++ b/bin/varnishtest/tests/v00043.vtc
@@ -72,7 +72,7 @@ varnish v1 -errvcl "Not available in subroutine 'vcl_init'" {
 }
 
 # give enough stack to 32bit systems
-varnish v1 -cliok "param.set thread_pool_stack 80k"
+varnish v1 -cliok "param.set thread_pool_stack 128k"
 varnish v1 -cliok "param.set debug +syncvsl"
 
 varnish v1 -vcl+backend {


### PR DESCRIPTION
The former threadpool size of 80k fails on 32bit ppc (at least on my Debian/ppc32)

**** v1    CLI TX|param.set thread_pool_stack 80k
**** dT    0.197
***  v1    CLI RX  106
**** v1    CLI RX|Must be at least 128k

Upping to 128k makes the test suite run.