### PR TITLE
[ci] fedora:42 needs awk

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -2,6 +2,7 @@ FROM fedora-latest
 
 RUN set -e; \
 	dnf -y install \
+	    awk \
 	    automake \
 	    git \
 	    jemalloc-devel \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
           name: Install deps
           command: |
             dnf -y install \
+                awk \
                 automake \
                 jemalloc-devel \
                 git \
@@ -245,6 +246,7 @@ jobs:
                         ;;
                     fedora:*)
                         dnf -y group install development-tools
+                        dnf -y install awk
                         ;;
                 esac
                 dnf -y install \


### PR DESCRIPTION
`awk` is apparently not installed by default on `fedora:42` images