### PR TITLE
Transport disembark

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -537,6 +537,7 @@ struct req {
 	struct ws		ws[1];
 	struct objcore		*objcore;
 	struct objcore		*stale_oc;
+	struct boc		*boc;		/* valid during cnt_transmit */
 
 	/* resp.body */
 	struct vdp_ctx		*vdc;

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -867,7 +867,7 @@ ved_close(struct req *req, int error)
 
 /*--------------------------------------------------------------------*/
 
-static void v_matchproto_(vtr_deliver_f)
+static enum vtr_deliver_e v_matchproto_(vtr_deliver_f)
 ved_deliver(struct req *req, int wantbody)
 {
 	int i = 0;
@@ -888,17 +888,17 @@ ved_deliver(struct req *req, int wantbody)
 	if (FEATURE(FEATURE_ESI_INCLUDE_ONERROR) &&
 	    status != 200 && status != 204) {
 		ved_close(req, ecx->abrt);
-		return;
+		return (VTR_D_DONE);
 	}
 
 	if (wantbody == 0) {
 		ved_close(req, 0);
-		return;
+		return (VTR_D_DONE);
 	}
 
 	if (req->boc == NULL && ObjGetLen(req->wrk, req->objcore) == 0) {
 		ved_close(req, 0);
-		return;
+		return (VTR_D_DONE);
 	}
 
 	if (http_GetHdr(req->resp, H_Content_Encoding, &p))
@@ -922,7 +922,7 @@ ved_deliver(struct req *req, int wantbody)
 			 * XXX change error argument to 1
 			 */
 			ved_close(req, 0);
-			return;
+			return (VTR_D_DONE);
 		}
 
 		INIT_OBJ(foo, VED_FOO_MAGIC);
@@ -948,4 +948,5 @@ ved_deliver(struct req *req, int wantbody)
 		req->doclose = SC_REM_CLOSE;
 
 	ved_close(req, i && ecx->abrt ? 1 : 0);
+	return (VTR_D_DONE);
 }

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -497,7 +497,7 @@ cnt_transmit(struct worker *wrk, struct req *req)
 		}
 		if (req->resp_len == 0)
 			sendbody = 0;
-		req->transport->deliver(req, req->boc, sendbody);
+		req->transport->deliver(req, sendbody);
 	}
 
 	VSLb_ts_req(req, "Resp", W_TIM_real(wrk));

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -66,7 +66,8 @@
   REQ_STEP(deliver,             DELIVER,	static) \
   REQ_STEP(vclfail,             VCLFAIL,	static) \
   REQ_STEP(synth,               SYNTH,		static) \
-  REQ_STEP(transmit,            TRANSMIT,	static)
+  REQ_STEP(transmit,            TRANSMIT,	static) \
+  REQ_STEP(finish,              FINISH,		static)
 
 #define REQ_STEP(l, U, priv) \
     static req_state_f cnt_##l; \
@@ -499,6 +500,16 @@ cnt_transmit(struct worker *wrk, struct req *req)
 			sendbody = 0;
 		req->transport->deliver(req, sendbody);
 	}
