### PR TITLE
[varnishstat] reset running averages

### DIFF
--- a/bin/varnishstat/varnishstat_bindings.h
+++ b/bin/varnishstat/varnishstat_bindings.h
@@ -101,6 +101,9 @@ BINDING(QUIT, "\tQuit.")
 BINDING_KEY(BINDING_CTRL('t'), "CTRL+T",)
 BINDING(SAMPLE, "\tSample now.")
 
+BINDING_KEY('0', "0",)
+BINDING(RESET_AVERAGES, "\tReset averages.")
+
 BINDING_KEY('+', "+",)
 BINDING(ACCEL, "\tIncrease refresh interval.")
 

--- a/bin/varnishstat/varnishstat_curses.c
+++ b/bin/varnishstat/varnishstat_curses.c
@@ -129,6 +129,7 @@ static int current = 0;
 static int rebuild = 0;
 static int redraw = 0;
 static int sample = 0;
+static int reset_averages = 0;
 static int scale = 1;
 static double t_sample = 0.;
 static double interval = 1.;
@@ -262,6 +263,12 @@ sample_points(void)
 		pt->t_last = pt->t_cur;
 		pt->t_cur = VTIM_mono();
 
+		if (reset_averages) {
+			pt->chg = 0;
+			pt->ma_10.n = 0;
+			pt->ma_100.n = 0;
+			pt->ma_1000.n = 0;
+		}
 		if (pt->t_last)
 			pt->chg = ((int64_t)pt->cur - (int64_t)pt->last) /
 			    (pt->t_cur - pt->t_last);
@@ -305,6 +312,11 @@ sample_hitrate(void)
 		ratio = hr / (hr + mr);
 	else
 		ratio = 0;
+	if (reset_averages) {
+		hitrate.hr_10.n = 0;
+		hitrate.hr_100.n = 0;
+		hitrate.hr_1000.n = 0;
+	}
 	update_ma(&hitrate.hr_10, ratio);
 	update_ma(&hitrate.hr_100, ratio);
 	update_ma(&hitrate.hr_1000, ratio);
@@ -318,6 +330,7 @@ sample_data(void)
 	redraw = 1;
 	sample_points();
 	sample_hitrate();
+	reset_averages = 0;
 }
 
 static void
@@ -1006,6 +1019,9 @@ handle_points_keypress(struct vsc *vsc, enum kb_e kb)
 	case KB_SAMPLE:
 		sample = 1;
 		return;
+	case KB_RESET_AVERAGES:
+		reset_averages = 1;
+		return;
 	case KB_QUIT:
 	case KB_SIG_INT:
 	case KB_SIG_TSTP:
@@ -1055,6 +1071,7 @@ handle_help_keypress(enum kb_e kb)
 	case KB_VERBOSE:
 	case KB_QUIET:
 	case KB_SAMPLE:
+	case KB_RESET_AVERAGES:
 		break;
 	case KB_QUIT:
 	case KB_SIG_INT:

--- a/bin/varnishtest/tests/u00021.vtc
+++ b/bin/varnishtest/tests/u00021.vtc
@@ -1,0 +1,23 @@
+varnishtest "varnishstat coverage"
+
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {} -start
+process p1 -dump {varnishstat -n ${v1_name}} -start
+delay 2
+
+client c1 -repeat 11 {
+	txreq
+	rxresp
+} -run
+
+delay 2
+process p1 -screen_dump
+process p1 -write 0
+delay 1
+process p1 -screen_dump
+process p1 -expect-text 0 0 "avg(n):   0.0000   0.0000   0.0000"


### PR DESCRIPTION
I've been running benchmark tests these last few days, and I've been wishing to be able to reset the average calculations without having to restart `varnishncsa`, so here we go.