### PR TITLE
Turn request body errors into 400 status

### DIFF
--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -1007,6 +1007,7 @@ cnt_recv(struct worker *wrk, struct req *req)
 	/* Attempts to cache req.body may fail */
 	if (req->req_body_status == BS_ERROR) {
 		req->doclose = SC_RX_BODY;
+		(void)req->transport->minimal_response(req, 400);
 		return (REQ_FSM_DONE);
 	}
 

--- a/bin/varnishd/http1/cache_http1_fetch.c
+++ b/bin/varnishd/http1/cache_http1_fetch.c
@@ -162,6 +162,7 @@ V1F_SendReq(struct worker *wrk, struct busyobj *bo, uint64_t *ctr_hdrbytes,
 			    "req.body read error: %d (%s)",
 			    errno, VAS_errtxt(errno));
 			bo->req->doclose = SC_RX_BODY;
+			bo->err_code = 400;
 		}
 		if (cl < 0)
 			V1L_EndChunk(v1l);

--- a/bin/varnishtest/tests/c00055.vtc
+++ b/bin/varnishtest/tests/c00055.vtc
@@ -72,5 +72,6 @@ client c4 {
 # req body overflow
 client c5 {
 	txreq -req POST -hdr "Content-Length: 1025"
-	expect_close
+	rxresp
+	expect resp.status == 400
 } -run

--- a/bin/varnishtest/tests/c00067.vtc
+++ b/bin/varnishtest/tests/c00067.vtc
@@ -91,7 +91,8 @@ client c1 {
 	chunked {BLAST}
 	delay .2
 	chunkedlen 106
-	expect_close
+	rxresp
+	expect resp.status == 400
 } -run
 
 logexpect l2 -wait

--- a/bin/varnishtest/tests/f00001.vtc
+++ b/bin/varnishtest/tests/f00001.vtc
@@ -18,7 +18,7 @@ client c1 {
 	send "0\r\n\r\n"
 
 	rxresp
-	expect resp.status == 503
+	expect resp.status == 400
 } -run
 
 # Check that the published workaround does not cause harm

--- a/bin/varnishtest/tests/f00016.vtc
+++ b/bin/varnishtest/tests/f00016.vtc
@@ -67,3 +67,24 @@ client c4 {
 } -run
 
 logexpect l1 -wait
+
+varnish v1 -vcl+backend {
+	import std;
+
+	sub vcl_recv {
+		std.cache_req_body(10kb);
+	}
+}
+
+client c5 {
+	non_fatal
+	txreq -req POST -hdr "Transfer-encoding: chunked"
+	send "1\r\n"
+	send "This is more than one byte of data\r\n"
+	send "0\r\n"
+	send "\r\n"
+	fatal
+	rxresp
+	expect resp.status == 400
+	expect_close
+} -run

--- a/bin/varnishtest/tests/f00016.vtc
+++ b/bin/varnishtest/tests/f00016.vtc
@@ -23,7 +23,7 @@ client c1 {
 	send "\r\n"
 	fatal
 	rxresp
-	expect resp.status == 503
+	expect resp.status == 400
 	expect_close
 } -run
 
@@ -38,7 +38,7 @@ client c2 {
 	send "\r\n"
 	fatal
 	rxresp
-	expect resp.status == 503
+	expect resp.status == 400
 	expect_close
 } -run
 
@@ -51,7 +51,7 @@ client c3 {
 	send "\r\n"
 	fatal
 	rxresp
-	expect resp.status == 503
+	expect resp.status == 400
 	expect_close
 } -run
 
@@ -62,7 +62,7 @@ client c4 {
 	send "\r\n"
 	fatal
 	rxresp
-	expect resp.status == 503
+	expect resp.status == 400
 	expect_close
 } -run
 

--- a/bin/varnishtest/tests/r02722.vtc
+++ b/bin/varnishtest/tests/r02722.vtc
@@ -18,7 +18,7 @@ client c1 {
         txreq -req POST -hdr "Content-Length: 100"
         send some
         rxresp
-        expect resp.status == 503
+        expect resp.status == 400
 }
 
 # This run performs the inheritance test on a TCP connection


### PR DESCRIPTION
This turns response status of req body errors into 400 instead of the generic 503.
Fixes #4329