### PR TITLE
vai: polish sml_ai_lease_boc()

### DIFF
--- a/bin/varnishd/storage/storage_simple.c
+++ b/bin/varnishd/storage/storage_simple.c
@@ -491,10 +491,8 @@ sml_ai_lease_boc(struct worker *wrk, vai_hdl vhdl, struct vscarab *scarab)
 	}
 	if (hdl->last != NULL)
 		hdl->last = NULL;
-	if (hdl->st == NULL) {
-		assert(hdl->returned == 0 || hdl->avail == hdl->returned);
+	if (hdl->st == NULL && hdl->returned == 0)
 		hdl->st = VTAILQ_LAST(&hdl->obj->list, storagehead);
-	}
 	if (hdl->st == NULL)
 		assert(hdl->avail == hdl->returned);
 


### PR DESCRIPTION
We really should get the logically first segment only one.

Follow-up to #4371, which I do not want to rush