### PR TITLE
cache_fetch: Send Content-Length: 0 for POST and PUT

### DIFF
--- a/bin/varnishtest/tests/r04331.vtc
+++ b/bin/varnishtest/tests/r04331.vtc
@@ -1,0 +1,18 @@
+varnishtest "C-L with empty POST"
+
+server s1 {
+	rxreq
+	txresp
+	expect req.http.content-length == 0
+} -start
+
+varnish v1 -vcl+backend {
+
+} -start
+
+client c1 {
+	txreq -method POST -hdr "content-length: 0"
+	rxresp
+} -run
+
+server s1 -wait


### PR DESCRIPTION
otherwise keep the existing logic of sending no Content-Length header if there is no request body.

This code runs before vcl_backend_fetch, so should VCL gain back control over Content-Length as proposed in #4331, it will be possible again to override this default.

Fixes #4331 for the special case