### PR TITLE
backend: add VSCs for backend errors

### DIFF
--- a/bin/varnishd/cache/cache_backend.c
+++ b/bin/varnishd/cache/cache_backend.c
@@ -350,6 +350,36 @@ vbe_dir_getfd(VRT_CTX, struct worker *wrk, VCL_BACKEND dir, struct backend *bp,
 	return (pfd);
 }
 
+/*--------------------------------------------------------------------
+ * Update bc_ counters by reason (implementing ses_close_acct for backends)
+ *
+ * assuming that the approximation of non-atomic global counters is sufficient.
+ * if not: update to per-wrk
+ */
+
+static void
+vbe_close_acct(const struct pfd *pfd, stream_close_t reason)
+{
+
+	if (reason == SC_NULL) {
+		assert(PFD_State(pfd) == PFD_STATE_USED);
+		VSC_C_main->bc_tx_proxy++;
+		return;
+	}
+
+#define SESS_CLOSE_BACKEND
+#define SESS_CLOSE(U, l, err, desc)					\
+	if (reason == SC_ ## U) {					\
+		VSC_C_main->bc_ ## l++;					\
+		if (err)						\
+			VSC_C_main->backend_closed_err++;		\
+		return;							\
+	}
+#include "tbl/sess_close.h"
+
+	WRONG("Wrong event in vbe_close_acct");
+}
+
 static void v_matchproto_(vdi_finish_f)
 vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 {
@@ -369,11 +399,13 @@ vbe_dir_finish(VRT_CTX, VCL_BACKEND d)
 	pfd = bo->htc->priv;
 	bo->htc->priv = NULL;
 	if (bo->htc->doclose != SC_NULL || bp->proxy_header != 0) {
+		vbe_close_acct(pfd, bo->htc->doclose);
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s close %s", *PFD_Fd(pfd),
 		    VRT_BACKEND_string(d), bo->htc->doclose->name);
 		VCP_Close(&pfd);
 		AZ(pfd);
 		Lck_Lock(bp->director->mtx);
+		VSC_C_main->backend_closed++;
 	} else {
 		assert (PFD_State(pfd) == PFD_STATE_USED);
 		VSLb(bo->vsl, SLT_BackendClose, "%d %s recycle", *PFD_Fd(pfd),

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -228,9 +228,9 @@ V1F_FetchRespHdr(struct busyobj *bo)
 			VSLb(bo->vsl, SLT_FetchError, "Received junk");
 			htc->doclose = SC_RX_JUNK;
 			break;
-		case HTC_S_CLOSE:
+		case HTC_S_EOF:
 			VSLb(bo->vsl, SLT_FetchError, "backend closed");
-			htc->doclose = SC_RESP_CLOSE;
+			htc->doclose = SC_REM_CLOSE;
 			break;
 		case HTC_S_TIMEOUT:
 			VSLb(bo->vsl, SLT_FetchError, "timeout");

--- a/bin/varnishtest/tests/c00036.vtc
+++ b/bin/varnishtest/tests/c00036.vtc
@@ -27,7 +27,7 @@ logexpect l1 -v v1 -q "vxid == 1004" {
 
 	# purpose of this vtc: test the internal retry when the
 	# backend goes away on a keepalive TCP connection:
-	expect 0 1004 FetchError      {^HTC eof .Unexpected end of input.}
+	expect 0 1004 FetchError      {^backend closed}
 	expect 0 1004 BackendClose    {^\d+ s1}
 	expect 0 1004 Timestamp       {^Connected:}
 	expect 0 1004 BackendOpen     {^\d+ s1}
@@ -54,9 +54,9 @@ client c1 {
 
 varnish v1 -expect backend_retry == 1
 varnish v1 -expect MAIN.backend_closed == 1
-varnish v1 -expect MAIN.backend_closed_err == 1
-varnish v1 -expect MAIN.bc_rx_bad == 1
+varnish v1 -expect MAIN.backend_closed_err == 0
+varnish v1 -expect MAIN.bc_rx_bad == 0
 varnish v1 -expect MAIN.bc_rx_timeout == 0
-varnish v1 -expect MAIN.bc_rem_close == 0
+varnish v1 -expect MAIN.bc_rem_close == 1
 
 logexpect l1 -wait

--- a/bin/varnishtest/tests/c00036.vtc
+++ b/bin/varnishtest/tests/c00036.vtc
@@ -53,4 +53,10 @@ client c1 {
 } -run
 
 varnish v1 -expect backend_retry == 1
+varnish v1 -expect MAIN.backend_closed == 1
+varnish v1 -expect MAIN.backend_closed_err == 1
+varnish v1 -expect MAIN.bc_rx_bad == 1
+varnish v1 -expect MAIN.bc_rx_timeout == 0
+varnish v1 -expect MAIN.bc_rem_close == 0
+
 logexpect l1 -wait

--- a/include/tbl/sess_close.h
+++ b/include/tbl/sess_close.h
@@ -32,8 +32,8 @@
 /*lint -save -e525 -e539 */
 
 // stream_close_t	  sc_* stat	is_err	Description
-SESS_CLOSE(REM_CLOSE,	  rem_close,	0,	"Client Closed")
-SESS_CLOSE(REQ_CLOSE,	  req_close,	0,	"Client requested close")
+SESS_CLOSE(REM_CLOSE,	  rem_close,	0,	"Peer Closed")
+SESS_CLOSE(REQ_CLOSE,	  req_close,	0,	"Peer requested close")
 SESS_CLOSE(REQ_HTTP10,	  req_http10,	1,	"Proto < HTTP/1.1")
 SESS_CLOSE(RX_BAD,	  rx_bad,	1,	"Received bad req/resp")
 SESS_CLOSE(RX_BODY,	  rx_body,	1,	"Failure receiving body")

--- a/include/tbl/sess_close.h
+++ b/include/tbl/sess_close.h
@@ -40,18 +40,22 @@ SESS_CLOSE(RX_BODY,	  rx_body,	1,	"Failure receiving body")
 SESS_CLOSE(RX_JUNK,	  rx_junk,	1,	"Received junk data")
 SESS_CLOSE(RX_OVERFLOW,   rx_overflow,	1,	"Received buffer overflow")
 SESS_CLOSE(RX_TIMEOUT,	  rx_timeout,	1,	"Receive timeout")
-SESS_CLOSE(RX_CLOSE_IDLE, rx_close_idle,0,	"timeout_idle reached")
 SESS_CLOSE(TX_PIPE,	  tx_pipe,	0,	"Piped transaction")
 SESS_CLOSE(TX_ERROR,	  tx_error,	1,	"Error transaction")
 SESS_CLOSE(TX_EOF,	  tx_eof,	0,	"EOF transmission")
 SESS_CLOSE(RESP_CLOSE,	  resp_close,	0,	"Backend/VCL requested close")
 SESS_CLOSE(OVERLOAD,	  overload,	1,	"Out of some resource")
-SESS_CLOSE(PIPE_OVERFLOW, pipe_overflow,1,	"Session pipe overflow")
-SESS_CLOSE(RANGE_SHORT,   range_short,	1,	"Insufficient data for range")
-SESS_CLOSE(REQ_HTTP20,	  req_http20,	1,	"HTTP2 not accepted")
-SESS_CLOSE(VCL_FAILURE,	  vcl_failure,	1,	"VCL failure")
-SESS_CLOSE(RAPID_RESET,	  rapid_reset,  1,      "HTTP2 rapid reset")
-SESS_CLOSE(BANKRUPT,	  bankrupt,	1,      "HTTP2 credit bankruptcy")
+#ifndef SESS_CLOSE_BACKEND
+  SESS_CLOSE(RX_CLOSE_IDLE,	rx_close_idle,	0,	"timeout_idle reached")
+  SESS_CLOSE(PIPE_OVERFLOW,	pipe_overflow,	1,	"Session pipe overflow")
+  SESS_CLOSE(RANGE_SHORT,	range_short,	1,	"Insufficient data for range")
+  SESS_CLOSE(REQ_HTTP20,	req_http20,	1,	"HTTP2 not accepted")
+  SESS_CLOSE(VCL_FAILURE,	vcl_failure,	1,	"VCL failure")
+  SESS_CLOSE(RAPID_RESET,	rapid_reset,	1,	"HTTP2 rapid reset")
+  SESS_CLOSE(BANKRUPT,		bankrupt,	1,	"HTTP2 credit bankruptcy")
+#else
+  #undef SESS_CLOSE_BACKEND
+#endif
 #undef SESS_CLOSE
 
 /*lint -restore */

--- a/lib/libvsc/VSC_main.vsc
+++ b/lib/libvsc/VSC_main.vsc
@@ -211,6 +211,100 @@
 	The maximum time to wait in the queue is defined by the backend
 	wait_timeout property.
 
+.. varnish_vsc:: backend_closed
+	:group: wrk
+	:oneliner:	Backend Closed
+
+.. varnish_vsc:: backend_closed_err
+	:oneliner:	Backend Closed with error
+
+	Total number of backends closed with errors. See bc_* diag counters
+	for detailed breakdown
+
+.. varnish_vsc:: bc_rem_close
+	:level:	diag
+	:oneliner:	Backend Close OK  REM_CLOSE
+
+	Number of backend closes with REM_CLOSE (Server Closed)
+
+.. varnish_vsc:: bc_req_close
+	:level:	diag
+	:oneliner:	Backend Close OK  REQ_CLOSE
+
+	Number of backend closes with REQ_CLOSE (Server requested close)
+
+.. varnish_vsc:: bc_req_http10
+	:level:	diag
+	:oneliner:	Backend Close Err REQ_HTTP10
+
+	Number of backend closes with Error REQ_HTTP10 (Proto < HTTP/1.1)
+
+.. varnish_vsc:: bc_rx_bad
+	:level:	diag
+	:oneliner:	Backend Close Err RX_BAD
+
+	Number of backend closes with Error RX_BAD (Received bad req/resp)
+
+.. varnish_vsc:: bc_rx_body
+	:level:	diag
+	:oneliner:	Backend Close Err RX_BODY
+
+	Number of backend closes with Error RX_BODY (Failure receiving request body)
+
+.. varnish_vsc:: bc_rx_junk
+	:level:	diag
+	:oneliner:	Backend Close Err RX_JUNK
+
+	Number of backend closes with Error RX_JUNK (Received junk data)
+
+.. varnish_vsc:: bc_rx_overflow
+	:level:	diag
+	:oneliner:	Backend Close Err RX_OVERFLOW
+
+	Number of backend closes with Error RX_OVERFLOW (Received buffer overflow)
+
+.. varnish_vsc:: bc_rx_timeout
+	:level:	diag
+	:oneliner:	Backend Close Err RX_TIMEOUT
+
+	Number of backend closes with Error RX_TIMEOUT (Receive timeout)
+
+.. varnish_vsc:: bc_tx_pipe
+	:level:	diag
+	:oneliner:	Backend Close OK  TX_PIPE
+
+	Number of backend closes with TX_PIPE (Piped transaction)
+
+.. varnish_vsc:: bc_tx_error
+	:level:	diag
+	:oneliner:	Backend Close Err TX_ERROR
+
+	Number of backend closes with Error TX_ERROR (Error transaction)
+
+.. varnish_vsc:: bc_tx_proxy
+	:level:	diag
+	:oneliner:	Backend Close OK  TX_PROXY
+
+	Number of backend closes with TX_PROXY (Proxy transaction).
+
+.. varnish_vsc:: bc_tx_eof
+	:level:	diag
+	:oneliner:	Backend Close OK  TX_EOF
+
+	Number of backend closes with TX_EOF (EOF transmission)
+
+.. varnish_vsc:: bc_resp_close
+	:level:	diag
+	:oneliner:	Backend Close OK  RESP_CLOSE
+
+	Number of backend closes with RESP_CLOSE (Backend/VCL requested close)
+
+.. varnish_vsc:: bc_overload
+	:level:	diag
+	:oneliner:	Backend Close Err OVERLOAD
+
+	Number of backend closes with Error OVERLOAD (Out of some resource)
+
 .. varnish_vsc:: fetch_head
 	:group: wrk
 	:oneliner:	Fetch no body (HEAD)


### PR DESCRIPTION
Abstract vbe_close_acct, this is supposed to mimic the ses_close_acct for backends.
    
We have up until now not exposed `htc->doclose` (backend errors) to any counters as we do for `req->doclose` (session errors).
    
That is unfortunate as these errors code are useful when trubleshooting fetches, so expose them as `bc_*` counters which is a subset of the `sc_*` counters.
    
Also add counters for backend closes: `backend_closed` and `backend_closed_err`.