### PR TITLE
varnishncsa: Support space separator in %{VSL:tag:record-prefix[field]}x format

### DIFF
--- a/bin/varnishtest/tests/u00003.vtc
+++ b/bin/varnishtest/tests/u00003.vtc
@@ -22,6 +22,10 @@ varnish v1 -vcl+backend {
 	sub vcl_hit {
 		return (synth(404));
 	}
+
+	sub vcl_backend_response {
+		set beresp.ttl = 360s;
+	}
 } -start
 
 shell {
@@ -197,3 +201,14 @@ shell {
 }
 
 # ESI coverage in e00003.vtc
+
+# %{VSL:tag:prefix} with space separator
+
+shell {
+	varnishncsa -n ${v1_name} -d -b -F '%{VSL:Begin:bereq[2]}x %{VSL:TTL:RFC[1]}x %{VSL:TTL:VCL[1]}x %{VSL:BerespHeader:server}x' -k1 > vsl_prefix.txt
+
+	cat >expected_vsl_prefix.txt <<-EOF
+	fetch 120 360 s1
+	EOF
+	diff -u expected_vsl_prefix.txt vsl_prefix.txt
+}

--- a/doc/sphinx/reference/varnishncsa.rst
+++ b/doc/sphinx/reference/varnishncsa.rst
@@ -223,7 +223,7 @@ Supported formatters are:
 
     The record prefix will limit the matches to those records that
     have this prefix as the first part of the record content followed
-    by a colon.
+    by a colon or a white space.
 
     The field will, if present, treat the log record as a white
     space separated list of fields, and only the nth part of the


### PR DESCRIPTION
This makes varnishncsa also accept `record-prefix` that are followed by whitespace (in addition to colon) for the `%{VSL:tag:record-prefix}x` formatter. This can be useful to match specific log records in multiple situations.

Fixes: #4403