### PR TITLE
vtim: Work with the "YYYY-MM-DDThh:mm:ss[.s]TZD" date-time format

### DIFF
--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -344,6 +344,7 @@ mgt_tests(void)
 	assert(VTIM_parse("Sun, 06 Nov 1994 08:49:37 GMT") == 784111777);
 	assert(VTIM_parse("Sunday, 06-Nov-94 08:49:37 GMT") == 784111777);
 	assert(VTIM_parse("Sun Nov  6 08:49:37 1994") == 784111777);
+	assert(VTIM_parse_web("1994-11-06T08:49:37.00Z") == 784111777);
 
 	/* Check that our VSHA256 works */
 	VSHA256_Test();

--- a/include/vtim.h
+++ b/include/vtim.h
@@ -34,6 +34,8 @@
 extern unsigned VTIM_postel;
 #define VTIM_FORMAT_SIZE 30
 void VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE]);
+#define VTIM_FORMAT_WEB_SIZE (sizeof "2025-12-31T23:59:59.123456Z")
+void VTIM_format_web(vtim_real t, char p[VTIM_FORMAT_WEB_SIZE]);
 vtim_real VTIM_parse(const char *p);
 vtim_real VTIM_parse_web(const char *p);
 vtim_mono VTIM_mono(void);

--- a/include/vtim.h
+++ b/include/vtim.h
@@ -35,6 +35,7 @@ extern unsigned VTIM_postel;
 #define VTIM_FORMAT_SIZE 30
 void VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE]);
 vtim_real VTIM_parse(const char *p);
+vtim_real VTIM_parse_web(const char *p);
 vtim_mono VTIM_mono(void);
 vtim_real VTIM_real(void);
 void VTIM_sleep(vtim_dur t);

--- a/include/vtim.h
+++ b/include/vtim.h
@@ -33,7 +33,7 @@
 /* from libvarnish/vtim.c */
 extern unsigned VTIM_postel;
 #define VTIM_FORMAT_SIZE 30
-void VTIM_format(vtim_real t, char *p);
+void VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE]);
 vtim_real VTIM_parse(const char *p);
 vtim_mono VTIM_mono(void);
 vtim_real VTIM_real(void);

--- a/lib/libvarnish/vtim.c
+++ b/lib/libvarnish/vtim.c
@@ -157,7 +157,7 @@ VTIM_real(void)
 }
 
 void
-VTIM_format(vtim_real t, char *p)
+VTIM_format(vtim_real t, char p[VTIM_FORMAT_SIZE])
 {
 	struct tm tm;
 	time_t tt;

--- a/lib/libvarnish/vtim.c
+++ b/lib/libvarnish/vtim.c
@@ -188,6 +188,7 @@ struct vtim {
 	int	hour;
 	int	min;
 	int	sec;
+	double	frac;
 };
 
 #define VTIM_INIT(vtim)			\
@@ -199,6 +200,7 @@ struct vtim {
 		(vtim)->hour = 0;	\
 		(vtim)->min = 0;	\
 		(vtim)->sec = 0;	\
+		(vtim)->frac = 0;	\
 	} while (0)
 
 #ifdef TEST_DRIVER
@@ -418,6 +420,11 @@ vtim_calc(struct vtim *vtim)
 	t += d * 86400.;
 
 	t += 10957. * 86400.;	/* 10957 days frm UNIX epoch to y2000 */
+
+	assert(vtim->frac >= 0);
+	assert(vtim->frac < 1);
+
+	t += vtim->frac;
 
 	return (t);
 }


### PR DESCRIPTION
This is a format shared by a W3C note and an old IETF RFC, and still in use 5000+ RFCs later.

It's not being used anywhere in this patch series (I'm using it in a separate project) but I think it could be very useful in certain areas where we print timestamps, like the ban list, the first (non-prefix) field of `SLT_Timestamp` records, and possibly others not popping off the top of my head.

Three interesting properties of this specific format:

- timestamps are naturally sorted
- no spaces, a good fit for field/column layouts
- sub-second resolution
- human readable

I'm submitting this independently of any usage, but I thought the 8.0 release could be a good occasion to "break" the output of CLI responses, or the layout of VSL records, or anything else where we print timestamps.