### PR TITLE
Prepare for 7.7.1

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -2,6 +2,7 @@ FROM fedora-latest
 
 RUN set -e; \
 	dnf -y install \
+	    awk \
 	    automake \
 	    git \
 	    jemalloc-devel \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
           name: Install deps
           command: |
             dnf -y install \
+                awk \
                 automake \
                 jemalloc-devel \
                 git \
@@ -245,6 +246,7 @@ jobs:
                         ;;
                     fedora:*)
                         dnf -y group install development-tools
+                        dnf -y install awk
                         ;;
                 esac
                 dnf -y install \

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -132,7 +132,7 @@ v1f_chunked_hdr(struct vfp_ctx *vc, struct http_conn *htc, ssize_t *szp)
 		lr = v1f_read(vc, htc, buf, 1);
 		if (lr <= 0)
 			return (VFP_Error(vc, "chunked read err"));
-	} while (vct_islws(buf[0]));
+	} while (vct_isows(buf[0]));
 
 	if (!vct_ishex(buf[0]))
 		return (VFP_Error(vc, "chunked header non-hex"));
@@ -152,12 +152,14 @@ v1f_chunked_hdr(struct vfp_ctx *vc, struct http_conn *htc, ssize_t *szp)
 		return (VFP_Error(vc, "chunked header too long"));
 
 	/* Skip trailing white space */
