### PR TITLE
vcc: New VPI_Probe_Cmp function

### DIFF
--- a/bin/varnishd/cache/cache_vpi.c
+++ b/bin/varnishd/cache/cache_vpi.c
@@ -302,3 +302,10 @@ VPI_Call_End(VRT_CTX, unsigned n)
 	AN(vbm);
 	vbit_clr(vbm, n);
 }
+
+VCL_BOOL
+VPI_PtrCmp(const void *p1, const void *p2)
+{
+
+	return (p1 != p2);
+}

--- a/bin/varnishtest/tests/r04417.vtc
+++ b/bin/varnishtest/tests/r04417.vtc
@@ -11,11 +11,25 @@ varnish v1 -vcl {
 	probe p1 { }
 	probe p2 { }
 
+	acl a1 { "localhost"; }
+
 	sub vcl_recv {
 		return (synth(200));
 	}
 
 	sub vcl_synth {
+		if (a1 == a1) {
+			set resp.http.be-cmp = "true";
+		}
+		if (be == be) {
+			set resp.http.be-cmp = "true";
+		}
+		if (p1 == p1) {
+			set resp.http.pb-cmp = "true";
+		}
+		if (p1 == p2) {
+			set resp.http.false = "false";
+		}
 		set resp.http.self-cmp = (p1 == p1);
 		set resp.http.cmp = (p1 == p2);
 		set resp.http.name = p1 + "/" + p2;
@@ -28,4 +42,7 @@ client c1 {
 	expect resp.http.cmp == false
 	expect resp.http.self-cmp == true
 	expect resp.http.name == p1/p2
+	expect resp.http.be-cmp == "true"
+	expect resp.http.pb-cmp == "true"
+	expect resp.http.false == <undef>
 } -run

--- a/include/vcc_interface.h
+++ b/include/vcc_interface.h
@@ -118,3 +118,4 @@ enum vcl_func_fail_e VPI_Call_Check(VRT_CTX, const struct VCL_conf *conf,
     unsigned methods, unsigned n);
 void VPI_Call_Begin(VRT_CTX, unsigned n);
 void VPI_Call_End(VRT_CTX, unsigned n);
+VCL_BOOL VPI_PtrCmp(const void *p1, const void *p2);

--- a/lib/libvcc/vcc_expr.c
+++ b/lib/libvcc/vcc_expr.c
@@ -1215,6 +1215,10 @@ cmp_string(struct vcc *tl, struct expr **e, const struct cmps *cp)
 	}
 }
 
+#define PTR_REL(typ)								\
+	{typ,		T_EQ,		cmp_simple, "!VPI_PtrCmp(\v1, \v2)" },	\
+	{typ,		T_NEQ,		cmp_simple, "VPI_PtrCmp(\v1, \v2)" }
+
 #define IDENT_REL(typ)							\
 	{typ,		T_EQ,		cmp_simple, "(\v1 == \v2)" },	\
 	{typ,		T_NEQ,		cmp_simple, "(\v1 != \v2)" }
@@ -1232,9 +1236,9 @@ static const struct cmps vcc_cmps[] = {
 	NUM_REL(BYTES),
 	NUM_REL(REAL),
 	NUM_REL(TIME),
-	IDENT_REL(BACKEND),
-	IDENT_REL(ACL),
-	IDENT_REL(PROBE),
+	PTR_REL(BACKEND),
+	PTR_REL(ACL),
+	PTR_REL(PROBE),
 	IDENT_REL(STEVEDORE),
 	IDENT_REL(SUB),
 	IDENT_REL(INSTANCE),


### PR DESCRIPTION
This is just a wrapper around probes pointers comparison, it avoids C-compiler failures like:

 error: self-comparison always evaluates to true
 error: array comparison always evaluates to false

Fixes: #4410
And should also fix the failing test case in master branch.