### PR TITLE
fix: always wake the new head of the waiting queue when there is available connections

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -246,6 +246,12 @@ vbe_dir_getfd(VRT_CTX, struct worker *wrk, VCL_BACKEND dir, struct backend *bp,
 	}
 	if (cw->cw_state != CW_BE_BUSY)
 		bp->n_conn++;
+
+	if (!VTAILQ_EMPTY(&bp->cw_head) && !BE_BUSY(bp)) {
+		/* Signal the new head of the waiting queue */
+		vbe_connwait_signal_locked(bp);
+	}
+
 	Lck_Unlock(bp->director->mtx);
 
 	if (cw->cw_state == CW_BE_BUSY) {


### PR DESCRIPTION
There is a fundamental concurrency issue with the backend connection wait queue implementation.

With the current implementation, when there are items on the waiting queue, every in-progress backend request that complete signals the request at the head of the waiting queue to notify it that should resume obtaining a connection.  

However the current implementation assumes this means that if N in-progress requests complete then N waiting requests will be notified - but this is not the case.  This is because multiple in-progress requests can all complete simultaneously and all signal the same waiting request - the current head of the waiting queue.  Eventually that thread will obtain the lock and continue, however it reduces the maximum concurrency through the backend as N requests completed and only 1 resumed.

This patch we believe is a safe and effective way to fix the problem.  Each thread that awakes from the waiting queue simply checks to see if there is spare capacity in the connection pool and if so signals the next waiting thread that it too can continue.  When that next thread resumes it will also do the same check and so on down the queue, so eventually N threads will resume and peak concurrency is maintained.

We have run and verified both the behaviour of the unpatched code and the implementation with our patch under very high loads.  The unpatched code shows the expected (undesirable) behaviour when requests begin to queue - that is that the number of connections in use to the backend quickly drops below the maximum even though there are still new requests going on to the wait queue.  This in turn reduces overall throughput and degrades performance.   Eventually the queue gets long enough that the requests on the queue begin to timeout and fail - once enough requests off the queue fail the queue empties and normal throughput returns - until the next time requests begin to queue.

The patched code operates as expected, with the maximum number of connections maintained to the backend while there are requests on the wait queue.