### PR TITLE
H2: Use the correct queue context when sending rapid reset goaway

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -408,9 +408,9 @@ h2_rx_rst_stream(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 	if (r2 == NULL)
 		return (0);
 	if (h2_rapid_reset_check(wrk, h2, r2)) {
-		H2_Send_Get(wrk, h2, r2);
-		h2e = h2_rapid_reset_charge(wrk, h2, r2);
-		H2_Send_Rel(h2, r2);
+		H2_Send_Get(wrk, h2, h2->req0);
+		h2e = h2_rapid_reset_charge(wrk, h2, h2->req0);
+		H2_Send_Rel(h2, h2->req0);
 	}
 	h2_kill_req(wrk, h2, r2, h2_streamerror(vbe32dec(h2->rxf_data)));
 	return (h2e);

--- a/bin/varnishd/http2/cache_http2_send.c
+++ b/bin/varnishd/http2/cache_http2_send.c
@@ -107,6 +107,8 @@ h2_send_get_locked(struct worker *wrk, struct h2_sess *h2, struct h2_req *r2)
 	Lck_AssertHeld(&h2->sess->mtx);
 	if (&wrk->cond == h2->cond)
 		ASSERT_RXTHR(h2);
+	AZ(H2_SEND_HELD(h2, r2));
+	AZ(r2->wrk);
 	r2->wrk = wrk;
 	VTAILQ_INSERT_TAIL(&h2->txqueue, r2, tx_list);
 	while (!H2_SEND_HELD(h2, r2))


### PR DESCRIPTION
When queing for send during rapid reset handling on incoming frame, it is `h2->req0` that should be used for queueing, not the `struct h2_req` of the stream for which we are handling the incoming frame. This error would lead to the queue structure becoming corrupted.