### PR TITLE
Expose VARNISH_{STATE_DIR,DEFAULT_REL_NAME} in installed headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -647,6 +647,10 @@ else
 fi
 AC_SUBST(VARNISH_STATE_DIR)
 
+# Default relative name for working directory
+VARNISH_DEFAULT_REL_NAME='varnishd'
+AC_SUBST(VARNISH_DEFAULT_REL_NAME)
+
 # Default configuration directory.
 pkgsysconfdir='${sysconfdir}/varnish'
 AC_SUBST(pkgsysconfdir)
@@ -931,6 +935,7 @@ AC_CONFIG_FILES([
     doc/sphinx/conf.py
     etc/Makefile
     include/Makefile
+    include/vapi/workdir.h
     lib/Makefile
     lib/libvsc/Makefile
     lib/libvarnish/Makefile

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -56,6 +56,7 @@ nobase_pkginclude_HEADERS = \
 	vapi/vsm.h \
 	vapi/voptget.h \
 	vapi/vapi_options.h \
+	vapi/workdir.h \
 	vcli.h \
 	vut.h \
 	vut_options.h

--- a/include/vapi/workdir.h.in
+++ b/include/vapi/workdir.h.in
@@ -1,8 +1,8 @@
 /*-
- * Copyright (c) 2007-2010 Varnish Software AS
+ * Copyright (c) 2026 Varnish Software AS
  * All rights reserved.
  *
- * Author: Dag-Erling Smørgrav <des@des.no>
+ * Author: Guillaume Quintard <guillaume.quintard@varnish-software.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -27,57 +27,23 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * NB: also used in libvarnishapi
+ * Varnish working directory paths
  */
 
-#include "config.h"
+/**
+ * VARNISH_STATE_DIR - Default state directory
+ *
+ * The default directory where Varnish stores runtime state files.
+ * This is configured at build time and typically points to /var/run
+ * or ${localstatedir}/varnish depending on the installation.
+ */
+#define VARNISH_STATE_DIR "@VARNISH_STATE_DIR@"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "vdef.h"
-
-#include "vas.h"
-#include "vin.h"
-#include "vsb.h"
-
-#include "vapi/workdir.h"
-
-char *
-VIN_n_Arg(const char *n_arg)
-{
-	struct vsb *vsb;
-	char *retval;
-
-	vsb = VSB_new_auto();
-	AN(vsb);
-	if (n_arg == NULL || n_arg[0] == '\0') {
-		VSB_cat(vsb, VARNISH_STATE_DIR);
-		VSB_cat(vsb, "/" VARNISH_DEFAULT_REL_NAME);
-	} else if (n_arg[0] == '/') {
-		VSB_cat(vsb, n_arg);
-	} else {
-		VSB_cat(vsb, VARNISH_STATE_DIR);
-		VSB_cat(vsb, "/");
-		VSB_cat(vsb, n_arg);
-	}
-	AZ(VSB_finish(vsb));
-
-	retval = strdup(VSB_data(vsb));
-	VSB_destroy(&vsb);
-	return (retval);
-}
-
-void
-VIN_DumpDefaults(void)
-{
-	printf("  The default is taken from the ``VARNISH_DEFAULT_N`` "
-	       "environment variable.\n\n");
-	printf("  Relative paths will be appended to ``%s``.\n\n",
-	       VARNISH_STATE_DIR);
-	printf("  If neither ``VARNISH_DEFAULT_N`` nor ``-n`` are "
-	       "present, the value is ``%s``.\n\n",
-	       VARNISH_STATE_DIR "/" VARNISH_DEFAULT_REL_NAME);
-	printf("  Note: These defaults may be distribution specific.\n\n");
-}
+/**
+ * VARNISH_DEFAULT_REL_NAME - Default relative name
+ *
+ * The default relative name used for Varnish instance directories.
+ * This is used as the default -n argument when constructing working
+ * directory paths.
+ */
+#define VARNISH_DEFAULT_REL_NAME "@VARNISH_DEFAULT_REL_NAME@"

--- a/lib/libvarnish/Makefile.am
+++ b/lib/libvarnish/Makefile.am
@@ -11,7 +11,6 @@ AM_LDFLAGS  = $(AM_LT_LDFLAGS)
 noinst_LTLIBRARIES = libvarnish.la
 
 libvarnish_la_CFLAGS = \
-	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
 	$(AM_CFLAGS)
 
 libvarnish_la_SOURCES = \

--- a/lib/libvarnishapi/Makefile.am
+++ b/lib/libvarnishapi/Makefile.am
@@ -34,9 +34,6 @@ if ! HAVE_DAEMON
 libvarnishapi_la_SOURCES += daemon.c
 endif
 
-libvarnishapi_la_CFLAGS = \
-	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"'
-
 libvarnishapi_la_LIBADD = \
 	$(top_builddir)/lib/libvarnish/libvarnish.la \
 	${NET_LIBS} ${RT_LIBS} ${LIBM}


### PR DESCRIPTION
note: this *doesn't* compete with #444 

Varnish has a lot of runtime dependencies, mainly because of the C compiler, and this is an obstacle for VSM tools trying to reduce the size of their container images.

Exposing `VARNISH_{STATE_DIR,DEFAULT_REL_NAME}` in a new header allows languages such has `go` and `rust` to discover the default workdir at compile-time, and skip the runtime dependency on `varnish`