+	req->req_step = R_STP_FINISH;
+	return (REQ_FSM_MORE);
+}
+
+static enum req_fsm_nxt v_matchproto_(req_state_f)
+cnt_finish(struct worker *wrk, struct req *req)
+{
+
+	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
 
 	VSLb_ts_req(req, "Resp", W_TIM_real(wrk));
 

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -38,7 +38,13 @@
 struct req;
 struct boc;
 
-typedef void vtr_deliver_f (struct req *, int sendbody);
+enum vtr_deliver_e {
+	VTR_D_INVAL = 0,
+	VTR_D_DONE = 1,
+	VTR_D_DISEMBARK
+};
+
+typedef enum vtr_deliver_e vtr_deliver_f (struct req *, int sendbody);
 typedef void vtr_req_body_f (struct req *);
 typedef void vtr_sess_panic_f (struct vsb *, const struct sess *);
 typedef void vtr_req_panic_f (struct vsb *, const struct req *);

--- a/bin/varnishd/cache/cache_transport.h
+++ b/bin/varnishd/cache/cache_transport.h
@@ -38,7 +38,7 @@
 struct req;
 struct boc;
 
-typedef void vtr_deliver_f (struct req *, struct boc *, int sendbody);
+typedef void vtr_deliver_f (struct req *, int sendbody);
 typedef void vtr_req_body_f (struct req *);
 typedef void vtr_sess_panic_f (struct vsb *, const struct sess *);
 typedef void vtr_req_panic_f (struct vsb *, const struct req *);

--- a/bin/varnishd/http1/cache_http1.h
+++ b/bin/varnishd/http1/cache_http1.h
@@ -42,7 +42,7 @@ extern const int HTTP1_Req[3];
 extern const int HTTP1_Resp[3];
 
 /* cache_http1_deliver.c */
-void V1D_Deliver(struct req *, int sendbody);
+enum vtr_deliver_e V1D_Deliver(struct req *, int sendbody);
 
 /* cache_http1_pipe.c */
 struct v1p_acct {

--- a/bin/varnishd/http1/cache_http1.h
+++ b/bin/varnishd/http1/cache_http1.h
@@ -42,7 +42,7 @@ extern const int HTTP1_Req[3];
 extern const int HTTP1_Resp[3];
 
 /* cache_http1_deliver.c */
-void V1D_Deliver(struct req *, struct boc *, int sendbody);
+void V1D_Deliver(struct req *, int sendbody);
 
 /* cache_http1_pipe.c */
 struct v1p_acct {

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -74,7 +74,7 @@ V1D_Deliver(struct req *req, int sendbody)
 	struct vrt_ctx ctx[1];
 	int err = 0, chunked = 0;
 	stream_close_t sc;
-	uint64_t hdrbytes, bytes;
+	uint64_t bytes;
 	struct v1l *v1l;
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
@@ -136,7 +136,7 @@ V1D_Deliver(struct req *req, int sendbody)
 		return (VTR_D_DONE);
 	}
 
-	hdrbytes = HTTP1_Write(v1l, req->resp, HTTP1_Resp);
+	req->acct.resp_hdrbytes += HTTP1_Write(v1l, req->resp, HTTP1_Resp);
 
 	if (sendbody) {
 		if (DO_DEBUG(DBG_FLUSH_HEAD))
@@ -150,7 +150,6 @@ V1D_Deliver(struct req *req, int sendbody)
 
 	sc = V1L_Close(&v1l, &bytes);
 
-	req->acct.resp_hdrbytes += hdrbytes;
 	req->acct.resp_bodybytes += VDP_Close(req->vdc, req->objcore, req->boc);
 
 	if (sc == SC_NULL && err && req->sp->fd >= 0)

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -292,7 +292,7 @@ h2_build_headers(struct vsb *resp, struct req *req)
 	}
 }
 
-void v_matchproto_(vtr_deliver_f)
+enum vtr_deliver_e v_matchproto_(vtr_deliver_f)
 h2_deliver(struct req *req, int sendbody)
 {
 	size_t sz;
@@ -349,4 +349,5 @@ h2_deliver(struct req *req, int sendbody)
 	}
 
 	req->acct.resp_bodybytes += VDP_Close(req->vdc, req->objcore, req->boc);
+	return (VTR_D_DONE);
 }

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -293,7 +293,7 @@ h2_build_headers(struct vsb *resp, struct req *req)
 }
 
 void v_matchproto_(vtr_deliver_f)
