### PR TITLE
Add a few more to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ cscope.*out
 /vmod/vcc_*_if.c
 /vmod/vcc_*_if.h
 /vmod/vmod_*.rst
+/vcc_if.*
+/vmod_*.*
 
 # Man-files and binaries
 /man/*.1


### PR DESCRIPTION
My repo ended up with these files in the root due to some build process. Not certain if others may run into the same, so adding to ignore.

```
vcc_if.c
vcc_if.c.tmp
vcc_if.c.tmp2
vcc_if.h
vcc_if.h.tmp
vmod_example.man.rst
vmod_example.man.rst.tmp
vmod_example.rst
vmod_example.rst.tmp
```