### PR TITLE
Add VARRAY_FOREACH and VPTRS_ITER macros to iterate over arrays and pointer arrays

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -379,11 +379,9 @@ VRT_HashStrands32(VCL_STRANDS s)
 
 	AN(s);
 	VSHA256_Init(&sha_ctx);
-	VARRAY_FOREACH(elem, s->p, s->n) {
-		p = *elem;
+	VPTRS_ITER(p, s->p, s->n)
 		if (p != NULL && *p != '\0')
 			VSHA256_Update(&sha_ctx, p, strlen(p));
-	}
 	VSHA256_Final(sha256, &sha_ctx);
 
 	/* NB: for some reason vmod_director's shard director specifically

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -376,12 +376,11 @@ VRT_HashStrands32(VCL_STRANDS s)
 	struct VSHA256Context sha_ctx;
 	unsigned char sha256[VSHA256_LEN];
 	const char *p;
-	int i;
 
 	AN(s);
 	VSHA256_Init(&sha_ctx);
-	for (i = 0; i < s->n; i++) {
-		p = s->p[i];
+	VARRAY_FOREACH(elem, s->p, s->n) {
+		p = *elem;
 		if (p != NULL && *p != '\0')
 			VSHA256_Update(&sha_ctx, p, strlen(p));
 	}

--- a/bin/varnishd/storage/storage_debug.c
+++ b/bin/varnishd/storage/storage_debug.c
@@ -100,8 +100,7 @@ smd_init(struct stevedore *parent, int aac, char * const *aav)
 	nac++;
 	av = calloc(nac, sizeof *av);
 	AN(av);
-	VARRAY_FOREACH(elem, aav, aac) {
-		a = *elem;
+	VPTRS_ITER(a, aav, aac) {
 		if (a != NULL) {
 			if (! strcmp(a, "lessspace")) {
 				methods->objgetspace = smd_lsp_getspace;

--- a/bin/varnishd/storage/storage_debug.c
+++ b/bin/varnishd/storage/storage_debug.c
@@ -79,7 +79,7 @@ smd_init(struct stevedore *parent, int aac, char * const *aav)
 {
 	struct obj_methods *methods;
 	const char *ident;
-	int i, ac = 0;
+	int ac = 0;
 	size_t nac;
 	vtim_dur d, dinit = 0.0;
 	char **av;	//lint -e429
@@ -100,8 +100,8 @@ smd_init(struct stevedore *parent, int aac, char * const *aav)
 	nac++;
 	av = calloc(nac, sizeof *av);
 	AN(av);
-	for (i = 0; i < aac; i++) {
-		a = aav[i];
+	VARRAY_FOREACH(elem, aav, aac) {
+		a = *elem;
 		if (a != NULL) {
 			if (! strcmp(a, "lessspace")) {
 				methods->objgetspace = smd_lsp_getspace;

--- a/include/vdef.h
+++ b/include/vdef.h
@@ -270,3 +270,17 @@ typedef struct {
 /* #3020 dummy definitions until PR is merged*/
 #define LIKELY(x)	(x)
 #define UNLIKELY(x)	(x)
