### PR TITLE
h2: Consistently release the session workspace in h2_rxframe

### DIFF
--- a/bin/varnishd/http2/cache_http2_proto.c
+++ b/bin/varnishd/http2/cache_http2_proto.c
@@ -1517,8 +1517,11 @@ h2_rxframe(struct worker *wrk, struct h2_sess *h2)
 
 	ASSERT_RXTHR(h2);
 
-	if (h2->goaway && h2->open_streams == 0)
+	if (h2->goaway && h2->open_streams == 0) {
+		// XXX: h2 WS must always be released before returning
+		WS_ReleaseP(h2->ws, h2->htc->rxbuf_b);
 		return (0);
+	}
 
 	h2->t1 = NAN;
 	VTCP_blocking(*h2->htc->rfd);

--- a/bin/varnishd/http2/cache_http2_session.c
+++ b/bin/varnishd/http2/cache_http2_session.c
@@ -436,6 +436,7 @@ h2_new_session(struct worker *wrk, void *arg)
 		AN(WS_Reservation(h2->ws));
 	}
 
+	assert(!WS_IsReserved(h2->ws));
 	AN(h2->error);
 
 	/* Delete all idle streams */


### PR DESCRIPTION
> All other code paths returning from h2_rxframe guarantee that the h2 session workspace is released as they all go through HTC_RxStuff. The only exception was this code path that is particularly hard to hit, as it requires h2->goaway to be set without having h2->error at the same time.

That code path is currently not covered by our tests ([gcov](https://varnish-cache.org/gcov/bin/varnishd/http2/cache_http2_proto.c.html)), I spent a lot of time trying to make a test case that reproduces the panic, but it is particularly hard with all the things going on concurrently in h2.

Fixes: #4396