### PR TITLE
backend.list -j now outputs IPs/port information

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -624,12 +624,17 @@ static void v_matchproto_(vdi_list_f)
 vbe_list(VRT_CTX, const struct director *d, struct vsb *vsb, int pflag,
     int jflag)
 {
+	char buf[VTCP_ADDRBUFSIZE];
 	struct backend *bp;
+	struct vrt_endpoint *vep;
 
 	(void)ctx;
 
 	CHECK_OBJ_NOTNULL(d, DIRECTOR_MAGIC);
 	CAST_OBJ_NOTNULL(bp, d->priv, BACKEND_MAGIC);
+	CHECK_OBJ_NOTNULL(bp->endpoint, VRT_ENDPOINT_MAGIC);
+
+	vep = bp->endpoint;
 
 	if (bp->probe != NULL)
 		VBP_Status(vsb, bp, pflag, jflag);
@@ -641,6 +646,17 @@ vbe_list(VRT_CTX, const struct director *d, struct vsb *vsb, int pflag,
 		return;
 	else
 		VSB_cat(vsb, "0/0\thealthy");
+
+	if (jflag && pflag) {
+		if (vep->ipv4 != NULL) {
+			VTCP_name(vep->ipv4, buf, sizeof buf, NULL, 0);
+			VSB_printf(vsb, "\"ipv4\": \"%s\",\n", buf);
+		}
+		if (vep->ipv6 != NULL) {
+			VTCP_name(vep->ipv6, buf, sizeof buf, NULL, 0);
+			VSB_printf(vsb, "\"ipv6\": \"%s\",\n", buf);
+		}
+	}
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishtest/tests/b00091.vtc
+++ b/bin/varnishtest/tests/b00091.vtc
@@ -1,0 +1,41 @@
+varnishtest "IPs/port in varnishadm backend.list -j"
+
+feature cmd "jq -V"
+
+server s0 {
+} -start
+
+
+varnish v1 -vcl+backend {
+	backend s1 {
+		.host = "127.0.0.1";
+		.port = "2222";
+		.probe = { .url = "/"; }
+	}
+	backend s2 {
+		.host = "::1:2:3:4";
+		.port = "3333";
+	}
+
+	sub vcl_recv {
+		set req.backend_hint = s0;
+		set req.backend_hint = s1;
+		set req.backend_hint = s2;
+	}
+} -start
+
+shell {
+	set -e
+
+varnishadm -n ${v1_name} backend.list -j
+	varnishadm -n ${v1_name} backend.list -jp > result.json
+	jq '
+		.[3]["vcl1.s0"].ipv4 == "${s0_addr}" or error("wrong s0 ipv4"),
+		.[3]["vcl1.s1"].ipv4 == "127.0.0.1" or error("wrong s2 ipv4"),
+		.[3]["vcl1.s2"].ipv4 == null or error("s3 ipv4 exists"),
+
+		.[3]["vcl1.s0"].ipv6 == null or error("s0 ipv6 exists"),
+		.[3]["vcl1.s1"].ipv6 == null or error("s2 ipv6 exists"),
+		.[3]["vcl1.s2"].ipv6 == "::1:2:3:4" or error("wrong s3 ipv6")
+	' result.json
+}


### PR DESCRIPTION
since DNS resolution happens only once for static backends and can be a bit obscure for dynamic backend, it's valuable to be able to dump the IPs that are used.

In order to not break existing scripts which may `varnishadm backend.list`, only update the JSON ouput

side note: it's a bit confusing that `vbe_list` needs to produce a JSON value ending with a coma if `pflag` is true, but not if it's false. Do we want to change that? And also maybe make printing the `probe_details` and `probe_message` a responsibilty of the backend implementation, rather than splitting the key-value pair across two functions?