### PR TITLE
vcc_backend: Forbid ip addresses as .authority with .via

### DIFF
--- a/bin/varnishtest/tests/c00042.vtc
+++ b/bin/varnishtest/tests/c00042.vtc
@@ -110,7 +110,7 @@ varnish v1 -vcl {
 		.via = v2;
 		.host = "${s1_addr}";
 		.port = "${s1_port}";
-		.host_header = "host.com";
+		.host_header = "host.com:1234";
 	}
 
 	sub vcl_recv {

--- a/bin/varnishtest/tests/c00042.vtc
+++ b/bin/varnishtest/tests/c00042.vtc
@@ -47,8 +47,8 @@ varnish v2 -cliok "param.set debug +syncvsl"
 
 varnish v1 -vcl {
 	backend v2 { .host = "${v2_addr}"; .port = "${v2_port}"; }
-	backend s1 { .via = v2; .host = "${s1_addr}"; .port = "${s1_port}"; }
-	backend s2 { .via = v2; .host = "${s2_addr}"; .port = "${s2_port}"; }
+	backend s1 { .via = v2; .authority = "1.2.3.4.example.com"; .host = "${s1_addr}"; .port = "${s1_port}"; }
+	backend s2 { .via = v2; .authority = "s2"; .host = "${s2_addr}"; .port = "${s2_port}"; }
 
 	sub vcl_recv {
 		if (req.url ~ "^/s1/") {
@@ -65,19 +65,19 @@ client c1 {
 	txreq -url /s1/1
 	rxresp
 	expect resp.status == 200
-	expect resp.http.Authority == "${s1_addr}"
+	expect resp.http.Authority == "1.2.3.4.example.com"
 	expect resp.http.Server == "s1"
 
 	txreq -url /s2/1
 	rxresp
 	expect resp.status == 200
-	expect resp.http.Authority == "${s2_addr}"
+	expect resp.http.Authority == "s2"
 	expect resp.http.Server == "s2"
 
 	txreq -url /s1/2
 	rxresp
 	expect resp.status == 200
-	expect resp.http.Authority == "${s1_addr}"
+	expect resp.http.Authority == "1.2.3.4.example.com"
 	expect resp.http.Server == "s1"
 } -run
 
@@ -150,6 +150,27 @@ client c1 {
 	expect resp.http.Authority == ""
 } -run
 
+varnish v1 -errvcl ".host used as authority can not be an ip address with .via" {
+	backend v2 { .host = "${v2_addr}"; .port = "${v2_port}"; }
+
+	backend s1 {
+		.via = v2;
+		.host = "${s1_addr}";
+		.port = "${s1_port}";
+	}
+}
+
+varnish v1 -errvcl ".host_header used as authority can not be an ip address with .via" {
+	backend v2 { .host = "${v2_addr}"; .port = "${v2_port}"; }
+
+	backend s1 {
+		.via = v2;
+		.host = "${s1_addr}";
+		.host_header = "${s1_addr}";
+		.port = "${s1_port}";
+	}
+}
+
 varnish v1 -errvcl "Cannot set both .via and .path" {
 	backend v2 { .host = "${v2_addr}"; .port = "${v2_port}"; }
 
@@ -164,11 +185,13 @@ varnish v1 -errvcl "Cannot stack .via backends" {
 
 	backend b {
 		.via = a;
+		.host_header = "b";
 		.host = "127.0.0.1";
 	}
 
 	backend c {
 		.via = b;
+		.authority = "c";
 		.host = "127.0.0.2";
 	}
 
@@ -180,5 +203,5 @@ varnish v1 -errvcl "Cannot stack .via backends" {
 # issue #4177: backend named default with .via property
 varnish v1 -vcl {
 	backend via { .host = "${localhost}"; }
-	backend default { .via = via; .host = "${localhost}"; }
+	backend default { .via = via; .authority = "localhost"; .host = "${localhost}"; }
 }

--- a/doc/sphinx/reference/vcl-backend.rst
+++ b/doc/sphinx/reference/vcl-backend.rst
@@ -219,6 +219,8 @@ The HTTP authority to use when connecting to this backend. If unset,
 
 ``.authority = ""`` disables sending an authority.
 
+``.authority`` can not be an IP address.
+
 As of this release, the attribute is only used by ``.via`` connections
 as a ``PP2_TYPE_AUTHORITY`` Type-Length-Value (TLV) in the `PROXY2`_
 preamble.

--- a/doc/sphinx/reference/vcl-backend.rst
+++ b/doc/sphinx/reference/vcl-backend.rst
@@ -221,6 +221,8 @@ The HTTP authority to use when connecting to this backend. If unset,
 
 ``.authority`` can not be an IP address.
 
+A colon and anything following (signifying a port) is removed from the authority.
+
 As of this release, the attribute is only used by ``.via`` connections
 as a ``PP2_TYPE_AUTHORITY`` Type-Length-Value (TLV) in the `PROXY2`_
 preamble.

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -392,8 +392,9 @@ vcc_ParseHostDef(struct vcc *tl, struct symbol *sym,
 	vtim_dur first_byte_timeout = NAN;
 	vtim_dur between_bytes_timeout = NAN;
 	vtim_dur backend_wait_timeout = NAN;
-	char *p;
+	char *p, *pp;
 	unsigned u;
+	int l;
 
 	if (tl->t->tok == ID &&
 	    (vcc_IdIs(tl->t, "none") || vcc_IdIs(tl->t, "None"))) {
@@ -706,8 +707,11 @@ vcc_ParseHostDef(struct vcc *tl, struct symbol *sym,
 			vcc_ErrWhere(tl, t_val);
 		}
 
+		pp = strchr(p, ':');
+		l = (pp == NULL) ? -1 : (int)(pp - p);
+
 		Fb(tl, 0, "\t.authority = ");
-		VSB_quote(tl->fb, p, -1, VSB_QUOTE_CSTR);
+		VSB_quote(tl->fb, p, l, VSB_QUOTE_CSTR);
 		Fb(tl, 0, ",\n");
 	}
 


### PR DESCRIPTION
Second half of the fix for #3963:

So far, we deliberately allowed IP addresses in the `.authority` field of backends, which might be derived from `.host_header` or `.host`.

There is a fair argument in #3963 that this should not be allowed.

This patch adds a `getaddrinfo()` call via `VSS_ResolveOne()` to check if the value parses as an ip address and, if so, fails VCL compilation.