### PR TITLE
VCC: Prohibit the use of relative paths with +glob

### DIFF
--- a/bin/varnishtest/tests/c00053.vtc
+++ b/bin/varnishtest/tests/c00053.vtc
@@ -67,3 +67,8 @@ client c1 {
 	expect resp.http.foo == foo
 	expect resp.http.bar == bar
 } -run
+
+varnish v1 -errvcl "+glob can only be used with absolute paths or relative paths starting with './'" {
+	include +glob "sub_*.vcl";
+	backend default none;
+}

--- a/doc/sphinx/reference/vcl.rst
+++ b/doc/sphinx/reference/vcl.rst
@@ -258,7 +258,11 @@ The included file can be specified as follows:
 Optionally, the ``include`` keyword can take a ``+glob`` flag to include all
 files matching a glob pattern::
 
-    include +glob "example.org/*.vcl";
+    include +glob "/etc/varnish/example.org/*.vcl";
+
+Note that the ``+glob`` option can only be used with absolute paths and
+relative paths starting with './', which means that ``+glob`` includes cannot
+be searched in ``vcl_path`` directories.
 
 Import statement
 ----------------

--- a/doc/sphinx/reference/vcl.rst
+++ b/doc/sphinx/reference/vcl.rst
@@ -249,6 +249,12 @@ To include a VCL file in another file use the ``include`` keyword::
 
     include "foo.vcl";
 
+The included file can be specified as follows:
+
+- If the path starts with '/', it is an absolute path.
+- If the path starts with './', it is relative to the including VCL file.
+- Otherwise, it is a relative path searched in one of the ``vcl_path`` directories.
+
 Optionally, the ``include`` keyword can take a ``+glob`` flag to include all
 files matching a glob pattern::
 

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -1814,7 +1814,8 @@ PARAM_STRING(
 	"VCL files in both the system configuration and shared "
 	"data directories to allow packages to drop their VCL "
 	"files in a standard location where relative includes "
-	"would work.",
+	"would work. Includes using +glob cannot be searched "
+	"in vcl_path.",
 	/* flags */	BUILD_OPTIONS,
 	/* dyn_min_reason */	NULL,
 	/* dyn_max_reason */	NULL,

--- a/lib/libvcc/vcc_source.c
+++ b/lib/libvcc/vcc_source.c
@@ -110,6 +110,13 @@ vcc_include_glob_file(struct vcc *tl, const struct source *src_sp,
 	unsigned u;
 	int i;
 
+	if (filename[0] != '/' && (filename[0] != '.' || filename[1] != '/')) {
+		VSB_cat(tl->sb,
+		    "+glob can only be used with absolute paths or relative "
+		    "paths starting with './'\n");
+		tl->err = 1;
+		return;
+	}
 	memset(g, 0, sizeof g);
 	i = glob(filename, 0, NULL, g);
 	switch (i) {


### PR DESCRIPTION
This is a replacement for https://github.com/varnishcache/varnish-cache/pull/4250, where [it appeared](https://github.com/varnishcache/varnish-cache/pull/4250#issuecomment-2575730478) that finding an unambiguous and easy to predict behavior when using `+glob` includes with relative paths involving `vcl_path` was not an easy task.

After some discussions, the consensus was that relative paths should not be allowed when using `+glob` includes.

Refs #4250
Closes #4249
