### PR TITLE
vrt: Turn hdr_t into a structured type

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -83,8 +83,6 @@ struct body_status {
 
 typedef const struct body_status *body_status_t;
 
-typedef const char *hdr_t;
-
 /*--------------------------------------------------------------------*/
 
 struct stream_close {

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -673,12 +673,12 @@ int http_IsFiltered(const struct http *hp, unsigned u, unsigned how);
 #define HTTPH_A_PASS		(1 << 3)	/* Response (b->o) for pass */
 #define HTTPH_C_SPECIFIC	(1 << 4)	/* Connection-specific */
 
-#define HTTPH(a, b, c) extern char b[];
+#define HTTPH(a, b, c) extern char *b;
 #include "tbl/http_headers.h"
 
-extern const char H__Status[];
-extern const char H__Proto[];
-extern const char H__Reason[];
+extern const char *H__Status;
+extern const char *H__Proto;
+extern const char *H__Reason;
 
 // rfc7233,l,1207,1208
 #define http_tok_eq(s1, s2)		(!vct_casecmp(s1, s2))

--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -673,12 +673,12 @@ int http_IsFiltered(const struct http *hp, unsigned u, unsigned how);
 #define HTTPH_A_PASS		(1 << 3)	/* Response (b->o) for pass */
 #define HTTPH_C_SPECIFIC	(1 << 4)	/* Connection-specific */
 
-#define HTTPH(a, b, c) extern char *b;
+#define HTTPH(a, b, c) extern hdr_t b;
 #include "tbl/http_headers.h"
 
-extern const char *H__Status;
-extern const char *H__Proto;
-extern const char *H__Reason;
+extern hdr_t H__Status;
+extern hdr_t H__Proto;
+extern hdr_t H__Reason;
 
 // rfc7233,l,1207,1208
 #define http_tok_eq(s1, s2)		(!vct_casecmp(s1, s2))

--- a/bin/varnishd/cache/cache_ban.c
+++ b/bin/varnishd/cache/cache_ban.c
@@ -495,6 +495,7 @@ ban_evaluate(struct worker *wrk, const uint8_t *bsarg, struct objcore *oc,
 	const char *p;
 	const char *arg1;
 	double darg1, darg2;
+	hdr_t hdr;
 	int rv;
 
 	/*
@@ -521,11 +522,13 @@ ban_evaluate(struct worker *wrk, const uint8_t *bsarg, struct objcore *oc,
 			break;
 		case BANS_ARG_REQHTTP:
 			AN(reqhttp);
-			(void)http_GetHdr(reqhttp, bt.arg1_spec, &p);
+			CAST_HDR(hdr, bt.arg1_spec);
+			(void)http_GetHdr(reqhttp, hdr, &p);
 			arg1 = p;
 			break;
 		case BANS_ARG_OBJHTTP:
-			arg1 = HTTP_GetHdrPack(wrk, oc, bt.arg1_spec);
+			CAST_HDR(hdr, bt.arg1_spec);
+			arg1 = HTTP_GetHdrPack(wrk, oc, hdr);
 			break;
 		case BANS_ARG_OBJSTATUS:
 			arg1 = HTTP_GetHdrPack(wrk, oc, H__Status);

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -64,6 +64,8 @@ struct fetch_step {
 FETCH_STEPS
 #undef FETCH_STEP
 
+static hdr_t H_X_Varnish = "\012X-Varnish:";
+
 /*--------------------------------------------------------------------
  * Allocate an object, with fall-back to Transient.
  * XXX: This somewhat overlaps the stuff in stevedore.c
@@ -405,7 +407,7 @@ vbf_stp_startfetch(struct worker *wrk, struct busyobj *bo)
 	bo->storage = bo->uncacheable ? stv_transient : STV_next();
 
 	if (bo->retries > 0)
-		http_Unset(bo->bereq, "\012X-Varnish:");
+		http_Unset(bo->bereq, H_X_Varnish);
 
 	http_PrintfHeader(bo->bereq, "X-Varnish: %ju", VXID(bo->vsl->wid));
 

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -64,7 +64,7 @@ struct fetch_step {
 FETCH_STEPS
 #undef FETCH_STEP
 
-static hdr_t H_X_Varnish = "\012X-Varnish:";
+static hdr_t H_X_Varnish = HDR("X-Varnish");
 
 /*--------------------------------------------------------------------
  * Allocate an object, with fall-back to Transient.

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -187,9 +187,7 @@ http_hdr_flags(const char *b, const char *e)
 
 	if (b == NULL || e == NULL)
 		return (NULL);
-	assert(b <= e);
-	u = (unsigned)(e - b);
-	assert(b + u == e);
+	u = pdiff(b, e);
 	if (u < GPERF_MIN_WORD_LENGTH || u > GPERF_MAX_WORD_LENGTH)
 		return (NULL);
 	u += http_asso_values[(uint8_t)(e[-1])] +

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -482,10 +482,8 @@ http_IsHdr(const txt *hh, hdr_t hdr)
 	unsigned l;
 
 	Tcheck(*hh);
-	AN(hdr);
+	CHECK_HDR(hdr);
 	l = hdr[0];
-	assert(l == strlen(hdr + 1));
-	assert(hdr[l] == ':');
 	hdr++;
 	return (http_hdr_at(hdr, hh->b, l));
 }
@@ -556,6 +554,8 @@ http_CollectHdrSep(struct http *hp, hdr_t hdr, const char *sep)
 	const char *v;
 
 	CHECK_OBJ_NOTNULL(hp, HTTP_MAGIC);
+	CHECK_HDR(hdr);
+
 	if (WS_Overflowed(hp->ws))
 		return;
 
@@ -564,8 +564,6 @@ http_CollectHdrSep(struct http *hp, hdr_t hdr, const char *sep)
 	lsep = strlen(sep);
 
 	l = hdr[0];
-	assert(l == strlen(hdr + 1));
-	assert(hdr[l] == ':');
 	f = http_findhdr(hp, l - 1, hdr + 1);
 	if (f == 0)
 		return;
@@ -638,9 +636,8 @@ http_GetHdr(const struct http *hp, hdr_t hdr, const char **ptr)
 	unsigned u, l;
 	const char *p;
 
+	CHECK_HDR(hdr);
 	l = hdr[0];
-	assert(l == strlen(hdr + 1));
-	assert(hdr[l] == ':');
 	hdr++;
 	u = http_findhdr(hp, l - 1, hdr);
 	if (u == 0) {
@@ -1373,12 +1370,9 @@ HTTP_GetHdrPack(struct worker *wrk, struct objcore *oc, hdr_t hdr)
 
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
-	AN(hdr);
+	CHECK_HDR(hdr);
 
 	l = hdr[0];
-	assert(l > 0);
-	assert(l == strlen(hdr + 1));
-	assert(hdr[l] == ':');
 	hdr++;
 
 	if (hdr[0] == ':') {

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -56,12 +56,12 @@
 
 #define HTTPH(a, b, c) \
 static char _##b[] = "*" a ":"; \
-char *b = _##b;
+hdr_t b = _##b;
 #include "tbl/http_headers.h"
 
-const char *H__Status	= "\010:status:";
-const char *H__Proto	= "\007:proto:";
-const char *H__Reason	= "\010:reason:";
+hdr_t H__Status	= "\010:status:";
+hdr_t H__Proto	= "\007:proto:";
+hdr_t H__Reason	= "\010:reason:";
 
 static char * via_hdr;
 
@@ -111,7 +111,7 @@ static const unsigned char http_asso_values[256] = {
 };
 
 static struct http_hdrflg {
-	char		**hdr;
+	hdr_t		*hdr;
 	unsigned	flag;
 } http_hdrflg[GPERF_MAX_HASH_VALUE + 1] = {
 	{ NULL }, { NULL }, { NULL }, { NULL },
@@ -224,7 +224,7 @@ HTTP_Init(void)
 {
 	struct vsb *vsb;
 
-#define HTTPH(a, b, c) http_init_hdr(b, c);
+#define HTTPH(a, b, c) http_init_hdr(TRUST_ME(b), c);
 #include "tbl/http_headers.h"
 
 	vsb = VSB_new_auto();

--- a/bin/varnishd/cache/cache_http.c
+++ b/bin/varnishd/cache/cache_http.c
@@ -54,12 +54,14 @@
 #include "tbl/body_status.h"
 
 
-#define HTTPH(a, b, c) char b[] = "*" a ":";
+#define HTTPH(a, b, c) \
+static char _##b[] = "*" a ":"; \
+char *b = _##b;
 #include "tbl/http_headers.h"
 
-const char H__Status[]	= "\010:status:";
-const char H__Proto[]	= "\007:proto:";
-const char H__Reason[]	= "\010:reason:";
+const char *H__Status	= "\010:status:";
+const char *H__Proto	= "\007:proto:";
+const char *H__Reason	= "\010:reason:";
 
 static char * via_hdr;
 
@@ -109,74 +111,74 @@ static const unsigned char http_asso_values[256] = {
 };
 
 static struct http_hdrflg {
-	char		*hdr;
+	char		**hdr;
 	unsigned	flag;
 } http_hdrflg[GPERF_MAX_HASH_VALUE + 1] = {
 	{ NULL }, { NULL }, { NULL }, { NULL },
-	{ H_Date },
-	{ H_Range },
+	{ &H_Date },
+	{ &H_Range },
 	{ NULL },
-	{ H_Referer },
-	{ H_Age },
-	{ H_From },
-	{ H_Keep_Alive },
-	{ H_Retry_After },
-	{ H_TE },
-	{ H_If_Range },
-	{ H_ETag },
-	{ H_X_Forwarded_For },
-	{ H_Expect },
-	{ H_Trailer },
-	{ H_If_Match },
-	{ H_Host },
-	{ H_Accept_Language },
-	{ H_Accept },
-	{ H_If_Modified_Since },
-	{ H_If_None_Match },
-	{ H_If_Unmodified_Since },
+	{ &H_Referer },
+	{ &H_Age },
+	{ &H_From },
+	{ &H_Keep_Alive },
+	{ &H_Retry_After },
+	{ &H_TE },
+	{ &H_If_Range },
+	{ &H_ETag },
+	{ &H_X_Forwarded_For },
+	{ &H_Expect },
+	{ &H_Trailer },
+	{ &H_If_Match },
+	{ &H_Host },
+	{ &H_Accept_Language },
+	{ &H_Accept },
+	{ &H_If_Modified_Since },
+	{ &H_If_None_Match },
+	{ &H_If_Unmodified_Since },
 	{ NULL },
-	{ H_Cookie },
-	{ H_Upgrade },
-	{ H_Last_Modified },
-	{ H_Accept_Charset },
-	{ H_Accept_Encoding },
-	{ H_Content_MD5 },
-	{ H_Content_Type },
-	{ H_Content_Range },
+	{ &H_Cookie },
+	{ &H_Upgrade },
+	{ &H_Last_Modified },
+	{ &H_Accept_Charset },
+	{ &H_Accept_Encoding },
+	{ &H_Content_MD5 },
+	{ &H_Content_Type },
+	{ &H_Content_Range },
 	{ NULL }, { NULL },
-	{ H_Content_Language },
-	{ H_Transfer_Encoding },
-	{ H_Authorization },
-	{ H_Content_Length },
-	{ H_User_Agent },
-	{ H_Server },
-	{ H_Expires },
-	{ H_Location },
+	{ &H_Content_Language },
+	{ &H_Transfer_Encoding },
+	{ &H_Authorization },
+	{ &H_Content_Length },
+	{ &H_User_Agent },
+	{ &H_Server },
+	{ &H_Expires },
+	{ &H_Location },
 	{ NULL },
-	{ H_Set_Cookie },
-	{ H_Content_Encoding },
-	{ H_Max_Forwards },
-	{ H_Cache_Control },
+	{ &H_Set_Cookie },
+	{ &H_Content_Encoding },
+	{ &H_Max_Forwards },
+	{ &H_Cache_Control },
 	{ NULL },
-	{ H_Connection },
-	{ H_Pragma },
+	{ &H_Connection },
+	{ &H_Pragma },
 	{ NULL },
-	{ H_Accept_Ranges },
-	{ H_HTTP2_Settings },
-	{ H_Allow },
-	{ H_Content_Location },
+	{ &H_Accept_Ranges },
+	{ &H_HTTP2_Settings },
+	{ &H_Allow },
+	{ &H_Content_Location },
 	{ NULL },
-	{ H_Proxy_Authenticate },
-	{ H_Vary },
+	{ &H_Proxy_Authenticate },
+	{ &H_Vary },
 	{ NULL },
-	{ H_WWW_Authenticate },
-	{ H_Warning },
-	{ H_Via },
+	{ &H_WWW_Authenticate },
+	{ &H_Warning },
+	{ &H_Via },
 	{ NULL }, { NULL }, { NULL }, { NULL },
 	{ NULL }, { NULL }, { NULL }, { NULL },
 	{ NULL }, { NULL }, { NULL }, { NULL },
 	{ NULL }, { NULL }, { NULL },
-	{ H_Proxy_Authorization }
+	{ &H_Proxy_Authorization }
 };
 
 static struct http_hdrflg *
@@ -197,7 +199,8 @@ http_hdr_flags(const char *b, const char *e)
 	retval = &http_hdrflg[u];
 	if (retval->hdr == NULL)
 		return (NULL);
-	if (!http_hdr_at(retval->hdr + 1, b, e - b))
+	AN(*retval->hdr);
+	if (!http_hdr_at(*retval->hdr + 1, b, e - b))
 		return (NULL);
 	return (retval);
 }
@@ -212,7 +215,7 @@ http_init_hdr(char *hdr, int flg)
 	hdr[0] = strlen(hdr + 1);
 	f = http_hdr_flags(hdr + 1, hdr + hdr[0]);
 	AN(f);
-	assert(f->hdr == hdr);
+	assert(*f->hdr == hdr);
 	f->flag = flg;
 }
 

--- a/bin/varnishd/cache/cache_vary.c
+++ b/bin/varnishd/cache/cache_vary.c
@@ -81,6 +81,7 @@ VRY_Create(struct busyobj *bo, struct vsb **psb)
 {
 	const char *v, *p, *q, *h, *e;
 	struct vsb *sb, *sbh;
+	hdr_t hdr;
 	unsigned l;
 	int error = 0;
 
@@ -122,8 +123,9 @@ VRY_Create(struct busyobj *bo, struct vsb **psb)
 		AZ(VSB_printf(sbh, "%c%.*s:%c",
 		    (char)(1 + (q - p)), (int)(q - p), p, 0));
 		AZ(VSB_finish(sbh));
+		CAST_HDR(hdr, VSB_data(sbh));
 
-		if (http_GetHdr(bo->bereq, VSB_data(sbh), &h)) {
+		if (http_GetHdr(bo->bereq, hdr, &h)) {
 			AZ(vct_issp(*h));
 			/* Trim trailing space */
 			e = strchr(h, '\0');
@@ -292,6 +294,7 @@ VRY_Match(const struct req *req, const uint8_t *vary)
 	const char *h, *e;
 	unsigned lh, ln;
 	int i, oflo = 0;
+	hdr_t hdr;
 
 	AN(vsp);
 	AN(vary);
@@ -310,8 +313,9 @@ VRY_Match(const struct req *req, const uint8_t *vary)
 			 * then compare again with that new entry.
 			 */
 
+			CAST_HDR(hdr, vary + 2);
 			ln = 2 + vary[2] + 2;
-			i = http_GetHdr(req->http, (const char*)(vary+2), &h);
+			i = http_GetHdr(req->http, hdr, &h);
 			if (i) {
 				/* Trim trailing space */
 				e = strchr(h, '\0');

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -604,11 +604,11 @@ VRT_SetHdr(VRT_CTX, VCL_HEADER hs, const char *pfx, VCL_STRANDS s)
 
 	u = WS_ReserveAll(hp->ws);
 	pl = (pfx == NULL) ? 0 : strlen(pfx);
-	l = hs->what[0] + 1 + pl;
+	l = hs->what->len + 1 + pl;
 	if (u <= l) {
 		WS_Release(hp->ws, 0);
 		WS_MarkOverflow(hp->ws);
-		VSLbs(ctx->vsl, SLT_LostHeader, TOSTRAND(hs->what + 1));
+		VSLbs(ctx->vsl, SLT_LostHeader, TOSTRAND(hs->what->str));
 		return;
 	}
 	b = WS_Reservation(hp->ws);
@@ -618,15 +618,15 @@ VRT_SetHdr(VRT_CTX, VCL_HEADER hs, const char *pfx, VCL_STRANDS s)
 			WS_Release(hp->ws, 0);
 			WS_MarkOverflow(hp->ws);
 			VSLbs(ctx->vsl, SLT_LostHeader,
-			    TOSTRAND(hs->what + 1));
+			    TOSTRAND(hs->what->str));
 			return;
 		}
 	} else {
 		b[l] = '\0';
 	}
 	p = b;
-	memcpy(p, hs->what + 1, hs->what[0]);
-	p += hs->what[0];
+	memcpy(p, hs->what->str, hs->what->len);
+	p += hs->what->len;
 	*p++ = ' ';
 	if (pfx != NULL)
 		memcpy(p, pfx, pl);

--- a/bin/varnishtest/tests/r01406.vtc
+++ b/bin/varnishtest/tests/r01406.vtc
@@ -10,7 +10,7 @@ varnish v1 -arg "-p vcc_feature=+allow_inline_c" -vcl+backend {
 
 	C{
 		static const struct gethdr_s VGC_HDR_REQ_foo =
-		    { HDR_REQ, "\020X-CUSTOM-HEADER:"};
+		    { HDR_REQ, HDR("X-CUSTOM-HEADER")};
 	}C
 
 	sub vcl_recv {

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -693,9 +693,11 @@ enum gethdr_e {
 	HDR_BERESP
 };
 
+typedef const char *hdr_t;
+
 struct gethdr_s {
 	enum gethdr_e	where;
-	const char	*what;
+	hdr_t		what;
 };
 
 VCL_HTTP VRT_selecthttp(VRT_CTX, enum gethdr_e);

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -695,6 +695,15 @@ enum gethdr_e {
 
 typedef const char *hdr_t;
 
+#define CHECK_HDR(hdr)					\
+	do {						\
+		AN(hdr);				\
+		unsigned _l = hdr[0];			\
+		assert(_l > 0);				\
+		assert(_l == strlen(hdr + 1));		\
+		assert(hdr[_l] == ':');			\
+	} while (0)
+
 struct gethdr_s {
 	enum gethdr_e	where;
 	hdr_t		what;

--- a/lib/libvcc/vcc_var.c
+++ b/lib/libvcc/vcc_var.c
@@ -57,8 +57,7 @@ vcc_Header_Fh(const struct vcc *tl, const struct symbol *sym)
 
 	/* Create the static identifier */
 	Fh(tl, 0, "static const struct gethdr_s %s =\n", sym->rname + 1);
-	Fh(tl, 0, "    { %s, \"\\%03o%s:\"};\n",
-	    parent->rname, (unsigned int)strlen(sym->name) + 1, sym->name);
+	Fh(tl, 0, "    { %s, HDR(\"%s\")};\n", parent->rname, sym->name);
 }
 
 /*--------------------------------------------------------------------*/

--- a/vmod/vmod_debug.c
+++ b/vmod/vmod_debug.c
@@ -685,10 +685,10 @@ xyzzy_sethdr(VRT_CTX, VCL_HEADER hdr, VCL_STRANDS s)
 	if (s->n == 0) {
 		http_Unset(hp, hdr->what);
 	} else {
-		b = VRT_StrandsWS(hp->ws, hdr->what + 1, s);
+		b = VRT_StrandsWS(hp->ws, hdr->what->str, s);
 		if (b == NULL) {
 			VSLbs(ctx->vsl, SLT_LostHeader,
-			    TOSTRAND(hdr->what + 1));
+			    TOSTRAND(hdr->what->str));
 		} else {
 			if (*b != '\0')
 				AN(WS_Allocated(hp->ws, b, strlen(b) + 1));


### PR DESCRIPTION
Without changing the memory layout of our pseudo-pascal-string for header names, this structured alternative clarifies the semantics and removes error-prone pointer arithmetics spread out everywhere.

The new structure adds type safety to this specific use case.

It comes with a new static analyzer with the `HDR()` macro, and a `CAST_HDR()` macro that includes a check with the `CHECK_HDR()` macro also introduced by this patch series.

Solves #4304
Closes #3215