### PR TITLE
Generic Copyright

### DIFF
--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -38,7 +38,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Varnish Cache'
-copyright = u'2010-2014, Varnish Software AS'
+copyright = u'2010-2024, The Varnish Cache Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This commit mirrors https://github.com/varnishcache/homepage/commit/0f25620719c3568e166b9beff5c2c176236bf29a

as of today, each page redendered from the sphinx source contains the line

	© Copyright 2010-2014, Varnish Software AS.

While this is true for some of the content, it is not for all of it and because we, several people from UPLEX, intend to contribute significant amounts of documentation in the near future, we would like to change this into something more generic, without the need to state specific copyright and authorship on each page.