### PR TITLE
cache.h: give stevedores a small bitfield in struct objcore

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -353,6 +353,8 @@ struct objcore {
 
 	uint16_t		oa_present;
 
+	uint16_t		st_flags;	// owned by stv
+
 	unsigned		timer_idx;	// XXX 4Gobj limit
 	vtim_real		last_lru;
 	VTAILQ_ENTRY(objcore)	hsh_list;


### PR DESCRIPTION
On 64bit, there is currently a hole in struct objcore:

```c
(gdb) ptype /o struct objcore
/* offset      |    size */  type = struct objcore {
...
/*     88      |       4 */    unsigned int timer_idx;
/* XXX  4-byte hole      */
/*     96      |       8 */    vtim_real last_lru;
```

put a small bitfield there for use by stevedores.

Yes, conceptually, it would belong into `struct storeobj`, but if we put anything there, `struct objcore` will grow by 8 bytes.

Yes, the stevedore already owns the `(struct storeobj)` `priv` and `priv2` members, and some bits could get banged in there. This proposal is more motivated by the fact that there are 4 bytes currently unused.

Those who are interested in the backstory might want to grab some popcorn and read https://gitlab.com/uplex/varnish/slash/-/commit/c2e05e831ffc8095d9cc56510f24a5529ab16282