### PR TITLE
Scale private oh

### DIFF
--- a/bin/varnishd/cache/cache_hash.c
+++ b/bin/varnishd/cache/cache_hash.c
@@ -93,17 +93,23 @@ VCF_RETURNS()
 
 /*---------------------------------------------------------------------*/
 
-static struct objhead *
-hsh_newobjhead(void)
+static void
+hsh_initobjhead(struct objhead *oh)
 {
-	struct objhead *oh;
 
-	ALLOC_OBJ(oh, OBJHEAD_MAGIC);
 	XXXAN(oh);
+	INIT_OBJ(oh, OBJHEAD_MAGIC);
 	oh->refcnt = 1;
 	VTAILQ_INIT(&oh->objcs);
 	VTAILQ_INIT(&oh->waitinglist);
 	Lck_New(&oh->mtx, lck_objhdr);
+}
+
+static struct objhead *
+hsh_newobjhead(void)
+{
+	struct objhead *oh = malloc(sizeof *oh);
+	hsh_initobjhead(oh);
 	return (oh);
 }
 


### PR DESCRIPTION
With a lot of objects on the private objhead, the mtx would become contended.

We solve this contention by using an array of private objheads and spreading objects over the array elements using a fibonacci hash.

The choice of an array of objheads rather than an array of objhead pointers is motivated by hsh_deref_objhead_unlock(), which behaves differently for private objects. An alternative to the address check would be to add a flag field to struct objhead, but that would require to grow the struct (really not a good option for such a central data structure which, in many cases, is required once per object) or reduce the size of the magic value to 16 bits.

The drawback of the chosen solution is that flexelint thinks all objheads would need to be from the array, and hence reports out of bounds access all over the place. ~~Suppressing these for the whole source file is far from ideal, but I have not found a better option (yet).~~ These warnings are suppressed somehow specifically (see comment inline).

For performance see https://github.com/varnishcache/varnish-cache/pull/4365#issuecomment-3062459644 : Without #4365, the benefits are not particularly visible because other locks will contend