+
+/*
+ * VARRAY_FOREACH(var, arr, n):
+ *
+ * declare variable var and have it iterate over array arr of length n
+ */
+
+#define _varray_foreach(var, arr, n, end)					\
+	for (typeof(*(arr)) * var = (typeof(var))(arr), * end = var + n;	\
+	     var < end;								\
+	     var++)
+
+#define VARRAY_FOREACH(var, arr, n)						\
+	_varray_foreach(var, arr, n, VUNIQ_NAME(_v_ ## var ## _end))

--- a/include/vdef.h
+++ b/include/vdef.h
@@ -284,3 +284,23 @@ typedef struct {
 
 #define VARRAY_FOREACH(var, arr, n)						\
 	_varray_foreach(var, arr, n, VUNIQ_NAME(_v_ ## var ## _end))
+
+/*
+ * VPTRS_ITER(var, arr, n)
+ *
+ * given an array of pointers arr with length n,
+ * iterate variable var (declared outside the macro) over pointer values
+ *
+ * var has a broader scope to support keeping values from the array
+ */
+
+//lint -emacro(506, _vptrs_iter) constant value boolean
+#define _vptrs_iter(var, arr, n, iter, end)					\
+	for (typeof(*(arr)) * iter = (typeof(iter))(arr), * end = iter + n;	\
+	    iter < end && (var = *iter, 1);					\
+	    iter++)
+
+#define VPTRS_ITER(var, arr, n)							\
+	_vptrs_iter(var, arr, n,						\
+	    VUNIQ_NAME(_v_ ## var ## _iter),					\
+	    VUNIQ_NAME(_v_ ## var ## _end))

--- a/tools/coccinelle/varray_foreach.cocci
+++ b/tools/coccinelle/varray_foreach.cocci
@@ -1,0 +1,17 @@
+@@
+identifier i;
+expression lim, arr;
+iterator name VARRAY_FOREACH;
+type T;
+@@
+
+T i;
+...
+- for (i = 0; i < lim; i++)
++ VARRAY_FOREACH(elem, arr, lim)
+{
+...
+- arr[i]
++ *elem
+...
+}

--- a/tools/coccinelle/vptrs_iter.cocci
+++ b/tools/coccinelle/vptrs_iter.cocci
@@ -1,0 +1,13 @@
+@@
+identifier p, elem;
+expression lim, arr;
+iterator name VARRAY_FOREACH;
+iterator name VPTRS_ITER;
+@@
+
+- VARRAY_FOREACH(elem, arr, lim) {
+...
+-   p = *elem;
++ VPTRS_ITER(p, arr, lim) {
+...
+}

--- a/vmod/vmod_blob_hex.c
+++ b/vmod/vmod_blob_hex.c
@@ -116,8 +116,8 @@ hex_decode(const enum encoding dec, blob_dest_t buf,
 	AN(strings);
 	assert(dec == HEX);
 
-	for (i = 0; i < strings->n; i++) {
-		s = strings->p[i];
+	VARRAY_FOREACH(elem, strings->p, strings->n) {
+		s = *elem;
 
 		if (s == NULL)
 			continue;

--- a/vmod/vmod_blob_hex.c
+++ b/vmod/vmod_blob_hex.c
@@ -115,9 +115,7 @@ hex_decode(const enum encoding dec, blob_dest_t buf,
 	AN(buf);
 	AN(strings);
 	assert(dec == HEX);
-
-	VARRAY_FOREACH(elem, strings->p, strings->n) {
-		s = *elem;
+	VPTRS_ITER(s, strings->p, strings->n) {
 
 		if (s == NULL)
 			continue;

--- a/vmod/vmod_directors_shard_dir.c
+++ b/vmod/vmod_directors_shard_dir.c
@@ -283,7 +283,7 @@ init_state(struct shard_state *state,
 VCL_BOOL
 sharddir_any_healthy(VRT_CTX, struct sharddir *shardd, VCL_TIME *changed)
 {
-	unsigned i, retval = 0;
+	unsigned retval = 0;
 	VCL_BACKEND be;
 	vtim_real c;
 
@@ -291,8 +291,8 @@ sharddir_any_healthy(VRT_CTX, struct sharddir *shardd, VCL_TIME *changed)
 	sharddir_rdlock(shardd);
 	if (changed != NULL)
 		*changed = 0;
-	for (i = 0; i < shardd->n_backend; i++) {
-		be = shardd->backend[i].backend;
+	VARRAY_FOREACH(elem, shardd->backend, shardd->n_backend) {
+		be = elem->backend;
 		CHECK_OBJ_NOTNULL(be, DIRECTOR_MAGIC);
 		retval = VRT_Healthy(ctx, be, &c);
 		if (changed != NULL && c > *changed)

--- a/vmod/vmod_vtc.c
+++ b/vmod/vmod_vtc.c
@@ -498,9 +498,7 @@ vmod_vsl_replay(VRT_CTX, VCL_STRANDS s)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 	WS_VSB_new(cp, ctx->ws);
-
-	VARRAY_FOREACH(elem, s->p, s->n) {
-		p = *elem;
+	VPTRS_ITER(p, s->p, s->n) {
 		if (p == NULL || *p == '\0')
 			continue;
 		pp = strpbrk(p, "\r\n");

--- a/vmod/vmod_vtc.c
+++ b/vmod/vmod_vtc.c
@@ -490,7 +490,7 @@ vmod_vsl_replay(VRT_CTX, VCL_STRANDS s)
 	struct vsb cp[1];
 	const char *p, *pp;
 	size_t l;
-	int i, err = 0;
+	int err = 0;
 
 	if (s == NULL || s->n == 0)
 		return;
@@ -499,8 +499,8 @@ vmod_vsl_replay(VRT_CTX, VCL_STRANDS s)
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 	WS_VSB_new(cp, ctx->ws);
 
-	for (i = 0; i < s->n; i++) {
-		p = s->p[i];
+	VARRAY_FOREACH(elem, s->p, s->n) {
+		p = *elem;
 		if (p == NULL || *p == '\0')
 			continue;
 		pp = strpbrk(p, "\r\n");


### PR DESCRIPTION
These patches add two macros, semantic patches to start using them and the respective changes:

The `VARRAY_FOREACH` macro is intended to simplify loops over elements of an array using pointer arithmetic instead of an array index.

The usual pattern of iterating over the array index and then accessing the i-th element of the array is replaced with calculating the end pointer and looping over the array elements.

The macro basically implements

```c
for (pointer = array, end = array + length; pointer < end; pointer++)
```

This pattern is more efficient but less clear to read when written out. The macro is similar to the `*_FOREACH` pattern which we already use in many other places with trees, lists and queues, but declares the loop variable locally.

The second macro `VPTRS_ITER` further simplifies our "array of pointers" case as, for example, used in struct strands.

Here, the loop variable is to be declared outside the macro to support keeping found elements from within the loop.