### PR TITLE
Reapply "fetch: A beresp body cannot be BS_TAKEN"

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -141,10 +141,11 @@ Bereq_Rollback(VRT_CTX)
 	bo = ctx->bo;
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 
-	if (bo->htc != NULL &&
-	    bo->htc->body_status != BS_NONE &&
-	    bo->htc->body_status != BS_TAKEN)
-		bo->htc->doclose = SC_RESP_CLOSE;
+	if (bo->htc != NULL) {
+		assert(bo->htc->body_status != BS_TAKEN);
+		if (bo->htc->body_status != BS_NONE)
+			bo->htc->doclose = SC_RESP_CLOSE;
+	}
 
 	vbf_cleanup(bo);
 	VCL_TaskLeave(ctx, bo->privs);

--- a/include/tbl/body_status.h
+++ b/include/tbl/body_status.h
@@ -27,7 +27,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * Various ways to handle the body coming from the backend.
+ * Various ways to handle the body coming from a peer.
  */
 
 /*lint -save -e525 -e539 */


### PR DESCRIPTION
This reverts commit 8c4ae4f0e1c1990a48884b36e2b3e9acc8d162a1.

I dispute the claim from the revert commit that bo->htc->body_status
refers to the bereq, since this is managed by the V1F (HTTP/1 Fetch)
code. What we fetch on the backend side is a beresp.