### PR TITLE
introduce VRT_VSC_AllocVariadic

### DIFF
--- a/bin/varnishd/common/common_vsc.c
+++ b/bin/varnishd/common/common_vsc.c
@@ -183,6 +183,20 @@ VRT_VSC_Allocv(struct vsmw_cluster *vc, struct vsc_seg **sg,
 	return (vsg->ptr);
 }
 
+void *
+VRT_VSC_Alloc(struct vsmw_cluster *vc, struct vsc_seg **sg,
+    const char *nm, size_t sd,
+    const unsigned char *jp, size_t sj, const char *fmt, ...)
+{
+	va_list ap;
+	void *retval;
+
+	va_start(ap, fmt);
+	retval = VRT_VSC_Allocv(vc, sg, nm, sd, jp, sj, fmt, ap);
+	va_end(ap);
+	return(retval);
+}
+
 void
 VRT_VSC_Destroy(const char *nm, struct vsc_seg *vsg)
 {

--- a/bin/varnishd/common/common_vsc.c
+++ b/bin/varnishd/common/common_vsc.c
@@ -135,7 +135,7 @@ VRT_VSC_Reveal(const struct vsc_seg *vsg)
 }
 
 void *
-VRT_VSC_Alloc(struct vsmw_cluster *vc, struct vsc_seg **sg,
+VRT_VSC_Allocv(struct vsmw_cluster *vc, struct vsc_seg **sg,
     const char *nm, size_t sd,
     const unsigned char *jp, size_t sj, const char *fmt, va_list va)
 {

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -61,6 +61,7 @@
  *	typedef hdr_t added
  *	struct gethdr_s.what changed to hdr_t
  *	VRT_VSC_Alloc() renamed to VRT_VSC_Allocv()
+ *	new VRT_VSC_Alloc() added
  * 21.0 (2025-03-17)
  *	VRT_u_req_grace() added
  *	VRT_u_req_ttl() added
@@ -855,6 +856,8 @@ void VRT_VSM_Cluster_Destroy(VRT_CTX, struct vsmw_cluster **);
 #ifdef va_start	// XXX: hackish
 void *VRT_VSC_Allocv(struct vsmw_cluster *, struct vsc_seg **,
     const char *, size_t, const unsigned char *, size_t, const char *, va_list);
+void *VRT_VSC_Alloc(struct vsmw_cluster *, struct vsc_seg **,
+    const char *, size_t, const unsigned char *, size_t, const char *, ...);
 #endif
 void VRT_VSC_Destroy(const char *, struct vsc_seg *);
 void VRT_VSC_Hide(const struct vsc_seg *);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -60,6 +60,7 @@
  * XX.X (unreleased)
  *	typedef hdr_t added
  *	struct gethdr_s.what changed to hdr_t
+ *	VRT_VSC_Alloc() renamed to VRT_VSC_Allocv()
  * 21.0 (2025-03-17)
  *	VRT_u_req_grace() added
  *	VRT_u_req_ttl() added
@@ -852,7 +853,7 @@ struct vsmw_cluster *VRT_VSM_Cluster_New(VRT_CTX, size_t);
 void VRT_VSM_Cluster_Destroy(VRT_CTX, struct vsmw_cluster **);
 
 #ifdef va_start	// XXX: hackish
-void *VRT_VSC_Alloc(struct vsmw_cluster *, struct vsc_seg **,
+void *VRT_VSC_Allocv(struct vsmw_cluster *, struct vsc_seg **,
     const char *, size_t, const unsigned char *, size_t, const char *, va_list);
 #endif
 void VRT_VSC_Destroy(const char *, struct vsc_seg *);

--- a/lib/libvsc/vsctool.py
+++ b/lib/libvsc/vsctool.py
@@ -270,7 +270,7 @@ class CounterSet(object):
         fo.write("\t" + self.struct + " *retval;\n")
         fo.write("\n")
         fo.write("\tva_start(ap, fmt);\n")
-        fo.write("\tretval = VRT_VSC_Alloc")
+        fo.write("\tretval = VRT_VSC_Allocv")
         fo.write("(vc, sg, vsc_" + self.name + "_name, ")
         fo.write("VSC_" + self.name + "_size,\n")
         fo.write("\t    vsc_" + self.name + "_json, ")


### PR DESCRIPTION
VRT_VSC_Alloc requires `va_list` which isn't available on all platforms in `rust`. To bridge this FFI gap, provide a variadic version of it.