### PR TITLE
storage: pass the caller's struct boc * to the objiterator_f

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -754,7 +754,7 @@ typedef int objiterate_f(void *priv, unsigned flush,
 #define OBJ_ITER_FLUSH	0x01
 #define OBJ_ITER_END	0x02
 
-int ObjIterate(struct worker *, struct objcore *,
+int ObjIterate(struct worker *, struct objcore *, struct boc *,
     void *priv, objiterate_f *func, int final);
 
 vxid_t ObjGetXID(struct worker *, struct objcore *);

--- a/bin/varnishd/cache/cache_deliver_proc.c
+++ b/bin/varnishd/cache/cache_deliver_proc.c
@@ -261,7 +261,7 @@ VDP_ObjIterate(void *priv, unsigned flush, const void *ptr, ssize_t len)
 
 
 int
-VDP_DeliverObj(struct vdp_ctx *vdc, struct objcore *oc)
+VDP_DeliverObj(struct vdp_ctx *vdc, struct objcore *oc, struct boc *boc)
 {
 	int r, final;
 
@@ -273,7 +273,7 @@ VDP_DeliverObj(struct vdp_ctx *vdc, struct objcore *oc)
 	vdc->hp = NULL;
 	vdc->clen = NULL;
 	final = oc->flags & OC_F_TRANSIENT ? 1 : 0;
-	r = ObjIterate(vdc->wrk, oc, vdc, VDP_ObjIterate, final);
+	r = ObjIterate(vdc->wrk, oc, boc, vdc, VDP_ObjIterate, final);
 	if (r < 0)
 		return (r);
 	return (0);

--- a/bin/varnishd/cache/cache_esi_deliver.c
+++ b/bin/varnishd/cache/cache_esi_deliver.c
@@ -935,7 +935,7 @@ ved_deliver(struct req *req, int wantbody)
 	}
 
 	if (i == 0) {
-		i = VDP_DeliverObj(req->vdc, req->objcore);
+		i = VDP_DeliverObj(req->vdc, req->objcore, req->boc);
 	} else {
 		VSLb(req->vsl, SLT_Error, "Failure to push ESI processors");
 		req->doclose = SC_OVERLOAD;

--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -891,7 +891,7 @@ vbf_stp_condfetch(struct worker *wrk, struct busyobj *bo)
 	INIT_OBJ(vop, VBF_OBITER_PRIV_MAGIC);
 	vop->bo = bo;
 	vop->l = ObjGetLen(bo->wrk, stale_oc);
-	if (ObjIterate(wrk, stale_oc, vop, vbf_objiterate, 0))
+	if (ObjIterate(wrk, stale_oc, NULL, vop, vbf_objiterate, 0))
 		(void)VFP_Error(bo->vfc, "Template object failed");
 
 	if (bo->vfc->failed) {

--- a/bin/varnishd/cache/cache_obj.c
+++ b/bin/varnishd/cache/cache_obj.c
@@ -172,7 +172,7 @@ ObjDestroy(const struct worker *wrk, struct objcore **p)
  */
 
 int
-ObjIterate(struct worker *wrk, struct objcore *oc,
+ObjIterate(struct worker *wrk, struct objcore *oc, struct boc *boc,
     void *priv, objiterate_f *func, int final)
 {
 	const struct obj_methods *om = obj_getmethods(oc);
@@ -180,7 +180,7 @@ ObjIterate(struct worker *wrk, struct objcore *oc,
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	AN(func);
 	AN(om->objiterator);
-	return (om->objiterator(wrk, oc, priv, func, final));
+	return (om->objiterator(wrk, oc, boc, priv, func, final));
 }
 
 /*====================================================================

--- a/bin/varnishd/cache/cache_obj.h
+++ b/bin/varnishd/cache/cache_obj.h
@@ -36,7 +36,7 @@ typedef void objfree_f(struct worker *, struct objcore *);
 typedef void objsetstate_f(struct worker *, const struct objcore *,
     enum boc_state_e);
 
-typedef int objiterator_f(struct worker *, struct objcore *,
+typedef int objiterator_f(struct worker *, struct objcore *, struct boc *,
     void *priv, objiterate_f *func, int final);
 typedef int objgetspace_f(struct worker *, struct objcore *,
      ssize_t *sz, uint8_t **ptr);

--- a/bin/varnishd/cache/cache_req_body.c
+++ b/bin/varnishd/cache/cache_req_body.c
@@ -210,7 +210,7 @@ VRB_Iterate(struct worker *wrk, struct vsl_log *vsl,
 
 	if (req->req_body_status == BS_CACHED) {
 		AN(req->body_oc);
-		if (ObjIterate(wrk, req->body_oc, priv, func, 0))
+		if (ObjIterate(wrk, req->body_oc, NULL, priv, func, 0))
 			return (-1);
 		return (0);
 	}

--- a/bin/varnishd/cache/cache_varnishd.h
+++ b/bin/varnishd/cache/cache_varnishd.h
@@ -194,7 +194,7 @@ void VDP_Panic(struct vsb *vsb, const struct vdp_ctx *vdc);
 int VDP_Push(VRT_CTX, struct vdp_ctx *, struct ws *, const struct vdp *,
     void *priv);
 int VDP_ObjIterate(void *priv, unsigned flush, const void *ptr, ssize_t len);
-int VDP_DeliverObj(struct vdp_ctx *vdc, struct objcore *oc);
+int VDP_DeliverObj(struct vdp_ctx *vdc, struct objcore *oc, struct boc *boc);
 extern const struct vdp VDP_gunzip;
 extern const struct vdp VDP_esi;
 extern const struct vdp VDP_range;

--- a/bin/varnishd/http1/cache_http1_deliver.c
+++ b/bin/varnishd/http1/cache_http1_deliver.c
@@ -143,7 +143,7 @@ V1D_Deliver(struct req *req, int sendbody)
 			(void)V1L_Flush(v1l);
 		if (chunked)
 			V1L_Chunked(v1l);
-		err = VDP_DeliverObj(req->vdc, req->objcore);
+		err = VDP_DeliverObj(req->vdc, req->objcore, req->boc);
 		if (!err && chunked)
 			V1L_EndChunk(v1l);
 	}

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -136,7 +136,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 	if (bo->bereq_body != NULL) {
 		AZ(bo->req);
 		assert(cl >= 0);
-		(void)ObjIterate(bo->wrk, bo->bereq_body,
+		(void)ObjIterate(bo->wrk, bo->bereq_body, NULL,
 		    vdc, VDP_ObjIterate, 0);
 	} else if (bo->req != NULL &&
 	    bo->req->req_body_status != BS_NONE) {

--- a/bin/varnishd/http2/cache_http2_deliver.c
+++ b/bin/varnishd/http2/cache_http2_deliver.c
@@ -345,7 +345,7 @@ h2_deliver(struct req *req, int sendbody)
 		INIT_OBJ(ctx, VRT_CTX_MAGIC);
 		VCL_Req2Ctx(ctx, req);
 		if (! VDP_Push(ctx, req->vdc, req->ws, &h2_vdp, r2))
-			(void)VDP_DeliverObj(req->vdc, req->objcore);
+			(void)VDP_DeliverObj(req->vdc, req->objcore, req->boc);
 	}
 
 	req->acct.resp_bodybytes += VDP_Close(req->vdc, req->objcore, req->boc);

--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -307,10 +307,9 @@ sml_objfree(struct worker *wrk, struct objcore *oc)
 }
 
 static int v_matchproto_(objiterator_f)
-sml_iterator(struct worker *wrk, struct objcore *oc,
+sml_iterator(struct worker *wrk, struct objcore *oc, struct boc *boc,
     void *priv, objiterate_f *func, int final)
 {
-	struct boc *boc;
 	enum boc_state_e state;
 	struct object *obj;
 	struct storage *st;
@@ -330,8 +329,6 @@ sml_iterator(struct worker *wrk, struct objcore *oc,
 	CHECK_OBJ_NOTNULL(obj, OBJECT_MAGIC);
 	stv = oc->stobj->stevedore;
 	CHECK_OBJ_NOTNULL(stv, STEVEDORE_MAGIC);
-
-	boc = HSH_RefBoc(oc);
 
 	if (boc == NULL) {
 		VTAILQ_FOREACH_REVERSE_SAFE(
@@ -423,7 +420,6 @@ sml_iterator(struct worker *wrk, struct objcore *oc,
 		if (ret)
 			break;
 	}
-	HSH_DerefBoc(wrk, oc);
 	if ((u & OBJ_ITER_END) == 0) {
 		ret2 = func(priv, OBJ_ITER_END, NULL, 0);
 		if (ret == 0)

--- a/vmod/vmod_debug_transport_reembarking_http1.c
+++ b/vmod/vmod_debug_transport_reembarking_http1.c
@@ -173,7 +173,7 @@ dbg_sendbody(struct worker *wrk, void *arg)
 	chunked = http_GetHdr(req->resp, H_Transfer_Encoding, &p) && strcmp(p, "chunked") == 0;
 	if (chunked)
 		V1L_Chunked(v1l);
-	err = VDP_DeliverObj(req->vdc, req->objcore);
+	err = VDP_DeliverObj(req->vdc, req->objcore, req->boc);
 	if (!err && chunked)
 		V1L_EndChunk(v1l);
 	dbg_deliver_finish(req, &v1l, err);


### PR DESCRIPTION
Storage body iterator functions need to hold a reference to a `struct boc` while the object is being created, if only to call `ObjWaitExtend()` and/or `ObjWaitState()` in order to only deliver available data.

Before this patch, the design was to either have zero or two `boc` references in a client worker:

```c
cnt_transmit() {
	// ...
	req->boc = HSH_RefBoc(req->objcore);

// then later, called via VDP iterate:

xxx_iterator() {
	// ...
	boc = HSH_RefBoc(oc);
```

Now between the two calls, the `boc` might transition to `BOS_FINISHED` or `BOS_FAILED`, such that the second call from the iterator does not get a `boc` reference, because `HSH_RefBoc()` rightly does not return any for these states:

```c
HSH_RefBoc(const struct objcore *oc) {
	// ...
        if (boc != NULL) {
		assert(boc->refcount > 0);
		if (boc->state < BOS_FINISHED)
			boc->refcount++;
		else
			boc = NULL;
	}
}
```

This logic is important because otherwise a `boc` might exist forever.

Now a problem arises for storage engines which need different methods to iterate over busy objects vs. non-busy objects.

https://gitlab.com/uplex/varnish/slash/-/issues/104 documents such a case where the iterating thread holds a `boc` reference from `cnt_transmit()`, but none on the iterator level and thus deadlocks waiting for an unbusy event which never comes (because the thread itself holds the boc reference).