### PR TITLE
Simplify key=val argument handling

### DIFF
--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -38,6 +38,7 @@
 
 #include <stdint.h>
 
+#include "string.h"
 #include <sys/types.h>
 
 #include "vdef.h"
@@ -63,6 +64,16 @@ struct vclprog;
 extern struct vev_root	*mgt_evb;
 extern unsigned		d_flag;
 extern int		exit_status;
+
+/* option=value argument parse helper */
+static inline const char *
+keyval(const char *p, const char *name)
+{
+	size_t l = strlen(name);
+	if (strncmp(p, name, l))
+		return (NULL);
+	return (p + l);
+}
 
 /* builtin_vcl.c */
 

--- a/bin/varnishd/mgt/mgt_jail_solaris.c
+++ b/bin/varnishd/mgt/mgt_jail_solaris.c
@@ -323,13 +323,14 @@ static int v_matchproto_(jail_init_f)
 vjs_init(char **args)
 {
 	priv_set_t **sets, *permitted, *inheritable, *user = NULL;
-	const char *e;
+	const char *e, *val;
 	int vj, vs;
 
 	if (args != NULL && *args != NULL) {
 		for (;*args != NULL; args++) {
-			if (!strncmp(*args, "worker=", 7)) {
-				user = priv_str_to_set((*args) + 7, ",", &e);
+			val = keyval(*args, "worker=");
+			if (val != NULL) {
+				user = priv_str_to_set(val, ",", &e);
 				if (user == NULL)
 					ARGV_ERR(
 					    "-jsolaris: parsing worker= "


### PR DESCRIPTION
@dridi I would use this in place of #4202. Do you agree?

This is a Draft because I still want to look if we can replace other similar cases and probably move the helper function to a better place as a `static inline` [^1]

----

we add a simple utility function to return the pointer to the thing after "key=" if the first argument begins with "key=".

Note that this is no worse than a macro with a "reasonable good" compiler *) and default (-O2) optimization, because the function call gets inlined and the strlen() turned into a constant.

```
  0x00000000000a1bd1 <+49>:     lea    0x6ed49(%rip),%r14        # 0x110921
  ...
  0x00000000000a1c01 <+97>:    mov    $0x5,%edx
  0x00000000000a1c06 <+102>:   mov    %rbx,%rdi
  0x00000000000a1c09 <+105>:   mov    %r14,%rsi
  0x00000000000a1c0c <+108>:   call   0x2d360 <strncmp@plt>
  0x00000000000a1c11 <+113>:   lea    0x5(%rbx),%rbp
  0x00000000000a1c15 <+117>:   test   %eax,%eax

  (gdb) p (const char *)0x110921
  $2 = 0x110921 "user="
```

Replaces #4202
Polishes 4001ea251bac6924c2e86bac3d0f2c8d93c96bd8

*) tested:
   gcc version 12.2.0 (Debian 12.2.0-14)
   Debian clang version 14.0.6

[^1]: Reminder that `inline` has no other relevance than "do not complain if unused", as the compiler is free to inline no matter what