### PR TITLE
constify headers

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -673,7 +673,7 @@ int http_IsFiltered(const struct http *hp, unsigned u, unsigned how);
 #define HTTPH_A_PASS		(1 << 3)	/* Response (b->o) for pass */
 #define HTTPH_C_SPECIFIC	(1 << 4)	/* Connection-specific */
 
-#define HTTPH(a, b, c) extern char b[];
+#define HTTPH(a, b, c) extern const char b[];
 #include "tbl/http_headers.h"
 
 extern const char H__Status[];


### PR DESCRIPTION
one of my vmod is complaining that headers in `tbl/http_headers.h` are not immutable and technically, there aren't because of `http_init_hdr`, but as `extern` they should be const?