### PR TITLE
http2: The client closing the connection is not an error

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -1451,6 +1451,22 @@ h2_sweep(struct worker *wrk, struct h2_sess *h2)
 	return (h2e);
 }
 
+/*
+ * if we have received end_headers, the new request is started
+ * if we have not received end_stream, DATA frames are expected later
+ *
+ * neither of these make much sense to output here
+ *
+ * goaway currently is always 0, see #4285
+ */
+static void
+h2_eof_debug(struct h2_sess *h2)
+{
+
+	H2S_Lock_VSLb(h2, SLT_Debug, "H2: eof frame=%s goaway=%d",
+	    h2->htc->rxbuf_b == h2->htc->rxbuf_e ? "complete" : "partial",
+	    h2->goaway);
+}
 
 /***********************************************************************
  * Called in loop from h2_new_session()
@@ -1488,6 +1504,8 @@ h2_rxframe(struct worker *wrk, struct h2_sess *h2)
 	h2e = NULL;
 	switch (hs) {
 	case HTC_S_EOF:
+		h2_eof_debug(h2);
+
 		h2e = H2CE_NO_ERROR;
 		break;
 	case HTC_S_COMPLETE:

--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -1487,6 +1487,9 @@ h2_rxframe(struct worker *wrk, struct h2_sess *h2)
 
 	h2e = NULL;
 	switch (hs) {
+	case HTC_S_EOF:
+		h2e = H2CE_NO_ERROR;
+		break;
 	case HTC_S_COMPLETE:
 		h2->sess->t_idle = VTIM_real();
 		if (h2->do_sweep)

--- a/bin/varnishtest/tests/t02027.vtc
+++ b/bin/varnishtest/tests/t02027.vtc
@@ -1,0 +1,89 @@
+varnishtest "H2 RxStuff conditions"
+
+varnish v1 -arg "-p feature=+http2" -arg "-p debug=+syncvsl" -vcl {
+	backend none none;
+	sub vcl_recv {
+		return (synth(200));
+	}
+} -start
+
+logexpect l0 -v v1 -g vxid -q "Begin ~ sess" {
+	expect * * Debug           {^H2: Got pu PRISM}
+	expect 0 = Debug           {^H2: eof frame=complete goaway=0}
+	expect 0 = SessError       {^H2: HTC eof}
+	expect 0 = Debug           {^H2 CLEANUP H2CE_NO_ERROR}
+	expect 0 = ReqAcct         {^0 0 0 18 26 44}
+	expect 0 = SessClose       {^REM_CLOSE}
+	expect 0 = End
+} -start
+
+# no streams open
+client c0 {
+	txpri
+	shutdown -write
+} -run
+
+logexpect l1 -v v1 -g vxid -q "Begin ~ sess" {
+	expect * * Debug           {^H2: eof frame=complete goaway=0}
+	expect 0 = SessError       {^H2: HTC eof}
+	expect 0 = Debug           {^H2 CLEANUP H2CE_NO_ERROR}
+	expect 9 = ReqAcct         {^27 0 27 27 26 53}
+	expect 0 = SessClose       {^REM_CLOSE}
+	expect 0 = End
+} -start
+
+# after frame, no END_HEADERS
+client c1 {
+	stream 1 {
+		txreq -nohdrend
+	} -run
+	shutdown -write
+} -run
+
+logexpect l2 -v v1 -g vxid -q "Begin ~ sess" {
+	expect * * Debug           {^H2: eof frame=complete goaway=0}
+	expect 0 = SessError       {^H2: HTC eof}
+	expect 0 = Debug           {^H2 CLEANUP H2CE_NO_ERROR}
+	expect 9 = ReqAcct         {^27 0 27 27 26 53}
+	expect 0 = SessClose       {^REM_CLOSE}
+	expect 0 = End
+} -start
+
+# after frame, no END_STREAM
+client c2 {
+	stream 1 {
+		txreq -nostrend
+	} -run
+	shutdown -write
+} -run
+
+logexpect l3 -v v1 -g vxid -q "Begin ~ sess" {
+	expect * * Debug           {^H2: eof frame=partial goaway=0}
+	expect 0 = SessError       {^H2: HTC eof}
+	expect 0 = Debug           {^H2 CLEANUP H2CE_NO_ERROR}
+	expect 0 = ReqAcct         {^18 0 18 27 26 53}
+	expect 0 = SessClose       {^REM_CLOSE}
+	expect 0 = End
+} -start
+
+# middle of frame
+client c3 {
+	stream 1 {
+		#		   +- 01 END_STREAM
+		#                  +- 04 END_HEADERS
+		#		   |
+		#	   len ty fl strmid
+		sendhex {
+			000024 01 05 00000001
+			00053a70617468012f00073a6d6574686f640347455400073a736368656d6504687474
+		}
+		# ori:
+		#	00053a70617468012f00073a6d6574686f640347455400073a736368656d650468747470
+	} -run
+	shutdown -write
+} -run
+
+logexpect l0 -wait
+logexpect l1 -wait
+logexpect l2 -wait
+logexpect l3 -wait

--- a/bin/varnishtest/tests/t02027.vtc
+++ b/bin/varnishtest/tests/t02027.vtc
@@ -8,13 +8,14 @@ varnish v1 -arg "-p feature=+http2" -arg "-p debug=+syncvsl" -vcl {
 } -start
 
 logexpect l0 -v v1 -g vxid -q "Begin ~ sess" {
+	fail add * SessError
 	expect * * Debug           {^H2: Got pu PRISM}
-	expect 0 = Debug           {^H2: eof frame=complete goaway=0}
-	expect 0 = SessError       {^H2: HTC eof}
+	expect 0 = Debug           {^H2: HTC eof.*frame=complete goaway=0}
 	expect 0 = Debug           {^H2 CLEANUP H2CE_NO_ERROR}
 	expect 0 = ReqAcct         {^0 0 0 18 26 44}
 	expect 0 = SessClose       {^REM_CLOSE}
 	expect 0 = End
+	fail clear
 } -start
 
 # no streams open
@@ -24,12 +25,13 @@ client c0 {
 } -run
 
 logexpect l1 -v v1 -g vxid -q "Begin ~ sess" {
-	expect * * Debug           {^H2: eof frame=complete goaway=0}
-	expect 0 = SessError       {^H2: HTC eof}
+	fail add * SessError
+	expect * * Debug           {^H2: HTC eof.*frame=complete goaway=0}
 	expect 0 = Debug           {^H2 CLEANUP H2CE_NO_ERROR}
 	expect 9 = ReqAcct         {^27 0 27 27 26 53}
 	expect 0 = SessClose       {^REM_CLOSE}
 	expect 0 = End
+	fail clear
 } -start
 
 # after frame, no END_HEADERS
@@ -41,12 +43,13 @@ client c1 {
 } -run
 
 logexpect l2 -v v1 -g vxid -q "Begin ~ sess" {
-	expect * * Debug           {^H2: eof frame=complete goaway=0}
-	expect 0 = SessError       {^H2: HTC eof}
+	fail add * SessError
+	expect * * Debug           {^H2: HTC eof.*frame=complete goaway=0}
 	expect 0 = Debug           {^H2 CLEANUP H2CE_NO_ERROR}
 	expect 9 = ReqAcct         {^27 0 27 27 26 53}
 	expect 0 = SessClose       {^REM_CLOSE}
 	expect 0 = End
+	fail clear
 } -start
 
 # after frame, no END_STREAM
@@ -58,12 +61,13 @@ client c2 {
 } -run
 
 logexpect l3 -v v1 -g vxid -q "Begin ~ sess" {
-	expect * * Debug           {^H2: eof frame=partial goaway=0}
-	expect 0 = SessError       {^H2: HTC eof}
+	fail add * SessError
+	expect * * Debug           {^H2: HTC eof.*frame=partial goaway=0}
 	expect 0 = Debug           {^H2 CLEANUP H2CE_NO_ERROR}
 	expect 0 = ReqAcct         {^18 0 18 27 26 53}
 	expect 0 = SessClose       {^REM_CLOSE}
 	expect 0 = End
+	fail clear
 } -start
 
 # middle of frame


### PR DESCRIPTION
It is fine for a client to close the connection, we should say a friendly goodbye and log this as no error.

Closes #4281
Related to #4283