### PR TITLE
Prepare for 7.6.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
 Copyright (c) 2006-2024 Varnish Software
 Copyright 2010-2024 UPLEX - Nils Goroll Systemoptimierung])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [7.6.0], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [7.6.1], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -35,7 +35,7 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
-Varnish Cache 7.6.1 (unreleased)
+Varnish Cache 7.6.1 (2024-11-08)
 ================================
 
 * Fixed a bug introduced in 7.6.0 that could trigger a panic when using dynamic

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -35,6 +35,30 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
+Varnish Cache 7.6.1 (unreleased)
+================================
+
+* Fixed a bug introduced in 7.6.0 that could trigger a panic when using dynamic
+  backends (4183_).
+
+* Resolved a race condition that caused Varnish to exceed the connection limit
+  set to a backend with the `.max_connections` attribute (4154_).
+
+* Fixed an assertion that was added in 7.6.0 and that could lead to a panic in
+  the waiter code under certain conditions (4204_).
+
+* Removed an assertion on the pid value of varnishd that could trigger a panic in
+  container environments.
+
+* Added attempt to raise RLIMIT_MEMLOCK to infinity on startup and improved logging
+  for VSM mlock() errors. (4193_)
+
+.. _4183: https://github.com/varnishcache/varnish-cache/issues/4183
+.. _4154: https://github.com/varnishcache/varnish-cache/pull/4154
+.. _4204: https://github.com/varnishcache/varnish-cache/issues/4204
+.. _4193: https://github.com/varnishcache/varnish-cache/issues/4193
+
+================================
 Varnish Cache 7.6.0 (2024-09-13)
 ================================
 


### PR DESCRIPTION
Reviewers must check the following items:

- [ ] Release notes are complete (major release only)
- [ ] Release notes no longer target trunk (major release only)
- [x] The change log is populated
- [x] The VRT history in `include/vrt.h` is populated
- [x] The VRT history refers to the next VRT version
- [ ] The macro `VRT_MAJOR_VERSION` was updated if applicable
- [x] The macro `VRT_MINOR_VERSION` was updated if applicable
- [x] The new VRT version follows releases guidelines
- [x] The new VRT version matches the one from the VRT history
- [ ] Bundled `devicedetect.vcl` was updated (major release only)
- [x] Running `./autogen.des && make distcheck` succeeds
- [x] The version in `configure.ac` is correct
- [x] The copyright notice in `configure.ac` covers the current year
- [x] The copyright output in `lib/libvarnish/version.c` covers the current year
- [x] There are no other changes than the ones listed above