### PR TITLE
-x json parameter

### DIFF
--- a/bin/varnishd/mgt/mgt.h
+++ b/bin/varnishd/mgt/mgt.h
@@ -199,6 +199,7 @@ void MCF_ParamConf(enum mcf_which_e, const char *param, const char *, ...)
 void MCF_ParamSet(struct cli *, const char *param, const char *val);
 void MCF_ParamProtect(struct cli *, const char *arg);
 void MCF_DumpRstParam(void);
+void MCF_DumpJsonParam(void);
 extern struct params mgt_param;
 
 /* mgt_shmem.c */

--- a/bin/varnishd/mgt/mgt_main.c
+++ b/bin/varnishd/mgt/mgt_main.c
@@ -138,7 +138,8 @@ usage(void)
 
 	printf("\nDocumentation options:\n");
 	printf(FMT, "-?", "Prints this usage message");
-	printf(FMT, "-x parameter", "Parameter documentation");
+	printf(FMT, "-x parameter", "Parameter documentation in RST format");
+	printf(FMT, "-x parameter-json", "Parameter documentation in JSON format");
 	printf(FMT, "-x vsl", "VSL record documentation");
 	printf(FMT, "-x cli", "CLI command documentation");
 	printf(FMT, "-x builtin", "Builtin VCL program");
@@ -378,6 +379,8 @@ mgt_x_arg(const char *x_arg)
 {
 	if (!strcmp(x_arg, "parameter"))
 		MCF_DumpRstParam();
+	else if (!strcmp(x_arg, "parameter-json"))
+		MCF_DumpJsonParam();
 	else if (!strcmp(x_arg, "vsl"))
 		mgt_DumpRstVsl();
 	else if (!strcmp(x_arg, "cli"))


### PR DESCRIPTION
I've been thinking that it would be pretty nice to have shell completion for `varnishd`, but the parameter part is a bit unwieldy because to discover all the parameters, one would need to parse the `varnishd -x parameter` output, which isn't fun.

So, I brute-forced a `-x paramer-json` implementation to gauge interest in implementing this.

If we do want to do this, I'm make sure we have tests before we merge, but the actual completion scripts can/should be worried about later