### PR TITLE
vcc: Reference unsued probes in vgc.c

### DIFF
--- a/bin/varnishtest/tests/v00031.vtc
+++ b/bin/varnishtest/tests/v00031.vtc
@@ -12,9 +12,19 @@ varnish v1 -vcl {
 	backend c { .host = "${localhost}"; }
 }
 
+varnish v1 -vcl {
+	backend default none;
+	probe p { }
+}
+
 varnish v1 -cliok "param.set vcc_feature +err_unref"
 
 varnish v1 -errvcl {Unused backend c, defined:} {
 	backend b { .host = "${localhost}"; }
 	backend c { .host = "${localhost}"; }
+}
+
+varnish v1 -errvcl {Unused probe p, defined:} {
+	backend default none;
+	probe p { }
 }

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -147,6 +147,13 @@ TLWriteVSB(struct vcc *tl, const char *fn, const struct vsb *vsb,
 
 /*--------------------------------------------------------------------*/
 
+static void
+vcc_refUnusedProbes(struct vcc *tl, const struct symbol *sym)
+{
+	if (sym->ndef != 0 && sym->nref == 0)
+		Fc(tl, 0, "\t(void)%s;\n", sym->rname);
+}
+
 struct proc *
 vcc_NewProc(struct vcc *tl, struct symbol *sym)
 {
@@ -426,7 +433,7 @@ EmitCoordinates(const struct vcc *tl, struct vsb *vsb)
  */
 
 static void
-EmitInitFini(const struct vcc *tl)
+EmitInitFini(struct vcc *tl)
 {
 	struct inifin *p, *q = NULL;
 	unsigned has_event = 0;
@@ -574,6 +581,7 @@ EmitInitFini(const struct vcc *tl)
 	Fc(tl, 0, "\n");
 	if (!has_event)
 		Fc(tl, 0, "\t(void)vgc_warmupstep;\n");
+	VCC_WalkSymbols(tl, vcc_refUnusedProbes, SYM_MAIN, SYM_PROBE);
 	Fc(tl, 0, "\treturn (%d);\n", has_event ? 1 : 0);
 	Fc(tl, 0, "}\n");
 }


### PR DESCRIPTION
This avoids C compiler failures when an unreferenced probe is used with 'vcc_feature=-err_unref'

Fixes: #4410