### PR TITLE
vmodtool: Add option to specify c names of arguments and avoid "bool"

### DIFF
--- a/bin/varnishtest/tests/m00003.vtc
+++ b/bin/varnishtest/tests/m00003.vtc
@@ -59,12 +59,15 @@ varnish v1 -errvcl {Not string[2]} { import wrong; }
 filewrite ${tmpdir}/libvmod_wrong.so "VMOD_JSON_SPEC\x02" "[[\"$VBLA\"]]" "\x03"
 varnish v1 -errvcl {Not $VMOD[3]} { import wrong; }
 
+filewrite ${tmpdir}/libvmod_wrong.so "VMOD_JSON_SPEC\x02" "[[\"$VMOD\",\"1.0\"]]" "\x03"
+varnish v1 -errvcl {Syntax != 2.0} { import wrong; }
+
 filewrite ${tmpdir}/libvmod_wrong.so "VMOD_JSON_SPEC\x02"
 filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -82,7 +85,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -103,7 +106,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -123,7 +126,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -141,7 +144,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -163,7 +166,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "std",
 	    "Vmod_vmod_std_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",

--- a/bin/varnishtest/tests/m00055.vtc
+++ b/bin/varnishtest/tests/m00055.vtc
@@ -16,7 +16,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
 [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -196,6 +196,9 @@ declarations:
 	  with `n` starting at 1 and incrementing with the argument's
 	  position.
 
+Optionally, the VCL and C argument names can be specified independently using
+the ``<vclname>:<cname>`` syntax. See :ref:`ref-vmod-symbols` for details.
+
 .. _ref-vmod-vcl-c-objects:
 
 Objects and methods
@@ -550,13 +553,14 @@ For the above, the *<xxx>* placeholders are defined as:
         The vmod name fro the ``$Module`` stanza of the ``.vcc`` file.
 
 *<argument>*
-        The function or method argument name
+        The function or method argument *cname* or, if not given, *vclname*
+        as specified using the *<vclname>:<cname>* syntax.
 
 The other placeholders should be self-explanatory as the name of the respective
-function, class, method or handler name.
+function, class, method or handler.
 
-In summary, only some symbol names (those with *<prefix>*) can be influenced by
-the vmod author.
+In summary, symbol names can either be influenced by the vmod author globally
+using ``$Prefix``, or using the *<vclname>:<cname>* syntax for argument names.
 
 .. _ref-vmod-private-pointers:
 

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -444,6 +444,7 @@ vcc_priv_arg(struct vcc *tl, const char *p, struct symbol *sym)
 struct func_arg {
 	vcc_type_t		type;
 	const struct vjsn_val	*enums;
+	const char		*cname;
 	const char		*name;
 	const char		*val;
 	struct expr		*result;

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -558,7 +558,7 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 			fa->result = vcc_priv_arg(tl, vvp->value, sym);
 			vvp = VTAILQ_NEXT(vvp, list);
 			if (vvp != NULL)
-				fa->name = vvp->value;
+				fa->cname = fa->name = vvp->value;
 			continue;
 		}
 		fa->type = VCC_Type(vvp->value);
@@ -566,6 +566,9 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 		vvp = VTAILQ_NEXT(vvp, list);
 		if (vvp != NULL) {
 			fa->name = vvp->value;
+			vvp = VTAILQ_NEXT(vvp, list);
+			AN(vvp); /* vmod_syntax 2.0 */
+			fa->cname = vvp->value;
 			vvp = VTAILQ_NEXT(vvp, list);
 			if (vvp != NULL) {
 				fa->val = vvp->value;
@@ -642,9 +645,9 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 	VTAILQ_FOREACH_SAFE(fa, &head, list, fa2) {
 		n++;
 		if (fa->optional) {
-			AN(fa->name);
+			AN(fa->cname);
 			bprintf(ssa, "\v1.valid_%s = %d,\n",
-			    fa->name, fa->avail);
+			    fa->cname, fa->avail);
 			e1 = vcc_expr_edit(tl, e1->fmt, ssa, e1, NULL);
 		}
 		if (fa->result == NULL && fa->type == ENUM && fa->val != NULL)
@@ -652,8 +655,8 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 		if (fa->result == NULL && fa->val != NULL)
 			fa->result = vcc_mk_expr(fa->type, "%s", fa->val);
 		if (fa->result != NULL && sa != NULL) {
-			if (fa->name)
-				bprintf(ssa, "\v1.%s = \v2,\n", fa->name);
+			if (fa->cname)
+				bprintf(ssa, "\v1.%s = \v2,\n", fa->cname);
 			else
 				bprintf(ssa, "\v1.arg%d = \v2,\n", n);
 			e1 = vcc_expr_edit(tl, e1->fmt, ssa, e1, fa->result);

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -162,7 +162,8 @@ vcc_ParseJSON(const struct vcc *tl, const char *jsn, struct vmod_import *vim)
 	AN(vv3);
 	assert(vjsn_is_string(vv3));
 	vim->vmod_syntax = strtod(vv3->value, NULL);
-	assert (vim->vmod_syntax == 1.0);
+	if (vim->vmod_syntax != 2.0)
+		return ("Syntax != 2.0");
 
 	vv3 = VTAILQ_NEXT(vv3, list);
 	AN(vv3);

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -27,6 +27,10 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
+#
+# syntax version history:
+# 1.0: initial
+# 2.0: added cname (nm2) after argument name
 
 """
 Read the first existing file from arguments or vmod.vcc and produce:
@@ -319,7 +323,7 @@ class arg(CType):
         self.defval = x
 
     def jsonproto(self, jl):
-        jl.append([self.vt, self.nm, self.defval, self.spec])
+        jl.append([self.vt, self.nm, self.nm2, self.defval, self.spec])
         if self.opt:
             jl[-1].append(True)
         while jl[-1][-1] is None:
@@ -385,6 +389,8 @@ class ProtoType():
                 err("arguments cannot be of type '%s'" % t.vt, warn=False)
             if t.nm is None:
                 t.nm2 = "arg%d" % n
+            elif ':' in t.nm:
+                [t.nm, t.nm2] = t.nm.split(':')
             else:
                 t.nm2 = t.nm
             self.args.append(t)
@@ -466,8 +472,8 @@ class ProtoType():
         s = "\n" + self.argstructname() + " {\n"
         for i in self.args:
             if i.opt:
-                assert i.nm is not None
-                s += "\tchar\t\t\tvalid_%s;\n" % i.nm
+                assert i.nm2 is not None
+                s += "\tchar\t\t\tvalid_%s;\n" % i.nm2
         for i in self.args:
             s += "\t" + i.ct
             if len(i.ct) < 8:
@@ -1163,7 +1169,7 @@ class vcc():
 
     def iter_json(self, fnx):
 
-        jl = [["$VMOD", "1.0", self.modname, self.csn, self.file_id]]
+        jl = [["$VMOD", "2.0", self.modname, self.csn, self.file_id]]
         jl.append(["$CPROTO"])
         for i in open(fnx):
             jl[-1].append(i.rstrip())

--- a/vmod/vmod_std.vcc
+++ b/vmod/vmod_std.vcc
@@ -308,7 +308,7 @@ Example::
 	std.cache_req_body(std.bytes(real=10.0*1024));
 
 $Function INT integer([STRING s], [INT fallback],
-    [BOOL bool], [BYTES bytes], [DURATION duration], [REAL real],
+    [BOOL bool:boolean], [BYTES bytes], [DURATION duration], [REAL real],
     [TIME time])
 
 Returns an INT from a STRING, BOOL or other quantity.
@@ -376,7 +376,7 @@ Example::
 	}
 
 $Function REAL real([STRING s], [REAL fallback], [INT integer],
-    [BOOL bool], [BYTES bytes], [DURATION duration],
+    [BOOL bool:boolean], [BYTES bytes], [DURATION duration],
     [TIME time])
 
 Returns a REAL from a STRING, BOOL or other quantity.

--- a/vmod/vmod_std_conversions.c
+++ b/vmod/vmod_std_conversions.c
@@ -149,15 +149,15 @@ vmod_integer(VRT_CTX, struct VARGS(integer) *a)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
-	nargs = a->valid_s + a->valid_bool + a->valid_bytes +
+	nargs = a->valid_s + a->valid_boolean + a->valid_bytes +
 	    a->valid_duration + a->valid_real + a->valid_time;
 
 	if (!onearg(ctx, "integer", nargs))
 		return (0);
 
 	r = NAN;
-	if (a->valid_bool)
-		return (a->bool ? 1 : 0);
+	if (a->valid_boolean)
+		return (a->boolean ? 1 : 0);
 
 	if (a->valid_bytes)
 		return (a->bytes);
@@ -245,7 +245,7 @@ vmod_real(VRT_CTX, struct VARGS(real) *a)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
-	nargs = a->valid_s + a->valid_integer + a->valid_bool + a->valid_bytes +
+	nargs = a->valid_s + a->valid_integer + a->valid_boolean + a->valid_bytes +
 	    a->valid_duration + a->valid_time;
 
 	if (!onearg(ctx, "real", nargs))
@@ -254,8 +254,8 @@ vmod_real(VRT_CTX, struct VARGS(real) *a)
 	if (a->valid_integer)
 		return ((VCL_REAL)a->integer);
 
-	if (a->valid_bool)
-		return ((VCL_REAL)(a->bool ? 1 : 0));
+	if (a->valid_boolean)
+		return ((VCL_REAL)(a->boolean ? 1 : 0));
 
 	if (a->valid_bytes)
 		return ((VCL_REAL)a->bytes);


### PR DESCRIPTION
I tried gcc version 15.0.0 20241203 and even without -std=c23, it would reserve "bool":

```
In file included from vcc_std_if.c:10:
vcc_std_if.h:78:33: error: two or more data types in declaration specifiers
   78 |         VCL_BOOL                bool;
      |                                 ^~~~
```

(and more)

So this patch adds the option to specify the c name of arguments to vmod functions/methods by separating it with a colon:

	vclname:cname

We use this facility to rename the "bool" argument to vmod_std functions to "boola".

**Implementation**
    
 cname needs to be specified by the VMOD author because it is also used in the vmod implementation.
    
Obviously, VCC needs to know that name, too, to generate argument structs, so we need to transport it from the VMOD to VCC via the JSON spec. A logical place for  is next to the name, because the other attributes following in the argument spec array are optional. So this changes the JSON spec format, and, consequently, we need to increase the version number.
    
So, ultimately, this is a breaking change with respect to vmodtool: One can not import vmods built before this change. We could add compatibility for this case, but as we have a tradition of forcing rebuilds with each release by bumping the VRT major number anyway, I did not see my time well spent on implementing backwards compatibility.