### PR TITLE
support VCL_SUB calls from vcl_init and vcl_fini

### DIFF
--- a/bin/varnishtest/tests/m00053.vtc
+++ b/bin/varnishtest/tests/m00053.vtc
@@ -240,3 +240,22 @@ client c2 {
 
 client c1 -wait
 client c2 -wait
+
+varnish v1 -vcl {
+	import debug;
+	import std;
+
+	backend b None;
+
+	sub logger {
+		std.log("logger called");
+	}
+
+	sub vcl_init {
+		debug.call(logger);
+	}
+
+	sub vcl_fini {
+		debug.call(logger);
+	}
+}


### PR DESCRIPTION
The housekeeping subs did not yet support calling sub handles because the recursion bitmap was missing in the VRT context.

Fixes #4394