### PR TITLE
Constify sentinel pointers

### DIFF
--- a/bin/varnishd/cache/cache_vrt.c
+++ b/bin/varnishd/cache/cache_vrt.c
@@ -55,11 +55,11 @@
 #include "proxy/cache_proxy.h"
 
 // NOT using TOSTRANDS() to create a NULL pointer element despite n == 0
-const struct strands *vrt_null_strands = &(struct strands){
+const struct strands *const vrt_null_strands = &(struct strands){
 	.n = 0,
 	.p = (const char *[1]){NULL}
 };
-const struct vrt_blob *vrt_null_blob = &(struct vrt_blob){
+const struct vrt_blob *const vrt_null_blob = &(struct vrt_blob){
 	.type = VRT_NULL_BLOB_TYPE,
 	.len = 0,
 	.blob = "\0"

--- a/include/vapi/vsl.h
+++ b/include/vapi/vsl.h
@@ -230,7 +230,7 @@ int VSL_List2Tags(const char *list, int l, VSL_tagfind_f *func, void *priv);
 	 *     -3: Syntax error
 	 */
 
-extern const char *VSLQ_grouping[VSL_g__MAX];
+extern const char *const VSLQ_grouping[VSL_g__MAX];
 	/*
 	 * Grouping mode to string array.
 	 */

--- a/include/vrt.h
+++ b/include/vrt.h
@@ -375,7 +375,7 @@ struct strands {
 /*
  * A VCL_STRANDS return value must never be NULL. Use this instead
  */
-extern const struct strands *vrt_null_strands;
+extern const struct strands *const vrt_null_strands;
 
 /*
  * Macros for VCL_STRANDS creation
@@ -409,7 +409,7 @@ struct vrt_blob {
 };
 
 #define VRT_NULL_BLOB_TYPE 0xfade4fa0
-extern const struct vrt_blob *vrt_null_blob;
+extern const struct vrt_blob *const vrt_null_blob;
 
 /***********************************************************************
  * This is the central definition of the mapping from VCL types to

--- a/lib/libvarnishapi/vsl_arg.c
+++ b/lib/libvarnishapi/vsl_arg.c
@@ -175,7 +175,7 @@ VSL_List2Tags(const char *list, int l, VSL_tagfind_f *func, void *priv)
 	return (t);
 }
 
-const char *VSLQ_grouping[VSL_g__MAX] = {
+const char *const VSLQ_grouping[VSL_g__MAX] = {
 	[VSL_g_raw]	= "raw",
 	[VSL_g_vxid]	= "vxid",
 	[VSL_g_request]	= "request",


### PR DESCRIPTION
I made this mistake of creating a variable pointing to a sentinel value, and forgot to seal the variable itself to prevent it from pointing to a different constant value. Then I wondered whether I could find other cases and hit 3 of them.

These are technically breaking changes since they are adding new ABI constraints, but it should only break invalid (and most likely nonexistent) use cases without compromising legitimate use cases. So I'm hereby waiving ABI concerns.