### PR TITLE
varnishncsa: VARNISHNCSA_COMPAT environment variable

### DIFF
--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -176,6 +176,9 @@ frag_needed(const struct fragment *frag, enum format_policy fp)
 {
 	unsigned is_first, want_first, want_frag;
 
+	if (getenv("VARNISHNCSA_COMPAT") != NULL)
+		return (1);
+
         is_first = CTX.gen != frag->gen;
 
         switch (fp) {

--- a/bin/varnishtest/tests/u00020.vtc
+++ b/bin/varnishtest/tests/u00020.vtc
@@ -166,3 +166,15 @@ shell {
 	EOF
 	diff -u expected_rc.txt ncsa_rc.txt
 }
+
+shell {
+	VARNISHNCSA_COMPAT=1
+	export VARNISHNCSA_COMPAT
+
+	varnishncsa -n ${v1_name} -d -c -F '%H %{reqhdr}i %{notreceived}i %{unset}i %m %q %U %u' > ncsa_rc.txt
+
+	cat >expected_rc.txt <<-EOF
+	HTTP/1.1 hash-modified hash - GET ?q=hashQuerry /hash-url hash
+	EOF
+	diff -u expected_rc.txt ncsa_rc.txt
+}

--- a/doc/sphinx/reference/varnishncsa.rst
+++ b/doc/sphinx/reference/varnishncsa.rst
@@ -238,6 +238,22 @@ SIGNALS
 
   Flush any outstanding transactions.
 
+ENVIRONMENT
+===========
+
+The following environment variables shall affect the execution of
+``varnishncsa``:
+
+``VARNISH_DEFAULT_N``
+
+    Default value for the ``-n`` option when omitted from the command line.
+
+``VARNISHNCSA_COMPAT``
+
+    Restore compatibility with the previous interpretation of formats ``%{X}i``
+    and ``%{X}o``. They used to include header fields populated from VCL.
+    Consider ``%{VCL_Log:key}x`` instead to capture data from VCL transactions.
+
 NOTES
 =====
 
@@ -257,10 +273,6 @@ Furthermore, these rules also apply to items that appear multiple times in a
 transaction. For example, if a header appears multiple times in a client
 request, the first occurrence is logged in client mode, while in backend mode
 the last occurrence is logged.
-
-Prior to 7.7, formats %{X}i and %{X}o used to include header fields populated
-from VCL. Consider %{VCL_Log:key}x instead to capture data from VCL
-transactions.
 
 EXAMPLE
 =======


### PR DESCRIPTION
In turn, vtest2 should be updated to `unsetenv("VARNISHNCSA_COMPAT")` to ensure sane defaults for test cases.

We may also want to start a formal `ENVIRONMENT` section in all manual pages for Varnish programs since they all share at least support for `VARNISH_DEFAULT_N`.

Fixes #4385