### PR TITLE
vcc: Internal type for the reserved 'default' symbol

### DIFF
--- a/bin/varnishtest/tests/c00042.vtc
+++ b/bin/varnishtest/tests/c00042.vtc
@@ -176,3 +176,9 @@ varnish v1 -errvcl "Cannot stack .via backends" {
 		set bereq.backend = c;
 	}
 }
+
+# issue #4177: backend named default with .via property
+varnish v1 -vcl {
+	backend via { .host = "${localhost}"; }
+	backend default { .via = via; .host = "${localhost}"; }
+}

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -118,6 +118,8 @@ struct type {
 	const char		*global_pfx;
 	const char		*tostring;
 	vcc_type_t		multype;
+	struct symbol		*default_sym;
+
 	int			stringform;
 	int			bodyform;
 	int			noindent;
@@ -125,6 +127,8 @@ struct type {
 
 #define VCC_TYPE(UC, lc)	extern const struct type UC[1];
 #include "vcc_types.h"
+
+extern const struct type DEFAULT[1]; /* type for pseudo-symbol "default" */
 
 /*---------------------------------------------------------------------*/
 
@@ -317,7 +321,6 @@ void vcc_Action_Init(struct vcc *);
 /* vcc_backend.c */
 struct fld_spec;
 
-const char *vcc_default_probe(struct vcc *);
 void vcc_Backend_Init(struct vcc *tl);
 void vcc_ParseProbe(struct vcc *tl);
 void vcc_ParseBackend(struct vcc *tl);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1606,14 +1606,13 @@ vcc_Eval_Default(struct vcc *tl, struct expr **e, struct token *t,
 	(void)sym;
 	(void)t;
 
-	if (fmt == PROBE)
-		*e = vcc_mk_expr(PROBE, "%s", vcc_default_probe(tl));
-	else if (fmt == BACKEND)
-		*e = vcc_mk_expr(BACKEND, "*(VCL_conf.default_director)");
-	else {
+	if (fmt->default_sym == NULL) {
 		VSB_cat(tl->sb, "Symbol 'default' is a reserved word.\n");
 		vcc_ErrWhere(tl, t);
+		return;
 	}
+
+	*e = vcc_mk_expr(fmt, "%s", fmt->default_sym->rname);
 }
 
 /*--------------------------------------------------------------------
@@ -1650,6 +1649,6 @@ vcc_Expr_Init(struct vcc *tl)
 
 	sym = VCC_MkSym(tl, "default", SYM_MAIN, SYM_FUNC, VCL_LOW, VCL_HIGH);
 	AN(sym);
-	sym->type = BACKEND;	// ... can also (sometimes) deliver PROBE
+	sym->type = DEFAULT;
 	sym->eval = vcc_Eval_Default;
 }

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -363,7 +363,7 @@ VCC_SymbolGet(struct vcc *tl, vcc_ns_t ns, vcc_kind_t kind,
 		vcc_ErrWhere2(tl, t0, tl->t);
 		return (NULL);
 	}
-	if (kind != SYM_NONE && kind != sym->kind) {
+	if (kind != SYM_NONE && kind != sym->kind && sym->type != DEFAULT) {
 		VSB_cat(tl->sb, "Symbol '");
 		vcc_PrintTokens(tl, t0, tl->t);
 		VSB_printf(tl->sb, "' has wrong type (%s), expected %s:",
@@ -576,6 +576,11 @@ VCC_HandleSymbol(struct vcc *tl, vcc_type_t fmt)
 	vcc_kind_t kind;
 	struct token *t;
 	const char *p;
+
+	if (vcc_IdIs(tl->t, "default") && fmt->default_sym != NULL) {
+		vcc_NextToken(tl);
+		return (fmt->default_sym);
+	}
 
 	kind = VCC_HandleKind(fmt);
 	assert(kind != SYM_NONE);

--- a/lib/libvcc/vcc_types.c
+++ b/lib/libvcc/vcc_types.c
@@ -67,12 +67,23 @@ static const struct vcc_method backend_methods[] = {
 	{ VCC_METHOD_MAGIC, NULL },
 };
 
+static struct symbol default_backend[1] = {{
+	.magic =		SYMBOL_MAGIC,
+	.name =			"default",
+	.lorev =		0,
+	.hirev =		99,
+	.kind =			SYM_BACKEND,
+	.type =			DEFAULT,
+	.rname =		"*(VCL_conf.default_director)",
+}};
+
 const struct type BACKEND[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"BACKEND",
 	.methods =		backend_methods,
 	.global_pfx =		"vgc_backend",
 	.tostring =		"VRT_BACKEND_string(\v1)",
+	.default_sym =		default_backend,
 }};
 
 const struct type BLOB[1] = {{
@@ -99,6 +110,11 @@ const struct type BYTES[1] = {{
 	.name =			"BYTES",
 	.tostring =		"VRT_INT_string(ctx, \v1)",
 	.multype =		REAL,	// XXX: wrong
+}};
+
+const struct type DEFAULT[1] = {{
+	.magic =		TYPE_MAGIC,
+	.name =			"DEFAULT",
 }};
 
 const struct type DURATION[1] = {{
@@ -144,10 +160,21 @@ const struct type IP[1] = {{
 	.tostring =		"VRT_IP_string(ctx, \v1)",
 }};
 
+static struct symbol default_probe[1] = {{
+	.magic =		SYMBOL_MAGIC,
+	.name =			"default",
+	.lorev =		0,
+	.hirev =		99,
+	.kind =			SYM_PROBE,
+	.type =			DEFAULT,
+	.rname =		"vgc_probe_default",
+}};
+
 const struct type PROBE[1] = {{
 	.magic =		TYPE_MAGIC,
 	.name =			"PROBE",
 	.global_pfx =		"vgc_probe",
+	.default_sym =		default_probe,
 }};
 
 const struct type REAL[1] = {{


### PR DESCRIPTION
A new DEFAULT type identifies symbols called 'default' and types that can have a default symbol carry a pseudo symbol. This approach can reconcile the overloaded default symbols that all share the generic type DEFAULT but carry their respective kinds.

This helps remove some of the special casing for default probes and backends whilst offering a sentinel DEFAULT type to safely deal with the special casing where it is actually needed, simplifying the code a wee bit in those areas.

Fixes #4177