### PR TITLE
vcl: Make 'none' a reserved keyword and use it for probes

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -893,6 +893,8 @@ VRT_new_backend_clustered(VRT_CTX, struct vsmw_cluster *vc,
 	vbp = vrt->probe;
 	if (vbp == NULL)
 		vbp = VCL_DefaultProbe(vcl);
+	if (vbp != NULL && vbp->window == ~0U) /* none probe */
+		vbp = NULL;
 
 	if (vbp != NULL) {
 		VBP_Insert(be, vbp, be->conn_pool);

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -65,6 +65,8 @@ const struct vrt_blob *vrt_null_blob = &(struct vrt_blob){
 	.blob = "\0"
 };
 
+const struct director *const vrt_none_backend = NULL;
+
 /*--------------------------------------------------------------------*/
 
 VCL_VOID

--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -67,6 +67,12 @@ const struct vrt_blob *vrt_null_blob = &(struct vrt_blob){
 
 const struct director *const vrt_none_backend = NULL;
 
+const struct vrt_backend_probe *const vrt_none_probe =
+    &(const struct vrt_backend_probe){
+	.magic = VRT_BACKEND_PROBE_MAGIC,
+	.window = ~0U,
+};
+
 /*--------------------------------------------------------------------*/
 
 VCL_VOID

--- a/bin/varnishtest/tests/c00136.vtc
+++ b/bin/varnishtest/tests/c00136.vtc
@@ -1,0 +1,20 @@
+varnishtest "none probe"
+
+server s0 {
+	rxreq
+	txresp -status 500
+} -dispatch
+
+varnish v1 -vcl {
+	probe default {
+		.interval = 100ms;
+	}
+	backend s0 {
+		.host = "${s0_sock}";
+		.probe = none;
+	}
+} -start
+
+delay 1
+
+varnish v1 -cliexpect healthy "backend.list -p"

--- a/bin/varnishtest/tests/m00000.vtc
+++ b/bin/varnishtest/tests/m00000.vtc
@@ -142,7 +142,7 @@ varnish v1 -errvcl {Symbol not found: 'obj'} {
 
 varnish v1 -errvcl {rot13: VFP already registered (per-vcl)} {
 	import debug;
-	backend none none;
+	backend be none;
 	sub vcl_init {
 		debug.rot104();
 	}
@@ -167,7 +167,7 @@ varnish v1 -errvcl {Failed from VCL} {
 
 varnish v1 -errvcl {Failed initialization} {
 	import debug;
-	backend none none;
+	backend be none;
 	sub vcl_init {
 		new fails = debug.obj("fail");
 	}
@@ -177,7 +177,7 @@ shell {
 	cat >${tmpdir}/f1 <<-EOF
 	vcl 4.1;
 	import debug;
-	backend none none;
+	backend be none;
 	sub vcl_init {
 		new fails = debug.obj("fail");
 	}

--- a/bin/varnishtest/tests/m00048.vtc
+++ b/bin/varnishtest/tests/m00048.vtc
@@ -82,7 +82,7 @@ client c1 -repeat 2 {
 
 varnish v1 -vcl {
 	import debug;
-	backend none none;
+	backend be none;
 
 	sub vcl_recv {
 		return (synth(200));

--- a/bin/varnishtest/tests/r03940.vtc
+++ b/bin/varnishtest/tests/r03940.vtc
@@ -7,7 +7,7 @@ varnishtest "test startup_timeout vs. stevedore init / open"
 # startup_timeout used, delay in stevedore init
 varnish v1 -arg "-sdebug=debug,dinit=5s -pstartup_timeout=3s -pcli_timeout=2s" \
 	-arg "-p feature=+no_coredump" \
-	-vcl "backend none none;" \
+	-vcl "backend be none;" \
 	-expectexit 0x40
 varnish v1 -cliexpect \
 	"Child failed on launch within startup_timeout=3.00s" \
@@ -31,7 +31,7 @@ shell {grep -q "Child failed on launch within startup_timeout=3.00s" ${p1_out}}
 
 varnish v2 -arg "-sdebug=debug,dopen=5s -pstartup_timeout=2s -pcli_timeout=3s" \
 	-arg "-p feature=+no_coredump" \
-	-vcl "backend none none;" \
+	-vcl "backend be none;" \
 	-expectexit 0x40
 varnish v2 -cliexpect \
 	"launch within cli_timeout=3.00s .tip: set startup_" \

--- a/bin/varnishtest/tests/t02027.vtc
+++ b/bin/varnishtest/tests/t02027.vtc
@@ -1,7 +1,7 @@
 varnishtest "H2 RxStuff conditions"
 
 varnish v1 -arg "-p feature=+http2" -arg "-p debug=+syncvsl" -vcl {
-	backend none none;
+	backend be none;
 	sub vcl_recv {
 		return (synth(200));
 	}

--- a/bin/varnishtest/tests/u00002.vtc
+++ b/bin/varnishtest/tests/u00002.vtc
@@ -6,7 +6,7 @@ server s1 -repeat 4 {
 } -start
 
 varnish v1 -vcl+backend {
-	backend none none;
+	backend be none;
 
 	sub vcl_backend_fetch {
 		# XXX would like to do everything in v_b_e, but
@@ -14,7 +14,7 @@ varnish v1 -vcl+backend {
 		if (bereq.url == "/hitpass") {
 			set bereq.backend = s1;
 		} else {
-			set bereq.backend = none;
+			set bereq.backend = be;
 		}
 	}
 

--- a/bin/varnishtest/tests/v00021.vtc
+++ b/bin/varnishtest/tests/v00021.vtc
@@ -95,14 +95,6 @@ varnish v1 -errvcl {Unused sub foo, defined:} {
 	}
 }
 
-# deliberately testing for name "none"
-varnish v1 -errvcl {Unused sub none, defined:} {
-	backend b { .host = "${localhost}"; }
-
-	sub none {
-	}
-}
-
 varnish v1 -errvcl {Invalid return "deliver"} {
 	backend b { .host = "${localhost}"; }
 
@@ -175,6 +167,11 @@ varnish v1 -errvcl {Symbol 'default' is a reserved word.} {
 varnish v1 -errvcl {Symbol 'default' is a reserved word.} {
 	import debug;
 	sub vcl_init { new default = debug.obj(); }
+}
+
+varnish v1 -errvcl {Symbol 'none' is a reserved word.} {
+	import debug;
+	sub vcl_init { new none = debug.obj(); }
 }
 
 varnish v1 -syntax 4.1 -errvcl {(Only available when VCL syntax <= 4.0)} {

--- a/bin/varnishtest/tests/v00021.vtc
+++ b/bin/varnishtest/tests/v00021.vtc
@@ -172,6 +172,11 @@ varnish v1 -errvcl {Symbol 'default' is a reserved word.} {
 	}
 }
 
+varnish v1 -errvcl {Symbol 'default' is a reserved word.} {
+	import debug;
+	sub vcl_init { new default = debug.obj(); }
+}
+
 varnish v1 -syntax 4.1 -errvcl {(Only available when VCL syntax <= 4.0)} {
 	sub vcl_recv {
 		set req.esi = false;

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -529,6 +529,7 @@ typedef int vmod_event_f(VRT_CTX, struct vmod_priv *, enum vcl_event_e);
 int VRT_acl_match(VRT_CTX, VCL_ACL, VCL_IP);
 
 /* VCL_BACKEND */
+extern VCL_BACKEND const vrt_none_backend;
 VCL_BACKEND VRT_DirectorResolve(VRT_CTX, VCL_BACKEND);
 
 /* VCL_BLOB */

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -543,6 +543,9 @@ int VRT_VSA_GetPtr(VRT_CTX, VCL_IP sua, const unsigned char ** dst);
 VCL_BOOL VRT_ipcmp(VRT_CTX, VCL_IP, VCL_IP);
 void VRT_Format_Proxy(struct vsb *, VCL_INT, VCL_IP, VCL_IP, VCL_STRING);
 
+/* VCL_PROBE */
+extern VCL_PROBE const vrt_none_probe;
+
 /* VCL_REAL */
 int VRT_REAL_is_valid(VCL_REAL);
 

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -403,6 +403,7 @@ vcc_ParseHostDef(struct vcc *tl, struct symbol *sym,
 		ifp = New_IniFin(tl);
 		VSB_printf(ifp->ini, "\t(void)%s;", vgcname);
 		VSB_printf(ifp->fin, "\t\t(void)%s;", vgcname);
+		sym->rname = "vrt_none_backend";
 		return;
 	}
 

--- a/lib/libvcc/vcc_backend.c
+++ b/lib/libvcc/vcc_backend.c
@@ -364,6 +364,25 @@ vcc_ParseProbe(struct vcc *tl)
 }
 
 /*--------------------------------------------------------------------
+ */
+
+static void
+vcc_EmitNoneProbe(struct vcc *tl)
+{
+	static unsigned emitted = 0;
+
+	if (emitted)
+		return;
+
+	Fh(tl, 0,
+	    "static const struct vrt_backend_probe vgc_probe_none[] = {{\n"
+	    "\t.magic = VRT_BACKEND_PROBE_MAGIC,\n"
+	    "\t.window = ~0U,\n"
+	    "}};\n");
+	emitted = 1;
+}
+
+/*--------------------------------------------------------------------
  * Parse and emit a backend host definition
  *
  * The struct vrt_backend is emitted to Fh().
@@ -535,6 +554,13 @@ vcc_ParseHostDef(struct vcc *tl, struct symbol *sym,
 			ERRCHK(tl);
 		} else if (vcc_IdIs(t_field, "probe") && tl->t->tok == ID) {
 			t_probe = tl->t;
+			if (vcc_IdIs(t_probe, "none")) {
+				vcc_EmitNoneProbe(tl);
+				Fb(tl, 0, "\t.probe = vgc_probe_none,\n");
+				vcc_NextToken(tl);
+				SkipToken(tl, ';');
+				continue;
+			}
 			pb = VCC_SymbolGet(tl, SYM_MAIN, SYM_PROBE,
 			    SYMTAB_EXISTING, XREF_REF);
 			ERRCHK(tl);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1599,10 +1599,8 @@ static void v_matchproto_(sym_expr_t)
 vcc_Eval_Default(struct vcc *tl, struct expr **e, struct token *t,
     struct symbol *sym, vcc_type_t fmt)
 {
-	(void)e;
-	(void)fmt;
+
 	(void)sym;
-	(void)t;
 
 	if (fmt->default_sym == NULL) {
 		VSB_cat(tl->sb, "Symbol 'default' is a reserved word.\n");
@@ -1611,6 +1609,19 @@ vcc_Eval_Default(struct vcc *tl, struct expr **e, struct token *t,
 	}
 
 	*e = vcc_mk_expr(fmt, "%s", fmt->default_sym->rname);
+}
+
+static void v_matchproto_(sym_expr_t)
+vcc_Eval_None(struct vcc *tl, struct expr **e, struct token *t,
+    struct symbol *sym, vcc_type_t fmt)
+{
+
+	(void)e;
+	(void)fmt;
+	(void)sym;
+
+	VSB_cat(tl->sb, "'none' is a reserved word.\n");
+	vcc_ErrWhere(tl, t);
 }
 
 /*--------------------------------------------------------------------
@@ -1649,4 +1660,9 @@ vcc_Expr_Init(struct vcc *tl)
 	AN(sym);
 	sym->type = DEFAULT;
 	sym->eval = vcc_Eval_Default;
+
+	sym = VCC_MkSym(tl, "none", SYM_MAIN, SYM_FUNC, VCL_LOW, VCL_HIGH);
+	AN(sym);
+	sym->type = DEFAULT;
+	sym->eval = vcc_Eval_None;
 }

--- a/lib/libvcc/vcc_symb.c
+++ b/lib/libvcc/vcc_symb.c
@@ -604,9 +604,14 @@ VCC_HandleSymbol(struct vcc *tl, vcc_type_t fmt)
 		vcc_ErrWhere(tl, sym->def_b);
 		return (sym);
 	} else if (sym != NULL && sym->kind != kind) {
-		VSB_printf(tl->sb,
-		    "Name %.*s must have type '%s'.\n",
-		    PF(t), sym->kind->name);
+		if (sym->type == DEFAULT) {
+			VSB_printf(tl->sb,
+			    "Symbol '%.*s' is a reserved word.\n", PF(t));
+		} else {
+			VSB_printf(tl->sb,
+			    "Name %.*s must have type '%s'.\n",
+			    PF(t), sym->kind->name);
+		}
 		vcc_ErrWhere(tl, t);
 		return (sym);
 	}


### PR DESCRIPTION
:warning: This is technically a VCL BREAKING CHANGE but we should make it. :warning:

This patch series does several things, but the effective goal is to enable this:

```vcl
backend improbable {
        .host = "legacy.example.com";
        .probe = none;
}
```

Having backends we can't probe also prevents the use of a default probe, so my suggestion here is to allow `none` as a special value for the `.probe` field in backend definitions.

This is a breaking change, but I believe we should treat it as a bug fix and proceed without concern for broken VCL. In exchange, it should of course be one of the headlines in the release notes.

Once `none` becomes a reserved word, we can imagine solving the recurring confusion around unset values:

- https://github.com/varnishcache/varnish-cache/issues/2846
- https://github.com/varnishcache/varnish-cache/issues/3634
- https://github.com/varnishcache/varnish-cache/issues/3844

We could imagine the two if statements becoming equivalent:

```vcl
if (req.http.foo) { }
if (req.http.foo != none) { }
```

In the :warning: ACTUALLY BREAKING :warning: department, some would like to change the behavior of `set HEADER = HEADER;`:

```vcl
unset req.http.missing;
set req.http.assigned = req.http.missing;
# expect both headers to be 'none' here
```

I personally think it's an interesting question that should extend to `set HEADER = STRING;` for null strings. For comparisons in general, it could apply to any expression that can yield a null pointer. Something to consider for the next revision of VCL.

This pull requests stops after turning `none` into the keyword it should have become on day one, in hindsight, and then uses this keyword to explicitly circumvent the default probe.