-	while (vct_islws(buf[u]) && buf[u] != '\n') {
+	while (vct_isows(buf[u])) {
 		lr = v1f_read(vc, htc, buf + u, 1);
 		if (lr <= 0)
 			return (VFP_Error(vc, "chunked read err"));
 	}
 
+	if (buf[u] == '\r' && v1f_read(vc, htc, buf + u, 1) <= 0)
+		return (VFP_Error(vc, "chunked read err"));
 	if (buf[u] != '\n')
 		return (VFP_Error(vc, "chunked header no NL"));
 

--- a/bin/varnishd/http1/cache_http1_vfp.c
+++ b/bin/varnishd/http1/cache_http1_vfp.c
@@ -108,9 +108,76 @@ v1f_chunk_end(struct vfp_ctx *vc, struct http_conn *htc)
 
 
 /*--------------------------------------------------------------------
- * Read a chunked HTTP object.
+ * Parse a chunk header and, for VFP_OK, return size in a pointer
  *
  * XXX: Reading one byte at a time is pretty pessimal.
+ */
+
+static enum vfp_status
+v1f_chunked_hdr(struct vfp_ctx *vc, struct http_conn *htc, ssize_t *szp)
+{
+	char buf[20];		/* XXX: 20 is arbitrary */
+	unsigned u;
+	uintmax_t cll;
+	ssize_t cl, lr;
+	char *q;
+
+	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(htc, HTTP_CONN_MAGIC);
+	AN(szp);
+	assert(*szp == -1);
+
+	/* Skip leading whitespace */
+	do {
+		lr = v1f_read(vc, htc, buf, 1);
+		if (lr <= 0)
+			return (VFP_Error(vc, "chunked read err"));
+	} while (vct_islws(buf[0]));
+
+	if (!vct_ishex(buf[0]))
+		return (VFP_Error(vc, "chunked header non-hex"));
+
+	/* Collect hex digits, skipping leading zeros */
+	for (u = 1; u < sizeof buf; u++) {
+		do {
+			lr = v1f_read(vc, htc, buf + u, 1);
+			if (lr <= 0)
+				return (VFP_Error(vc, "chunked read err"));
+		} while (u == 1 && buf[0] == '0' && buf[u] == '0');
+		if (!vct_ishex(buf[u]))
+			break;
+	}
+
+	if (u >= sizeof buf)
+		return (VFP_Error(vc, "chunked header too long"));
+
+	/* Skip trailing white space */
+	while (vct_islws(buf[u]) && buf[u] != '\n') {
+		lr = v1f_read(vc, htc, buf + u, 1);
+		if (lr <= 0)
+			return (VFP_Error(vc, "chunked read err"));
+	}
+
+	if (buf[u] != '\n')
+		return (VFP_Error(vc, "chunked header no NL"));
+
+	buf[u] = '\0';
+
+	cll = strtoumax(buf, &q, 16);
+	if (q == NULL || *q != '\0')
+		return (VFP_Error(vc, "chunked header number syntax"));
+	cl = (ssize_t)cll;
+	if (cl < 0 || (uintmax_t)cl != cll)
+		return (VFP_Error(vc, "bogusly large chunk size"));
+
+	*szp = cl;
+	return (VFP_OK);
+}
+
+
+/*--------------------------------------------------------------------
+ * Read a chunked HTTP object.
+ *
  */
 
 static enum vfp_status v_matchproto_(vfp_pull_f)
@@ -119,11 +186,7 @@ v1f_chunked_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 {
 	static enum vfp_status vfps;
 	struct http_conn *htc;
-	char buf[20];		/* XXX: 20 is arbitrary */
-	char *q;
-	unsigned u;
-	uintmax_t cll;
-	ssize_t cl, l, lr;
+	ssize_t l, lr;
 
 	CHECK_OBJ_NOTNULL(vc, VFP_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(vfe, VFP_ENTRY_MAGIC);
@@ -134,50 +197,9 @@ v1f_chunked_pull(struct vfp_ctx *vc, struct vfp_entry *vfe, void *ptr,
 	l = *lp;
 	*lp = 0;
 	if (vfe->priv2 == -1) {
-		/* Skip leading whitespace */
-		do {
-			lr = v1f_read(vc, htc, buf, 1);
-			if (lr <= 0)
-				return (VFP_Error(vc, "chunked read err"));
-		} while (vct_islws(buf[0]));
-
-		if (!vct_ishex(buf[0]))
-			 return (VFP_Error(vc, "chunked header non-hex"));
-
-		/* Collect hex digits, skipping leading zeros */
-		for (u = 1; u < sizeof buf; u++) {
-			do {
-				lr = v1f_read(vc, htc, buf + u, 1);
-				if (lr <= 0)
-					return (VFP_Error(vc, "chunked read err"));
-			} while (u == 1 && buf[0] == '0' && buf[u] == '0');
-			if (!vct_ishex(buf[u]))
-				break;
-		}
-
-		if (u >= sizeof buf)
-			return (VFP_Error(vc, "chunked header too long"));
-
-		/* Skip trailing white space */
-		while (vct_islws(buf[u]) && buf[u] != '\n') {
-			lr = v1f_read(vc, htc, buf + u, 1);
-			if (lr <= 0)
-				return (VFP_Error(vc, "chunked read err"));
-		}
-
-		if (buf[u] != '\n')
-			return (VFP_Error(vc, "chunked header no NL"));
-
-		buf[u] = '\0';
-
-		cll = strtoumax(buf, &q, 16);
-		if (q == NULL || *q != '\0')
-			return (VFP_Error(vc, "chunked header number syntax"));
-		cl = (ssize_t)cll;
-		if (cl < 0 || (uintmax_t)cl != cll)
-			return (VFP_Error(vc, "bogusly large chunk size"));
-
-		vfe->priv2 = cl;
+		vfps = v1f_chunked_hdr(vc, htc, &vfe->priv2);
+		if (vfps != VFP_OK)
+			return (vfps);
 	}
 	if (vfe->priv2 > 0) {
 		if (vfe->priv2 < l)

--- a/bin/varnishtest/tests/f00016.vtc
+++ b/bin/varnishtest/tests/f00016.vtc
@@ -1,0 +1,69 @@
+varnishtest "Do not tolerate anything else than CRLF as chunked ending"
+
+server s0 {
+	rxreq
+	expect_close
+} -dispatch
+
+varnish v1 -vcl+backend {} -start
+
+logexpect l1 -v v1 {
+	expect * 1001 FetchError "chunked tail no NL"
+	expect * 1004 FetchError "chunked tail no NL"
+	expect * 1007 FetchError "chunked header non-hex"
+	expect * 1010 FetchError "chunked header non-hex"
+} -start
+
+client c1 {
+	non_fatal
+	txreq -req POST -hdr "Transfer-encoding: chunked"
+	send "1\r\n"
+	send "This is more than one byte of data\r\n"
+	send "0\r\n"
+	send "\r\n"
+	fatal
+	rxresp
+	expect resp.status == 503
+	expect_close
+} -run
+
+client c2 {
+	non_fatal
+	txreq -req POST -hdr "Transfer-encoding: chunked"
+	send "1\r\n"
+	send "Z  2\r\n"
+	send "3d\r\n"
+	send "0\r\n\r\nPOST /evil HTTP/1.1\r\nHost: whatever\r\nContent-Length: 5\r\n\r\n"
+	send "0\r\n"
+	send "\r\n"
+	fatal
+	rxresp
+	expect resp.status == 503
+	expect_close
+} -run
+
+client c3 {
+	non_fatal
+	txreq -req POST -hdr "Transfer-encoding: chunked"
+	send "d\r\n"
+	send "Spurious CRLF\r\n\r\n"
+	send "0\r\n"
+	send "\r\n"
+	fatal
+	rxresp
+	expect resp.status == 503
+	expect_close
+} -run
+
+client c4 {
+	non_fatal
+	txreq -req POST -hdr "Transfer-encoding: chunked"
+	send "\n0\r\n"
+	send "\r\n"
+	fatal
+	rxresp
+	expect resp.status == 503
+	expect_close
+} -run
+
+logexpect l1 -wait

--- a/bin/varnishtest/tests/m00003.vtc
+++ b/bin/varnishtest/tests/m00003.vtc
@@ -59,12 +59,15 @@ varnish v1 -errvcl {Not string[2]} { import wrong; }
 filewrite ${tmpdir}/libvmod_wrong.so "VMOD_JSON_SPEC\x02" "[[\"$VBLA\"]]" "\x03"
 varnish v1 -errvcl {Not $VMOD[3]} { import wrong; }
 
+filewrite ${tmpdir}/libvmod_wrong.so "VMOD_JSON_SPEC\x02" "[[\"$VMOD\",\"1.0\"]]" "\x03"
+varnish v1 -errvcl {Syntax != 2.0} { import wrong; }
+
 filewrite ${tmpdir}/libvmod_wrong.so "VMOD_JSON_SPEC\x02"
 filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -82,7 +85,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -103,7 +106,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -123,7 +126,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -141,7 +144,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",
@@ -163,7 +166,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
     [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "std",
 	    "Vmod_vmod_std_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",

--- a/bin/varnishtest/tests/m00055.vtc
+++ b/bin/varnishtest/tests/m00055.vtc
@@ -16,7 +16,7 @@ filewrite -a ${tmpdir}/libvmod_wrong.so {
 [
 	[
 	    "$VMOD",
-	    "1.0",
+	    "2.0",
 	    "wrong",
 	    "Vmod_vmod_wrong_Func",
 	    "0000000000000000000000000000000000000000000000000000000000000000",

--- a/bin/varnishtest/tests/r01184.vtc
+++ b/bin/varnishtest/tests/r01184.vtc
@@ -62,6 +62,7 @@ server s1 {
 		sendhex " 10 45 f3 a9 83 b8 18 1c  7b c2 30 55 04 17 13 c4"
 		sendhex " 0f 07 5f 7a 38 f4 8e 50  b3 37 d4 3a 32 4a 34 07"
 		sendhex " FF FF FF FF FF FF FF FF  72 ea 06 5f b3 1c fa dd"
+	send "\n"
 	expect_close
 } -start
 
@@ -93,6 +94,7 @@ server s1 {
 		sendhex " 10 45 f3 a9 83 b8 18 1c  7b c2 30 55 04 17 13 c4"
 		sendhex " 0f 07 5f 7a 38 f4 8e 50  b3 37 d4 3a 32 4a 34 07"
 		sendhex " FF FF FF FF FF FF FF FF  72 ea 06 5f b3 1c fa dd"
+	send "\n"
 	expect_close
 } -start
 

--- a/bin/varnishtest/tests/r01506.vtc
+++ b/bin/varnishtest/tests/r01506.vtc
@@ -7,15 +7,15 @@ server s0 {
 	txresp -nolen \
 	    -hdr "Transfer-Encoding: chunked" \
 	    -hdr "Connection: close"
-	send "11\r\n0_23456789abcdef\n"
-	send "11\r\n1_23456789abcdef\n"
-	send "11\r\n2_23456789abcdef\n"
-	send "11\r\n3_23456789abcdef\n"
+	send "11\r\n0_23456789abcdef\n\n"
+	send "11\r\n1_23456789abcdef\n\n"
+	send "11\r\n2_23456789abcdef\n\n"
+	send "11\r\n3_23456789abcdef\n\n"
 	barrier b1 sync
-	send "11\r\n4_23456789abcdef\n"
-	send "11\r\n5_23456789abcdef\n"
-	send "11\r\n6_23456789abcdef\n"
-	send "11\r\n7_23456789abcdef\n"
+	send "11\r\n4_23456789abcdef\n\n"
+	send "11\r\n5_23456789abcdef\n\n"
+	send "11\r\n6_23456789abcdef\n\n"
+	send "11\r\n7_23456789abcdef\n\n"
 	chunkedlen 0
 
 } -dispatch

--- a/bin/varnishtest/tests/r01729.vtc
+++ b/bin/varnishtest/tests/r01729.vtc
@@ -11,7 +11,7 @@ server s1 {
 	send "\r\n"
 	send "14\r\n"
 	send "0123456789"
-	send "0123456789"
+	send "0123456789\n"
 	send "0\r\n"
 	send "\r\n"
 
@@ -29,7 +29,7 @@ client c1 {
 	send "\r\n"
 	send "14\r\n"
 	send "0123456789"
-	send "0123456789"
+	send "0123456789\n"
 	send "0\r\n"
 	send "\r\n"
 
@@ -45,7 +45,7 @@ client c1 {
 	send "\r\n"
 	send "14\r\n"
 	send "0123456789"
-	send "0123456789"
+	send "0123456789\n"
 	send "0\r\n"
 	send "\r\n"
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_COPYRIGHT([Copyright (c) 2006 Verdens Gang AS
 Copyright (c) 2006-2025 Varnish Software
 Copyright 2010-2025 UPLEX - Nils Goroll Systemoptimierung])
 AC_REVISION([$Id$])
-AC_INIT([Varnish], [7.7.0], [varnish-dev@varnish-cache.org])
+AC_INIT([Varnish], [7.7.1], [varnish-dev@varnish-cache.org])
 AC_CONFIG_SRCDIR(include/miniobj.h)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -38,7 +38,7 @@ release process.
    (new to old)
 
 ================================
-Varnish-Cache 7.7.1 (unreleased)
+Varnish-Cache 7.7.1 (2025-05-12)
 ================================
 
 .. _VSV00016: https://varnish-cache.org/security/VSV00016.html

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -34,12 +34,25 @@ http://varnish-cache.org/docs/trunk/whats-new/index.html and via
 individual releases. These documents are updated as part of the
 release process.
 
+.. PLEASE keep this roughly in commit order as shown by git-log / tig
+   (new to old)
+
+================================
+Varnish-Cache 7.7.1 (unreleased)
+================================
+
+.. _VSV00016: https://varnish-cache.org/security/VSV00016.html
+
+* We now check for CRLF after chunked body in HTTP/1. (VSV00016_)
+
+.. _4240: https://github.com/varnishcache/varnish-cache/pull/4240
+
+* Add option to specify c names of arguments and avoid "bool". This makes it
+  possible to build VMODs using reserved names in the C language. (4240_)
+
 ==============================
 Varnish-Cache 7.7 (2025-03-17)
 ==============================
-
-.. PLEASE keep this roughly in commit order as shown by git-log / tig
-   (new to old)
 
 .. _VSV00015: https://varnish-cache.org/security/VSV00015.html
 

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -196,6 +196,9 @@ declarations:
 	  with `n` starting at 1 and incrementing with the argument's
 	  position.
 
+Optionally, the VCL and C argument names can be specified independently using
+the ``<vclname>:<cname>`` syntax. See :ref:`ref-vmod-symbols` for details.
+
 .. _ref-vmod-vcl-c-objects:
 
 Objects and methods
@@ -550,13 +553,14 @@ For the above, the *<xxx>* placeholders are defined as:
         The vmod name fro the ``$Module`` stanza of the ``.vcc`` file.
 
 *<argument>*
-        The function or method argument name
+        The function or method argument *cname* or, if not given, *vclname*
+        as specified using the *<vclname>:<cname>* syntax.
 
 The other placeholders should be self-explanatory as the name of the respective
-function, class, method or handler name.
+function, class, method or handler.
 
-In summary, only some symbol names (those with *<prefix>*) can be influenced by
-the vmod author.
+In summary, symbol names can either be influenced by the vmod author globally
+using ``$Prefix``, or using the *<vclname>:<cname>* syntax for argument names.
 
 .. _ref-vmod-private-pointers:
 

--- a/doc/sphinx/reference/vmod.rst
+++ b/doc/sphinx/reference/vmod.rst
@@ -121,7 +121,7 @@ For the std VMOD, the compiled vcc_if.h file looks like this::
 	vmod_event_f event_function;
 
 Those are your C prototypes.  Notice the ``vmod_`` prefix on the
-function names.
+function names, more on that in :ref:`ref-vmod-symbols`.
 
 Named arguments and default values
 ----------------------------------
@@ -512,6 +512,51 @@ VOID
 	Can only be used for return-value, which makes the function a VCL
 	procedure.
 
+.. _ref-vmod-symbols:
+
+C symbols
+=========
+
+Through generation of ``vcc_if.h``, ``vmodtool.py`` pre-defines the names of
+most symbols on the C side of the vmod interface, namely:
+
+* function names as *<prefix>_<function>*
+
+* event handler names as *<prefix>_<handler>*
+
+* method names as *<prefix>_<class>_<method>*, with two special methods named
+
+  * ``_init`` for the constructor and
+  * ``_fini`` for the destructor
+
+* class struct names as *<prefix>_<vmod>_<class>*
+
+* argument struct names for support of optional arguments as
+  *arg_<prefix>_<vmod>_<function>* for functions and
+  *arg_<prefix>_<vmod>_<class>_<method>* for methods, with member names
+
+  * *valid_<argument>* for the flag of optional arguments being present and
+  * *<argument>* for the argument name
+
+* enum values as *enum_<prefix>_<vmod>_<value>*
+
+For the above, the *<xxx>* placeholders are defined as:
+
+*<prefix>*
+        The ``$Prefix`` stanza value, if defined in the ``.vcc`` file, or
+        ``vmod`` by default.
+
+*<vmod>*
+        The vmod name fro the ``$Module`` stanza of the ``.vcc`` file.
+
+*<argument>*
+        The function or method argument name
+
+The other placeholders should be self-explanatory as the name of the respective
+function, class, method or handler name.
+
+In summary, only some symbol names (those with *<prefix>*) can be influenced by
+the vmod author.
 
 .. _ref-vmod-private-pointers:
 

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -444,6 +444,7 @@ vcc_priv_arg(struct vcc *tl, const char *p, struct symbol *sym)
 struct func_arg {
 	vcc_type_t		type;
 	const struct vjsn_val	*enums;
+	const char		*cname;
 	const char		*name;
 	const char		*val;
 	struct expr		*result;

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -558,7 +558,7 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 			fa->result = vcc_priv_arg(tl, vvp->value, sym);
 			vvp = VTAILQ_NEXT(vvp, list);
 			if (vvp != NULL)
-				fa->name = vvp->value;
+				fa->cname = fa->name = vvp->value;
 			continue;
 		}
 		fa->type = VCC_Type(vvp->value);
@@ -566,6 +566,9 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 		vvp = VTAILQ_NEXT(vvp, list);
 		if (vvp != NULL) {
 			fa->name = vvp->value;
+			vvp = VTAILQ_NEXT(vvp, list);
+			AN(vvp); /* vmod_syntax 2.0 */
+			fa->cname = vvp->value;
 			vvp = VTAILQ_NEXT(vvp, list);
 			if (vvp != NULL) {
 				fa->val = vvp->value;
@@ -642,9 +645,9 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 	VTAILQ_FOREACH_SAFE(fa, &head, list, fa2) {
 		n++;
 		if (fa->optional) {
-			AN(fa->name);
+			AN(fa->cname);
 			bprintf(ssa, "\v1.valid_%s = %d,\n",
-			    fa->name, fa->avail);
+			    fa->cname, fa->avail);
 			e1 = vcc_expr_edit(tl, e1->fmt, ssa, e1, NULL);
 		}
 		if (fa->result == NULL && fa->type == ENUM && fa->val != NULL)
@@ -652,8 +655,8 @@ vcc_func(struct vcc *tl, struct expr **e, const void *priv,
 		if (fa->result == NULL && fa->val != NULL)
 			fa->result = vcc_mk_expr(fa->type, "%s", fa->val);
 		if (fa->result != NULL && sa != NULL) {
-			if (fa->name)
-				bprintf(ssa, "\v1.%s = \v2,\n", fa->name);
+			if (fa->cname)
+				bprintf(ssa, "\v1.%s = \v2,\n", fa->cname);
 			else
 				bprintf(ssa, "\v1.arg%d = \v2,\n", n);
 			e1 = vcc_expr_edit(tl, e1->fmt, ssa, e1, fa->result);

--- a/lib/libvcc/vcc_vmod.c
+++ b/lib/libvcc/vcc_vmod.c
@@ -162,7 +162,8 @@ vcc_ParseJSON(const struct vcc *tl, const char *jsn, struct vmod_import *vim)
 	AN(vv3);
 	assert(vjsn_is_string(vv3));
 	vim->vmod_syntax = strtod(vv3->value, NULL);
-	assert (vim->vmod_syntax == 1.0);
+	if (vim->vmod_syntax != 2.0)
+		return ("Syntax != 2.0");
 
 	vv3 = VTAILQ_NEXT(vv3, list);
 	AN(vv3);

--- a/lib/libvcc/vmodtool.py
+++ b/lib/libvcc/vmodtool.py
@@ -27,6 +27,10 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
+#
+# syntax version history:
+# 1.0: initial
+# 2.0: added cname (nm2) after argument name
 
 """
 Read the first existing file from arguments or vmod.vcc and produce:
@@ -321,7 +325,7 @@ class arg(CType):
         self.defval = x
 
     def jsonproto(self, jl):
-        jl.append([self.vt, self.nm, self.defval, self.spec])
+        jl.append([self.vt, self.nm, self.nm2, self.defval, self.spec])
         if self.opt:
             jl[-1].append(True)
         while jl[-1][-1] is None:
@@ -387,6 +391,8 @@ class ProtoType():
                 err("arguments cannot be of type '%s'" % t.vt, warn=False)
             if t.nm is None:
                 t.nm2 = "arg%d" % n
+            elif ':' in t.nm:
+                [t.nm, t.nm2] = t.nm.split(':')
             else:
                 t.nm2 = t.nm
             self.args.append(t)
@@ -468,8 +474,8 @@ class ProtoType():
         s = "\n" + self.argstructname() + " {\n"
         for i in self.args:
             if i.opt:
-                assert i.nm is not None
-                s += "\tchar\t\t\tvalid_%s;\n" % i.nm
+                assert i.nm2 is not None
+                s += "\tchar\t\t\tvalid_%s;\n" % i.nm2
         for i in self.args:
             s += "\t" + i.ct
             if len(i.ct) < 8:
@@ -1158,7 +1164,7 @@ class vcc():
 
     def iter_json(self, fnx):
 
-        jl = [["$VMOD", "1.0", self.modname, self.csn, self.file_id]]
+        jl = [["$VMOD", "2.0", self.modname, self.csn, self.file_id]]
         jl.append(["$CPROTO"])
         for i in open(fnx):
             jl[-1].append(i.rstrip())

--- a/vmod/vmod_blob.h
+++ b/vmod/vmod_blob.h
@@ -140,7 +140,7 @@ len_f		hex_decode_l;
 encode_f	hex_encode;
 decode_f	hex_decode;
 
-extern const char	hex_alphabet[][16];
+extern const char	hex_alphabet[][17];
 extern const uint8_t	hex_nibble[];
 
 /* url.c */

--- a/vmod/vmod_blob_base64.c
+++ b/vmod/vmod_blob_base64.c
@@ -37,7 +37,7 @@
 #include "vmod_blob.h"
 
 static const struct b64_alphabet {
-	const char b64[64];
+	const char b64[65];
 	const int8_t i64[256];
 	const int padding;
 } b64_alphabet[] = {

--- a/vmod/vmod_blob_hex.c
+++ b/vmod/vmod_blob_hex.c
@@ -38,7 +38,7 @@
 
 #include "vmod_blob.h"
 
-const char hex_alphabet[][16] = {
+const char hex_alphabet[][17] = {
 	"0123456789abcdef",
 	"0123456789ABCDEF"
 };

--- a/vmod/vmod_std.vcc
+++ b/vmod/vmod_std.vcc
@@ -308,7 +308,7 @@ Example::
 	std.cache_req_body(std.bytes(real=10.0*1024));
 
 $Function INT integer([STRING s], [INT fallback],
-    [BOOL bool], [BYTES bytes], [DURATION duration], [REAL real],
+    [BOOL bool:boolean], [BYTES bytes], [DURATION duration], [REAL real],
     [TIME time])
 
 Returns an INT from a STRING, BOOL or other quantity.
@@ -376,7 +376,7 @@ Example::
 	}
 
 $Function REAL real([STRING s], [REAL fallback], [INT integer],
-    [BOOL bool], [BYTES bytes], [DURATION duration],
+    [BOOL bool:boolean], [BYTES bytes], [DURATION duration],
     [TIME time])
 
 Returns a REAL from a STRING, BOOL or other quantity.

--- a/vmod/vmod_std_conversions.c
+++ b/vmod/vmod_std_conversions.c
@@ -149,15 +149,15 @@ vmod_integer(VRT_CTX, struct VARGS(integer) *a)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
-	nargs = a->valid_s + a->valid_bool + a->valid_bytes +
+	nargs = a->valid_s + a->valid_boolean + a->valid_bytes +
 	    a->valid_duration + a->valid_real + a->valid_time;
 
 	if (!onearg(ctx, "integer", nargs))
 		return (0);
 
 	r = NAN;
-	if (a->valid_bool)
-		return (a->bool ? 1 : 0);
+	if (a->valid_boolean)
+		return (a->boolean ? 1 : 0);
 
 	if (a->valid_bytes)
 		return (a->bytes);
@@ -245,7 +245,7 @@ vmod_real(VRT_CTX, struct VARGS(real) *a)
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
-	nargs = a->valid_s + a->valid_integer + a->valid_bool + a->valid_bytes +
+	nargs = a->valid_s + a->valid_integer + a->valid_boolean + a->valid_bytes +
 	    a->valid_duration + a->valid_time;
 
 	if (!onearg(ctx, "real", nargs))
@@ -254,8 +254,8 @@ vmod_real(VRT_CTX, struct VARGS(real) *a)
 	if (a->valid_integer)
 		return ((VCL_REAL)a->integer);
 
-	if (a->valid_bool)
-		return ((VCL_REAL)(a->bool ? 1 : 0));
+	if (a->valid_boolean)
+		return ((VCL_REAL)(a->boolean ? 1 : 0));
 
 	if (a->valid_bytes)
 		return ((VCL_REAL)a->bytes);


### PR DESCRIPTION
Reviewers must check the following items:

- [ ] Release notes are complete (major release only)
- [ ] Release notes no longer target trunk (major release only)
- [x] The change log is populated
- [ ] The VRT history in `include/vrt.h` is populated
- [ ] The VRT history includes changes from `include/vrt_obj.h`
- [ ] The VRT history refers to the next VRT version
- [ ] The macro `VRT_MAJOR_VERSION` was updated if applicable
- [ ] The macro `VRT_MINOR_VERSION` was updated if applicable
- [ ] The new VRT version follows releases guidelines
- [ ] The new VRT version matches the one from the VRT history
- [ ] Bundled `devicedetect.vcl` was updated (major release only)
- [x] Running `./autogen.des && make distcheck` succeeds
- [x] The version in `configure.ac` is correct
- [x] The copyright notice in `configure.ac` covers the current year
- [x] The copyright output in `lib/libvarnish/version.c` covers the current year
- [x] There are no other changes than the ones listed above
