### PR TITLE
Varnisncsa: Change matching rules to reflect reality

### DIFF
--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -160,6 +160,7 @@ static struct ctx {
 	const char		*handling;
 	const char		*side;
 	int64_t			vxid;
+	int			recv_compl;
 } CTX;
 
 static void parse_format(const char *format);
@@ -971,6 +972,7 @@ dispatch_f(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 		} else
 			continue;
 
+		CTX.recv_compl = 0;
 		CTX.hitmiss = "-";
 		CTX.handling = "-";
 		CTX.vxid = t->vxid;
@@ -1073,6 +1075,7 @@ dispatch_f(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 				break;
 			case SLT_VCL_call:
 				if (!strcasecmp(b, "recv")) {
+					CTX.recv_compl = 1;
 					CTX.hitmiss = "-";
 					CTX.handling = "-";
 				} else if (!strcasecmp(b, "hit")) {
@@ -1090,6 +1093,8 @@ dispatch_f(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 					   wrong */
 					CTX.hitmiss = "miss";
 					CTX.handling = "synth";
+				} else if (!strcasecmp(b, "backend_response")) {
+					CTX.recv_compl = 1;
 				}
 				break;
 			case SLT_VCL_return:

--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -939,6 +939,9 @@ frag_line(enum format_policy fp, const char *b, const char *e,
 		/* We only grab the same matching record once */
 		return;
 
+	if (e == NULL)
+		e = b + strlen(b);
+
 	/* Skip leading space */
 	while (b < e && isspace(*b))
 		++b;

--- a/bin/varnishtest/tests/u00020.vtc
+++ b/bin/varnishtest/tests/u00020.vtc
@@ -14,11 +14,13 @@ varnish v1 -vcl+backend {
 		set bereq.method = "HEAD";
 		set bereq.url = "/vbf-url?q=vbfQuerry";
 		set bereq.http.Authorization = "basic dmJmOnBhc3M=";
+		unset bereq.http.unset;
 	}
 
 	sub vcl_backend_response {
 		set bereq.http.bereqhdr = "vbr-modified";
 		set bereq.http.notsent = "notsent";
+		set bereq.http.unset = "toolate";
 		set bereq.method = "CONNECT";
 		set bereq.url = "/vbr-url?q=vbrQuerry";
 		set bereq.http.Authorization = "basic dmJyOnBhc3M=";
@@ -28,15 +30,15 @@ varnish v1 -vcl+backend {
 
 
 client c1 {
-	txreq -url "/client-url?q=clientQuerry" -hdr "bereqhdr: client-header" -hdr "Authorization:basic Y2xpZW50OnBhc3M="
+	txreq -url "/client-url?q=clientQuerry" -hdr "bereqhdr: client-header" -hdr "unset: client" -hdr "Authorization:basic Y2xpZW50OnBhc3M="
 	rxresp
 } -run
 
 shell {
-	varnishncsa -n ${v1_name} -d -b -F '%H %{bereqhdr}i %{notsent}i %m %q %U %u' > ncsa_sb.txt
+	varnishncsa -n ${v1_name} -d -b -F '%H %{bereqhdr}i %{notsent}i %{unset}i %m %q %U %u' > ncsa_sb.txt
 
 	cat >expected_sb.txt <<-EOF
-	HTTP/1.1 vbf-modified - HEAD ?q=vbfQuerry /vbf-url vbf
+	HTTP/1.1 vbf-modified - - HEAD ?q=vbfQuerry /vbf-url vbf
 	EOF
 	diff -u expected_sb.txt ncsa_sb.txt
 }
@@ -47,7 +49,7 @@ varnish v1 -stop
 
 server s1 {
         rxreq
-        txresp -status 202 -hdr "beresp: origin"
+        txresp -status 202 -hdr "beresp: origin" -hdr "unset: origin"
 } -start
 
 varnish v1 -vcl+backend {
@@ -55,6 +57,7 @@ varnish v1 -vcl+backend {
         sub vcl_backend_response {
 		set beresp.http.beresp = "vbr-updated";
 		set beresp.status = 200;
+		unset beresp.http.unset;
         }
 
 } -start
@@ -67,10 +70,10 @@ client c1 {
 
 
 shell {
-	varnishncsa -n ${v1_name} -d -b -F '%s %{beresp}o' > ncsa_rb.txt
+	varnishncsa -n ${v1_name} -d -b -F '%s %{beresp}o %{unset}o' > ncsa_rb.txt
 
 	cat >expected_rb.txt <<-EOF
-	202 origin
+	202 origin origin
 	EOF
 	diff -u expected_rb.txt ncsa_rb.txt
 }
@@ -81,7 +84,7 @@ varnish v1 -stop
 
 server s1 {
 	rxreq
-	txresp -status 202 -hdr "resp: origin"
+	txresp -status 202 -hdr "resp: origin" -hdr "unset: origin"
 } -start
 
 varnish v1 -vcl+backend {
@@ -95,6 +98,7 @@ varnish v1 -vcl+backend {
 		set resp.http.resp = "deliver-updated";
 		set resp.status = 201;
 		set resp.http.added = "deliver";
+		unset resp.http.unset;
 	}
 
 } -start
@@ -106,10 +110,10 @@ client c1 {
 } -run
 
 shell {
-        varnishncsa -n ${v1_name} -d -c -F '%s %{resp}o %{added}o' > ncsa_sc.txt
+        varnishncsa -n ${v1_name} -d -c -F '%s %{resp}o %{unset}o %{added}o' > ncsa_sc.txt
 
         cat >expected_sc.txt <<-EOF
-	201 deliver-updated deliver
+	201 deliver-updated - deliver
 	EOF
 	diff -u expected_sc.txt ncsa_sc.txt
 }
@@ -131,6 +135,7 @@ varnish v1 -vcl+backend {
 		set req.url = "/recv-url?q=recvQuerry";
 		set req.http.Authorization = "basic cmVjdjpwYXNz";
 		set req.http.notreceived = "recv";
+		unset req.http.unset;
 	}
 
 	sub vcl_hash {
@@ -147,17 +152,17 @@ varnish v1 -vcl+backend {
 client c1 {
 	txreq -req "POST" -url "/client-url?q=clientQuerry" \
 	    -hdr "reqhdr: client-header" \
-	    -hdr "Authorization:basic Y2xpZW50OnBhc3M="
+	    -hdr "Authorization:basic Y2xpZW50OnBhc3M=" \
+	    -hdr "unset: client"
 	rxresp
 } -run
 
 
 shell {
-        varnishncsa -n ${v1_name} -d -c -F '%H %{reqhdr}i %{notreceived}i %m %q %U %u' > ncsa_rc.txt
+        varnishncsa -n ${v1_name} -d -c -F '%H %{reqhdr}i %{notreceived}i %{unset}i %m %q %U %u' > ncsa_rc.txt
 
         cat >expected_rc.txt <<-EOF
-	HTTP/1.1 client-header - POST ?q=clientQuerry /client-url client
+	HTTP/1.1 client-header - client POST ?q=clientQuerry /client-url client
         EOF
         diff -u expected_rc.txt ncsa_rc.txt
 }
-# TODO: Handle Unset

--- a/bin/varnishtest/tests/u00020.vtc
+++ b/bin/varnishtest/tests/u00020.vtc
@@ -1,0 +1,163 @@
+varnishtest "new varnishncsa matching rules"
+
+# Test things we send to the backend
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+
+	sub vcl_backend_fetch {
+		set bereq.http.bereqhdr = "vbf-modified";
+		set bereq.method = "HEAD";
+		set bereq.url = "/vbf-url?q=vbfQuerry";
+		set bereq.http.Authorization = "basic dmJmOnBhc3M=";
+	}
+
+	sub vcl_backend_response {
+		set bereq.http.bereqhdr = "vbr-modified";
+		set bereq.http.notsent = "notsent";
+		set bereq.method = "CONNECT";
+		set bereq.url = "/vbr-url?q=vbrQuerry";
+		set bereq.http.Authorization = "basic dmJyOnBhc3M=";
+	}
+
+} -start
+
+
+client c1 {
+	txreq -url "/client-url?q=clientQuerry" -hdr "bereqhdr: client-header" -hdr "Authorization:basic Y2xpZW50OnBhc3M="
+	rxresp
+} -run
+
+shell {
+	varnishncsa -n ${v1_name} -d -b -F '%H %{bereqhdr}i %{notsent}i %m %q %U %u' > ncsa_sb.txt
+
+	cat >expected_sb.txt <<-EOF
+	HTTP/1.1 vbf-modified - HEAD ?q=vbfQuerry /vbf-url vbf
+	EOF
+	diff -u expected_sb.txt ncsa_sb.txt
+}
+
+varnish v1 -stop
+
+# Test things we receive from the backend
+
+server s1 {
+        rxreq
+        txresp -status 202 -hdr "beresp: origin"
+} -start
+
+varnish v1 -vcl+backend {
+
+        sub vcl_backend_response {
+		set beresp.http.beresp = "vbr-updated";
+		set beresp.status = 200;
+        }
+
+} -start
+
+
+client c1 {
+        txreq
+        rxresp
+} -run
+
+
+shell {
+	varnishncsa -n ${v1_name} -d -b -F '%s %{beresp}o' > ncsa_rb.txt
+
+	cat >expected_rb.txt <<-EOF
+	202 origin
+	EOF
+	diff -u expected_rb.txt ncsa_rb.txt
+}
+
+varnish v1 -stop
+
+# Test things we send to the client
+
+server s1 {
+	rxreq
+	txresp -status 202 -hdr "resp: origin"
+} -start
+
+varnish v1 -vcl+backend {
+
+	sub vcl_backend_response {
+		set beresp.http.resp = "vbr-updated";
+		set beresp.status = 200;
+	}
+
+	sub vcl_deliver {
+		set resp.http.resp = "deliver-updated";
+		set resp.status = 201;
+		set resp.http.added = "deliver";
+	}
+
+} -start
+
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+shell {
+        varnishncsa -n ${v1_name} -d -c -F '%s %{resp}o %{added}o' > ncsa_sc.txt
+
+        cat >expected_sc.txt <<-EOF
+	201 deliver-updated deliver
+	EOF
+	diff -u expected_sc.txt ncsa_sc.txt
+}
+
+varnish v1 -stop
+
+# Test things we receive from the client
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+
+	sub vcl_recv {
+		set req.http.reqhdr = "recv-modified";
+		set req.method = "HEAD";
+		set req.url = "/recv-url?q=recvQuerry";
+		set req.http.Authorization = "basic cmVjdjpwYXNz";
+		set req.http.notreceived = "recv";
+	}
+
+	sub vcl_hash {
+		set req.http.reqhdr = "hash-modified";
+		set req.method = "GET";
+		set req.url = "/hash-url?q=hashQuerry";
+		set req.http.Authorization = "basic aGFzaDpwYXNz";
+		set req.http.notreceived = "hash";
+	}
+
+} -start
+
+
+client c1 {
+	txreq -req "POST" -url "/client-url?q=clientQuerry" \
+	    -hdr "reqhdr: client-header" \
+	    -hdr "Authorization:basic Y2xpZW50OnBhc3M="
+	rxresp
+} -run
+
+
+shell {
+        varnishncsa -n ${v1_name} -d -c -F '%H %{reqhdr}i %{notreceived}i %m %q %U %u' > ncsa_rc.txt
+
+        cat >expected_rc.txt <<-EOF
+	HTTP/1.1 client-header - POST ?q=clientQuerry /client-url client
+        EOF
+        diff -u expected_rc.txt ncsa_rc.txt
+}
+# TODO: Handle Unset

--- a/doc/sphinx/reference/varnishncsa.rst
+++ b/doc/sphinx/reference/varnishncsa.rst
@@ -106,7 +106,8 @@ Supported formatters are:
 
 %{X}i
   The contents of request header X. If the header appears multiple times
-  in a single transaction, the last occurrence is used.
+  in a single transaction, the last occurrence is used in backend mode
+  and the first one in client mode.
 
 %l
   Remote logname. Always '-'.
@@ -116,7 +117,8 @@ Supported formatters are:
 
 %{X}o
   The contents of response header X. If the header appears multiple
-  times in a single transaction, the last occurrence is used.
+  times in a single transaction, the last occurrence is used in client
+  mode and the first one in backend mode.
 
 %O
   In client mode, total bytes sent to client.  In backend mode, total
@@ -239,8 +241,20 @@ NOTES
 
 The %r formatter is equivalent to ``%m http://%{Host}i%U%q %H``. This
 differs from apache's %r behavior, equivalent to "%m %U%q %H".
-Furthermore, when using the %r formatter, if the Host header appears
-multiple times in a single transaction, the first occurrence is used.
+
+Note that request fields are collected on a first match basis in client mode
+and last match basis in backend mode. Similarly, response fields are collected
+on a first match basis in backend mode and last match basis in client mode.
+
+In other words, this means that requests are represented as they were received
+from the client and as they were sent to the backend, while responses are
+represented as they were sent to the client and as they were received from
+the backend.
+
+Furthermore, these rules also apply for items that appear multiple times in a
+transaction. For exampe, if a header appears multiple times in a client request,
+the first occurence would be shown in client mode, while the last one would be
+used in backend mode.
 
 EXAMPLE
 =======


### PR DESCRIPTION
This PR introduces the changes discussed in https://github.com/varnishcache/varnish-cache/issues/3528

The relevant parts of [BE]requests/responses are now shown as they were received/sent from/to the peer, without taking irrelevant VCL changes into account. This PR also introduces the handling of Unset headers in varnishncsa.

Note: this breaks the default behavior of varnishncsa.

Fixes #3528.