### PR TITLE
varnishncsa: Add hitmiss hitpass indicators to Varnish:handling

### DIFF
--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -1128,6 +1128,14 @@ dispatch_f(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 			case SLT_RespUnset:
 				process_hdr(FMTPOL_RESP, &CTX.watch_resphdr, b, e, 1);
 				break;
+			case SLT_HitMiss:
+				CTX.hitmiss = "miss";
+				CTX.handling = "hitmiss";
+				break;
+			case SLT_HitPass:
+				CTX.hitmiss = "miss";
+				CTX.handling = "hitpass";
+				break;
 			case SLT_VCL_call:
 				if (!strcasecmp(b, "recv")) {
 					CTX.recv_compl = 1;
@@ -1136,10 +1144,10 @@ dispatch_f(struct VSL_data *vsl, struct VSL_transaction * const pt[],
 				} else if (!strcasecmp(b, "hit")) {
 					CTX.hitmiss = "hit";
 					CTX.handling = "hit";
-				} else if (!strcasecmp(b, "miss")) {
+				} else if (!strcasecmp(b, "miss") && strcmp(CTX.handling, "hitmiss")) {
 					CTX.hitmiss = "miss";
 					CTX.handling = "miss";
-				} else if (!strcasecmp(b, "pass")) {
+				} else if (!strcasecmp(b, "pass") && strcmp(CTX.handling, "hitpass")) {
 					CTX.hitmiss = "miss";
 					CTX.handling = "pass";
 				} else if (!strcasecmp(b, "synth")) {

--- a/bin/varnishtest/tests/u00002.vtc
+++ b/bin/varnishtest/tests/u00002.vtc
@@ -1,0 +1,104 @@
+varnishtest "varnishncsa handling"
+
+server s1 -repeat 4 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	backend none none;
+
+	sub vcl_backend_fetch {
+		# XXX would like to do everything in v_b_e, but
+		#     return(pass(x)) is not supported
+		if (bereq.url == "/hitpass") {
+			set bereq.backend = s1;
+		} else {
+			set bereq.backend = none;
+		}
+	}
+
+	sub vcl_backend_response {
+		set beresp.ttl = 1y;
+		return (pass(1y));
+	}
+
+	sub vcl_backend_error {
+		set beresp.status = 200;
+		set beresp.ttl = 1y;
+		set beresp.body = bereq.url;
+		if (bereq.url ~ "^/hitmiss") {
+			set beresp.uncacheable  = true;
+		}
+		return (deliver);
+	}
+
+	sub vcl_miss {
+		if (req.url == "/hitmisspass" && req.is_hitmiss) {
+			return (pass);
+		}
+	}
+
+	sub vcl_recv {
+		if (req.url == "/pass") {
+			return (pass);
+		}
+		if (req.url == "/synth") {
+			return (synth(204));
+		}
+	}
+} -start
+
+client c1 {
+	# prime
+	txreq -url "/hitmiss"
+	rxresp
+	txreq -url "/hitmisspass"
+	rxresp
+	expect resp.status == 200
+	txreq -url "/hitpass"
+	rxresp
+	expect resp.status == 200
+	txreq -url "/hit"
+	rxresp
+	expect resp.status == 200
+
+	# re-check
+	txreq -url "/hitmiss"
+	rxresp
+	expect resp.status == 200
+	txreq -url "/hitmisspass"
+	rxresp
+	expect resp.status == 200
+	txreq -url "/hitpass"
+	rxresp
+	expect resp.status == 200
+	txreq -url "/hit"
+	rxresp
+	expect resp.status == 200
+
+	# others
+	txreq -url "/pass"
+	rxresp
+	expect resp.status == 200
+	txreq -url "/synth"
+	rxresp
+	expect resp.status == 204
+} -run
+
+shell {
+	cat <<EOF >expect
+miss /hitmiss
+miss /hitmisspass
+miss /hitpass
+miss /hit
+hitmiss /hitmiss
+pass /hitmisspass
+hitpass /hitpass
+hit /hit
+pass /pass
+synth /synth
+EOF
+	varnishncsa -d -n ${v1_name} -F "%{Varnish:handling}x %U" >have
+	diff -u expect have
+}

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -41,6 +41,13 @@ Varnish Cache NEXT (2025-03-15)
 .. PLEASE keep this roughly in commit order as shown by git-log / tig
    (new to old)
 
+* The ``hitmiss`` and ``hitpass`` handling indicators have been added to the
+  ``Varnish:handling`` format of ``varnishncsa``.
+
+* The scope of VCL variables `req.is_hitmiss` and `req.is_hitpass` is now restricted
+  to `vcl_miss, vcl_deliver, vcl_pass, vcl_synth` and `vcl_pass, vcl_deliver, vcl_synth`
+  respectively.
+
 * Two fields have been added to the VMOD data registered with varnish-cache:
 
   - ``vcs`` for Version Control System is intended as an identifier from the

--- a/doc/sphinx/reference/varnishncsa.rst
+++ b/doc/sphinx/reference/varnishncsa.rst
@@ -191,9 +191,9 @@ Supported formatters are:
     misses. In backend mode, this field is blank.
 
   Varnish:handling
-    In client mode, one of the 'hit', 'miss', 'pass', 'pipe' or 'synth' strings
-    indicating how the request was handled. In backend mode, this field is
-    blank.
+    In client mode, one of the 'hit', 'hitmiss', 'hitpass', 'miss', 'pass',
+    'pipe' or 'synth' strings indicating how the request was handled. In
+    backend mode, this field is blank.
 
   Varnish:side
     Backend or client side. One of two values, 'b' or 'c', depending


### PR DESCRIPTION
The title should say it all. Simple straight forward extension of the handling strings.

@martin-uplex 