### PR TITLE
vtcp,vus: Consistently establish blocking connections

### DIFF
--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -298,6 +298,8 @@ VTCP_connect(const struct suckaddr *name, int msec)
 	AZ(setsockopt(s, IPPROTO_TCP, TCP_NODELAY, &val, sizeof val));
 
 	i = connect(s, sa, sl);
+	if (i == 0 && msec > 0)
+		VTCP_blocking(s);
 	if (i == 0)
 		return (s);
 	if (errno != EINPROGRESS) {

--- a/lib/libvarnish/vus.c
+++ b/lib/libvarnish/vus.c
@@ -160,6 +160,8 @@ VUS_connect(const char *path, int msec)
 		VTCP_nonblocking(s);
 
 	i = connect(s, (const void*)&uds, sl);
+	if (i == 0 && msec > 0)
+		VTCP_blocking(s);
 	if (i == 0)
 		return (s);
 	if (errno != EINPROGRESS) {


### PR DESCRIPTION
It was originally observed by @scance that unix-domain sockets were in a non-blocking state, which was unexpected. After some digging, he found the root cause and fixed it. It was also independently observed by @fwsGonzo.

This patch series ensures that all successful outcomes of `V{TCP,US}_connect()` calls yield a socket in blocking mode for consistency.