### PR TITLE
Tolerate when endian.h is symlink to sys/endian.h

### DIFF
--- a/lib/libvarnish/vsha256.c
+++ b/lib/libvarnish/vsha256.c
@@ -33,8 +33,16 @@
 
 #ifndef __DARWIN_BYTE_ORDER
 #  include <endian.h>
-#  define VBYTE_ORDER	__BYTE_ORDER
-#  define VBIG_ENDIAN	__BIG_ENDIAN
+#  ifdef _BYTE_ORDER
+#    define VBYTE_ORDER	_BYTE_ORDER
+#  else
+#    define VBYTE_ORDER	__BYTE_ORDER
+#  endif
+#  ifdef _BIG_ENDIAN
+#    define VBIG_ENDIAN	_BIG_ENDIAN
+#  else
+#    define VBIG_ENDIAN	__BIG_ENDIAN
+#  endif
 #else
 #  define VBYTE_ORDER	__DARWIN_BYTE_ORDER
 #  define VBIG_ENDIAN	__DARWIN_BIG_ENDIAN


### PR DESCRIPTION
Since 5a60b36fe9b45b68244596d93db2b922d53e7b5c varnish drop support of sys/endian.h and they had a bit different API one or two leading `_`.

Some system may have symlink from endian.h to sys/endian.h, for example OpenBSD. On such system build fails due to wrong SHA256 hash.