### PR TITLE
No builtin pipe

### DIFF
--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -60,10 +60,6 @@ sub vcl_req_host {
 }
 
 sub vcl_req_method {
-	if (req.method == "PRI") {
-		# This will never happen in properly formed traffic.
-		return (synth(405));
-	}
 	if (req.method != "GET" &&
 	    req.method != "HEAD" &&
 	    req.method != "PUT" &&

--- a/bin/varnishd/builtin.vcl
+++ b/bin/varnishd/builtin.vcl
@@ -73,7 +73,8 @@ sub vcl_req_method {
 	    req.method != "DELETE" &&
 	    req.method != "PATCH") {
 		# Non-RFC2616 or CONNECT which is weird.
-		return (pipe);
+		set req.http.Connection = "close";
+		return (synth(501));
 	}
 	if (req.method != "GET" && req.method != "HEAD") {
 		# We only deal with GET and HEAD by default.

--- a/bin/varnishd/cache/cache_req_fsm.c
+++ b/bin/varnishd/cache/cache_req_fsm.c
@@ -376,7 +376,8 @@ cnt_synth(struct worker *wrk, struct req *req)
 	    VSB_len(synth_body));
 
 	if (req->doclose == SC_NULL &&
-	    http_HdrIs(req->resp, H_Connection, "close"))
+	    (http_HdrIs(req->resp, H_Connection, "close") ||
+	    http_HdrIs(req->http, H_Connection, "close")))
 		req->doclose = SC_RESP_CLOSE;
 
 	/* Discard any lingering request body before delivery */

--- a/bin/varnishtest/tests/r01524.vtc
+++ b/bin/varnishtest/tests/r01524.vtc
@@ -7,6 +7,9 @@ server s1 {
 } -start
 
 varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pipe);
+	}
 } -start
 
 client c1 {

--- a/bin/varnishtest/tests/r01890.vtc
+++ b/bin/varnishtest/tests/r01890.vtc
@@ -6,6 +6,10 @@ server s1 {
 } -start
 
 varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pipe);
+	}
+
 	sub vcl_pipe {
 		return (synth(401));
 	}

--- a/bin/varnishtest/tests/s00013.vtc
+++ b/bin/varnishtest/tests/s00013.vtc
@@ -26,6 +26,10 @@ server s1 {
 varnish v1 -cliok "param.set pipe_timeout 0s"
 varnish v1 -cliok "param.set pipe_task_deadline 0s"
 varnish v1 -vcl+backend {
+	sub vcl_recv {
+		return (pipe);
+	}
+
 	sub vcl_pipe {
 		set bereq.task_deadline = 1.1s;
 		if (req.method != "TMO") {

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -41,6 +41,10 @@ Varnish Cache NEXT (8.0, 2025-09-15)
 .. PLEASE keep this roughly in commit order as shown by git-log / tig
    (new to old)
 
+* ``builtin.vcl`` has been updated to return a synthetic 501 response and
+  close the connection when receiving requests with an unknown/unsupported
+  http method instead of piping them.
+
 * The default value for ``ban_any_variant`` is now ``0``. This means that
   during a lookup, only the matching variants of an object will be evaluated
   against the ban list.

--- a/doc/sphinx/reference/vcl-step.rst
+++ b/doc/sphinx/reference/vcl-step.rst
@@ -61,13 +61,17 @@ Common actions for the client and backend side
 
 .. _fail:
 
-``fail``
-~~~~~~~~
+``fail(err)``
+~~~~~~~~~~~~~
 
     Transition to :ref:`vcl_synth` on the client side as for
     ``return(synth(503, "VCL Failed"))``, but with any request state
     changes undone as if ``std.rollback()`` was called and forcing a
-    connection close.
+    connection close. The optional string argument `err` is logged to
+    VSL under a `VCL_Error` tag.
+
+    Returning `fail` from `vcl_synth` sends a minimal response with a 500
+    status.
 
     Intended for fatal errors, for which only minimal error handling is
     possible.

--- a/doc/sphinx/reference/vcl_step.rst
+++ b/doc/sphinx/reference/vcl_step.rst
@@ -24,7 +24,7 @@ The `vcl_recv` subroutine may terminate with calling ``return()`` on one
 of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``synth(status code, reason)``
@@ -75,7 +75,7 @@ The `vcl_pipe` subroutine may terminate with calling ``return()`` with one
 of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``synth(status code, reason)``
@@ -98,7 +98,7 @@ The `vcl_pass` subroutine may terminate with calling ``return()`` with one
 of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``synth(status code, reason)``
@@ -122,7 +122,7 @@ The `vcl_hash` subroutine may terminate with calling ``return()`` with one
 of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see  :ref:`fail` section above
   |
   | ``lookup``
@@ -154,7 +154,7 @@ The `vcl_purge` subroutine may terminate with calling ``return()`` with one
 of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``synth(status code, reason)``
@@ -179,7 +179,7 @@ The `vcl_miss` subroutine may terminate with calling ``return()`` with one
 of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``synth(status code, reason)``
@@ -207,7 +207,7 @@ stale: It can have a zero or negative `ttl` with only `grace` or
 The `vcl_hit` subroutine may terminate with calling ``return()``
 with one of the following keywords:
 
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``synth(status code, reason)``
@@ -234,7 +234,7 @@ The `vcl_deliver` subroutine may terminate with calling ``return()`` with one
 of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``synth(status code, reason)``
@@ -262,7 +262,7 @@ The subroutine may terminate with calling ``return()`` with one of the
 following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``restart``
@@ -287,7 +287,7 @@ The `vcl_backend_fetch` subroutine may terminate with calling
 ``return()`` with one of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``abandon``
@@ -343,7 +343,7 @@ The `vcl_backend_response` subroutine may terminate with calling
 ``return()`` with one of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``abandon``
@@ -398,7 +398,7 @@ The `vcl_backend_error` subroutine may terminate with calling ``return()``
 with one of the following keywords:
 
   |
-  | ``fail``
+  | ``fail(err)``
   |  see :ref:`fail` section above
   |
   | ``abandon``
@@ -433,7 +433,7 @@ with one of the following keywords:
   | ``ok``
   |  Normal return, VCL continues loading.
   |
-  | ``fail``
+  | ``fail(err)``
   |  Abort loading of this VCL.
 
 .. _vcl_fini:


### PR DESCRIPTION
It was agreed during a bugwash that we no longer want to pipe unknown request methods by default and instead return a synthetic 405 (Method Not Allowed) for the next 8.0 release.

Refs #3352