### PR TITLE
boc: Set up transit buffer only for a backend fetch

### DIFF
--- a/bin/varnishd/cache/cache_fetch.c
+++ b/bin/varnishd/cache/cache_fetch.c
@@ -1175,6 +1175,7 @@ VBF_Fetch(struct worker *wrk, struct req *req, struct objcore *oc,
 
 	boc = HSH_RefBoc(oc);
 	CHECK_OBJ_NOTNULL(boc, BOC_MAGIC);
+	boc->transit_buffer = cache_param->transit_buffer;
 
 	switch (mode) {
 	case VBF_PASS:

--- a/bin/varnishd/cache/cache_obj.c
+++ b/bin/varnishd/cache/cache_obj.c
@@ -109,7 +109,6 @@ obj_newboc(void)
 	Lck_New(&boc->mtx, lck_busyobj);
 	PTOK(pthread_cond_init(&boc->cond, NULL));
 	boc->refcount = 1;
-	boc->transit_buffer = cache_param->transit_buffer;
 	return (boc);
 }
 

--- a/bin/varnishd/cache/cache_obj.c
+++ b/bin/varnishd/cache/cache_obj.c
@@ -393,6 +393,11 @@ ObjExtend(struct worker *wrk, struct objcore *oc, ssize_t l, int final)
 		oc->boc->fetched_so_far += l;
 		obj_boc_notify(oc->boc);
 		Lck_Unlock(&oc->boc->mtx);
+
+		if (oc->boc->transit_buffer > 0)
+			wrk->stats->transit_buffered += l;
+		else if (oc->flags & OC_F_TRANSIENT)
+			wrk->stats->transit_stored += l;
 	}
 
 	assert(oc->boc->state < BOS_FINISHED);

--- a/bin/varnishtest/tests/c00111.vtc
+++ b/bin/varnishtest/tests/c00111.vtc
@@ -17,6 +17,9 @@ client c1 {
 varnish v1 -vsl_catchup
 # with vai, this no longer fails systematically (which is good)
 varnish v1 -expect fetch_failed <= 1
+varnish v1 -expect transit_stored > 0
+varnish v1 -expect transit_stored <= 1850000
+varnish v1 -expect transit_buffered == 0
 
 varnish v1 -cliok "param.set transit_buffer 4k"
 
@@ -29,3 +32,5 @@ client c2 {
 varnish v1 -vsl_catchup
 varnish v1 -expect s_fetch == 2
 varnish v1 -expect fetch_failed <= 1
+varnish v1 -expect transit_stored <= 1850000
+varnish v1 -expect transit_buffered == 1850000

--- a/bin/varnishtest/tests/r04362.vtc
+++ b/bin/varnishtest/tests/r04362.vtc
@@ -1,0 +1,24 @@
+varnishtest "No transit buffer for req.body and vcl_synth"
+
+varnish v1 -cliok "param.set transit_buffer 4k"
+varnish v1 -vcl {
+	import std;
+
+	backend be none;
+
+	sub vcl_recv {
+		if (!std.cache_req_body(10MB)) {
+			return (synth(503));
+		}
+		return (synth(200));
+	}
+} -start
+
+client c1 {
+	txreq -bodylen 10240
+	rxresp
+	expect resp.status == 200
+} -run
+
+varnish v1 -expect transit_stored > 10240
+varnish v1 -expect transit_buffered == 0

--- a/lib/libvsc/VSC_main.vsc
+++ b/lib/libvsc/VSC_main.vsc
@@ -533,6 +533,26 @@
 
 	Total number of bytes forwarded to clients in pipe sessions
 
+.. varnish_vsc:: transit_stored
+	:format:	bytes
+	:group:		wrk
+	:oneliner:	Stored uncacheable body bytes
+
+	Total number of transient body bytes written to storage as if they
+	were reusable like a cacheable backend response. Transient objects
+	are stored for a single transaction, this includes uncacheable backend
+	responses, synthetic responses and client requests.
+
+.. varnish_vsc:: transit_buffered
+	:format:	bytes
+	:group:		wrk
+	:oneliner:	Buffered uncacheable response body bytes
+
+	Total number of uncacheable responses body bytes forwarded using a
+	fixed buffer allocated from storage. This behavior can be enabled by
+	the 'transit_buffer' parameter, or the 'beresp.transit_buffer' VCL
+	variable.
+
 .. varnish_vsc:: sess_closed
 	:group: wrk
 	:oneliner:	Session Closed


### PR DESCRIPTION
It can otherwise lock up a client request body fetch indefinitely. An early setup at BOC creation time also increases the gap between updates to the transit_buffer parameter and its effectiveness, since BOCs can be created early through objcore preallocation made by worker threads.