### PR TITLE
param: Cut all (or none of the) loose ends for bits parameters

### DIFF
--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -698,7 +698,7 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
     uint8_t *p, unsigned l, const char * const *tags, const char *desc,
     char sign)
 {
-	unsigned j;
+	unsigned j, all;
 
 	if (arg != NULL && !strcmp(arg, "default")) {
 		/* XXX: deprecated in favor of param.reset */
@@ -709,10 +709,19 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 	if (arg != NULL && arg != JSON_FMT)
 		return (bit_tweak(vsb, p, l, arg, tags, desc, sign));
 
+	all = 1;
+	for (j = 0; all && j < l; j++) {
+		if (!bit(p, j, BTST))
+			all = 0;
+	}
+
 	if (arg == JSON_FMT)
 		VSB_putc(vsb, '"');
-	VSB_cat(vsb, sign == '+' ? "none" : "all");
-	for (j = 0; j < l; j++) {
+	if (all)
+		VSB_cat(vsb, sign == '+' ? "all" : "none");
+	else
+		VSB_cat(vsb, sign == '+' ? "none" : "all");
+	for (j = 0; !all && j < l; j++) {
 		if (bit(p, j, BTST))
 			VSB_printf(vsb, ",%c%s", sign, tags[j]);
 	}

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -637,6 +637,13 @@ bit_clear(uint8_t *p, unsigned l)
 	memset(p, 0, ((size_t)l + 7) >> 3);
 }
 
+static inline void
+bit_set(uint8_t *p, unsigned l)
+{
+
+	memset(p, 255, ((size_t)l + 7) >> 3);
+}
+
 /*--------------------------------------------------------------------
  */
 
@@ -661,8 +668,16 @@ bit_tweak(struct vsb *vsb, uint8_t *p, unsigned l, const char *arg,
 			bit_clear(p, l);
 			continue;
 		}
+		if (sign == '+' && !strcmp(s, "all")) {
+			bit_set(p, l);
+			continue;
+		}
 		if (sign == '-' && !strcmp(s, "all")) {
 			bit_clear(p, l);
+			continue;
+		}
+		if (sign == '-' && !strcmp(s, "none")) {
+			bit_set(p, l);
 			continue;
 		}
 		if (*s != '-' && *s != '+') {
@@ -711,6 +726,8 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 
 	all = 1;
 	for (j = 0; all && j < l; j++) {
+		if (tags[j] == NULL)
+			continue;
 		if (!bit(p, j, BTST))
 			all = 0;
 	}
@@ -722,6 +739,8 @@ tweak_generic_bits(struct vsb *vsb, const struct parspec *par, const char *arg,
 	else
 		VSB_cat(vsb, sign == '+' ? "none" : "all");
 	for (j = 0; !all && j < l; j++) {
+		if (tags[j] == NULL)
+			continue;
 		if (bit(p, j, BTST))
 			VSB_printf(vsb, ",%c%s", sign, tags[j]);
 	}

--- a/bin/varnishtest/tests/c00054.vtc
+++ b/bin/varnishtest/tests/c00054.vtc
@@ -9,6 +9,8 @@ varnish v1 -cliok "param.set vsl_mask +WorkThread,+TTL,+Hash"
 varnish v1 -cliok "param.show vsl_mask"
 
 varnish v1 -cliexpect {"value": "none"} "param.set -j feature none"
+varnish v1 -cliexpect {"value": "all"} "param.set -j feature all"
+varnish v1 -cliexpect {"value": "none"} "param.set -j vsl_mask none"
 varnish v1 -cliexpect {"value": "all"} "param.set -j vsl_mask all"
 varnish v1 -cliexpect {"value": "all(,-\w+)+"} "param.reset -j vsl_mask"
 


### PR DESCRIPTION
This enables:

- `param.set debug all`
- `param.set experimental all`
- `param.set feature all`
- `param.set vsl_mask none`

Based on an incomplete patch from @nigoroll.