### PR TITLE
param: Move alias resolution before protected check

### DIFF
--- a/bin/varnishd/mgt/mgt_param.c
+++ b/bin/varnishd/mgt/mgt_param.c
@@ -536,8 +536,9 @@ mcf_param_show_json(struct cli *cli, const char * const *av, void *priv)
 void
 MCF_ParamProtect(struct cli *cli, const char *args)
 {
-	char **av;
+	const struct parspec *orig;
 	struct parspec *pp;
+	char **av;
 	int i;
 
 	av = VAV_Parse(args, NULL, ARGV_COMMA);
@@ -552,8 +553,17 @@ MCF_ParamProtect(struct cli *cli, const char *args)
 		if (pp == NULL) {
 			VCLI_Out(cli, "Unknown parameter %s", av[i]);
 			VCLI_SetResult(cli, CLIS_PARAM);
-			VAV_Free(av);
-			return;
+			break;
+		}
+		if (pp->func == tweak_alias) {
+			orig = TRUST_ME(pp->priv);
+			AN(orig);
+			VCLI_Out(cli,
+			    "Cannot mark alias %s read only.\n"
+			    "Did you mean to mark %s read only?",
+			    pp->name, orig->name);
+			VCLI_SetResult(cli, CLIS_PARAM);
+			break;
 		}
 		pp->flags |= PROTECTED;
 	}

--- a/bin/varnishd/mgt/mgt_param_tweak.c
+++ b/bin/varnishd/mgt/mgt_param_tweak.c
@@ -614,15 +614,11 @@ tweak_storage(struct vsb *vsb, const struct parspec *par, const char *arg)
 int v_matchproto_(tweak_t)
 tweak_alias(struct vsb *vsb, const struct parspec *par, const char *arg)
 {
-	const struct parspec *orig;
-	struct parspec alias[1];
 
-	orig = TRUST_ME(par->priv);
-	AN(orig);
-	memcpy(alias, orig, sizeof *orig);
-	alias->name = par->name;
-	alias->priv = TRUST_ME(orig);
-	return (alias->func(vsb, alias, arg));
+	(void)vsb;
+	(void)par;
+	(void)arg;
+	WRONG("param tweak never called directly");
 }
 
 /*--------------------------------------------------------------------

--- a/bin/varnishtest/tests/r04323.vtc
+++ b/bin/varnishtest/tests/r04323.vtc
@@ -1,0 +1,6 @@
+varnishtest "parameter alias bypassing protection"
+
+varnish v1 -arg "-r vcc_feature"
+
+varnish v1 -clierr 107 "param.set vcc_feature all"
+varnish v1 -clierr 107 "param.set vcc_allow_inline_c on"

--- a/bin/varnishtest/tests/r04323.vtc
+++ b/bin/varnishtest/tests/r04323.vtc
@@ -4,3 +4,7 @@ varnish v1 -arg "-r vcc_feature"
 
 varnish v1 -clierr 107 "param.set vcc_feature all"
 varnish v1 -clierr 107 "param.set vcc_allow_inline_c on"
+
+shell -err -expect "Cannot mark alias vcc_allow_inline_c read only" {
+	varnishd -d -r vcc_allow_inline_c -n ${tmpdir}/vd
+}

--- a/doc/sphinx/users-guide/run_security.rst
+++ b/doc/sphinx/users-guide/run_security.rst
@@ -155,18 +155,18 @@ HTTP service, but a few can do more damage than others:
 :ref:`ref_param_cc_command`
 	Execute arbitrary programs
 
-:ref:`ref_param_vcc_allow_inline_c`
-	Allow inline C in VCL, which would allow any C code from VCL
-	to be executed by Varnish.
+:ref:`ref_param_vcc_feature`
+	The ``allow_inline_c`` flag would allow any C code from VCL to be
+	executed by Varnish.
 
 Furthermore you may want to look at and lock down:
 
 :ref:`ref_param_syslog_cli_traffic`
 	Log all CLI commands to `syslog(8)`, so you know what goes on.
 
-:ref:`ref_param_vcc_unsafe_path`
-	Restrict VCL/VMODs to :ref:`ref_param_vcl_path` and
-	:ref:`ref_param_vmod_path`
+:ref:`ref_param_vcc_feature` again
+	The ``unsafe_path`` flag allows VCL/VMODs to be loaded outside of
+	:ref:`ref_param_vcl_path` and :ref:`ref_param_vmod_path`.
 
 :ref:`ref_param_vmod_path`
 	The directory (or colon separated list of directories) where


### PR DESCRIPTION
param: Move alias resolution before protected check

Instead of resolving tweaks when the function is called, this is now
done in the MGT code performing the protected check. Since aliases may
be used to reset a single bit of another parameter (namely vcc_feature)
the default value is looked up before the alias resolution.

Unfortunately, that also means resolving deprecated aliases before
showing them to the user, adding a little bit of duplicated logic.

Refs #4323