### PR TITLE
circleci: Sanitizers job fail on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ workflows:
           release: noble
           rclass: large
           extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator --without-jemalloc
-          make_target: check -j2
+          make_target: check
       - build:
           name: build_alpine
           dist: alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,7 @@ workflows:
           dist: ubuntu
           release: noble
           rclass: large
-          extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator
+          extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator --without-jemalloc
           make_target: check
       - build:
           name: build_alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,49 +377,12 @@ workflows:
         - << pipeline.parameters.dist-url >>
     jobs:
       - build:
-          name: build_almalinux_8
-          dist: almalinux
-          release: "8"
-      - build:
-          name: build_almalinux_9
-          dist: almalinux
-          release: "9"
-      # fedora is our witness
-      - build:
-          name: build_fedora_latest
-          dist: fedora
-          release: latest
-          make_target: witness.dot
-      - build:
-          name: build_debian_bookworm
-          dist: debian
-          release: bookworm
-      # latest ubuntu uses sanitizers
-      - build:
-          name: build_ubuntu_focal
-          dist: ubuntu
-          release: focal
-      - build:
-          name: build_ubuntu_jammy
-          dist: ubuntu
-          release: jammy
-      - build:
           name: build_ubuntu_noble
           dist: ubuntu
           release: noble
           rclass: large
           extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator --without-jemalloc
           make_target: check
-      - build:
-          name: build_alpine
-          dist: alpine
-          release: latest
-          extra_conf: --without-contrib
-          make_target: check
-      - build:
-          name: build_archlinux
-          dist: archlinux
-          release: base-devel
   packaging:
     when: *packaging_cond
     jobs: &packaging_jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,12 +377,49 @@ workflows:
         - << pipeline.parameters.dist-url >>
     jobs:
       - build:
+          name: build_almalinux_8
+          dist: almalinux
+          release: "8"
+      - build:
+          name: build_almalinux_9
+          dist: almalinux
+          release: "9"
+      # fedora is our witness
+      - build:
+          name: build_fedora_latest
+          dist: fedora
+          release: latest
+          make_target: witness.dot
+      - build:
+          name: build_debian_bookworm
+          dist: debian
+          release: bookworm
+      # latest ubuntu uses sanitizers
+      - build:
+          name: build_ubuntu_focal
+          dist: ubuntu
+          release: focal
+      - build:
+          name: build_ubuntu_jammy
+          dist: ubuntu
+          release: jammy
+      - build:
           name: build_ubuntu_noble
           dist: ubuntu
           release: noble
           rclass: large
           extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator --without-jemalloc
           make_target: check
+      - build:
+          name: build_alpine
+          dist: alpine
+          release: latest
+          extra_conf: --without-contrib
+          make_target: check
+      - build:
+          name: build_archlinux
+          dist: archlinux
+          release: base-devel
   packaging:
     when: *packaging_cond
     jobs: &packaging_jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ workflows:
           release: noble
           rclass: large
           extra_conf: --enable-asan --enable-ubsan --enable-workspace-emulator --without-jemalloc
-          make_target: check
+          make_target: check -j2
       - build:
           name: build_alpine
           dist: alpine

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -33,6 +33,10 @@
 
 #include "config.h"
 
+#if HAVE_SANITIZER_ASAN_INTERFACE_H
+#  include <sanitizer/asan_interface.h>
+#endif
+
 #include <ctype.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -78,6 +82,19 @@ static char		*workdir;
 static struct vfil_path *vcl_path = NULL;
 
 static const char opt_spec[] = "?a:b:CdE:f:Fh:i:I:j:l:M:n:P:p:r:S:s:T:t:VW:x:";
+
+/*--------------------------------------------------------------------*/
+
+#if HAVE_SANITIZER_ASAN_INTERFACE_H && ENABLE_ASAN
+void
+__asan_on_error(void)
+{
+
+	printf("ASAN error: %s (errno=%d: %s)\n",
+	    __asan_get_report_description(),
+	    errno, strerror(errno));
+}
+#endif
 
 /*--------------------------------------------------------------------*/
 

--- a/configure.ac
+++ b/configure.ac
@@ -260,6 +260,7 @@ AC_ARG_ENABLE(asan,
 		AC_DEFINE([ENABLE_ASAN], [1],
 			[Define to 1 if ASAN sanitizer is enabled.])
 		ASAN_FLAGS=-fsanitize=address
+		AC_CHECK_HEADERS([sanitizer/asan_interface.h])
 	])
 
 if test -n "$ASAN_FLAGS"; then
@@ -305,7 +306,6 @@ AM_CONDITIONAL([ENABLE_WORKSPACE_EMULATOR],
 	[test "$enable_workspace_emulator" = yes])
 
 AM_COND_IF([ENABLE_WORKSPACE_EMULATOR], [
-	AC_CHECK_HEADERS([sanitizer/asan_interface.h])
 	AC_DEFINE([ENABLE_WORKSPACE_EMULATOR], [1],
               [Define to 1 if the workspace emulator is enabled])
 ])


### PR DESCRIPTION
A lot of job executions fail with a handful of test logs containing stack traces looking like this:

    abort+0xdf
    _ZN11__sanitizer5AbortEv+0x30
    _ZN11__sanitizer3DieEv+0x4d
    _ZN11__sanitizer11CheckFailedEPKciS1_yy+0x8b
    _ZN11__sanitizer14ThreadRegistry12CreateThreadEmbjPv+0x45b
    _ZN6__asan10AsanThread6CreateEPKvmjPN11__sanitizer10StackTraceEb+0xa9
    __interceptor_pthread_create+0x128

In that case errno is set to EAGAIN, indicating either an actual lack of resources in the constrained cci environment, or a limit reached. After finding bug reports describing similar problems (but not this case) in which the question of the allocator comes up, this change is an attempt at improving the reliability of the cci job running with sanitizers.

---

This starts as a draft pull request, I may attempt other changes to mitigate spurious failures in CI, triggering background jobs while I work on something else.