### PR TITLE
HSH: Limit the number of non matching variants evaluated against the ban list during lookup

### DIFF
--- a/bin/varnishtest/tests/c00133.vtc
+++ b/bin/varnishtest/tests/c00133.vtc
@@ -1,0 +1,41 @@
+varnishtest "test ban + vary behavior"
+
+server s0 {
+	rxreq
+	txresp -hdr "vary: version" -body "Variant A"
+	rxreq
+	txresp -hdr "vary: version" -body "Variant B"
+	rxreq
+	txresp -hdr "vary: version" -body "New variant A"
+	rxreq
+	txresp -hdr "vary: version" -body "New variant B"
+} -start
+
+varnish v1 -arg "-p ban_any_variant=0" -vcl+backend {} -start
+
+client c1 {
+	txreq -hdr "version: a"
+	rxresp
+	expect resp.body == "Variant A"
+} -run
+
+client c2 {
+	txreq -hdr "version: b"
+	rxresp
+	expect resp.body == "Variant B"
+} -run
+
+varnish v1 -cliok "ban req.http.version == a"
+
+# Should this remove a single variant from cache
+client c3 {
+	txreq -hdr "version: a"
+	rxresp
+	expect resp.body == "New variant A"
+} -run
+
+client c4 {
+	txreq -hdr "version: b"
+	rxresp
+	expect resp.body == "Variant B"
+} -run

--- a/bin/varnishtest/tests/c00134.vtc
+++ b/bin/varnishtest/tests/c00134.vtc
@@ -1,0 +1,86 @@
+varnishtest "Optimized HSH_Lookup - ban is checked after Vary is matched"
+
+server s1 {
+	rxreq
+	expect req.url == /foo
+	expect req.http.foobar == "1"
+	txresp -hdr "Vary: Foobar" -body "1111"
+
+	rxreq
+	expect req.url == /foo
+	expect req.http.foobar == "2"
+	txresp -hdr "Vary: Foobar" -body "2222"
+
+	rxreq
+	expect req.url == /foo
+	expect req.http.foobar == "3"
+	txresp -hdr "Vary: Foobar" -body "3333"
+
+	rxreq
+	expect req.url == /foo
+	expect req.http.foobar == "1"
+	txresp -hdr "Vary: Foobar" -body "1111"
+
+	rxreq
+	expect req.url == /foo
+	expect req.http.foobar == "1"
+	txresp -hdr "Vary: Foobar" -body "1111"
+
+} -start
+
+varnish v1 -arg "-p ban_any_variant=0" -vcl+backend {
+	sub vcl_backend_response {
+		set beresp.http.url = bereq.url;
+	}
+} -start
+
+
+client c1 {
+	txreq -url /foo -hdr "Foobar: 1"
+	rxresp
+	expect resp.body == "1111"
+} -run
+
+client c1 {
+	txreq -url /foo -hdr "Foobar: 2"
+	rxresp
+	expect resp.body == "2222"
+} -run
+
+client c1 {
+	txreq -url /foo -hdr "Foobar: 3"
+	rxresp
+	expect resp.body == "3333"
+
+} -run
+
+varnish v1 -expect n_object == 3
+varnish v1 -expect cache_hit == 0
+varnish v1 -expect cache_miss == 3
+
+client c1 {
+	txreq -url /foo -hdr "Foobar: 1"
+	rxresp
+} -run
+
+varnish v1 -expect cache_hit == 1
+varnish v1 -expect cache_miss == 3
+
+varnish v1 -cliok "ban obj.http.url == /foo"
+varnish v1 -cliok "ban obj.http.url == /bar"
+varnish v1 -cliok "ban obj.http.url == /baz"
+
+client c1 {
+	txreq -url /foo -hdr "Foobar: 1"
+	rxresp
+} -run
+
+varnish v1 -expect bans_tested == 1
+varnish v1 -expect bans_tests_tested == 3
+varnish v1 -expect bans_obj_killed == 1
+varnish v1 -expect n_object == 3
+
+
+varnish v1 -expect cache_hit == 1
+varnish v1 -expect cache_miss == 4
+varnish v1 -expect client_req == 5

--- a/doc/sphinx/users-guide/purging.rst
+++ b/doc/sphinx/users-guide/purging.rst
@@ -88,6 +88,23 @@ the regular expression is required by the Varnish cli interface.
 Bans are checked when we hit an object in the cache, but before we
 deliver it. *An object is only checked against newer bans*.
 
+During lookup, object variants that may not satisfy the current request
+are also tested against the ban list, which means that a ban may also
+hit a non matching variant.
+
+However, the parameter `ban_any_variant` can be used to limit the number
+of possibly non matching variants that are checked against the ban list during
+lookup for a particular request. This means that at most `ban_any_variant`
+variants will be evaluated, and possibly evicted, before looking for matching
+variants. A value of 0 means that every request would only evaluate bans
+against matching variants. In contrast, a value that is too high may cause a
+request to evaluate all variants against all active bans, which can add
+significant delays for configurations having a large number of variants
+and/or bans.
+
+In the next major release of varnish (8.0), the default value of
+`ban_any_variant` will be set to 0.
+
 Bans that only match against `obj.*` are also processed by a background
 worker threads called the `ban lurker`. The `ban lurker` will walk the
 heap and try to match objects and will evict the matching objects. How

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -722,6 +722,20 @@ PARAM_SIMPLE(
 )
 
 PARAM_SIMPLE(
+	/* name */	ban_any_variant,
+	/* type */	uint,
+	/* min */	"0",
+	/* max */	NULL,
+	/* def */	"10000",
+	/* units */	"checks",
+	/* descr */
+	"Maximum number of possibly non matching variants that we evaluate "
+	"against the ban list during a lookup.\n"
+	"Setting this to 0 means that only the matching variants will be "
+	"evaluated against the current ban list."
+)
+
+PARAM_SIMPLE(
 	/* name */	max_esi_depth,
 	/* type */	uint,
 	/* min */	"0",


### PR DESCRIPTION
This is an implementation of the solution suggested by @bsdphk in https://github.com/varnishcache/varnish-cache/pull/4236#issuecomment-2511729813

It adds a parameter to limit the number of possibly non matching variants that we evaluate against the ban list during a lookup.

Leaving this as a draft until we agree on the parameter name.

Refs: #4236 