### PR TITLE
Add VDI_EVENT_SICK and use it for admin health changes

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -139,16 +139,8 @@ VBE_Connect_Error(struct VSC_vbe *vsc, int err)
 
 /*--------------------------------------------------------------------*/
 
-int
-VBE_is_ah_auto(const struct backend *bp)
-{
-
-	CHECK_OBJ_NOTNULL(bp, BACKEND_MAGIC);
-	return (bp->director->vdir->admin_health == VDI_AH_AUTO);
-}
-
-void
-VBE_connwait_signal_all(const struct backend *bp)
+static void
+vbe_connwait_signal_all(const struct backend *bp)
 {
 	struct connwait *cw;
 
@@ -565,7 +557,7 @@ vbe_dir_event(const struct director *d, enum vcl_event_e ev)
 		const struct vdi_ahealth *ah = d->vdir->admin_health;
 
 		if (ah == VDI_AH_SICK || (ah == VDI_AH_AUTO && bp->sick))
-			VBE_connwait_signal_all(bp);
+			vbe_connwait_signal_all(bp);
 	}
 }
 

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -140,7 +140,7 @@ VBE_Connect_Error(struct VSC_vbe *vsc, int err)
 /*--------------------------------------------------------------------*/
 
 static void
-vbe_connwait_signal_all(const struct backend *bp)
+vbe_connwait_broadcast(const struct backend *bp)
 {
 	struct connwait *cw;
 
@@ -557,7 +557,7 @@ vbe_dir_event(const struct director *d, enum vcl_event_e ev)
 		const struct vdi_ahealth *ah = d->vdir->admin_health;
 
 		if (ah == VDI_AH_SICK || (ah == VDI_AH_AUTO && bp->sick))
-			vbe_connwait_signal_all(bp);
+			vbe_connwait_broadcast(bp);
 	}
 }
 

--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -561,6 +561,11 @@ vbe_dir_event(const struct director *d, enum vcl_event_e ev)
 		VRT_VSC_Hide(bp->vsc_seg);
 	} else if (ev == VCL_EVENT_DISCARD) {
 		VRT_DelDirector(&bp->director);
+	} else if (ev == VDI_EVENT_SICK) {
+		const struct vdi_ahealth *ah = d->vdir->admin_health;
+
+		if (ah == VDI_AH_SICK || (ah == VDI_AH_AUTO && bp->sick))
+			VBE_connwait_signal_all(bp);
 	}
 }
 
@@ -676,7 +681,6 @@ vbe_healthy(VRT_CTX, VCL_BACKEND d, VCL_TIME *t)
 
 	return (!bp->sick);
 }
-
 
 /*--------------------------------------------------------------------
  */

--- a/bin/varnishd/cache/cache_backend_probe.c
+++ b/bin/varnishd/cache/cache_backend_probe.c
@@ -190,10 +190,8 @@ VBP_Update_Backend(struct vbp_target *vt)
 	i = (vt->good < vt->threshold);
 	chg = (i != vt->backend->sick);
 	vt->backend->sick = i;
-	if (i && chg && (vt->backend->director != NULL &&
-	    VBE_is_ah_auto(vt->backend))) {
-		VBE_connwait_signal_all(vt->backend);
-	}
+	if (i && chg && vt->backend->director != NULL)
+		VDI_Event(vt->backend->director, VDI_EVENT_SICK);
 
 	AN(vt->backend->vcl_name);
 	VSL(SLT_Backend_health, NO_VXID,

--- a/bin/varnishd/cache/cache_director.c
+++ b/bin/varnishd/cache/cache_director.c
@@ -477,7 +477,6 @@ static int v_matchproto_(vcl_be_func)
 do_set_health(struct cli *cli, struct director *d, void *priv)
 {
 	struct set_health *sh;
-	struct vrt_ctx *ctx;
 
 	(void)cli;
 	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
@@ -488,12 +487,7 @@ do_set_health(struct cli *cli, struct director *d, void *priv)
 	if (d->vdir->admin_health != sh->ah) {
 		d->vdir->health_changed = VTIM_real();
 		d->vdir->admin_health = sh->ah;
-		ctx = VCL_Get_CliCtx(0);
-		if (sh->ah == VDI_AH_SICK || (sh->ah == VDI_AH_AUTO &&
-		    d->vdir->methods->healthy != NULL &&
-		    !d->vdir->methods->healthy(ctx, d, NULL))) {
-			VBE_connwait_signal_all(d->priv);
-		    }
+		VDI_Event(d, VDI_EVENT_SICK);
 	}
 	return (0);
 }

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -161,11 +161,7 @@ void VCA_Init(void);
 void VCA_Shutdown(void);
 
 /* cache_backend.c */
-struct backend;
-
 void VBE_InitCfg(void);
-void VBE_connwait_signal_all(const struct backend *bp);
-int VBE_is_ah_auto(const struct backend *bp);
 
 /* cache_ban.c */
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -496,7 +496,9 @@ struct vmod_data {
 };
 
 /***********************************************************************
- * VCL events sent to VMODs and directors
+ * Events sent to VMODs and directors:
+ * - VCL: VCL temperature events
+ * - VDI: director events
  */
 
 enum vcl_event_e {
@@ -504,7 +506,7 @@ enum vcl_event_e {
 	VCL_EVENT_WARM,
 	VCL_EVENT_COLD,
 	VCL_EVENT_DISCARD,
-	// Only for directors
+
 	VDI_EVENT_SICK,
 };
 

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -48,7 +48,7 @@
 
 #define VRT_MAJOR_VERSION	20U
 
-#define VRT_MINOR_VERSION	0U
+#define VRT_MINOR_VERSION	1U
 
 /***********************************************************************
  * Major and minor VRT API versions.
@@ -58,6 +58,8 @@
  * binary/load-time compatible, increment MAJOR version
  *
  * NEXT (2024-03-15)
+ * 20.1
+ *	VDI_EVENT_SICK added to enum vcl_event_e
  * 20.0 (2024-09-13)
  *	struct vrt_backend.backend_wait_timeout added
  *	struct vrt_backend.backend_wait_limit  added
@@ -494,7 +496,7 @@ struct vmod_data {
 };
 
 /***********************************************************************
- * VCL events sent to VMODs
+ * VCL events sent to VMODs and directors
  */
 
 enum vcl_event_e {
@@ -502,6 +504,8 @@ enum vcl_event_e {
 	VCL_EVENT_WARM,
 	VCL_EVENT_COLD,
 	VCL_EVENT_DISCARD,
+	// Only for directors
+	VDI_EVENT_SICK,
 };
 
 typedef int vmod_event_f(VRT_CTX, struct vmod_priv *, enum vcl_event_e);


### PR DESCRIPTION
Alternative implementation to #4186 as suggested by dridi and phk:

This patch adds an event to the existing event facility, which so far was only used for VCL-related events. We now add `VDI_EVENT_SICK` as a director-specific event, which is cheap and also helps us maintain clean layering.
The new event is posted when the admin health changes and used by VBE to cancel all waiting connection requests.