### PR TITLE
vcc_acl: Add +fold(-report) sub-flag omit +fold warnings

### DIFF
--- a/bin/varnishtest/tests/c00005.vtc
+++ b/bin/varnishtest/tests/c00005.vtc
@@ -375,3 +375,39 @@ client c1 {
 } -run
 
 logexpect l1 -wait
+
+# test +fold(-report)
+varnish v1 -cliexpect "^$" {vcl.inline silent << EOF
+	vcl 4.1;
+
+	backend dummy None;
+
+	acl acl1 +log +pedantic +fold(-report) {
+		"1.2.0.0"/23;
+		"1.2.2.0"/24;
+		"1.2.3.0"/24;
+	}
+
+	sub vcl_recv {
+		if (client.ip ~ acl1) {
+			return (synth(403));
+		}
+	}
+	EOF
+}
+
+varnish v1 -errvcl "-fold(...) is invalid, use -fold" {
+	backend dummy None;
+
+	acl acl1 +log +pedantic -fold(+foo) {
+		"1.2.0.0"/23;
+	}
+}
+
+varnish v1 -errvcl "The only ACL fold sub-flag is `report`" {
+	backend dummy None;
+
+	acl acl1 +log +pedantic +fold(+foo) {
+		"1.2.0.0"/23;
+	}
+}

--- a/doc/sphinx/reference/vcl.rst
+++ b/doc/sphinx/reference/vcl.rst
@@ -354,7 +354,7 @@ individually:
 
   Skip and fold operations on ACL entries are output as warnings
   during VCL compilation as entries from the VCL are processed in
-  order.
+  order unless the `-report` sub-flag is also given (see below).
 
   Logging under the ``VCL_acl`` tag can change with this parameter
   enabled: Matches on skipped subnet entries are now logged as matches
@@ -364,6 +364,19 @@ individually:
   ``fixed: folded``.
 
   Negated ACL entries are never folded.
+
+  Exactly one sub-flag is supported following `fold` in parenthesis:
+
+  - `+fold(+report)` - Fold with reporting (default)
+
+    Report about folding as described above
+
+  - `+fold(-report)` - Fold without reporting
+
+    Enable folding, but do not output folding-related warnings during VCL
+    compilation
+
+  The ``report`` sub-option is only valid with ``+fold``.
 
 VCL objects
 -----------


### PR DESCRIPTION
With a lot of folding going on, the warnings can easily bury more relevant CLI output.