### PR TITLE
Prepare for 7.6.2

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -941,6 +941,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 	if (http_CountHdr(req->http0, H_Host) > 1) {
 		VSLb(req->vsl, SLT_BogoHeader, "Multiple Host: headers");
 		wrk->stats->client_req_400++;
+		req->doclose = SC_RX_BAD;
 		(void)req->transport->minimal_response(req, 400);
 		return (REQ_FSM_DONE);
 	}
@@ -948,6 +949,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 	if (http_CountHdr(req->http0, H_Content_Length) > 1) {
 		VSLb(req->vsl, SLT_BogoHeader, "Multiple Content-Length: headers");
 		wrk->stats->client_req_400++;
+		req->doclose = SC_RX_BAD;
 		(void)req->transport->minimal_response(req, 400);
 		return (REQ_FSM_DONE);
 	}

--- a/bin/varnishtest/tests/b00037.vtc
+++ b/bin/varnishtest/tests/b00037.vtc
@@ -11,6 +11,7 @@ client c1 {
 
 varnish v1 -vsl_catchup
 varnish v1 -expect client_req_400 == 1
+varnish v1 -expect sc_rx_bad == 1
 
 client c1 {
 	txreq -method POST -hdr "Content-Length: 12" -hdr "Content-Length: 12" -bodylen 12
@@ -20,6 +21,7 @@ client c1 {
 
 varnish v1 -vsl_catchup
 varnish v1 -expect client_req_400 == 2
+varnish v1 -expect sc_rx_bad == 2
 
 varnish v1 -cliok "param.set feature +http2"
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,9 @@
 AC_PREREQ([2.69])
 AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
-Copyright (c) 2006-2024 Varnish Software
-Copyright 2010-2024 UPLEX - Nils Goroll Systemoptimierung])
+Copyright (c) 2006-2025 Varnish Software
+Copyright 2010-2025 UPLEX - Nils Goroll Systemoptimierung])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [7.6.1], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [7.6.2], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -35,7 +35,7 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
-Varnish Cache 7.6.2 (unreleased)
+Varnish Cache 7.6.2 (2025-03-17)
 ================================
 
 .. _VSV00015: https://varnish-cache.org/security/VSV00015.html

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -35,6 +35,15 @@ individual releases. These documents are updated as part of the
 release process.
 
 ================================
+Varnish Cache 7.6.2 (unreleased)
+================================
+
+.. _VSV00015: https://varnish-cache.org/security/VSV00015.html
+
+* The client connection is now always closed when a malformed request
+  is received. (VSV00015_)
+
+================================
 Varnish Cache 7.6.1 (2024-11-08)
 ================================
 

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -40,9 +40,9 @@ Conventions used in this manual include:
 Longer listings like example command output and VCL look like this::
 
     $ /opt/varnish/sbin/varnishd -V
-    varnishd (varnish-7.5.0 revision 1234567)
+    varnishd (varnish-7.6.2 revision 1234567)
     Copyright (c) 2006 Verdens Gang AS
-    Copyright (c) 2006-2024 Varnish Software
+    Copyright (c) 2006-2025 Varnish Software
 
 
 .. For maintainers:

--- a/lib/libvarnish/version.c
+++ b/lib/libvarnish/version.c
@@ -76,8 +76,8 @@ VCS_String(const char *which)
 		    ")"
 		    "\n"
 		    "Copyright (c) 2006 Verdens Gang AS\n"
-		    "Copyright (c) 2006-2024 Varnish Software\n"
-		    "Copyright 2010-2024 UPLEX - Nils Goroll Systemoptimierung\n"
+		    "Copyright (c) 2006-2025 Varnish Software\n"
+		    "Copyright 2010-2025 UPLEX - Nils Goroll Systemoptimierung\n"
 		);
 	default:
 		WRONG("Wrong argument to VCS_String");


### PR DESCRIPTION
Reviewers must check the following items:

- [ ] Release notes are complete (major release only)
- [ ] Release notes no longer target trunk (major release only)
- [x] The change log is populated
- [ ] The VRT history in `include/vrt.h` is populated
- [ ] The VRT history refers to the next VRT version
- [ ] The macro `VRT_MAJOR_VERSION` was updated if applicable
- [ ] The macro `VRT_MINOR_VERSION` was updated if applicable
- [ ] The new VRT version follows releases guidelines
- [ ] The new VRT version matches the one from the VRT history
- [ ] Bundled `devicedetect.vcl` was updated (major release only)
- [x] Running `./autogen.des && make distcheck` succeeds
- [x] The version in `configure.ac` is correct
- [x] The copyright notice in `configure.ac` covers the current year
- [x] The copyright output in `lib/libvarnish/version.c` covers the current year
- [x] There are no other changes than the ones listed above