### PR TITLE
storage_simple: mark buffers

### DIFF
--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -184,6 +184,7 @@ SML_AllocBuf(struct worker *wrk, const struct stevedore *stv, size_t size,
 	if (st == NULL)
 		return (NULL);
 	assert(st->space >= size);
+	st->flags = STORAGE_F_BUFFER;
 	st->len = size;
 	*ppriv = (uintptr_t)st;
 	return (st->ptr);
@@ -198,6 +199,7 @@ SML_FreeBuf(struct worker *wrk, const struct stevedore *stv, uintptr_t priv)
 	CHECK_OBJ_NOTNULL(stv, STEVEDORE_MAGIC);
 
 	CAST_OBJ_NOTNULL(st, (void *)priv, STORAGE_MAGIC);
+	assert(st->flags == STORAGE_F_BUFFER);
 	sml_stv_free(stv, st);
 }
 

--- a/bin/varnishd/storage/storage_simple.h
+++ b/bin/varnishd/storage/storage_simple.h
@@ -38,7 +38,8 @@
 struct storage {
 	unsigned		magic;
 #define STORAGE_MAGIC		0x1a4e51c0
-
+	unsigned		flags;
+#define STORAGE_F_BUFFER	1
 
 	VTAILQ_ENTRY(storage)	list;
 	void			*priv;


### PR DESCRIPTION
Make sure that we do not confuse buffers with object data.

The flags field comes at no extra memory cost on 64bit. For 32bit, this change breaks binary compatibility with any out-of-tree storages using storage_simple.