### PR TITLE
gzip: Allocate gzip buffers from storage

### DIFF
--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -146,7 +146,7 @@ vfp_esi_end(struct vfp_ctx *vc, struct vef_priv *vef,
 	if (vef->vgz != NULL) {
 		if (retval == VFP_END)
 			VGZ_UpdateObj(vc, vef->vgz, VGZ_END);
-		if (VGZ_Destroy(&vef->vgz) != VGZ_END)
+		if (VGZ_Destroy(vc->wrk, &vef->vgz) != VGZ_END)
 			retval = VFP_Error(vc,
 			    "ESI+Gzip Failed at the very end");
 	}

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -197,7 +197,7 @@ VGZ_Obuf(struct vgz *vg, void *ptr, ssize_t len)
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
 
-	vg->vz.next_out = TRUST_ME(ptr);
+	vg->vz.next_out = ptr;
 	vg->vz.avail_out = len;
 }
 

--- a/bin/varnishd/cache/cache_gzip.c
+++ b/bin/varnishd/cache/cache_gzip.c
@@ -175,8 +175,11 @@ VGZ_Ibuf(struct vgz *vg, const void *ptr, ssize_t len)
 {
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
-
 	AZ(vg->vz.avail_in);
+	assert(len >= 0);
+	if (len > 0)
+		AN(ptr);
+
 	vg->vz.next_in = TRUST_ME(ptr);
 	vg->vz.avail_in = len;
 }
@@ -196,6 +199,8 @@ VGZ_Obuf(struct vgz *vg, void *ptr, ssize_t len)
 {
 
 	CHECK_OBJ_NOTNULL(vg, VGZ_MAGIC);
+	AN(ptr);
+	assert(len > 0);
 
 	vg->vz.next_out = ptr;
 	vg->vz.avail_out = len;

--- a/bin/varnishd/cache/cache_vgz.h
+++ b/bin/varnishd/cache/cache_vgz.h
@@ -53,6 +53,6 @@ int VGZ_ObufFull(const struct vgz *vg);
 enum vgzret_e VGZ_Gzip(struct vgz *, const void **, ssize_t *len,
     enum vgz_flag);
 // enum vgzret_e VGZ_Gunzip(struct vgz *, const void **, ssize_t *len);
-enum vgzret_e VGZ_Destroy(struct vgz **);
+enum vgzret_e VGZ_Destroy(struct worker *wrk, struct vgz **);
 
 void VGZ_UpdateObj(const struct vfp_ctx *, struct vgz*, enum vgzret_e);

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -538,10 +538,12 @@ PARAM_SIMPLE(
 	/* units */	"bytes",
 	/* descr */
 	"Size of malloc buffer used for gzip processing.\n"
+	"Size of buffer used for gzip processing.\n"
 	"These buffers are used for in-transit data, for instance "
-	"gunzip'ed data being sent to a client.Making this space to small "
+	"gunzip'ed data being sent to a client. Making this space to small "
 	"results in more overhead, writes to sockets etc, making it too "
-	"big is probably just a waste of memory.",
+	"big is probably just a waste of memory.\n"
+	"Gzip buffers are allocated from Transient storage.",
 	/* flags */	EXPERIMENTAL
 )
 


### PR DESCRIPTION
Arbitrary allocation from storage was introduced to solve the h2
head-of-line blocking caused by early DATA frames, allowed by the
initial control flow window of new streams. The decision could have
been made then to allocate the window buffer from the heap, but it
was tied to storage instead, offering better control over the global
memory footprint of the cache process.

The gzip buffer is tied to a task, but too large to allocate from
workspace without posing a risk. Even worse, there may be multiple
concurrent gzip operations in a single task. For example a gunzip
needed to parse ESI followed by a gzip to store a compressed body.

For a similar reason, it was not opportune to allocate the h2 stream
window buffer from workspace, despite being tied to the task.

Following the same logic, the gzip allocation can be performed from
storage to remove one wild card in our heap consumption. Another
possibility could have been the addition of a mempool, and it could
also have been an alternative for the h2 stream window, but transient
storage seemed more appropriate and it matches the on-demand malloc
behavior.

The gzip buffer logic could have been better encapsulated, but the
amount of direct access to the m_buf field would have resulted in a
lot of noise. Most of the noise here is caused by the two function
signatures changed to take a worker argument.