### PR TITLE
[stat] use -1 is not outputting to a TTY

### DIFF
--- a/bin/varnishstat/varnishstat.c
+++ b/bin/varnishstat/varnishstat.c
@@ -296,6 +296,9 @@ main(int argc, char * const *argv)
 		case '1':
 			once = 1;
 			break;
+		case 'c':
+			curses = 1;
+			break;
 		case 'h':
 			/* Usage help */
 			usage(0);
@@ -333,8 +336,10 @@ main(int argc, char * const *argv)
 	if (optind != argc)
 		usage(1);
 
-	if (!(xml || json || once || f_list))
-		curses = 1;
+	if (!(curses || xml || json || once || f_list)) {
+		curses = isatty(STDOUT_FILENO);
+		once = !curses;
+	}
 
 	if (VSM_Attach(vd, STDERR_FILENO))
 		VUT_Error(vut, 1, "%s", VSM_Error(vd));

--- a/bin/varnishstat/varnishstat_options.h
+++ b/bin/varnishstat/varnishstat_options.h
@@ -36,7 +36,14 @@
 #define STAT_OPT_1							\
 	VOPT("1", "[-1]", "Print the statistics to stdout",		\
 	    "Instead of presenting a continuously updated display,"	\
-	    " print the statistics to stdout."				\
+	    " print the statistics to stdout. This is the default when"	\
+	    "standard output is being redirected"			\
+	)
+#define STAT_OPT_c							\
+	VOPT("c", "[-c]", "Live (curses) mode",				\
+	    "Presents a continuously updated, interactive display."	\
+	    " This is the default when the standard output isn't"	\
+	    " redirected."						\
 	)
 #define STAT_OPT_j							\
 	VOPT("j", "[-j]", "Print statistics to stdout as JSON",		\
@@ -57,6 +64,7 @@
 	)
 
 STAT_OPT_1
+STAT_OPT_c
 VSC_OPT_f
 VUT_OPT_h
 VSC_OPT_I

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -50,6 +50,10 @@ Varnish Cache NEXT (8.0, 2025-09-15)
   Developers should use ``make update`` to update the referenced vtest2 commit
   after changes to vtest2.
 
+* ``varnishstat`` will automatically switch to ``-1`` output if ``stdout``
+  isn't a terminal (allowing ``varnishstat | grep MAIN``). A new ``-c`` switch
+  has been added to force the live mode.
+
 ==============================
 Varnish-Cache 7.7 (2025-03-17)
 ==============================


### PR DESCRIPTION
Simple quality-of-life improvement to automatically detect that the `varnishstat` output is being piped, and to use `-1` if that's the case.