### PR TITLE
Return HTTP response to RX_OVERFLOW

### DIFF
--- a/bin/varnishd/common/common_param.h
+++ b/bin/varnishd/common/common_param.h
@@ -118,6 +118,7 @@ struct params {
 #define ptyp_thread_pool_min	unsigned
 #define ptyp_timeout		vtim_dur
 #define ptyp_uint		unsigned
+#define ptyp_uint_orzero	unsigned
 #define ptyp_vcc_feature	vcc_feature_t
 #define ptyp_vsl_buffer		unsigned
 #define ptyp_vsl_mask		vsl_mask_t

--- a/bin/varnishd/http1/cache_http1_fsm.c
+++ b/bin/varnishd/http1/cache_http1_fsm.c
@@ -327,6 +327,10 @@ HTTP1_Session(struct worker *wrk, struct req *req)
 			    cache_param->http_req_size);
 			assert(!WS_IsReserved(req->htc->ws));
 			if (hs < HTC_S_EMPTY) {
+				if (hs == HTC_S_OVERFLOW && cache_param->http_req_overflow_status != 0) {
+					(void)req->transport->minimal_response(req,
+					    cache_param->http_req_overflow_status);
+				}
 				req->acct.req_hdrbytes +=
 				    req->htc->rxbuf_e - req->htc->rxbuf_b;
 				Req_AcctLogCharge(wrk->stats, req);

--- a/bin/varnishd/mgt/mgt_param.h
+++ b/bin/varnishd/mgt/mgt_param.h
@@ -86,6 +86,7 @@ tweak_t tweak_thread_pool_min;
 tweak_t tweak_thread_pool_max;
 tweak_t tweak_timeout;
 tweak_t tweak_uint;
+tweak_t tweak_uint_orzero;
 tweak_t tweak_vcc_feature;
 tweak_t tweak_vsl_buffer;
 tweak_t tweak_vsl_mask;

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -293,6 +293,21 @@ tweak_uint(struct vsb *vsb, const struct parspec *par, const char *arg)
 	    par->dyn_min_reason, par->dyn_max_reason));
 }
 
+int v_matchproto_(tweak_t)
+tweak_uint_orzero(struct vsb *vsb, const struct parspec *par, const char *arg)
+{
+	volatile unsigned *dest;
+
+	dest = par->priv;
+	if (arg != NULL && arg != JSON_FMT && ! strcmp(arg, "0")) {
+		VSB_cat(vsb, "0");
+		*dest = 0;
+		return (0);
+	}
+	return (tweak_generic_uint(vsb, dest, arg, par->min, par->max,
+	    par->dyn_min_reason, par->dyn_max_reason));
+}
+
 /*--------------------------------------------------------------------*/
 
 static void

--- a/bin/varnishtest/tests/c00039.vtc
+++ b/bin/varnishtest/tests/c00039.vtc
@@ -62,3 +62,20 @@ client c1 {
 	send "1...5: ..0....5....0....5....\r\n\r\n"
 	expect_close
 } -run
+
+varnish v1 -cliok "param.set http_req_overflow_status 414"
+client c1 {
+	# Each line is 32 except last, which is 33. Total: 32 * 7 + 33 == 257
+	send "GET /..... HTTP/1.1\r\nHost: foo\r\n"
+	send "1...5: ..0....5....0....5....0\r\n"
+	send "1...5: ..0....5....0....5....0\r\n"
+	send "1...5: ..0....5....0....5....0\r\n"
+	send "1...5: ..0....5....0....5....0\r\n"
+	send "1...5: ..0....5....0....5....0\r\n"
+	send "1...5: ..0....5....0....5....0\r\n"
+	send "1...5: ..0....5....0....5....\r\n\r\n"
+	rxresp
+	expect resp.status == 414
+} -run
+
+varnish v1 -clierr 106 "param.set http_req_overflow_status 200"

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -650,6 +650,23 @@ PARAM_SIMPLE(
 )
 
 PARAM_SIMPLE(
+	/* name */	http_req_overflow_status,
+	/* type */	uint_orzero,
+	/* min */	"400",
+	/* max */	"499",
+	/* def */	"0",
+	/* units */	"HTTP status code or 0 to disable",
+	/* descr */
+	"HTTP status code to be returned if http_req_size is exceeded. "
+	"The default value of 0 closes the connection silently without "
+	"sending a HTTP response.\n"
+	"Note that there is no standard HTTP status which exactly matches "
+	"the implementation of http_req_size. 414 applies to the URL only, "
+	"while 413 applies to the request body. 400 is probably the least "
+	"incorrect alternative value to sending no response at all (0)."
+)
+
+PARAM_SIMPLE(
 	/* name */	http_resp_hdr_len,
 	/* type */	bytes_u,
 	/* min */	"40b",


### PR DESCRIPTION
Resolves https://github.com/varnishcache/varnish-cache/issues/2735

Before this PR, Varnish would silently close the connection to a client that triggered an RX_OVERFLOW (too long URI), this PR allows configuring Varnish to respond to RX_OVERFLOW with a minimal HTTP response that will contain a chosen HTTP code instead.

Its done by adding a new feature flag in order to enable the feature and a new parameter in order to set the HTTP code that will be sent in the response.
