### PR TITLE
Prepare Varnish-Cache for the age of AI

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -282,6 +282,10 @@ enum boc_state_e {
 #include "tbl/boc_state.h"
 };
 
+// cache_obj.h vai notify
+struct vai_qe;
+VSLIST_HEAD(vai_q_head, vai_qe);
+
 struct boc {
 	unsigned		magic;
 #define BOC_MAGIC		0x70c98476
@@ -294,6 +298,7 @@ struct boc {
 	uint64_t		fetched_so_far;
 	uint64_t		delivered_so_far;
 	uint64_t		transit_buffer;
+	struct vai_q_head	vai_q_head;
 };
 
 /* Object core structure ---------------------------------------------
@@ -760,6 +765,15 @@ uint64_t ObjGetLen(struct worker *, struct objcore *);
 int ObjGetDouble(struct worker *, struct objcore *, enum obj_attr, double *);
 int ObjGetU64(struct worker *, struct objcore *, enum obj_attr, uint64_t *);
 int ObjCheckFlag(struct worker *, struct objcore *, enum obj_flags of);
+
+/*====================================================================
+ * ObjVAI...(): Asynchronous Iteration
+ *
+ * see comments in cache_obj.c for usage
+ */
+
+typedef void *vai_hdl;
+typedef void vai_notify_cb(vai_hdl, void *priv);
 
 /* cache_req_body.c */
 ssize_t VRB_Iterate(struct worker *, struct vsl_log *, struct req *,

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -919,6 +919,7 @@ struct vscaret {
 vai_hdl ObjVAIinit(struct worker *, struct objcore *, struct ws *,
     vai_notify_cb *, void *);
 int ObjVAIlease(struct worker *, vai_hdl, struct vscarab *);
+int ObjVAIbuffer(struct worker *, vai_hdl, struct vscarab *);
 void ObjVAIreturn(struct worker *, vai_hdl, struct vscaret *);
 void ObjVAIfini(struct worker *, vai_hdl *);
 

--- a/bin/varnishd/cache/cache_filter.h
+++ b/bin/varnishd/cache/cache_filter.h
@@ -238,6 +238,8 @@ vdpio_pull(struct vdp_ctx *vdc, struct vdp_entry *vdpe, struct vscarab *scarab)
 		return (ObjVAIlease(vdc->wrk, vdc->vai_hdl, scarab));
 }
 
+uint64_t VDPIO_Close1(struct vdp_ctx *, struct vdp_entry *vdpe);
+
 /*
  * ============================================================
  * VDPIO helpers

--- a/bin/varnishd/cache/cache_filter.h
+++ b/bin/varnishd/cache/cache_filter.h
@@ -318,6 +318,11 @@ vdpio_consolidate_vscarab(const struct vdp_ctx *vdc, struct vscarab *scarab)
 		scarab->used = f - scarab->s;
 }
 
+// Lifecycle management in cache_deliver_proc.c
+int VDPIO_Init(struct vdp_ctx *vdc, struct objcore *oc, struct ws *ws,
+    vai_notify_cb *notify_cb, void *notify_priv, struct vscaret *scaret);
+void VDPIO_Return(const struct vdp_ctx *vdc);
+void VDPIO_Fini(struct vdp_ctx *vdc);
 
 void v_deprecated_ VRT_AddVDP(VRT_CTX, const struct vdp *);
 void v_deprecated_ VRT_RemoveVDP(VRT_CTX, const struct vdp *);

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -300,15 +300,13 @@ VGZ_Gzip(struct vgz *vg, const void **pptr, ssize_t *plen, enum vgz_flag flags)
  * VDP for gunzip'ing
  */
 
+// common for traditional interface and vdpio
+static int vdp_gunzip_init_common(struct vdp_ctx *vdc);
+
 static int v_matchproto_(vdp_init_f)
 vdp_gunzip_init(VRT_CTX, struct vdp_ctx *vdc, void **priv)
 {
 	struct vgz *vg;
-	struct boc *boc;
-	enum boc_state_e bos;
-	const char *p;
-	ssize_t dl;
-	uint64_t u;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(vdc, VDP_CTX_MAGIC);
@@ -326,7 +324,17 @@ vdp_gunzip_init(VRT_CTX, struct vdp_ctx *vdc, void **priv)
 
 	VGZ_Obuf(vg, vg->m_buf, vg->m_sz);
 	*priv = vg;
+	return (vdp_gunzip_init_common(vdc));
+}
 
+static int
+vdp_gunzip_init_common(struct vdp_ctx *vdc)
+{
+	struct boc *boc;
+	enum boc_state_e bos;
+	const char *p;
+	ssize_t dl;
+	uint64_t u;
 	http_Unset(vdc->hp, H_Content_Encoding);
 
 	*vdc->clen = -1;

--- a/bin/varnishd/cache/cache_main.c
+++ b/bin/varnishd/cache/cache_main.c
@@ -405,9 +405,55 @@ static struct cli_proto child_cmds[] = {
 	{ NULL }
 };
 
+#define CAP 17U
+
+static void
+t_vscarab1(struct vscarab *scarab)
+{
+	struct viov *v;
+	uint64_t sum;
+
+	VSCARAB_CHECK_NOTNULL(scarab);
+	AZ(scarab->used);
+
+	v = VSCARAB_GET(scarab);
+	AN(v);
+	v->lease = 12;
+
+	VSCARAB_ADD(scarab, (struct viov){.lease = 30});
+
+	sum = 0;
+	VSCARAB_FOREACH(v, scarab)
+		sum += v->lease;
+
+	assert(sum == 42);
+}
+
+static void
+t_vscarab(void)
+{
+	char testbuf[VSCARAB_SIZE(CAP)];
+	struct vscarab *frombuf = (void *)testbuf;
+	VSCARAB_INIT(frombuf, CAP);
+	t_vscarab1(frombuf);
+
+	// ---
+
+	VSCARAB_LOCAL(scarab, CAP);
+	t_vscarab1(scarab);
+
+	// ---
+
+	struct vscarab *heap;
+	VSCARAB_ALLOC(heap, CAP);
+	t_vscarab1(heap);
+	free(heap);
+}
+
 void
 child_main(int sigmagic, size_t altstksz)
 {
+	t_vscarab();
 
 	if (sigmagic)
 		child_sigmagic(altstksz);

--- a/bin/varnishd/cache/cache_obj.h
+++ b/bin/varnishd/cache/cache_obj.h
@@ -50,6 +50,26 @@ typedef void *objsetattr_f(struct worker *, struct objcore *,
     enum obj_attr attr, ssize_t len, const void *ptr);
 typedef void objtouch_f(struct worker *, struct objcore *, vtim_real now);
 
+/* called by Obj/storage to notify that the lease function (vai_lease_f) can be
+ * called again after a -EAGAIN / -ENOBUFS return value
+ * NOTE:
+ * - the callback gets executed by an arbitrary thread
+ * - WITH the boc mtx held
+ * so it should never block and be efficient
+ */
+
+/* notify entry added to struct boc::vai_q_head */
+struct vai_qe {
+	unsigned		magic;
+#define VAI_Q_MAGIC		0x573e27eb
+	unsigned		flags;
+#define VAI_QF_INQUEUE		(1U<<0)
+	VSLIST_ENTRY(vai_qe)	list;
+	vai_notify_cb		*cb;
+	vai_hdl			hdl;
+	void			*priv;
+};
+
 struct obj_methods {
 	/* required */
 	objfree_f	*objfree;

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -199,6 +199,11 @@ extern const struct vdp VDP_gunzip;
 extern const struct vdp VDP_esi;
 extern const struct vdp VDP_range;
 
+uint64_t VDPIO_Close(struct vdp_ctx *, struct objcore *, struct boc *);
+int VDPIO_Upgrade(VRT_CTX, struct vdp_ctx *vdc);
+int VDPIO_Push(VRT_CTX, struct vdp_ctx *, struct ws *, const struct vdp *,
+    void *priv);
+
 
 /* cache_exp.c */
 vtim_real EXP_Ttl(const struct req *, const struct objcore *);

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -348,6 +348,10 @@ void *ObjSetAttr(struct worker *, struct objcore *, enum obj_attr,
 int ObjCopyAttr(struct worker *, struct objcore *, struct objcore *,
     enum obj_attr attr);
 void ObjBocDone(struct worker *, struct objcore *, struct boc **);
+// VAI
+uint64_t ObjVAIGetExtend(struct worker *, const struct objcore *, uint64_t,
+    enum boc_state_e *, struct vai_qe *);
+void ObjVAICancel(struct worker *, struct boc *, struct vai_qe *);
 
 int ObjSetDouble(struct worker *, struct objcore *, enum obj_attr, double);
 int ObjSetU64(struct worker *, struct objcore *, enum obj_attr, uint64_t);

--- a/bin/varnishd/http1/cache_http1_line.c
+++ b/bin/varnishd/http1/cache_http1_line.c
@@ -462,9 +462,7 @@ const struct vdp * const VDP_v1l = &(struct vdp){
 	.init =		v1l_init,
 	.bytes =	v1l_bytes,
 
-#ifdef LATER
 	.io_init =	v1l_io_init,
-#endif
 	.io_upgrade =	v1l_io_upgrade,
 	.io_lease =	v1l_io_lease,
 };

--- a/bin/varnishd/storage/storage_persistent.c
+++ b/bin/varnishd/storage/storage_persistent.c
@@ -696,6 +696,7 @@ smp_init(void)
 	smp_oc_realmethods.objsetattr = SML_methods.objsetattr;
 	smp_oc_realmethods.objtouch = LRU_Touch;
 	smp_oc_realmethods.objfree = smp_oc_objfree;
+	smp_oc_realmethods.vai_init	= SML_methods.vai_init;
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -31,6 +31,8 @@
 
 #include "config.h"
 
+#include <stdlib.h>
+
 #include "cache/cache_varnishd.h"
 
 #include "cache/cache_obj.h"
@@ -306,130 +308,434 @@ sml_objfree(struct worker *wrk, struct objcore *oc)
 	wrk->stats->n_object--;
 }
 
+// kept for reviewers - XXX remove later
+#undef VAI_DBG
+
+struct sml_hdl {
+	struct vai_hdl_preamble	preamble;
+#define SML_HDL_MAGIC		0x37dfd996
+	struct vai_qe		qe;
+	struct ws		*ws;	// NULL is malloc()
+	struct objcore		*oc;
+	struct object		*obj;
+	const struct stevedore	*stv;
+	struct boc		*boc;
+
+	struct storage		*st;	// updated by _lease()
+
+	// only for _lease_boc()
+	uint64_t		st_off;	// already returned fragment of current st
+	uint64_t		avail, returned;
+	struct storage		*last;	// to resume, held back by _return()
+};
+
+static inline void
+sml_ai_viov_fill(struct viov *viov, struct storage *st)
+{
+	viov->iov.iov_base = st->ptr;
+	viov->iov.iov_len = st->len;
+	viov->lease = (uintptr_t)st;
+	VAI_ASSERT_LEASE(viov->lease);
+}
+
+static int
+sml_ai_lease_simple(struct worker *wrk, vai_hdl vhdl, struct vscarab *scarab)
+{
+	struct storage *st;
+	struct sml_hdl *hdl;
+	struct viov *viov;
+	int r = 0;
+
+	(void) wrk;
+	CAST_VAI_HDL_NOTNULL(hdl, vhdl, SML_HDL_MAGIC);
+	VSCARAB_CHECK_NOTNULL(scarab);
+
+	AZ(hdl->st_off);
+	st = hdl->st;
+	while (st != NULL && (viov = VSCARAB_GET(scarab)) != NULL) {
+		CHECK_OBJ(st, STORAGE_MAGIC);
+		sml_ai_viov_fill(viov, st);
+		r++;
+		st = VTAILQ_PREV(st, storagehead, list);
+	}
+	hdl->st = st;
+	if (st == NULL)
+		scarab->flags |= VSCARAB_F_END;
+	return (r);
+}
+
+/*
+ * on leases while streaming (with a boc):
+ *
+ * SML uses the lease return facility to implement the "free behind" for
+ * OC_F_TRANSIENT objects. When streaming, we also return leases on
+ * fragments of sts, but we must only "free behind" when we are done with the
+ * last fragment.
+ *
+ * So we use a magic lease to signal "this is only a fragment", which we ignore
+ * on returns
+ */
+
+static int
+sml_ai_lease_boc(struct worker *wrk, vai_hdl vhdl, struct vscarab *scarab)
+{
+	enum boc_state_e state = BOS_INVALID;
+	struct storage *next;
+	struct sml_hdl *hdl;
+	struct viov *viov;
+	int r = 0;
+
+	CAST_VAI_HDL_NOTNULL(hdl, vhdl, SML_HDL_MAGIC);
+	VSCARAB_CHECK_NOTNULL(scarab);
+
+	if (hdl->avail == hdl->returned) {
+		hdl->avail = ObjVAIGetExtend(wrk, hdl->oc, hdl->returned,
+		    &state, &hdl->qe);
+		if (state == BOS_FAILED) {
+			hdl->last = NULL;
+			return (-EPIPE);
+		}
+		else if (state == BOS_FINISHED)
+			(void)0;
+		else if (hdl->avail == hdl->returned) {
+			// ObjVAIGetExtend() has scheduled a notification
+			if (hdl->boc->transit_buffer > 0)
+				return (-ENOBUFS);
+			else
+				return (-EAGAIN);
+		}
+		else
+			assert(state < BOS_FINISHED);
+	}
+	Lck_Lock(&hdl->boc->mtx);
+	if (hdl->st == NULL && hdl->last != NULL) {
+		/* when the "last" st completed, we did not yet have a next, so
+		 * resume from there. Because "last" might have been returned and
+		 * deleted, we can not just use the pointer, but rather need to
+		 * iterate the st list.
+		 * if we can not find "last", it also has been returned and
+		 * deleted, and the current write head (VTAILQ_LAST) is our next
+		 * st, which can also be null if we are done.
+		 */
+		VTAILQ_FOREACH_REVERSE(next, &hdl->obj->list, storagehead, list) {
+			if (next == hdl->last) {
+				hdl->st = VTAILQ_PREV(next, storagehead, list);
+				break;
+			}
+		}
+	}
+	hdl->last = NULL;
+	if (hdl->st == NULL) {
+		assert(hdl->returned == 0 || hdl->avail == hdl->returned);
+		hdl->st = VTAILQ_LAST(&hdl->obj->list, storagehead);
+	}
+	if (hdl->st == NULL)
+		assert(hdl->avail == hdl->returned);
+
+	while (hdl->avail > hdl->returned && (viov = VSCARAB_GET(scarab)) != NULL) {
+		CHECK_OBJ_NOTNULL(hdl->st, STORAGE_MAGIC); // ObjVAIGetExtend ensures
+		assert(hdl->st_off <= hdl->st->space);
+		size_t av = hdl->avail - hdl->returned;
+		size_t l = hdl->st->space - hdl->st_off;
+		AN(l);
+		if (l > av)
+			l = av;
+		viov->iov.iov_base = hdl->st->ptr + hdl->st_off;
+		viov->iov.iov_len = l;
+		if (hdl->st_off + l == hdl->st->space) {
+			next = VTAILQ_PREV(hdl->st, storagehead, list);
+			AZ(hdl->last);
+			if (next == NULL)
+				hdl->last = hdl->st;
+			else
+				CHECK_OBJ(next, STORAGE_MAGIC);
+#ifdef VAI_DBG
+			VSLb(wrk->vsl, SLT_Debug, "off %zu + l %zu == space st %p next st %p stvprv %p",
+			    hdl->st_off, l, hdl->st, next, hdl->boc->stevedore_priv);
+#endif
+			viov->lease = (uintptr_t)hdl->st;
+			hdl->st_off = 0;
+			hdl->st = next;
+		}
+		else {
+			viov->lease = VAI_LEASE_NORET;
+			hdl->st_off += l;
+		}
+		hdl->returned += l;
+		VAI_ASSERT_LEASE(viov->lease);
+		r++;
+	}
+
+	Lck_Unlock(&hdl->boc->mtx);
+	if (state != BOS_FINISHED && hdl->avail == hdl->returned) {
+		hdl->avail = ObjVAIGetExtend(wrk, hdl->oc, hdl->returned,
+		    &state, &hdl->qe);
+	}
+	if (state == BOS_FINISHED && hdl->avail == hdl->returned)
+		scarab->flags |= VSCARAB_F_END;
+	return (r);
+}
+
+static void v_matchproto_(vai_return_f)
+sml_ai_return(struct worker *wrk, vai_hdl vhdl, struct vscaret *scaret)
+{
+	struct storage *st;
+	struct sml_hdl *hdl;
+	uint64_t *p;
+
+	(void) wrk;
+	CAST_VAI_HDL_NOTNULL(hdl, vhdl, SML_HDL_MAGIC);
+	VSCARET_CHECK_NOTNULL(scaret);
+	if (scaret->used == 0)
+		return;
+
+	// callback is only registered if needed
+	assert(hdl->boc != NULL && (hdl->oc->flags & OC_F_TRANSIENT) != 0);
+
+	// filter noret and last
+	VSCARET_LOCAL(todo, scaret->used);
+	VSCARET_FOREACH(p, scaret) {
+		if (*p == VAI_LEASE_NORET)
+			continue;
+		CAST_OBJ_NOTNULL(st, (void *)*p, STORAGE_MAGIC);
+		if (st == hdl->last)
+			continue;
+		VSCARET_ADD(todo, *p);
+	}
+	VSCARET_INIT(scaret, scaret->capacity);
+
+	Lck_Lock(&hdl->boc->mtx);
+	VSCARET_FOREACH(p, todo) {
+		CAST_OBJ_NOTNULL(st, (void *)*p, STORAGE_MAGIC);
+		VTAILQ_REMOVE(&hdl->obj->list, st, list);
+		if (st == hdl->boc->stevedore_priv)
+			hdl->boc->stevedore_priv = trim_once;
+	}
+	Lck_Unlock(&hdl->boc->mtx);
+
+	VSCARET_FOREACH(p, todo) {
+		CAST_OBJ_NOTNULL(st, (void *)*p, STORAGE_MAGIC);
+		sml_stv_free(hdl->stv, st);
+	}
+}
+
+static void v_matchproto_(vai_fini_f)
+sml_ai_fini(struct worker *wrk, vai_hdl *vai_hdlp)
+{
+	struct sml_hdl *hdl;
+
+	AN(vai_hdlp);
+	CAST_VAI_HDL_NOTNULL(hdl, *vai_hdlp, SML_HDL_MAGIC);
+	*vai_hdlp = NULL;
+
+	if (hdl->boc != NULL) {
+		ObjVAICancel(wrk, hdl->boc, &hdl->qe);
+		HSH_DerefBoc(wrk, hdl->oc);
+		hdl->boc = NULL;
+	}
+
+	if (hdl->ws != NULL)
+		WS_Release(hdl->ws, 0);
+	else
+		free(hdl);
+}
+
+static vai_hdl v_matchproto_(vai_init_f)
+sml_ai_init(struct worker *wrk, struct objcore *oc, struct ws *ws,
+    vai_notify_cb *notify, void *notify_priv)
+{
+	struct sml_hdl *hdl;
+	const size_t sz = sizeof *hdl;
+
+	if (ws != NULL && WS_ReserveSize(ws, (unsigned)sz))
+		hdl = WS_Reservation(ws);
+	else {
+		hdl = malloc(sz);
+		ws = NULL;
+	}
+
+	AN(hdl);
+	INIT_VAI_HDL(hdl, SML_HDL_MAGIC);
+	hdl->preamble.vai_lease = sml_ai_lease_simple;
+	hdl->preamble.vai_fini = sml_ai_fini;
+	hdl->ws = ws;
+
+	hdl->oc = oc;
+	hdl->obj = sml_getobj(wrk, oc);
+	CHECK_OBJ_NOTNULL(hdl->obj, OBJECT_MAGIC);
+	hdl->stv = oc->stobj->stevedore;
+	CHECK_OBJ_NOTNULL(hdl->stv, STEVEDORE_MAGIC);
+
+	hdl->st = VTAILQ_LAST(&hdl->obj->list, storagehead);
+	CHECK_OBJ_ORNULL(hdl->st, STORAGE_MAGIC);
+
+	hdl->boc = HSH_RefBoc(oc);
+	if (hdl->boc == NULL)
+		return (hdl);
+	/* we only initialize notifications if we have a boc, so
+	 * any wrong attempt triggers magic checks.
+	 */
+	hdl->preamble.vai_lease = sml_ai_lease_boc;
+	if ((hdl->oc->flags & OC_F_TRANSIENT) != 0)
+		hdl->preamble.vai_return = sml_ai_return;
+	hdl->qe.magic = VAI_Q_MAGIC;
+	hdl->qe.cb = notify;
+	hdl->qe.hdl = hdl;
+	hdl->qe.priv = notify_priv;
+	return (hdl);
+}
+
+/*
+ * trivial notification to allow the iterator to simply block
+ */
+struct sml_notify {
+	unsigned		magic;
+#define SML_NOTIFY_MAGIC	0x4589af31
+	unsigned		hasmore;
+	pthread_mutex_t		mtx;
+	pthread_cond_t		cond;
+};
+
+static void
+sml_notify_init(struct sml_notify *sn)
+{
+
+	INIT_OBJ(sn, SML_NOTIFY_MAGIC);
+	AZ(pthread_mutex_init(&sn->mtx, NULL));
+	AZ(pthread_cond_init(&sn->cond, NULL));
+}
+
+static void
+sml_notify_fini(struct sml_notify *sn)
+{
+
+	CHECK_OBJ_NOTNULL(sn, SML_NOTIFY_MAGIC);
+	AZ(pthread_mutex_destroy(&sn->mtx));
+	AZ(pthread_cond_destroy(&sn->cond));
+}
+
+static void v_matchproto_(vai_notify_cb)
+sml_notify(vai_hdl hdl, void *priv)
+{
+	struct sml_notify *sn;
+
+	(void) hdl;
+	CAST_OBJ_NOTNULL(sn, priv, SML_NOTIFY_MAGIC);
+	AZ(pthread_mutex_lock(&sn->mtx));
+	sn->hasmore = 1;
+	AZ(pthread_cond_signal(&sn->cond));
+	AZ(pthread_mutex_unlock(&sn->mtx));
+
+}
+
+static void
+sml_notify_wait(struct sml_notify *sn)
+{
+
+	CHECK_OBJ_NOTNULL(sn, SML_NOTIFY_MAGIC);
+	AZ(pthread_mutex_lock(&sn->mtx));
+	while (sn->hasmore == 0)
+		AZ(pthread_cond_wait(&sn->cond, &sn->mtx));
+	AN(sn->hasmore);
+	sn->hasmore = 0;
+	AZ(pthread_mutex_unlock(&sn->mtx));
+}
+
 static int v_matchproto_(objiterator_f)
 sml_iterator(struct worker *wrk, struct objcore *oc,
     void *priv, objiterate_f *func, int final)
 {
-	struct boc *boc;
-	enum boc_state_e state;
-	struct object *obj;
-	struct storage *st;
-	struct storage *checkpoint = NULL;
-	const struct stevedore *stv;
-	ssize_t checkpoint_len = 0;
-	ssize_t len = 0;
-	int ret = 0, ret2;
-	ssize_t ol;
-	ssize_t nl;
-	ssize_t sl;
-	void *p;
-	ssize_t l;
-	unsigned u;
+	struct sml_notify sn;
+	struct viov *vio, *last;
+	unsigned u, uu;
+	vai_hdl hdl;
+	int nn, r, r2, islast;
 
-	obj = sml_getobj(wrk, oc);
-	CHECK_OBJ_NOTNULL(obj, OBJECT_MAGIC);
-	stv = oc->stobj->stevedore;
-	CHECK_OBJ_NOTNULL(stv, STEVEDORE_MAGIC);
+	VSCARAB_LOCAL(scarab, 16);
+	VSCARET_LOCAL(scaret, 16);
 
-	boc = HSH_RefBoc(oc);
+	(void) final; // phase out?
+	sml_notify_init(&sn);
+	hdl = ObjVAIinit(wrk, oc, NULL, sml_notify, &sn);
+	AN(hdl);
 
-	if (boc == NULL) {
-		VTAILQ_FOREACH_REVERSE_SAFE(
-		    st, &obj->list, storagehead, list, checkpoint) {
+	r = u = 0;
 
-			u = 0;
-			if (VTAILQ_PREV(st, storagehead, list) == NULL)
+	do {
+		do {
+			nn = ObjVAIlease(wrk, hdl, scarab);
+			if (nn <= 0 || scarab->flags & VSCARAB_F_END)
+				break;
+		} while (scarab->used < scarab->capacity);
+
+		/*
+		 * nn is the wait/return action or 0
+		 * nn tells us if to flush
+		 */
+		uu = u;
+		last = VSCARAB_LAST(scarab);
+		VSCARAB_FOREACH(vio, scarab) {
+			islast = vio == last;
+			AZ(u & OBJ_ITER_END);
+			if (islast && scarab->flags & VSCARAB_F_END)
 				u |= OBJ_ITER_END;
-			if (final)
-				u |= OBJ_ITER_FLUSH;
-			if (ret == 0 && st->len > 0)
-				ret = func(priv, u, st->ptr, st->len);
-			if (final) {
-				VTAILQ_REMOVE(&obj->list, st, list);
-				sml_stv_free(stv, st);
-			} else if (ret)
-				break;
-		}
-		return (ret);
-	}
 
-	p = NULL;
-	l = 0;
-
-	u = 0;
-	if (boc->fetched_so_far == 0) {
-		ret = func(priv, OBJ_ITER_FLUSH, NULL, 0);
-		if (ret)
-			return (ret);
-	}
-	while (1) {
-		ol = len;
-		nl = ObjWaitExtend(wrk, oc, ol, &state);
-		if (state == BOS_FAILED) {
-			ret = -1;
-			break;
-		}
-		if (nl == ol) {
-			assert(state == BOS_FINISHED);
-			break;
-		}
-		assert(nl > ol);
-		Lck_Lock(&boc->mtx);
-		AZ(VTAILQ_EMPTY(&obj->list));
-		if (checkpoint == NULL) {
-			st = VTAILQ_LAST(&obj->list, storagehead);
-			sl = 0;
-		} else {
-			st = checkpoint;
-			sl = checkpoint_len;
-			ol -= checkpoint_len;
-		}
-		while (st != NULL) {
-			if (st->len > ol) {
-				p = st->ptr + ol;
-				l = st->len - ol;
-				len += l;
+			// flush if it is the scarab's last IOV and we will block next
+			// or if we need space in the return leases array
+			uu = u;
+			if ((islast && nn < 0) || scaret->used == scaret->capacity - 1)
+				uu |= OBJ_ITER_FLUSH;
+			r = func(priv, uu, vio->iov.iov_base, vio->iov.iov_len);
+			if (r != 0)
 				break;
-			}
-			ol -= st->len;
-			assert(ol >= 0);
-			nl -= st->len;
-			assert(nl > 0);
-			sl += st->len;
-			st = VTAILQ_PREV(st, storagehead, list);
-			if (final && checkpoint != NULL) {
-				if (checkpoint == boc->stevedore_priv)
-					boc->stevedore_priv = trim_once;
-				else
-					VTAILQ_REMOVE(&obj->list, checkpoint, list);
-				sml_stv_free(stv, checkpoint);
-			}
-			checkpoint = st;
-			checkpoint_len = sl;
+
+			// sufficient space ensured by capacity check above
+			VSCARET_ADD(scaret, vio->lease);
+
+			// whenever we have flushed, return leases
+			if ((uu & OBJ_ITER_FLUSH) && scaret->used > 0)
+				ObjVAIreturn(wrk, hdl, scaret);
 		}
-		CHECK_OBJ_NOTNULL(obj, OBJECT_MAGIC);
-		CHECK_OBJ_NOTNULL(st, STORAGE_MAGIC);
-		st = VTAILQ_PREV(st, storagehead, list);
-		if (st != NULL && st->len == 0)
-			st = NULL;
-		Lck_Unlock(&boc->mtx);
-		assert(l > 0 || state == BOS_FINISHED);
-		u = 0;
-		if (st == NULL || final)
-			u |= OBJ_ITER_FLUSH;
-		if (st == NULL && state == BOS_FINISHED)
-			u |= OBJ_ITER_END;
-		ret = func(priv, u, p, l);
-		if (ret)
-			break;
-	}
-	HSH_DerefBoc(wrk, oc);
+
+		// return leases which we did not use if error (break)
+		VSCARAB_FOREACH_RESUME(vio, scarab) {
+			if (scaret->used == scaret->capacity)
+				ObjVAIreturn(wrk, hdl, scaret);
+			VSCARET_ADD(scaret, vio->lease);
+		}
+
+		// we have now completed the scarab
+		VSCARAB_INIT(scarab, scarab->capacity);
+
+		// flush before blocking if we did not already
+		if (r == 0 && (nn == -ENOBUFS || nn == -EAGAIN) &&
+		    (uu & OBJ_ITER_FLUSH) == 0) {
+			r = func(priv, OBJ_ITER_FLUSH, NULL, 0);
+			if (scaret->used > 0)
+				ObjVAIreturn(wrk, hdl, scaret);
+		}
+
+		if (r == 0 && (nn == -ENOBUFS || nn == -EAGAIN)) {
+			assert(scaret->used <= 1);
+			sml_notify_wait(&sn);
+		}
+		else if (r == 0 && nn < 0)
+			r = -1;
+	} while (nn != 0 && r == 0);
+
 	if ((u & OBJ_ITER_END) == 0) {
-		ret2 = func(priv, OBJ_ITER_END, NULL, 0);
-		if (ret == 0)
-			ret = ret2;
+		r2 = func(priv, OBJ_ITER_END, NULL, 0);
+		if (r == 0)
+			r = r2;
 	}
-	return (ret);
+
+	if (scaret->used > 0)
+		ObjVAIreturn(wrk, hdl, scaret);
+
+	ObjVAIfini(wrk, &hdl);
+	sml_notify_fini(&sn);
+
+	return (r);
 }
 
 /*--------------------------------------------------------------------
@@ -736,6 +1042,7 @@ const struct obj_methods SML_methods = {
 	.objgetattr	= sml_getattr,
 	.objsetattr	= sml_setattr,
 	.objtouch	= LRU_Touch,
+	.vai_init	= sml_ai_init
 };
 
 static void

--- a/bin/varnishtest/tests/c00111.vtc
+++ b/bin/varnishtest/tests/c00111.vtc
@@ -15,7 +15,8 @@ client c1 {
 } -run
 
 varnish v1 -vsl_catchup
-varnish v1 -expect fetch_failed == 1
+# with vai, this no longer fails systematically (which is good)
+varnish v1 -expect fetch_failed <= 1
 
 varnish v1 -cliok "param.set transit_buffer 4k"
 
@@ -26,4 +27,4 @@ client c2 {
 
 varnish v1 -vsl_catchup
 varnish v1 -expect s_fetch == 2
-varnish v1 -expect fetch_failed == 1
+varnish v1 -expect fetch_failed <= 1

--- a/bin/varnishtest/tests/m00061.vtc
+++ b/bin/varnishtest/tests/m00061.vtc
@@ -43,7 +43,8 @@ client c0 -repeat 16 -keepalive {
 client c1 -repeat 16 -keepalive {
 	txreq
 	rxresp
-	expect resp.bodylen == 13107
+	expect resp.bodylen == 13113
+	expect req.body ~ "^hello "
 } -start
 
 #client c2 -repeat 16 -keepalive {

--- a/bin/varnishtest/tests/m00061.vtc
+++ b/bin/varnishtest/tests/m00061.vtc
@@ -1,0 +1,44 @@
+varnishtest "VMOD debug vai transport"
+
+server s1 {
+	rxreq
+	txresp -gziplen 13107
+} -start
+
+varnish v1 \
+    -arg "-p fetch_chunksize=4k" \
+    -vcl+backend {
+	import debug;
+
+	sub vcl_hash {
+		hash_data("");
+		return (lookup);
+	}
+
+	sub vcl_deliver {
+		if (req.url == "/chunked") {
+			set resp.filters += " debug.chunked";
+		}
+		debug.use_vai_http1();
+		set resp.http.filters = resp.filters;
+	}
+} -start
+
+varnish v1 -cliok "param.set debug +syncvsl"
+varnish v1 -cliok "param.set debug +req_state"
+
+client c1 -repeat 16 -keepalive {
+	txreq
+	rxresp
+	expect resp.bodylen == 13107
+} -start
+
+client c2 -repeat 16 -keepalive {
+	txreq -url "/chunked"
+	rxresp
+	expect resp.http.Content-Length == <undef>
+	expect resp.bodylen == 13107
+} -start
+
+client c1 -wait
+client c2 -wait

--- a/bin/varnishtest/tests/m00061.vtc
+++ b/bin/varnishtest/tests/m00061.vtc
@@ -24,8 +24,21 @@ varnish v1 \
 	}
 } -start
 
+logexpect l1 -v v1 -g raw {
+	fail add *	Debug "scheduling dbg_vai_deliverobj"
+	expect * *	Debug "scheduling dbg_vai_lease"
+	expect * *	ReqHeader "Last: Request"
+	fail clear
+} -start
+
 varnish v1 -cliok "param.set debug +syncvsl"
 varnish v1 -cliok "param.set debug +req_state"
+varnish v1 -cliok "param.set debug +processors"
+
+client c0 -repeat 16 -keepalive {
+	txreq -hdr "Accept-Encoding: gzip"
+	rxresp
+} -start
 
 client c1 -repeat 16 -keepalive {
 	txreq
@@ -33,12 +46,20 @@ client c1 -repeat 16 -keepalive {
 	expect resp.bodylen == 13107
 } -start
 
-client c2 -repeat 16 -keepalive {
-	txreq -url "/chunked"
-	rxresp
-	expect resp.http.Content-Length == <undef>
-	expect resp.bodylen == 13107
-} -start
+#client c2 -repeat 16 -keepalive {
+#	txreq -url "/chunked"
+#	rxresp
+#	expect resp.http.Content-Length == <undef>
+#	expect resp.bodylen == 13107
+#} -start
 
+client c0 -wait
 client c1 -wait
-client c2 -wait
+#client c2 -wait
+
+client c0 {
+	txreq -hdr "Accept-Encoding: gzip" -hdr "Last: Request"
+	rxresp
+} -run
+
+logexpect l1 -wait

--- a/vmod/automake_boilerplate_debug.am
+++ b/vmod/automake_boilerplate_debug.am
@@ -10,7 +10,8 @@ libvmod_debug_la_SOURCES = \
 	vmod_debug_dyn.c \
 	vmod_debug_filters.c \
 	vmod_debug_obj.c \
-	vmod_debug_transport_reembarking_http1.c
+	vmod_debug_transport_reembarking_http1.c \
+	vmod_debug_transport_vai.c
 
 libvmod_debug_la_CFLAGS =
 

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -333,6 +333,7 @@ event_load(VRT_CTX, struct vmod_priv *priv)
 
 	debug_add_filters(ctx);
 	debug_transport_reembarking_http1_init();
+	debug_transport_vai_init();
 	return (0);
 }
 
@@ -1287,6 +1288,12 @@ VCL_VOID
 xyzzy_use_reembarking_http1(VRT_CTX)
 {
 	debug_transport_reembarking_http1_use(ctx);
+}
+
+VCL_VOID
+xyzzy_use_vai_http1(VRT_CTX)
+{
+	debug_transport_vai_use(ctx);
 }
 
 static int

--- a/vmod/vmod_debug.h
+++ b/vmod/vmod_debug.h
@@ -39,3 +39,9 @@ void
 debug_transport_reembarking_http1_use(VRT_CTX);
 void
 debug_transport_reembarking_http1_init(void);
+
+/* vmod_debug_transport_vai.c */
+void
+debug_transport_vai_use(VRT_CTX);
+void
+debug_transport_vai_init(void);

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -491,6 +491,13 @@ Example::
 
 	Debug		c prefix[0]: (ws) 0x7fe69ef80420 abcd...
 
+$Function VOID use_vai_http1()
+
+$Restrict vcl_deliver
+
+Switch to the VAI http1 debug transport. Calling it from any other
+transport than http1 results in VCL failure.
+
 DEPRECATED
 ==========
 

--- a/vmod/vmod_debug_transport_vai.c
+++ b/vmod/vmod_debug_transport_vai.c
@@ -1,0 +1,227 @@
+/*-
+ * Copyright (c) 2006 Verdens Gang AS
+ * Copyright (c) 2006-2015 Varnish Software AS
+ * Copyright 2024 UPLEX - Nils Goroll Systemoptimierung
+ * All rights reserved.
+ *
+ * Authors: Poul-Henning Kamp <phk@phk.freebsd.dk>
+ *	    Nils Goroll <slink@uplex.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "cache/cache_varnishd.h"
+
+#include "cache/cache_filter.h"
+#include "cache/cache_transport.h"
+#include "http1/cache_http1.h"
+
+#include "vmod_debug.h"
+
+static void
+dbg_vai_error(struct req *req, struct v1l **v1lp, const char *msg)
+{
+
+	(void)req;
+	(void)v1lp;
+	(void)msg;
+	INCOMPL();
+}
+
+static void dbg_vai_deliver_finish(struct req *req, struct v1l **v1lp, int err);
+static void dbg_vai_sendbody(struct worker *wrk, void *arg);
+
+static task_func_t *hack_http1_req = NULL;
+
+// copied from cache_http_deliver.c, then split & modified
+static enum vtr_deliver_e v_matchproto_(vtr_deliver_f)
+dbg_vai_deliver(struct req *req, int sendbody)
+{
+	struct vrt_ctx ctx[1];
+	struct v1l *v1l;
+
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	CHECK_OBJ_ORNULL(req->boc, BOC_MAGIC);
+	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
+
+	if (req->doclose == SC_NULL &&
+	    http_HdrIs(req->resp, H_Connection, "close")) {
+		req->doclose = SC_RESP_CLOSE;
+	} else if (req->doclose != SC_NULL) {
+		if (!http_HdrIs(req->resp, H_Connection, "close")) {
+			http_Unset(req->resp, H_Connection);
+			http_SetHeader(req->resp, "Connection: close");
+		}
+	} else if (!http_GetHdr(req->resp, H_Connection, NULL))
+		http_SetHeader(req->resp, "Connection: keep-alive");
+
+	CHECK_OBJ_NOTNULL(req->wrk, WORKER_MAGIC);
+
+	v1l = V1L_Open(req->ws, &req->sp->fd, req->vsl,
+	    req->t_prev + SESS_TMO(req->sp, send_timeout),
+	    cache_param->http1_iovs);
+
+	if (v1l == NULL) {
+		dbg_vai_error(req, &v1l, "Failure to init v1d (workspace_thread overflow)");
+		return (VTR_D_DONE);
+	}
+
+	// Do not roll back req->ws upon V1L_Close()
+	V1L_NoRollback(v1l);
+
+	if (sendbody) {
+		if (!http_GetHdr(req->resp, H_Content_Length, NULL)) {
+			if (req->http->protover == 11) {
+				http_SetHeader(req->resp,
+				    "Transfer-Encoding: chunked");
+			} else {
+				req->doclose = SC_TX_EOF;
+			}
+		}
+		INIT_OBJ(ctx, VRT_CTX_MAGIC);
+		VCL_Req2Ctx(ctx, req);
+		if (VDP_Push(ctx, req->vdc, req->ws, VDP_v1l, v1l)) {
+			dbg_vai_error(req, &v1l, "Failure to push v1d processor");
+			return (VTR_D_DONE);
+		}
+	}
+
+	if (WS_Overflowed(req->ws)) {
+		dbg_vai_error(req, &v1l, "workspace_client overflow");
+		return (VTR_D_DONE);
+	}
+
+	if (WS_Overflowed(req->sp->ws)) {
+		dbg_vai_error(req, &v1l, "workspace_session overflow");
+		return (VTR_D_DONE);
+	}
+
+	if (WS_Overflowed(req->wrk->aws)) {
+		dbg_vai_error(req, &v1l, "workspace_thread overflow");
+		return (VTR_D_DONE);
+	}
+
+	req->acct.resp_hdrbytes += HTTP1_Write(v1l, req->resp, HTTP1_Resp);
+
+	if (! sendbody) {
+		dbg_vai_deliver_finish(req, &v1l, 0);
+		return (VTR_D_DONE);
+	}
+
+	(void)V1L_Flush(v1l);
+
+	if (hack_http1_req == NULL)
+		hack_http1_req = req->task->func;
+	AN(hack_http1_req);
+
+	VSLb(req->vsl, SLT_Debug, "w=%p scheduling dbg_vai_sendbody", req->wrk);
+
+	req->task->func = dbg_vai_sendbody;
+	req->task->priv = req;
+
+	req->wrk = NULL;
+	req->vdc->wrk = NULL;
+	req->transport_priv = v1l;
+
+	AZ(Pool_Task(req->sp->pool, req->task, TASK_QUEUE_RUSH));
+	return (VTR_D_DISEMBARK);
+}
+
+static void v_matchproto_(task_func_t)
+dbg_vai_sendbody(struct worker *wrk, void *arg)
+{
+	struct req *req;
+	struct v1l *v1l;
+	const char *p;
+	int err, chunked;
+
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	CAST_OBJ_NOTNULL(req, arg, REQ_MAGIC);
+	v1l = req->transport_priv;
+	req->transport_priv = NULL;
+	AN(v1l);
+
+	THR_SetRequest(req);
+	VSLb(req->vsl, SLT_Debug, "w=%p enter dbg_vai_sendbody", wrk);
+	AZ(req->wrk);
+	CNT_Embark(wrk, req);
+	req->vdc->wrk = wrk;	// move to CNT_Embark?
+
+	chunked = http_GetHdr(req->resp, H_Transfer_Encoding, &p) && strcmp(p, "chunked") == 0;
+	if (chunked)
+		V1L_Chunked(v1l);
+	err = VDP_DeliverObj(req->vdc, req->objcore);
+	if (!err && chunked)
+		V1L_EndChunk(v1l);
+	dbg_vai_deliver_finish(req, &v1l, err);
+
+	VSLb(req->vsl, SLT_Debug, "w=%p resuming http1_req", wrk);
+	wrk->task->func = hack_http1_req;
+	wrk->task->priv = req;
+}
+
+static void
+dbg_vai_deliver_finish(struct req *req, struct v1l **v1lp, int err)
+{
+	stream_close_t sc;
+	uint64_t bytes;
+
+	sc = V1L_Close(v1lp, &bytes);
+
+	req->acct.resp_bodybytes += VDP_Close(req->vdc, req->objcore, req->boc);
+
+	if (sc == SC_NULL && err && req->sp->fd >= 0)
+		sc = SC_REM_CLOSE;
+	if (sc != SC_NULL)
+		Req_Fail(req, sc);
+}
+
+static struct transport DBG_transport;
+
+void
+debug_transport_vai_init(void)
+{
+	DBG_transport = HTTP1_transport;
+	DBG_transport.name = "DBG VAI";
+	DBG_transport.deliver = dbg_vai_deliver;
+}
+
+void
+debug_transport_vai_use(VRT_CTX)
+{
+	struct req *req;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	req = ctx->req;
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+
+	if (req->transport != &HTTP1_transport) {
+		VRT_fail(ctx, "Only works on built-in http1 transport");
+		return;
+	}
+	AZ(req->transport_priv);
+	req->transport = &DBG_transport;
+}


### PR DESCRIPTION
... where _of course_ AI stands for **Asynchronous Iterators** ;)

### On this PR

This PR might be more extensive than others, and I would like to ask reviewers to lean back and take some time for it. Thank you in advance to anyone who invests their time into looking at this.

The PR description has been written to give an overview; individual commit messages have more details.

While the code proposed here works, and I am already building on top of it, I am deliberately marking this PR as a draft to make clear that I am very interested in feedback and comments before committing to a particular interface. Also I expect sensible changes to arrive still, but the fundamentals are ripe, IMHO.

### Intro

This PR suggests a new API to enable use of asynchronous I/O on the delivery side of Varnish-Cache. The design has been highly influenced by [io_uring](https://unixism.net/loti/what_is_io_uring.html), because my [prior experience](https://unixism.net/loti/what_is_io_uring.html) has been that creating compatibility with it is fairly easy: The io_uring interface is extremely simple in that completions are identified by a single `uint64_t` value, so once calling code is prepared to work with this limited interface, adding other implementations is relatively easy.

### Advantages of asynchronous I/O

In my mind, efficient asynchronous I/O interfaces primarily provides two main benefits:

a) using less threads

b) significantly lower context switching overhead when many I/O requests can be combined into a single system call (or, in the case of io_uring, optionally none at all)

a) has long been achieved with the traditional `select()` (`poll()` / `epoll()` / `kqueue()`) event loop model, which Varnish-Cache uses for the [waiter](https://github.com/varnishcache/varnish-cache/tree/master/bin/varnishd/waiter) facility. This technique saves on threads, but each I/O still requires >1 system call per I/O. As long as we used HTTP1 with TCP, this overhead was not too bad, because we could simply make our I/O system calls very big (using `writev()`). But already with HTTP2, handing large batches of data to the kernel becomes problematic, because the (questionable) benefits of the protocol require reacting to client events with lowest latency. And with HTTP3, we definitely need system calls to handle lots of small UDP datagrams, unless we want to map hardware into user address space and talk directly to it.

So b) becomes much more important now: More than ever, we will need to be able to batch I/O requests into as small a number of system calls as possible with a tight feedback loop to the client. If we want to stay efficient and not push too much data for each client at once, consequently we also need to handle many clients from a central instance (a thread or a few threads).

Or, summarizing even more, we need to use an event loop-ish architeture for client I/O.

### Existing interfaces vs. asynchronous I/O

Our existing [ObjIterate()](https://github.com/varnishcache/varnish-cache/blob/508306fd06341c6e960353680245b373a8f406e9/bin/varnishd/cache/cache_obj.c#L174-L184) interface calls into the storage engine with a delivery function to execute on every _extent_ (pointer + length) of body data. Iteration can block at any point: The storage engine may issue blocking I/O, as certainly will the delivery function while sending data to the client.

For asynchronous I/O, we need to turn this inside out: Firstly, our iteration state can not live on the stack as it currently does, we need a data structure containing all we need to know about the iteration such that we can come back later and ask the storage engine for more data. Secondly, we need a guarantee from the storage engine to never block. And, following from that, we need some notification mechanism allowing the storage engine to tell client I/O code that it now has more data available. A special case of the last point is streaming a busy object, where it is not just the storage engine that blocks, but rather creation of the cache object itself.

### Overview

This series of commits starts with the last aspect: `ObjVAIGetExtend()` in the second commit checks for more streaming data and, if none is available, registers a callback, allowing for asynchronous notification.

The third commit contains the proposed new API, which follows the idea that the storage engine hands out "leases" on segments of data to callers, which can then use them until they return the leases - where the storage engine might require leases to be returned before handing out new ones.

With an array of leases at hand, the caller can then do its asynchronous thing, also returning leases in an asynchronous fashion.

The last commit implements the new API for simple storage and reimplements the existing simple storage iterator using the new API as a PoC.

### Performance

Performance of malloc storage with current varnish-cache head 508306fd06341c6e960353680245b373a8f406e9 has been measured against the reimplementation using the new API. The test has been set up such that the more relevant case of streaming data from small-ish extents is tested with varnish-cache as its own backend: A cache object is created from 64MB of random data, which is then streamed in pass mode by using a request from Varnish-Cache against itself. The test has also been run with `debug.chkcrc32` from #4208 and also for much longer periods.

Details are given below.

Typical results for `wrk -t100 -c400 -d100 http://localhost:8080` on my laptop are:

#### baseline 508306fd06341c6e960353680245b373a8f406e9

```
Running 2m test @ http://localhost:8080/
  100 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.68s   306.07ms   2.00s    79.02%
    Req/Sec     0.60      1.80    20.00     92.79%
  4872 requests in 1.70m, 305.13GB read
  Socket errors: connect 0, read 263, write 0, timeout 4729
Requests/sec:     47.82
Transfer/sec:      2.99GB
```

#### with VAI reimplementation 125dc28478bda5f759e991f930dd0e59adf863f8

```
Running 2m test @ http://localhost:8080/
  100 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.61s   348.34ms   2.00s    75.63%
    Req/Sec     0.56      1.68    20.00     93.12%
  4897 requests in 1.70m, 306.35GB read
  Socket errors: connect 0, read 327, write 0, timeout 4700
Requests/sec:     48.04
Transfer/sec:      3.01GB
```

#### baseline 508306fd06341c6e960353680245b373a8f406e9 with `debug.chkcrc32`

```
Running 2m test @ http://localhost:8080/
  100 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.00us    0.00us   0.00us    -nan%
    Req/Sec     0.56      1.76    10.00     93.36%
  1065 requests in 1.67m, 75.61GB read
  Socket errors: connect 0, read 0, write 0, timeout 1065
Requests/sec:     10.64
Transfer/sec:    773.51MB
```

#### with VAI reimplementation 125dc28478bda5f759e991f930dd0e59adf863f8 with `debug.chkcrc32`

```
Running 2m test @ http://localhost:8080/
  100 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   846.94ms    0.00us 846.94ms  100.00%
    Req/Sec     0.67      1.91    10.00     92.55%
  1128 requests in 1.67m, 81.11GB read
  Socket errors: connect 0, read 0, write 0, timeout 1127
Requests/sec:     11.27
Transfer/sec:    829.73MB
```

### Performance Test details

VCL with varnishd start command line in a comment (code in vcl_deliver commented out for no-crc test)

```vcl
vcl 4.1;

# VCL to benchmark passes.
# A single object is created from a file, then varnish makes pass requests
# against itself which are hits on that file.
#
# Uses linux abstract sockets, but can easily be adjusted to using UDS
#
# example start command line:
#
# /tmp/sbin/varnishd -f $PWD/slink/bench_pass/bench_pass.vcl -a :8080 -a self=@varnish -n /tmp/t -p fetch_chunksize=4k -F

import debug;
import std;
import blob;
import blobsynth;

backend none none;

backend self {
	.path = "@varnish";
}

sub vcl_init {
	new data = blob.blob(BASE64,
	   std.fileread("/home/slink/Devel/varnish-git/slash/slink/misc/64mb.b64"));
}

sub vcl_recv {
	if (local.socket == "self") {
		set req.url = "/";
		return (hash);
	} else {
		return (pass);
	}
}

sub vcl_backend_fetch {
	if (local.socket == "self") {
		set bereq.backend = none;
	} else {
		set bereq.backend = self;
	}
	return (fetch);
}

sub vcl_backend_error {
	set beresp.status = 200;
	blobsynth.synthetic(data.get());
	set beresp.ttl = 1y;
	return (deliver);
}

sub vcl_deliver {
	debug.chkcrc32(2561873268, panic_unless_error);
	set resp.filters += " debug.chkcrc32";
}
```