### PR TITLE
fix backend.list x.y when labels are in use

### DIFF
--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -530,6 +530,8 @@ vcl_iterdir(struct cli *cli, const char *pat, const struct vcl *vcl,
 	int i, found = 0;
 	struct vcldir *vdir;
 
+	AN(vcl->vdire);	// no labels
+
 	Lck_AssertHeld(&vcl_mtx);
 	VTAILQ_FOREACH(vdir, &vcl->vdire->directors, directors_list) {
 		CHECK_OBJ(vdir, VCLDIR_MAGIC);
@@ -575,6 +577,9 @@ VCL_IterDirector(struct cli *cli, const char *pat,
 	} else {
 		Lck_Lock(&vcl_mtx);
 		VTAILQ_FOREACH(vcl, &vcl_head, list) {
+			// skip labels
+			if (! vcl->vdire)
+				continue;
 			i = vcl_iterdir(cli, VSB_data(vsb), vcl, func, priv);
 			if (i < 0) {
 				found = i;

--- a/bin/varnishtest/tests/c00077.vtc
+++ b/bin/varnishtest/tests/c00077.vtc
@@ -15,6 +15,7 @@ varnish v1 -clierr 106 "vcl.label vcl.A vcl1"
 varnish v1 -cliok "vcl.label vclA vcl1"
 # labeling twice #2834
 varnish v1 -cliok "vcl.label vclA vcl1"
+varnish v1 -cliok "backend.list vcl1.*"
 
 varnish v1 -vcl+backend {
 	sub vcl_recv {


### PR DESCRIPTION
labels are struct vcl objects for which most members are empty/null, with the label member pointing to the labeled vcl.

As such, label vcl objects also have no vdire struct. Hence, when iterating over VCLs to find backends, labels need to be skipped.