### PR TITLE
Minor doc fix

### DIFF
--- a/doc/sphinx/users-guide/vcl-grace.rst
+++ b/doc/sphinx/users-guide/vcl-grace.rst
@@ -69,7 +69,7 @@ behave as described above. However, if you want to customize how
 Varnish behaves, then you should know some of the details on how this
 works.
 
-When ``sub vcl_recv`` ends with ``return (lookup)`` (which is the
+When ``sub vcl_recv`` ends with ``return (hash)`` (which is the
 default behavior), Varnish will look for a matching object in its
 cache. Then, if it only found an object whose TTL has run out, Varnish
 will consider the following:


### PR DESCRIPTION
`sub vcl_recv` does not have `return (lookup)`