### PR TITLE
vtree: Inject contextual parent checks during import

### DIFF
--- a/tools/import_vtree_from_freebsd.sh
+++ b/tools/import_vtree_from_freebsd.sh
@@ -16,8 +16,7 @@ git diff vtree.h | git apply -R > /dev/null 2>&1 || true
 GR=f6e54eb360a78856dcde930a00d9b2b3627309ab
 (cd /usr/src/ && git show $GR:sys/sys/tree.h ) |
 sed -E '
-485a\
-		AN(parent);			\\
+s/(\t*)parent = RB_PARENT.*/\0\n\1AN(parent);\t\t\t\t\\/
 s/_SYS_TREE_H_/_VTREE_H_/
 s/__uintptr_t/uintptr_t/g
 s/SPLAY/VSPLAY/g


### PR DESCRIPTION
This is an attempt at adding assertions without keeping track of a specific line of code. Tested with tree.h from the current tip of the main branch.

Refs freebsd/freebsd-src@a962800a09a45b8f702ebd1a06b8f20bc84e97b1