### PR TITLE
lru: Do not add failed objects

### DIFF
--- a/bin/varnishd/storage/storage_lru.c
+++ b/bin/varnishd/storage/storage_lru.c
@@ -87,7 +87,7 @@ LRU_Add(struct objcore *oc, vtim_real now)
 
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
-	if (oc->flags & OC_F_PRIVATE)
+	if (oc->flags & (OC_F_PRIVATE|OC_F_FAILED))
 		return;
 
 	AZ(oc->boc);
@@ -109,7 +109,7 @@ LRU_Remove(struct objcore *oc)
 
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
-	if (oc->flags & OC_F_PRIVATE)
+	if (oc->flags & (OC_F_PRIVATE|OC_F_FAILED))
 		return;
 
 	AZ(oc->boc);
@@ -130,7 +130,7 @@ LRU_Touch(struct worker *wrk, struct objcore *oc, vtim_real now)
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(oc, OBJCORE_MAGIC);
 
-	if (oc->flags & OC_F_PRIVATE || isnan(oc->last_lru))
+	if (oc->flags & (OC_F_PRIVATE|OC_F_FAILED) || isnan(oc->last_lru))
 		return;
 
 	/*


### PR DESCRIPTION
Until now we kept failed objects momentarily on the LRU. This is wasteful, because they never get inserted into EXP (which happens via HSH_Unbusy() -> EXP_Insert), and as such will be removed from cache when the last reference goes away.

Why is this change correct?

- in HSH_Lookup(), we explicitly skip OC_F_FAILED
- the only place where OC_F_FAILED can be gained is HSH_Fail()
- HSH_Fail() asserts that the object is still busy
- LRU_Add() gets called via HSH_DerefBoc() -> ObjBocDone() when the boc's last reference goes away