### PR TITLE
sml: Optimize freebehind (transient) memory usage

### DIFF
--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -395,15 +395,14 @@ sml_iterator(struct worker *wrk, struct objcore *oc,
 			assert(nl > 0);
 			sl += st->len;
 			st = VTAILQ_PREV(st, storagehead, list);
-			if (VTAILQ_PREV(st, storagehead, list) != NULL) {
-				if (final && checkpoint != NULL) {
-					VTAILQ_REMOVE(&obj->list,
-					    checkpoint, list);
-					sml_stv_free(stv, checkpoint);
-				}
-				checkpoint = st;
-				checkpoint_len = sl;
+			if (final && checkpoint != NULL) {
+				VTAILQ_REMOVE(&obj->list, checkpoint, list);
+				if (checkpoint == boc->stevedore_priv)
+					boc->stevedore_priv = trim_once;
+				sml_stv_free(stv, checkpoint);
 			}
+			checkpoint = st;
+			checkpoint_len = sl;
 		}
 		CHECK_OBJ_NOTNULL(obj, OBJECT_MAGIC);
 		CHECK_OBJ_NOTNULL(st, STORAGE_MAGIC);

--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -560,7 +560,8 @@ sml_trimstore(struct worker *wrk, struct objcore *oc)
 		Lck_Lock(&oc->boc->mtx);
 		VTAILQ_REMOVE(&o->list, st, list);
 		Lck_Unlock(&oc->boc->mtx);
-		sml_stv_free(stv, st);
+		/* sml_bocdone frees this */
+		oc->boc->stevedore_priv = st;
 		return;
 	}
 


### PR DESCRIPTION
Previously, `sml_iterator()` could not free the last segment while iterating, because it could have turned out to be over-allocated at any time and be removed.

We now delay freeing any over-allocated segments, identical to how we delay any reallocated segments, which enables us to "free behind" all sent segments.

This is relevant because, due to of the race between the fetch and iterator side of a transient operation, the "is last segment" condition can happen repeatedly while an object is busy.
