### PR TITLE
vcp: add counters

### DIFF
--- a/bin/varnishtest/tests/b00093.vtc
+++ b/bin/varnishtest/tests/b00093.vtc
@@ -1,0 +1,43 @@
+varnishtest "Check connection pool counters"
+
+server s1 {} -start
+server s2 {} -start
+
+shell {
+	cat >${tmpdir}/simple.vcl <<-EOF
+	vcl 4.1;
+	backend default {
+		.host = "${s2_sock}";
+	}
+	EOF
+}
+
+varnish v1 -vcl {
+	backend default {
+		.host = "${s1_sock}";
+	}
+} -start
+
+# Initially expect a miss
+varnish v1 -expect VCP.ref_hit == 0
+varnish v1 -expect VCP.ref_miss == 1
+
+varnish v1 -vcl+backend {
+	sub vcl_recv {
+		if (req.url ~ "^/blah$") {
+			set req.backend_hint = s1;
+		} else {
+			set req.backend_hint = s2;
+		}
+	}
+}
+
+# Expect a hit and a miss
+varnish v1 -expect VCP.ref_hit == 1
+varnish v1 -expect VCP.ref_miss == 2
+
+varnish v1 -cliok "vcl.load foo ${tmpdir}/simple.vcl"
+
+# Pure hit
+varnish v1 -expect VCP.ref_hit == 2
+varnish v1 -expect VCP.ref_miss == 2

--- a/lib/libvsc/Makefile.am
+++ b/lib/libvsc/Makefile.am
@@ -15,6 +15,7 @@ VSC_SRC = \
 	VSC_smf.vsc \
 	VSC_smu.vsc \
 	VSC_vbe.vsc \
+	VSC_vcp.vsc \
 	VSC_waiter.vsc
 
 noinst_LTLIBRARIES = libvsc.la

--- a/lib/libvsc/VSC_vcp.vsc
+++ b/lib/libvsc/VSC_vcp.vsc
@@ -1,0 +1,25 @@
+..
+	This is *NOT* a RST file but the syntax has been chosen so
+	that it may become an RST file at some later date.
+
+.. varnish_vsc_begin::	vcp
+	:oneliner:	Connection Pool counters
+	:order:		80
+
+.. varnish_vsc:: ref_hit
+	:type:	counter
+	:level:	debug
+	:oneliner:	Number of times we have found an existing conn. pool
+
+	Number of times we have found an existing connection pool while creating
+	a backend.
+
+.. varnish_vsc:: ref_miss
+	:type:	counter
+	:level:	debug
+	:oneliner:	Number of times we have not found an existing conn. pool
+
+	Number of times we have not found an existing connection pool while
+	creating a backend.
+
+.. varnish_vsc_end::	vcp


### PR DESCRIPTION
Add counter for the Connection Pool.
Initially start out with just 2 counters:
> VCP.ref_hit                                   0         0.00 Number of times we have found an existing conn. pool
> VCP.ref_miss                                  1         0.10 Number of times we have not found an existing conn. pool

Fixes: #4311 