### PR TITLE
cache_vcl: Do the temperature dance for backend creation races

### DIFF
--- a/bin/varnishd/cache/cache_vcl.h
+++ b/bin/varnishd/cache/cache_vcl.h
@@ -37,7 +37,7 @@ struct vfilter;
 struct vcltemp;
 
 VTAILQ_HEAD(vfilter_head, vfilter);
-
+VTAILQ_HEAD(director_head, vcldir);
 
 struct vcl {
 	unsigned		magic;
@@ -50,7 +50,7 @@ struct vcl {
 	unsigned		busy;
 	unsigned		discard;
 	const struct vcltemp	*temp;
-	VTAILQ_HEAD(,vcldir)	director_list;
+	struct director_head	director_list;
 	VTAILQ_HEAD(,vclref)	ref_list;
 	int			nrefs;
 	struct vcl		*label;


### PR DESCRIPTION
Dynamic backends may get created while we transition a VCL to the WARM temperature: Because we first set the new temperature and then post the event, backends might get created when the temperature is already WARM, but before the `VCL_EVENT_WARM` gets posted, which leads to double warming. This can be demonstrated with an appropriate delay during `vcl_send_event()`.

The solution to this problem is simple: Only post WARM events to backends from before the start of the transition.

In code, it looks a little more involved, but it is not complicated:

Under the vcl mutex, we take all directors onto a separate "cold" list and change the temperature, and send the warm event only to the "cold" directors. When all are warm, we concatenate.

To undo, we basically do the inverse: Save the warm directors, put the cold ones back, send a cold event to all warm ones and concatenate again.

Fixes #4199