### PR TITLE
[adm] introduce admin_socket.info

### DIFF
--- a/bin/varnishtest/tests/b00094.vtc
+++ b/bin/varnishtest/tests/b00094.vtc
@@ -1,0 +1,12 @@
+vtest "admin_socket.info"
+
+varnish v1 -vcl {
+	backend be none;
+} -start
+
+varnish v1 -cliok "admin_socket.info"
+
+shell {
+	varnishadm -n ${v1_name} admin_socket.info | grep -E 'secret=${v1_name}/_.secret'
+	varnishadm -n ${v1_name} admin_socket.info | grep -E 'sockets=\S+ [0-9]+'
+}

--- a/bin/varnishtest/tests/b00095.vtc
+++ b/bin/varnishtest/tests/b00095.vtc
@@ -1,0 +1,23 @@
+vtest "admin_socket.info -j"
+
+feature cmd "jq -V"
+
+varnish v1 -vcl {
+	backend be none;
+} -start
+
+varnish v1 -cliok "admin_socket.info -j"
+
+shell {
+	t() {
+		el=$1
+		ty=$2
+		[[ $(varnishadm -n ${v1_name} admin_socket.info -j | jq -r "$el | type") == $ty ]]
+	}
+
+	t .[3].secret string
+	t .[3].sockets array
+	t .[3].sockets[0] object
+	t .[3].sockets[0].address string
+	t .[3].sockets[0].port number
+}

--- a/include/tbl/cli_cmds.h
+++ b/include/tbl/cli_cmds.h
@@ -451,6 +451,13 @@ CLI_CMD(PID,
 	0, 0
 )
 
+CLI_CMD(ADMIN_SOCKET_INFO,
+	"admin_socket.info",
+	"admin_socket.info [-j]",
+	"List admin socket addresses/ports as well as the secret file path.",
+	"  ``-j`` specifies JSON output.",
+	0, 0
+)
 #undef CLI_CMD
 
 /*lint -restore */


### PR DESCRIPTION
provide an easy way for external script/programs to extract admin socket data without C bindings.

JSON output example:
```
[ 2, ["admin_socket.info", "-j"], 1755637539.258,
  {
    "sockets": [
      {
        "address": "::1",
        "port": 46391
      },
      {
        "address": "127.0.0.1",
        "port": 38191
      }
    ],
    "secret": "/tmp/vtc.1013468.3b74cfce/v1/_.secret"
  }
]
```

Non-JSON:
```
sockets=::1 46129,127.0.0.1 44135
secret=/tmp/vtc.1014381.62ab002d/v1/_.secret
```