### PR TITLE
Seems like fedora:latest now new awk explicitly installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ jobs:
                 make \
                 pcre2-devel \
                 python3 \
-                python3-sphinx
+                python3-sphinx \
+                awk
       - checkout
       - when:
           condition: << pipeline.parameters.dist-url >>


### PR DESCRIPTION
Not tested at all but might fix issues like : 

https://app.circleci.com/pipelines/github/varnishcache/varnish-cache/6980/workflows/5a566469-b5e6-4e5d-b6a0-bba3f3b2822a/jobs/89714