-h2_deliver(struct req *req, struct boc *boc, int sendbody)
+h2_deliver(struct req *req, int sendbody)
 {
 	size_t sz;
 	const char *r;
@@ -304,7 +304,6 @@ h2_deliver(struct req *req, struct boc *boc, int sendbody)
 	uintptr_t ss;
 
 	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
-	CHECK_OBJ_ORNULL(boc, BOC_MAGIC);
 	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
 	CAST_OBJ_NOTNULL(r2, req->transport_priv, H2_REQ_MAGIC);
 	sp = req->sp;
@@ -349,5 +348,5 @@ h2_deliver(struct req *req, struct boc *boc, int sendbody)
 			(void)VDP_DeliverObj(req->vdc, req->objcore);
 	}
 
-	req->acct.resp_bodybytes += VDP_Close(req->vdc, req->objcore, boc);
+	req->acct.resp_bodybytes += VDP_Close(req->vdc, req->objcore, req->boc);
 }

--- a/bin/varnishtest/tests/m00060.vtc
+++ b/bin/varnishtest/tests/m00060.vtc
@@ -1,0 +1,39 @@
+varnishtest "VMOD debug reembarking transport"
+
+server s1 {
+	rxreq
+	txresp -bodylen 131072
+} -start
+
+varnish v1 \
+    -vcl+backend {
+	import debug;
+
+	sub vcl_hash {
+		hash_data("");
+		return (lookup);
+	}
+
+	sub vcl_deliver {
+		if (req.url == "/chunked") {
+			set resp.filters = "debug.chunked";
+		}
+		debug.use_reembarking_http1();
+	}
+} -start
+
+varnish v1 -cliok "param.set debug +syncvsl"
+varnish v1 -cliok "param.set debug +req_state"
+
+client c1 -repeat 16 -keepalive {
+	txreq
+	rxresp
+} -start
+
+client c2 -repeat 16 -keepalive {
+	txreq -url "/chunked"
+	rxresp
+} -start
+
+client c1 -wait
+client c2 -wait

--- a/vmod/automake_boilerplate_debug.am
+++ b/vmod/automake_boilerplate_debug.am
@@ -12,7 +12,8 @@ libvmod_debug_la_SOURCES = \
 	vmod_debug_acl.c \
 	vmod_debug_dyn.c \
 	vmod_debug_filters.c \
-	vmod_debug_obj.c
+	vmod_debug_obj.c \
+	vmod_debug_transports.c
 
 libvmod_debug_la_CFLAGS =
 

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -332,6 +332,7 @@ event_load(VRT_CTX, struct vmod_priv *priv)
 	priv->methods = priv_vcl_methods;
 
 	debug_add_filters(ctx);
+	debug_transport_init();
 	return (0);
 }
 
@@ -1280,4 +1281,10 @@ xyzzy_resolve_range(VRT_CTX, struct VARGS(resolve_range) *args)
 		VSB_printf(p.vsb, "%s%s", VSB_len(p.vsb) ? ", " : "Failed: ",
 		    *(p.errp));
 	return (WS_VSB_finish(p.vsb, ctx->ws, NULL));
+}
+
+VCL_VOID
+xyzzy_use_reembarking_http1(VRT_CTX)
+{
+	debug_transport_use_reembarking_http1(ctx);
 }

--- a/vmod/vmod_debug.h
+++ b/vmod/vmod_debug.h
@@ -33,3 +33,9 @@ void
 debug_add_filters(VRT_CTX);
 void
 debug_remove_filters(VRT_CTX);
+
+/* vmod_debug_transports.c */
+void
+debug_transport_use_reembarking_http1(VRT_CTX);
+void
+debug_transport_init(void);

--- a/vmod/vmod_debug.vcc
+++ b/vmod/vmod_debug.vcc
@@ -440,6 +440,13 @@ be hanged to zero. Any larger value will be taken modulo UINT32_MAX.
 
 The *mode* argument behaves as for `debug.chksha256()`_.
 
+$Function VOID use_reembarking_http1()
+
+$Restrict vcl_deliver
+
+Switch to the reembarking http1 debug transport. Calling it from any other
+transport than http1 results in VCL failure.
+
 DEPRECATED
 ==========
 

