### PR TITLE
param: Add shutdown_timeout

### DIFF
--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -383,6 +383,19 @@ PARAM_SIMPLE(
 )
 
 PARAM_SIMPLE(
+	/* name */	shutdown_timeout,
+	/* type */	timeout,
+	/* min */	"0.000",
+	/* max */	NULL,
+	/* def */	"0.000",
+	/* units */	"seconds",
+	/* descr */
+	"Alternative timeout for the worker process shutdown after a stop "
+	"cli command.\n"
+	"If cli_timeout is longer than shutdown_timeout, it is used instead."
+)
+
+PARAM_SIMPLE(
 	/* name */	clock_skew,
 	/* type */	uint,
 	/* min */	"0",


### PR DESCRIPTION
Similar to why we added `startup_timeout`, orderly shutdown of a varnishd worker process might take considerably longer than cli_timeout. Consequently, we add `shutdown_timeout`.