--- a/vmod/vmod_debug_transports.c
+++ b/vmod/vmod_debug_transports.c
@@ -1,0 +1,224 @@
+/*-
+ * Copyright (c) 2006 Verdens Gang AS
+ * Copyright (c) 2006-2015 Varnish Software AS
+ * Copyright 2024 UPLEX - Nils Goroll Systemoptimierung
+ * All rights reserved.
+ *
+ * Authors: Poul-Henning Kamp <phk@phk.freebsd.dk>
+ *          Nils Goroll <slink@uplex.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "cache/cache_varnishd.h"
+
+#include "cache/cache_filter.h"
+#include "cache/cache_transport.h"
+#include "http1/cache_http1.h"
+
+#include "vmod_debug.h"
+
+static void
+dbg_error(struct req *req, struct v1l **v1lp, const char *msg)
+{
+
+	(void)req;
+	(void)v1lp;
+	(void)msg;
+	INCOMPL();
+}
+
+static void dbg_deliver_finish(struct req *req, struct v1l **v1lp, int err);
+static void dbg_sendbody(struct worker *wrk, void *arg);
+
+static task_func_t *hack_http1_req = NULL;
+
+// copied from cache_http_deliver.c, then split & modified
+static enum vtr_deliver_e v_matchproto_(vtr_deliver_f)
+dbg_deliver(struct req *req, int sendbody)
+{
+	struct vrt_ctx ctx[1];
+	struct v1l *v1l;
+
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+	CHECK_OBJ_ORNULL(req->boc, BOC_MAGIC);
+	CHECK_OBJ_NOTNULL(req->objcore, OBJCORE_MAGIC);
+
+	if (req->doclose == SC_NULL &&
+	    http_HdrIs(req->resp, H_Connection, "close")) {
+		req->doclose = SC_RESP_CLOSE;
+	} else if (req->doclose != SC_NULL) {
+		if (!http_HdrIs(req->resp, H_Connection, "close")) {
+			http_Unset(req->resp, H_Connection);
+			http_SetHeader(req->resp, "Connection: close");
+		}
+	} else if (!http_GetHdr(req->resp, H_Connection, NULL))
+		http_SetHeader(req->resp, "Connection: keep-alive");
+
+	CHECK_OBJ_NOTNULL(req->wrk, WORKER_MAGIC);
+
+	v1l = V1L_Open(req->wrk->aws, &req->sp->fd, req->vsl,
+	    req->t_prev + SESS_TMO(req->sp, send_timeout),
+	    cache_param->http1_iovs);
+
+	if (v1l == NULL) {
+		dbg_error(req, &v1l, "Failure to init v1d (workspace_thread overflow)");
+		return (VTR_D_DONE);
+	}
+
+	if (sendbody) {
+		if (!http_GetHdr(req->resp, H_Content_Length, NULL)) {
+			if (req->http->protover == 11) {
+				http_SetHeader(req->resp,
+				    "Transfer-Encoding: chunked");
+			} else {
+				req->doclose = SC_TX_EOF;
+			}
+		}
+		INIT_OBJ(ctx, VRT_CTX_MAGIC);
+		VCL_Req2Ctx(ctx, req);
+		if (VDP_Push(ctx, req->vdc, req->ws, VDP_v1l, v1l)) {
+			dbg_error(req, &v1l, "Failure to push v1d processor");
+			return (VTR_D_DONE);
+		}
+	}
+
+	if (WS_Overflowed(req->ws)) {
+		dbg_error(req, &v1l, "workspace_client overflow");
+		return (VTR_D_DONE);
+	}
+
+	if (WS_Overflowed(req->sp->ws)) {
+		dbg_error(req, &v1l, "workspace_session overflow");
+		return (VTR_D_DONE);
+	}
+
+	if (WS_Overflowed(req->wrk->aws)) {
+		dbg_error(req, &v1l, "workspace_thread overflow");
+		return (VTR_D_DONE);
+	}
+
+	req->acct.resp_hdrbytes += HTTP1_Write(v1l, req->resp, HTTP1_Resp);
+
+	if (! sendbody) {
+		dbg_deliver_finish(req, &v1l, 0);
+		return (VTR_D_DONE);
+	}
+
+	(void)V1L_Flush(v1l);
+
+	if (hack_http1_req == NULL)
+		hack_http1_req = req->task->func;
+	AN(hack_http1_req);
+
+	VSLb(req->vsl, SLT_Debug, "w=%p scheduling dbg_sendbody", req->wrk);
+
+	req->task->func = dbg_sendbody;
+	req->task->priv = req;
+
+	req->wrk = NULL;
+	req->vdc->wrk = NULL;
+	req->transport_priv = v1l;
+
+	AZ(Pool_Task(req->sp->pool, req->task, TASK_QUEUE_RUSH));
+	return (VTR_D_DISEMBARK);
+}
+
+static void v_matchproto_(task_func_t)
+dbg_sendbody(struct worker *wrk, void *arg)
+{
+        struct req *req;
+	struct v1l *v1l;
+	const char *p;
+	int err, chunked;
+
+        CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
+        CAST_OBJ_NOTNULL(req, arg, REQ_MAGIC);
+	v1l = req->transport_priv;
+	req->transport_priv = NULL;
+	AN(v1l);
+
+        THR_SetRequest(req);
+	VSLb(req->vsl, SLT_Debug, "w=%p enter dbg_sendbody", wrk);
+	AZ(req->wrk);
+	CNT_Embark(wrk, req);
+	req->vdc->wrk = wrk;	// move to CNT_Embark?
+
+	chunked = http_GetHdr(req->resp, H_Transfer_Encoding, &p) && strcmp(p, "chunked") == 0;
+	if (chunked)
+		V1L_Chunked(v1l);
+	err = VDP_DeliverObj(req->vdc, req->objcore);
+	if (!err && chunked)
+		V1L_EndChunk(v1l);
+	dbg_deliver_finish(req, &v1l, err);
+
+	VSLb(req->vsl, SLT_Debug, "w=%p resuming http1_req", wrk);
+	wrk->task->func = hack_http1_req;
+	wrk->task->priv = req;
+}
+
+static void
+dbg_deliver_finish(struct req *req, struct v1l **v1lp, int err)
+{
+	stream_close_t sc;
+	uint64_t bytes;
+
+	sc = V1L_Close(v1lp, &bytes);
+
+	req->acct.resp_bodybytes += VDP_Close(req->vdc, req->objcore, req->boc);
+
+	if (sc == SC_NULL && err && req->sp->fd >= 0)
+		sc = SC_REM_CLOSE;
+	if (sc != SC_NULL)
+		Req_Fail(req, sc);
+}
+
+struct transport DBG_transport;
+
+void
+debug_transport_init(void)
+{
+	DBG_transport = HTTP1_transport;
+	DBG_transport.name = "DBG";
+	DBG_transport.deliver = dbg_deliver;
+}
+
+void
+debug_transport_use_reembarking_http1(VRT_CTX)
+{
+	struct req *req;
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	req = ctx->req;
+	CHECK_OBJ_NOTNULL(req, REQ_MAGIC);
+
+	if (req->transport != &HTTP1_transport) {
+		VRT_fail(ctx, "Only works on built-in http1 transport");
+		return;
+	}
+	AZ(req->transport_priv);
+	req->transport = &DBG_transport;
+}


### PR DESCRIPTION
This is the next chapter of the book of AI, see #4209

To eventually get to event driven, asynchronous IO where a smaller number of threads handles a large number of requests, we also need a way to disembark a request from a worker and have another thread pick up where it left of, then reentering the state machine later to finish off.

Thanks to the already existing disembark facility used for waitinglist wakeups, implementing this is pretty straight forward: We basically only need to allow the vtr_deliver_f (transport deliver function) to tell the state engine to disembark, add a "finish" state, and everything else more or less works out of the box.

The last commit has a demonstration in a test case.

Everything else in this patch is refactoring.